### PR TITLE
Fix syntax errors in all .po translation files for Weblate parsing

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -2216,7 +2216,7 @@ msgstr "aksie"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr "Vloei"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr "Ekstras"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "maak hoop skoon"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "haal af"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "druk"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "Skilpad"
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "Skilpad"
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "pen op"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "pen af"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "stel pengrootte"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "wys"
+#~ msgid "show"
+#~ msgstr "wys"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Maak skoon"
+#~ msgid "Clean"
+#~ msgstr "Maak skoon"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "versteek blokke"
+#~ msgid "hide blocks"
+#~ msgstr "versteek blokke"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "bokant"
+#~ msgid "stop"
+#~ msgstr "bokant"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "Skilpad"
+#~ msgid "turtle"
+#~ msgstr "Skilpad"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/agr.po
+++ b/po/agr.po
@@ -2213,7 +2213,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2280,7 +2280,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2294,33 +2294,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2342,7 +2342,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2420,7 +2420,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2649,8 +2649,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2809,7 +2809,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2819,14 +2819,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2857,7 +2857,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2882,7 +2882,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2912,7 +2912,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2930,8 +2930,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3033,7 +3033,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3167,14 +3167,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3249,7 +3249,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3285,7 +3285,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3294,7 +3294,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3785,7 +3785,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3797,8 +3797,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3820,8 +3820,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3831,15 +3831,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3848,14 +3848,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3864,14 +3864,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3912,7 +3912,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3921,7 +3921,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3938,7 +3938,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4007,8 +4007,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4030,7 +4030,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4316,7 +4316,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4647,21 +4647,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4670,12 +4670,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4688,62 +4688,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4778,7 +4778,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4787,17 +4787,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4806,12 +4806,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4824,7 +4824,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4833,17 +4833,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4860,56 +4860,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4917,7 +4917,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4925,7 +4925,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4934,7 +4934,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4942,7 +4942,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4951,8 +4951,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4960,7 +4960,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4974,116 +4974,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5102,19 +5102,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5122,61 +5122,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5186,149 +5186,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5337,7 +5337,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5416,22 +5416,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5588,7 +5588,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5610,7 +5610,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5621,7 +5621,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5650,7 +5650,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5659,7 +5659,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5702,7 +5702,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5711,7 +5711,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5720,7 +5720,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5743,13 +5743,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5758,7 +5758,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5767,7 +5767,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5787,7 +5787,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5812,7 +5812,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5826,7 +5826,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5836,7 +5836,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5874,7 +5874,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5883,7 +5883,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5896,18 +5896,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6028,7 +6028,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6047,7 +6047,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6056,7 +6056,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6073,7 +6073,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6086,7 +6086,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6115,7 +6115,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6138,7 +6138,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6155,7 +6155,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6164,7 +6164,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6181,7 +6181,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6190,7 +6190,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6224,7 +6224,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6233,7 +6233,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6265,7 +6265,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6299,12 +6299,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6313,12 +6313,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6327,13 +6327,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6351,7 +6351,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6383,8 +6383,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6440,7 +6440,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6597,12 +6597,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6612,8 +6612,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6621,12 +6621,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6635,7 +6635,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6652,7 +6652,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6662,12 +6662,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6677,7 +6677,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6686,7 +6686,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6736,7 +6736,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6769,7 +6769,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6778,12 +6778,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6792,7 +6792,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6801,7 +6801,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6810,7 +6810,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6821,8 +6821,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6832,7 +6832,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6858,7 +6858,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6896,12 +6896,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6913,12 +6913,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6927,7 +6927,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6973,22 +6973,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6997,7 +6997,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7010,7 +7010,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7019,47 +7019,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7072,7 +7072,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7081,7 +7081,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7089,7 +7089,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7103,8 +7103,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7133,7 +7133,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7158,14 +7158,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7175,7 +7175,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7194,7 +7194,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7204,7 +7204,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7221,17 +7221,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7240,7 +7240,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7250,7 +7250,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7260,7 +7260,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7272,7 +7272,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7280,7 +7280,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7290,7 +7290,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7311,7 +7311,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7326,7 +7326,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7336,7 +7336,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7350,7 +7350,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7406,7 +7406,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7584,7 +7584,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7593,7 +7593,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7602,7 +7602,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7611,7 +7611,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7621,13 +7621,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7640,7 +7640,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7649,7 +7649,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7658,7 +7658,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7667,7 +7667,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7676,7 +7676,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7685,7 +7685,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7694,7 +7694,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7703,7 +7703,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7713,17 +7713,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7732,7 +7732,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8159,7 +8159,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8169,7 +8169,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8213,12 +8213,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8227,7 +8227,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8284,7 +8284,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8302,7 +8302,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8315,7 +8315,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8380,7 +8380,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8445,7 +8445,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8454,12 +8454,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8468,7 +8468,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8477,7 +8477,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8486,7 +8486,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8511,7 +8511,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8646,27 +8646,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8692,18 +8692,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8718,7 +8718,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8739,7 +8739,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8756,7 +8756,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8769,7 +8769,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8779,7 +8779,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8793,7 +8793,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8814,7 +8814,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8828,7 +8828,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9015,7 +9015,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9024,7 +9024,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9146,7 +9146,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9229,7 +9229,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9279,7 +9279,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9396,7 +9396,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9475,48 +9475,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9949,38 +9949,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9988,8 +9988,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -9999,8 +9999,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10012,35 +10012,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10054,69 +10054,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10136,13 +10136,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10150,58 +10150,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10217,25 +10217,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10245,43 +10245,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10291,190 +10291,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10484,305 +10484,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10792,97 +10792,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10892,144 +10892,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11039,15 +11039,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11057,23 +11057,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11083,8 +11083,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11092,224 +11092,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11325,37 +11325,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11363,28 +11363,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11398,8 +11398,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11409,65 +11409,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11475,8 +11475,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11486,127 +11486,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11614,608 +11614,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12225,165 +12225,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12397,28 +12397,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12426,133 +12426,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12560,136 +12560,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12699,127 +12699,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12827,397 +12827,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13229,196 +13229,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13426,155 +13426,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13582,257 +13582,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13846,223 +13846,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14072,144 +14072,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14217,57 +14217,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14277,30 +14277,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14308,112 +14308,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14421,287 +14421,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14709,13 +14709,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14723,86 +14723,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/am.po
+++ b/po/am.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "ላይኛ"
+#~ msgid "stop"
+#~ msgstr "ላይኛ"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "ክፈት"
+#~ msgid "Open"
+#~ msgstr "ክፈት"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -1,5 +1,4 @@
 # Walter Bender <walter@sugarlabs.org>. 2018
-#
 msgid ""
 msgstr ""
 "Project-Id-Version:\n"
@@ -14,10 +13,10 @@ msgstr ""
 "X-Generator: Poedit 1.8.6\n"
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -103,7 +102,7 @@ msgstr "الإجراء"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -170,7 +169,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -184,33 +183,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -232,7 +231,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -310,7 +309,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -539,8 +538,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -699,7 +698,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -709,14 +708,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -747,7 +746,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -772,7 +771,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -781,7 +780,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -802,7 +801,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -820,8 +819,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -923,7 +922,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -1057,14 +1056,14 @@ msgstr "ليس هنالك صندوق تم إختياره"
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "الصورة"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "النموذج"
 
@@ -1139,7 +1138,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -1175,7 +1174,7 @@ msgstr "تدفق"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -1184,7 +1183,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -1675,7 +1674,7 @@ msgstr "الإستماع مرة أخرى حاضر"
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "ثنائي حاد"
 
@@ -1687,8 +1686,8 @@ msgstr "ثنائي حاد"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "حاد"
 
@@ -1698,7 +1697,7 @@ msgstr "حاد"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "طبيعي"
 
@@ -1710,8 +1709,8 @@ msgstr "طبيعي"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "مبسط"
 
@@ -1721,15 +1720,15 @@ msgstr "مبسط"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "ثنائي مبسط"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -1738,14 +1737,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -1754,14 +1753,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -1802,7 +1801,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -1811,7 +1810,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -1828,7 +1827,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -1897,8 +1896,8 @@ msgstr "إضافات"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -1920,7 +1919,7 @@ msgstr "منطقي"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -2206,7 +2205,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -2537,21 +2536,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -2560,12 +2559,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -2578,62 +2577,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -2646,7 +2645,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -2655,7 +2654,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -2668,7 +2667,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -2677,17 +2676,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -2696,12 +2695,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -2714,7 +2713,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -2723,17 +2722,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -2750,56 +2749,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -2807,7 +2806,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -2815,7 +2814,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -2824,7 +2823,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -2832,7 +2831,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -2841,8 +2840,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -2850,7 +2849,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -2864,116 +2863,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -2992,19 +2991,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -3012,61 +3011,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -3076,149 +3075,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -3227,7 +3226,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3306,22 +3305,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -3478,7 +3477,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -3500,7 +3499,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -3511,7 +3510,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -3540,7 +3539,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -3549,7 +3548,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -3582,7 +3581,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "هل الكومة فارغة؟"
 
@@ -3592,7 +3591,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "قم بتفريغ الكومة"
 
@@ -3601,7 +3600,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -3610,7 +3609,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "قيمة (مؤشر) الكومة"
 
@@ -3633,13 +3632,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "حدد القيمة المدخلة إلى الكومة"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "مؤشر"
 
@@ -3648,7 +3647,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "أظهر"
 
@@ -3657,7 +3656,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "ادفع قيمة إلى أعلى الكومة"
 
@@ -3677,7 +3676,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "اوكتاف"
 
@@ -3702,7 +3701,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -3716,7 +3715,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -3726,7 +3725,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -3764,7 +3763,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -3773,7 +3772,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -3786,18 +3785,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -3918,7 +3917,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -3937,7 +3936,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -3946,7 +3945,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -3963,7 +3962,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -3976,7 +3975,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "حمّل الكومة"
 
@@ -4005,7 +4004,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -4028,7 +4027,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -4045,7 +4044,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "قم بتخزين الكومة"
 
@@ -4054,7 +4053,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -4071,7 +4070,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -4080,7 +4079,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -4114,7 +4113,7 @@ msgid "y"
 msgstr "ص"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -4123,7 +4122,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -4140,7 +4139,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -4155,7 +4154,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "ملاحظة"
 
@@ -4189,12 +4188,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -4203,12 +4202,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -4217,13 +4216,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -4241,7 +4240,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -4273,8 +4272,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -4330,7 +4329,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -4487,12 +4486,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -4502,8 +4501,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -4511,12 +4510,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -4525,7 +4524,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -4542,7 +4541,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -4552,12 +4551,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -4567,7 +4566,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -4576,7 +4575,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -4626,7 +4625,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -4659,7 +4658,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -4668,12 +4667,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -4682,7 +4681,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -4691,7 +4690,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -4700,7 +4699,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -4711,8 +4710,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -4722,7 +4721,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -4748,7 +4747,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -4786,12 +4785,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -4803,12 +4802,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -4817,7 +4816,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -4863,22 +4862,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -4887,7 +4886,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -4900,7 +4899,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -4909,47 +4908,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -4962,7 +4961,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -4971,7 +4970,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -4979,7 +4978,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -4993,8 +4992,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -5023,7 +5022,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -5048,14 +5047,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -5065,7 +5064,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -5084,7 +5083,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -5094,7 +5093,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -5111,17 +5110,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -5130,7 +5129,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -5140,7 +5139,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -5150,7 +5149,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -5162,7 +5161,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -5170,7 +5169,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -5180,7 +5179,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -5201,7 +5200,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -5216,7 +5215,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -5226,7 +5225,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -5240,7 +5239,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -5296,7 +5295,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -5474,7 +5473,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -5483,7 +5482,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -5492,7 +5491,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -5501,7 +5500,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -5511,13 +5510,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -5530,7 +5529,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "الفأرة ص"
 
@@ -5539,7 +5538,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "السلحفاة ص"
 
@@ -5548,7 +5547,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "الفأرة س"
 
@@ -5557,7 +5556,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "السلحفاة س"
 
@@ -5566,7 +5565,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -5575,7 +5574,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -5584,7 +5583,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -5593,7 +5592,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -5603,17 +5602,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -5622,7 +5621,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -6049,7 +6048,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -6059,7 +6058,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -6103,12 +6102,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "أوقف العرض"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -6117,7 +6116,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "شغل"
 
@@ -6174,7 +6173,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "النغمة إلى التردد"
 
@@ -6192,7 +6191,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "الحجم"
 
@@ -6205,7 +6204,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -6270,7 +6269,7 @@ msgstr "أنه تعبئة اللون"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "الخلفية"
 
@@ -6335,7 +6334,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -6344,12 +6343,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "احتجز"
 
@@ -6358,7 +6357,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "احتجز"
 
@@ -6367,7 +6366,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "اضبط حجم القلم"
 
@@ -6376,7 +6375,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -6401,7 +6400,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "اختر الرمادي"
 
@@ -6536,27 +6535,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -6582,18 +6581,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -6608,7 +6607,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -6629,7 +6628,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -6646,7 +6645,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -6659,7 +6658,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -6669,7 +6668,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -6683,7 +6682,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -6704,7 +6703,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -6718,7 +6717,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -6905,7 +6904,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -6914,7 +6913,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -7036,7 +7035,7 @@ msgid "Undo"
 msgstr "إلغاء الإجراء السابق"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -7119,7 +7118,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -7169,7 +7168,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -7286,7 +7285,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -7365,48 +7364,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -7839,38 +7838,38 @@ msgstr "حرّك"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "أظهر هذه الرسائل."
+#~ msgid "Show these messages."
+#~ msgstr "أظهر هذه الرسائل."
 
 #: js/rubrics.js:531
 
@@ -7878,8 +7877,8 @@ msgstr "حرّك"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "الحسّاسات"
+#~ msgid "sensors"
+#~ msgstr "الحسّاسات"
 
 #: js/rubrics.js:532
 
@@ -7889,8 +7888,8 @@ msgstr "حرّك"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "وسائل الإعلام"
+#~ msgid "media"
+#~ msgstr "وسائل الإعلام"
 
 #: js/block-verbose.js:3837
 
@@ -7902,35 +7901,35 @@ msgstr "حرّك"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "نص"
+#~ msgid "show"
+#~ msgstr "نص"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -7944,69 +7943,69 @@ msgstr "حرّك"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "نظف"
+#~ msgid "Clean"
+#~ msgstr "نظف"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "نفذ ببطء"
+#~ msgid "Run slow"
+#~ msgstr "نفذ ببطء"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "قم بإخفاؤ اللبنات"
+#~ msgid "hide blocks"
+#~ msgstr "قم بإخفاؤ اللبنات"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8026,13 +8025,13 @@ msgstr "حرّك"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "توقف"
+#~ msgid "stop"
+#~ msgstr "توقف"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "المدة الزمنية (بالميكرو ثانية)"
+#~ msgid "duration (ms)"
+#~ msgstr "المدة الزمنية (بالميكرو ثانية)"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8040,58 +8039,58 @@ msgstr "حرّك"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "نظف الشاشة"
+#~ msgid "clear"
+#~ msgstr "نظف الشاشة"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -8107,25 +8106,25 @@ msgstr "حرّك"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "المدة"
+#~ msgid "duration"
+#~ msgstr "المدة"
 
 #: js/widgets/temperament.js:454
 
@@ -8135,46 +8134,46 @@ msgstr "حرّك"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
-#~msgid ""Toggle Fullscreen"
-#~msgstr ""تبديل ملء الشاشة"
+#~ msgid "Toggle Fullscreen"
+#~ msgstr "تبديل ملء الشاشة"
 
 #: js/toolbar.js:70
 
@@ -8184,190 +8183,190 @@ msgstr "حرّك"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -8377,305 +8376,305 @@ msgstr "حرّك"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "شغل بشكل سريع"
+#~ msgid "Run fast"
+#~ msgstr "شغل بشكل سريع"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "توسيع/ تقليص اللبنات القابلة للتقليص"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "توسيع/ تقليص اللبنات القابلة للتقليص"
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -8685,97 +8684,97 @@ msgstr "حرّك"
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "العملة"
+#~ msgid "currency"
+#~ msgstr "العملة"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "من"
+#~ msgid "from"
+#~ msgstr "من"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "سعر الكومة"
+#~ msgid "stock price"
+#~ msgstr "سعر الكومة"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "ترجم"
+#~ msgid "translate"
+#~ msgstr "ترجم"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "مرحباً"
+#~ msgid "hello"
+#~ msgstr "مرحباً"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "اكتشف اللغة"
+#~ msgid "detect lang"
+#~ msgstr "اكتشف اللغة"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "اضبط اللغة"
+#~ msgid "set lang"
+#~ msgstr "اضبط اللغة"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "خط عرض المدينة"
+#~ msgid "city latitude"
+#~ msgstr "خط عرض المدينة"
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "طول المدينة"
+#~ msgid "city longitude"
+#~ msgstr "طول المدينة"
 
 #: plugins/gmap.rtp:71
 
@@ -8785,144 +8784,144 @@ msgstr "حرّك"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "بيانات الإحداثيات غير متوفرة"
+#~ msgid "Coordinate data not available."
+#~ msgstr "بيانات الإحداثيات غير متوفرة"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "خريطة غوغل"
+#~ msgid "Google map"
+#~ msgstr "خريطة غوغل"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "الإحداثيات"
+#~ msgid "coordinates"
+#~ msgstr "الإحداثيات"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "عامل التقريب"
+#~ msgid "zoom factor"
+#~ msgstr "عامل التقريب"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "تقريب"
+#~ msgid "zoom"
+#~ msgstr "تقريب"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "خط العرض"
+#~ msgid "latitude"
+#~ msgstr "خط العرض"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "الطول"
+#~ msgid "longitude"
+#~ msgstr "الطول"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "الدرجات"
+#~ msgid "degrees"
+#~ msgstr "الدرجات"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "النظام الدائري"
+#~ msgid "radians"
+#~ msgstr "النظام الدائري"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "عرّف"
+#~ msgid "define"
+#~ msgstr "عرّف"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "bitcoin"
+#~ msgid "bitcoin"
+#~ msgstr "bitcoin"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -8932,15 +8931,15 @@ msgstr "حرّك"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr "إخفاء"
+#~ msgid "hide"
+#~ msgstr "إخفاء"
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -8950,23 +8949,23 @@ msgstr "حرّك"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr "الصندوق المنبثق"
+#~ msgid "popout"
+#~ msgstr "الصندوق المنبثق"
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -8976,8 +8975,8 @@ msgstr "حرّك"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -8985,224 +8984,224 @@ msgstr "حرّك"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr "قيّم"
+#~ msgid "eval"
+#~ msgstr "قيّم"
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -9218,37 +9217,37 @@ msgstr "حرّك"
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -9256,28 +9255,28 @@ msgstr "حرّك"
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -9291,8 +9290,8 @@ msgstr "حرّك"
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -9302,65 +9301,65 @@ msgstr "حرّك"
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -9368,8 +9367,8 @@ msgstr "حرّك"
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -9379,127 +9378,127 @@ msgstr "حرّك"
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr "قبل عدة ساعات"
+#~ msgid "hours ago"
+#~ msgstr "قبل عدة ساعات"
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -9507,608 +9506,608 @@ msgstr "حرّك"
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr "eatme"
+#~ msgid "eatme"
+#~ msgstr "eatme"
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "افتح لوحة لتكوين لبنات السلحفاة."
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "افتح لوحة لتكوين لبنات السلحفاة."
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr "يتم تفعيل زر اللصق عندما يتم نسخ لبنات إلى الحافظة."
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr "يتم تفعيل زر اللصق عندما يتم نسخ لبنات إلى الحافظة."
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr "mashape"
+#~ msgid "mashape"
+#~ msgstr "mashape"
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "يمكنك تحميل لبنات جديدة من نظام الملفات."
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "يمكنك تحميل لبنات جديدة من نظام الملفات."
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr "الإعدادات"
+#~ msgid "Settings"
+#~ msgstr "الإعدادات"
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr "حذف الكل"
+#~ msgid "Delete all"
+#~ msgstr "حذف الكل"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr "هويّة فريدة"
+#~ msgid "UID"
+#~ msgstr "هويّة فريدة"
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -10118,165 +10117,165 @@ msgstr "حرّك"
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -10290,28 +10289,28 @@ msgstr "حرّك"
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10319,133 +10318,133 @@ msgstr "حرّك"
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr "احفظ مشروعك على خادم"
+#~ msgid "Save your project to a server."
+#~ msgstr "احفظ مشروعك على خادم"
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr "توسيع/ تقليص شريط الأدوات"
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr "توسيع/ تقليص شريط الأدوات"
 
 #: js/turtledefs.js:187
 
@@ -10453,136 +10452,136 @@ msgstr "حرّك"
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "السلحفاة"
+#~ msgid "turtle"
+#~ msgstr "السلحفاة"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -10592,127 +10591,127 @@ msgstr "حرّك"
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr "نشر"
+#~ msgid "Publish"
+#~ msgstr "نشر"
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -10720,397 +10719,397 @@ msgstr "حرّك"
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr "في جميع أنحاء العالم"
+#~ msgid "Worldwide"
+#~ msgstr "في جميع أنحاء العالم"
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr "أنهِ الخط المجوف"
+#~ msgid "end hollow line"
+#~ msgstr "أنهِ الخط المجوف"
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "افتح"
+#~ msgid "Open"
+#~ msgstr "افتح"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr "تأكيد"
+#~ msgid "confirm"
+#~ msgstr "تأكيد"
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr "مجال الاهتمام"
+#~ msgid "field"
+#~ msgstr "مجال الاهتمام"
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -11122,196 +11121,196 @@ msgstr "حرّك"
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "إخفاء أو إظهار لوحات المنع."
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "إخفاء أو إظهار لوحات المنع."
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr "الطعام"
+#~ msgid "food"
+#~ msgstr "الطعام"
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11319,155 +11318,155 @@ msgstr "حرّك"
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr "الرياضيات"
+#~ msgid "maths"
+#~ msgstr "الرياضيات"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr "الفراغ الأفقي"
+#~ msgid "hspace"
+#~ msgstr "الفراغ الأفقي"
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11475,257 +11474,257 @@ msgstr "حرّك"
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "إخفاء أو إظهار شبكة التنسيق القطبي."
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "إخفاء أو إظهار شبكة التنسيق القطبي."
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "نظف الشاشة وأعد السلاحف إلى مكانها الأساسي."
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "نظف الشاشة وأعد السلاحف إلى مكانها الأساسي."
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr "ابدأ الخط المجوف"
+#~ msgid "begin hollow line"
+#~ msgstr "ابدأ الخط المجوف"
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -11739,223 +11738,223 @@ msgstr "حرّك"
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr "قطبي"
+#~ msgid "Polar"
+#~ msgstr "قطبي"
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "إظهار أو إخفاء شبكة التنسيق الديكارتي."
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "إظهار أو إخفاء شبكة التنسيق الديكارتي."
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr "تحميل البرنامج المساعد من الملف"
+#~ msgid "Load plugin from file"
+#~ msgstr "تحميل البرنامج المساعد من الملف"
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr "غنِّ"
+#~ msgid "sing"
+#~ msgstr "غنِّ"
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -11965,144 +11964,144 @@ msgstr "حرّك"
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr "تحميل"
+#~ msgid "Download"
+#~ msgstr "تحميل"
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr "السحابة"
+#~ msgid "cloud"
+#~ msgstr "السحابة"
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr "إظهار/ إخفاء اللوحات"
+#~ msgid "Show/hide palettes"
+#~ msgstr "إظهار/ إخفاء اللوحات"
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr "الاستحضار"
+#~ msgid "fetch"
+#~ msgstr "الاستحضار"
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr "rodi"
+#~ msgid "rodi"
+#~ msgstr "rodi"
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr "لبنات"
+#~ msgid "blocks"
+#~ msgstr "لبنات"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -12110,57 +12109,57 @@ msgstr "حرّك"
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -12170,30 +12169,30 @@ msgstr "حرّك"
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12201,112 +12200,112 @@ msgstr "حرّك"
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "انقر لتنفيذ المشروع بشكل سريع."
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "انقر لتنفيذ المشروع بشكل سريع."
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr "صدفة السلحفاة"
+#~ msgid "shell"
+#~ msgstr "صدفة السلحفاة"
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -12314,287 +12313,287 @@ msgstr "حرّك"
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr "يقوم هذا الزر بفتح وإغلاق شريط الأدوات الأساسي."
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr "يقوم هذا الزر بفتح وإغلاق شريط الأدوات الأساسي."
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr "الفراغ العامودي"
+#~ msgid "vspace"
+#~ msgstr "الفراغ العامودي"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "قم بإزالة المحتويات الموجودة على اللوحات, بما في ذلك اللبنات."
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "قم بإزالة المحتويات الموجودة على اللوحات, بما في ذلك اللبنات."
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr "حفظ المشروع كرسم متجه بسيط (SVG)"
+#~ msgid "save svg"
+#~ msgstr "حفظ المشروع كرسم متجه بسيط (SVG)"
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr "على جهازي"
+#~ msgid "On my device"
+#~ msgstr "على جهازي"
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12602,13 +12601,13 @@ msgstr "حرّك"
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -12616,86 +12615,86 @@ msgstr "حرّك"
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/ayc.po
+++ b/po/ayc.po
@@ -13,10 +13,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: ini-to-pot script\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -36,7 +36,7 @@ msgstr ""
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
 #: js/languagebox.js:208
-#.TRANS: Actualice su navegador para cambiar su preferencia de idioma.
+#. TRANS: Actualice su navegador para cambiar su preferencia de idioma.
 msgid "Refresh your browser to change your language preference."
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Music Blocks is already set to this language."
 msgstr "Music Blocks ya está configurado en este idioma."
 
 #: js/planetInterface.js:131
-#.TRANS: El proyecto no está definido.
+#. TRANS: El proyecto no está definido.
 msgid "project undefined"
 msgstr ""
 
@@ -98,15 +98,15 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2501
 #: js/widgets/rhythmruler.js:2508
 #: js/widgets/phrasemaker.js:4996
-#.TRANS: acción
+#. TRANS: acción
 msgid "action"
 msgstr "ruway"
 
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
-#.TRANS: pato
+#. TRANS: animal sound effect
+#. TRANS: pato
 msgid "duck"
 msgstr "patu"
 
@@ -117,60 +117,60 @@ msgstr ""
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
-#.TRANS: Proyecto de Bloques de Música
+#. TRANS: Proyecto de Bloques de Música
 msgid "Music Blocks Project"
 msgstr ""
 
 #: js/SaveInterface.js:63
-#.TRANS: Este proyecto fue creado en Bloques de Música
+#. TRANS: Este proyecto fue creado en Bloques de Música
 msgid "This project was created in Music Blocks"
 msgstr ""
 
 #: js/SaveInterface.js:67
-#.TRANS: Bloques de Música es una aplicación de Software Libre
+#. TRANS: Bloques de Música es una aplicación de Software Libre
 msgid "Music Blocks is a Free/Libre Software application."
 msgstr ""
 
 #: js/SaveInterface.js:69
-#.TRANS: Se puede acceder al código fuente en
+#. TRANS: Se puede acceder al código fuente en
 msgid "The source code can be accessed at"
 msgstr ""
 
 #: js/SaveInterface.js:72
-#.TRANS: Para más información, consulte el
+#. TRANS: Para más información, consulte el
 msgid "For more information, please consult the"
 msgstr ""
 
 #: js/SaveInterface.js:76
 #: js/turtledefs.js:489
-#.TRANS: Guía de Bloques de Música
+#. TRANS: Guía de Bloques de Música
 msgid "Music Blocks Guide"
 msgstr ""
 
 #: js/SaveInterface.js:83
-#.TRANS: Alternativamente, abra el archivo en Bloques de Música usando el botón Cargar proyecto.
+#. TRANS: Alternativamente, abra el archivo en Bloques de Música usando el botón Cargar proyecto.
 msgid "Alternatively, open the file in Music Blocks using the Load project button."
 msgstr ""
 
 #: js/SaveInterface.js:85
-#.TRANS: Código de proyecto
+#. TRANS: Código de proyecto
 msgid "Project Code"
 msgstr ""
 
 #: js/SaveInterface.js:87
-#.TRANS: Este código almacena datos sobre los bloques en un proyecto.
+#. TRANS: Este código almacena datos sobre los bloques en un proyecto.
 msgid "This code stores data about the blocks in a project."
 msgstr ""
 
 #: js/SaveInterface.js:89
 #: js/blocks.js:5091
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: Mostrar
+#. TRANS: Mostrar
 msgid "Show"
 msgstr ""
 
 #: js/SaveInterface.js:91
-#.TRANS: Ocultar
+#. TRANS: Ocultar
 msgid "Hide"
 msgstr ""
 
@@ -184,56 +184,56 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
-#.TRANS: Mi proyecto
+#. TRANS: default project title when saving as Lilypond
+#. TRANS: Mi proyecto
 msgid "My Project"
 msgstr "Wakichäwija"
 
 #: js/SaveInterface.js:197
 #: planet/js/SaveInterface.js:58
-#.TRANS: Ninguna descripción provista
+#. TRANS: Ninguna descripción provista
 msgid "No description provided"
 msgstr "Ninguna descripción provista"
 
 #: js/SaveInterface.js:346
-#.TRANS: Tu grabación está en curso.
+#. TRANS: Tu grabación está en curso.
 msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
-#.TRANS: Nombre del archivo
+#. TRANS: File name prompt for save as Lilypond
+#. TRANS: Nombre del archivo
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
-#.TRANS: Título del proyecto
+#. TRANS: Project title prompt for save as Lilypond
+#. TRANS: Título del proyecto
 msgid "Project title"
 msgstr "Título del proyecto"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
-#.TRANS: Autor del Proyecto
+#. TRANS: Project title prompt for save as Lilypond
+#. TRANS: Autor del Proyecto
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
-#.TRANS: Incluye MIDI?
+#. TRANS: MIDI prompt for save as Lilypond
+#. TRANS: Incluye MIDI?
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
-#.TRANS: Incluye tablatura de guitarra
+#. TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Incluye tablatura de guitarra
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
-#.TRANS: Guardar como lilypond
+#. TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Guardar como lilypond
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -255,19 +255,19 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
-#.TRANS: Sr. Ratón
+#. TRANS: default project author when saving as Lilypond
+#. TRANS: Sr. Ratón
 msgid "Mr. Mouse"
 msgstr "Tata Jithiyaña Achaku"
 
 #: js/SaveInterface.js:589
-#.TRANS: El código de Lilypond se copia al portapapeles. Puedes pegarlo aquí:
+#. TRANS: El código de Lilypond se copia al portapapeles. Puedes pegarlo aquí:
 msgid "The Lilypond code is copied to clipboard. You can paste it here: "
 msgstr ""
 
 #: js/activity.js:411
 #: js/activity.js:416
-#.TRANS: Buscar bloques
+#. TRANS: Buscar bloques
 msgid "Search for blocks"
 msgstr ""
 
@@ -288,57 +288,57 @@ msgid "Click on stop saving"
 msgstr ""
 
 #: js/activity.js:1882
-#.TRANS: atrapar ratones
+#. TRANS: atrapar ratones
 msgid "Catching mice"
 msgstr ""
 
 #: js/activity.js:1883
-#.TRANS: limpiar los instrumentos
+#. TRANS: limpiar los instrumentos
 msgid "Cleaning the instruments"
 msgstr ""
 
 #: js/activity.js:1884
-#.TRANS: probando piezas clave
+#. TRANS: probando piezas clave
 msgid "Testing key pieces"
 msgstr ""
 
 #: js/activity.js:1885
-#.TRANS: lectura a primera vista
+#. TRANS: lectura a primera vista
 msgid "Sight-reading"
 msgstr ""
 
 #: js/activity.js:1886
-#.TRANS: combinando matemáticas y música
+#. TRANS: combinando matemáticas y música
 msgid "Combining math and music"
 msgstr ""
 
 #: js/activity.js:1887
-#.TRANS: generando más bloques
+#. TRANS: generando más bloques
 msgid "Generating more blocks"
 msgstr ""
 
 #: js/activity.js:1888
-#.TRANS: Do Re Mi Fa Sol La Si Do
+#. TRANS: Do Re Mi Fa Sol La Si Do
 msgid "Do Re Mi Fa Sol La Ti Do"
 msgstr ""
 
 #: js/activity.js:1889
-#.TRANS: afinar instrumentos de cuerda
+#. TRANS: afinar instrumentos de cuerda
 msgid "Tuning string instruments"
 msgstr ""
 
 #: js/activity.js:1890
-#.TRANS: presionando teclas aleatorias
+#. TRANS: presionando teclas aleatorias
 msgid "Pressing random keys"
 msgstr ""
 
 #: js/activity.js:2072
-#.TRANS: los plugins se eliminarán al reiniciar.
+#. TRANS: los plugins se eliminarán al reiniciar.
 msgid "plugins will be removed upon restart."
 msgstr ""
 
 #: js/activity.js:2081
-#.TRANS: Mostrar Cartesiano
+#. TRANS: Mostrar Cartesiano
 msgid "show Cartesian"
 msgstr ""
 
@@ -347,144 +347,144 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: grado de escala
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: grado de escala
 msgid "scale degree"
 msgstr ""
 
 #: js/activity.js:2606
 #: js/palette.js:681
-#.TRANS: nombre de voz
+#. TRANS: nombre de voz
 msgid "voice name"
 msgstr ""
 
 #: js/activity.js:2609
 #: js/palette.js:678
-#.TRANS: modo invertido
+#. TRANS: modo invertido
 msgid "invert mode"
 msgstr ""
 
 #: js/activity.js:2612
-#.TRANS: herramientas de producción
+#. TRANS: herramientas de producción
 msgid "output tools"
 msgstr ""
 
 #: js/activity.js:2615
-#.TRANS: nota personalizada
+#. TRANS: nota personalizada
 msgid "custom note"
 msgstr ""
 
 #: js/activity.js:2618
-#.TRANS: nombre accidental
+#. TRANS: nombre accidental
 msgid "accidental name"
 msgstr ""
 
 #: js/activity.js:2621
 #: js/blocks/PitchBlocks.js:855
-#.TRANS: 
+#. TRANS: 
 msgid "east indian solfege"
 msgstr ""
 
 #: js/activity.js:2624
 #: js/blocks/PitchBlocks.js:869
-#.TRANS: nombre de la nota
+#. TRANS: nombre de la nota
 msgid "note name"
 msgstr ""
 
 #: js/activity.js:2627
 #: js/blocks/IntervalsBlocks.js:94
-#.TRANS: nombre de temperamento
+#. TRANS: nombre de temperamento
 msgid "temperament name"
 msgstr ""
 
 #: js/activity.js:2630
 #: js/palette.js:675
-#.TRANS: nombre de modo
+#. TRANS: nombre de modo
 msgid "mode name"
 msgstr ""
 
 #: js/activity.js:2633
-#.TRANS: nombre de achorde
+#. TRANS: nombre de achorde
 msgid "chord name"
 msgstr ""
 
 #: js/activity.js:2636
 #: js/palette.js:698
-#.TRANS: nombre de intervalo
+#. TRANS: nombre de intervalo
 msgid "interval name"
 msgstr ""
 
 #: js/activity.js:2639
-#.TRANS: tipo de filtro
+#. TRANS: tipo de filtro
 msgid "filter type"
 msgstr ""
 
 #: js/activity.js:2642
-#.TRANS: tipo de oscilador
+#. TRANS: tipo de oscilador
 msgid "oscillator type"
 msgstr ""
 
 #: js/activity.js:2645
 #: js/blocks.js:2479
 #: js/blocks.js:2487
-#.TRANS: archivo de audio
+#. TRANS: archivo de audio
 msgid "audio file"
 msgstr ""
 
 #: js/activity.js:2648
 #: js/blocks/DrumBlocks.js:32
-#.TRANS: nombre de ruido
+#. TRANS: nombre de ruido
 msgid "noise name"
 msgstr ""
 
 #: js/activity.js:2651
 #: js/blocks/DrumBlocks.js:75
-#.TRANS: nombre del tambor
+#. TRANS: nombre del tambor
 msgid "drum name"
 msgstr ""
 
 #: js/activity.js:2654
 #: js/blocks/DrumBlocks.js:119
-#.TRANS: nombre de efectos
+#. TRANS: nombre de efectos
 msgid "effects name"
 msgstr ""
 
 #: js/activity.js:2657
-#.TRANS: modo de envoltura
+#. TRANS: modo de envoltura
 msgid "wrap mode"
 msgstr ""
 
 #: js/activity.js:2660
-#.TRANS: cargar archivo
+#. TRANS: cargar archivo
 msgid "load file"
 msgstr ""
 
 #: js/activity.js:2830
 #: js/activity.js:6368
-#.TRANS: Este bloque está en desuso.
+#. TRANS: Este bloque está en desuso.
 msgid "This block is deprecated."
 msgstr ""
 
 #: js/activity.js:2832
 #: js/activity.js:6370
-#.TRANS: Este bloque no se puede encontrar.
+#. TRANS: Este bloque no se puede encontrar.
 msgid "Block cannot be found."
 msgstr ""
 
 #: js/activity.js:3041
-#.TRANS: Guardar ilustraciones de bloques
+#. TRANS: Guardar ilustraciones de bloques
 msgid "Saving block artwork"
 msgstr ""
 
 #: js/activity.js:3045
 #: js/turtledefs.js:708
 #: planet/js/LocalCard.js:31
-#.TRANS: Copiar
+#. TRANS: Copiar
 msgid "Copy"
 msgstr "Apaqata"
 
 #: js/activity.js:3052
-#.TRANS: Borrar
+#. TRANS: Borrar
 msgid "Erase"
 msgstr ""
 
@@ -551,7 +551,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:4608
 #: js/widgets/phrasemaker.js:4722
 #: plugins/rodi.rtp:191
-#.TRANS: Tocar
+#. TRANS: Tocar
 msgid "Play"
 msgstr "waqachiy"
 
@@ -583,18 +583,18 @@ msgstr "waqachiy"
 #: plugins/rodi.rtp:29
 #: plugins/rodi.rtp:73
 #: plugins/rodi.rtp:413
-#.TRANS: Detener
+#. TRANS: Detener
 msgid "Stop"
 msgstr "Sayachiy"
 
 #: js/activity.js:3084
 #: js/activity.js:3106
-#.TRANS: Pegar
+#. TRANS: Pegar
 msgid "Paste"
 msgstr ""
 
 #: js/activity.js:3088
-#.TRANS: Guardar ayuda de bloque
+#. TRANS: Guardar ayuda de bloque
 msgid "Save block help"
 msgstr ""
 
@@ -605,60 +605,60 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: si la sol fa mi re do
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: si la sol fa mi re do
 msgid "ti la sol fa mi re do"
 msgstr "si la sol fa mi re do"
 
 #: js/activity.js:3173
-#.TRANS: Saltando al final de la página
+#. TRANS: Saltando al final de la página
 msgid "Jumping to the bottom of the page."
 msgstr ""
 
 #: js/activity.js:3179
-#.TRANS: Desplazarse hacia arriba
+#. TRANS: Desplazarse hacia arriba
 msgid "Scrolling up."
 msgstr ""
 
 #: js/activity.js:3184
-#.TRANS: Desplazarse hacia abajo
+#. TRANS: Desplazarse hacia abajo
 msgid "Scrolling down."
 msgstr ""
 
 #: js/activity.js:3189
-#.TRANS: Bloque de extracción
+#. TRANS: Bloque de extracción
 msgid "Extracting block"
 msgstr ""
 
 #: js/activity.js:3197
-#.TRANS: Mover bloque hacia arriba
+#. TRANS: Mover bloque hacia arriba
 msgid "Moving block up."
 msgstr ""
 
 #: js/activity.js:3218
-#.TRANS: Mover bloque hacia abajo
+#. TRANS: Mover bloque hacia abajo
 msgid "Moving block down."
 msgstr ""
 
 #: js/activity.js:3239
-#.TRANS: Mover bloque a la izquierda
+#. TRANS: Mover bloque a la izquierda
 msgid "Moving block left."
 msgstr ""
 
 #: js/activity.js:3256
-#.TRANS: Mover bloque a la derecha
+#. TRANS: Mover bloque a la derecha
 msgid "Moving block right."
 msgstr ""
 
 #: js/activity.js:3271
-#.TRANS: Saltar a la posición inicial
+#. TRANS: Saltar a la posición inicial
 msgid "Jump to home position."
 msgstr ""
 
 #: js/activity.js:3298
 #: js/blocks/ExtrasBlocks.js:274
-#.TRANS: Ocultar bloques
+#. TRANS: Ocultar bloques
 msgid "Hide blocks"
 msgstr ""
 
@@ -669,7 +669,7 @@ msgstr ""
 
 #: js/activity.js:3679
 #: js/activity.js:3760
-#.TRANS: Objeto recuperado de la basura.
+#. TRANS: Objeto recuperado de la basura.
 msgid "Item restored from the trash."
 msgstr ""
 
@@ -682,69 +682,69 @@ msgid "Restore all items"
 msgstr ""
 
 #: js/activity.js:5016
-#.TRANS: Haga clic en el botón ejecutar para ejecutar el proyecto.
+#. TRANS: Haga clic en el botón ejecutar para ejecutar el proyecto.
 msgid "Click the run button to run the project."
 msgstr ""
 
 #: js/activity.js:6201
 #: js/turtledefs.js:756
-#.TRANS: Casa
+#. TRANS: Casa
 msgid "Home"
 msgstr ""
 
 #: js/activity.js:6209
 #: js/turtledefs.js:762
-#.TRANS: Mostrar u ocultar los bloques.
+#. TRANS: Mostrar u ocultar los bloques.
 msgid "Show/hide blocks"
 msgstr ""
 
 #: js/activity.js:6215
 #: js/turtledefs.js:768
-#.TRANS: Expandir / Contraer bloques
+#. TRANS: Expandir / Contraer bloques
 msgid "Expand/collapse blocks"
 msgstr ""
 
 #: js/activity.js:6221
 #: js/turtledefs.js:776
-#.TRANS: Disminuir el tamaño de los bloques
+#. TRANS: Disminuir el tamaño de los bloques
 msgid "Decrease block size"
 msgstr ""
 
 #: js/activity.js:6227
 #: js/turtledefs.js:782
-#.TRANS: Incrementar tamaño de bloques
+#. TRANS: Incrementar tamaño de bloques
 msgid "Increase block size"
 msgstr ""
 
 #: js/activity.js:6493
-#.TRANS: No se pudo analizar la entrada de JSON.
+#. TRANS: No se pudo analizar la entrada de JSON.
 msgid "Could not parse JSON input."
 msgstr ""
 
 #: js/activity.js:6624
-#.TRANS: Seleccionar está habilitado.
+#. TRANS: Seleccionar está habilitado.
 msgid "Select is enabled."
 msgstr ""
 
 #: js/activity.js:6624
-#.TRANS: Seleccionar está deshabilitado.
+#. TRANS: Seleccionar está deshabilitado.
 msgid "Select is disabled."
 msgstr ""
 
 #: js/activity.js:7005
 #: js/activity.js:7111
 #: js/activity.js:7162
-#.TRANS: No se puede cargar el proyecto desde el archivo. Compruebe el tipo de archivo.
+#. TRANS: No se puede cargar el proyecto desde el archivo. Compruebe el tipo de archivo.
 msgid "Cannot load project from the file. Please check the file type."
 msgstr ""
 
 #: js/activity.js:7448
-#.TRANS: El parametro es invalido.
+#. TRANS: El parametro es invalido.
 msgid "Invalid parameters"
 msgstr ""
 
 #: js/activity.js:7599
-#.TRANS: Error al regenerar las paletas. Actualice la página.
+#. TRANS: Error al regenerar las paletas. Actualice la página.
 msgid "Error regenerating palettes. Please refresh the page."
 msgstr ""
 
@@ -753,7 +753,7 @@ msgstr ""
 #: js/palette.js:688
 #: js/blocks/IntervalsBlocks.js:63
 #: js/blocks/WidgetBlocks.js:259
-#.TRANS: temperamento
+#. TRANS: temperamento
 msgid "temperament"
 msgstr "munasqanman tikrakuq"
 
@@ -767,67 +767,67 @@ msgstr "munasqanman tikrakuq"
 #: js/turtles.js:119
 #: js/blocks/ProgramBlocks.js:1267
 #: js/blocks/ActionBlocks.js:1223
-#.TRANS: iniciar
+#. TRANS: iniciar
 msgid "start"
 msgstr "qallari"
 
 #: js/block.js:1590
-#.TRANS: matriz
+#. TRANS: matriz
 msgid "matrix"
 msgstr ""
 
 #: js/block.js:1597
 #: js/blocks/WidgetBlocks.js:1510
 #: plugins/rodi.rtp:324
-#.TRANS: estatus
+#. TRANS: estatus
 msgid "status"
 msgstr "kasta"
 
 #: js/block.js:1604
-#.TRANS: mapa del tambor
+#. TRANS: mapa del tambor
 msgid "drum mapper"
 msgstr ""
 
 #: js/block.js:1611
-#.TRANS: regla
+#. TRANS: regla
 msgid "ruler"
 msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
-#.TRANS: timbre
+#. TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre
 msgid "timbre"
 msgstr "kunkariq"
 
 #: js/block.js:1625
-#.TRANS: escalera
+#. TRANS: escalera
 msgid "stair"
 msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
-#.TRANS: tempo
+#. TRANS: the speed at music is should be played.
+#. TRANS: tempo
 msgid "tempo"
 msgstr "pacha"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
-#.TRANS: modo
+#. TRANS: mode, e.g., Major in C Major
+#. TRANS: modo
 msgid "mode"
 msgstr "Tupasqa kunkakuna"
 
 #: js/block.js:1646
-#.TRANS: deslizador
+#. TRANS: deslizador
 msgid "slider"
 msgstr ""
 
 #: js/block.js:1653
 #: js/blocks/SensorsBlocks.js:1002
-#.TRANS: teclado
+#. TRANS: teclado
 msgid "keyboard"
 msgstr "ñup’una taqi"
 
@@ -843,15 +843,15 @@ msgstr "ñup’una taqi"
 #: js/blocks/RhythmBlocks.js:766
 #: js/blocks/VolumeBlocks.js:502
 #: js/widgets/phrasemaker.js:1124
-#.TRANS: tambor
+#. TRANS: tambor
 msgid "drum"
 msgstr "tarula"
 
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
-#.TRANS: hacer un ritmo
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: hacer un ritmo
 msgid "rhythm maker"
 msgstr " kunka ruray"
 
@@ -876,8 +876,8 @@ msgstr " kunka ruray"
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
-#.TRANS: valor de la nota
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: valor de la nota
 msgid "note value"
 msgstr "warurt'äwi chimpu chani"
 
@@ -886,14 +886,14 @@ msgstr "warurt'äwi chimpu chani"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
-#.TRANS: intervalo escalar
+#. TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: intervalo escalar
 msgid "scalar interval"
 msgstr "intervalo escalar"
 
 #: js/block.js:1688
 #: js/blocks/RhythmBlocks.js:148
-#.TRANS: milisegundos
+#. TRANS: milisegundos
 msgid "milliseconds"
 msgstr "k’ata tip"
 
@@ -905,18 +905,18 @@ msgstr "k’ata tip"
 #: js/blocks/RhythmBlocks.js:712
 #: js/widgets/rhythmruler.js:1177
 #: js/widgets/rhythmruler.js:1323
-#.TRANS: silencio
+#. TRANS: silencio
 msgid "silence"
 msgstr "ch’in"
 
 #: js/block.js:2542
-#.TRANS: scalar step
-#.TRANS: abajo
+#. TRANS: scalar step
+#. TRANS: abajo
 msgid "down"
 msgstr ""
 
 #: js/block.js:2543
-#.TRANS: arriba
+#. TRANS: arriba
 msgid "up"
 msgstr ""
 
@@ -930,20 +930,20 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
-#.TRANS: tono
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: tono
 msgid "pitch"
 msgstr "kunka"
 
 #: js/block.js:2963
-#.TRANS: El bloqueo de silencio no se puede eliminar.
+#. TRANS: El bloqueo de silencio no se puede eliminar.
 msgid "Silence block cannot be removed."
 msgstr ""
 
 #: js/block.js:3135
 #: js/piemenus.js:3457
-#.TRANS: Puedes restaurar bloques eliminados de la papelera con el botón Restaurar desde la papelera.
+#. TRANS: Puedes restaurar bloques eliminados de la papelera con el botón Restaurar desde la papelera.
 msgid "You can restore deleted blocks from the trash with the Restore From Trash button."
 msgstr ""
 
@@ -963,7 +963,7 @@ msgstr ""
 #: js/blocks/BooleanBlocks.js:948
 #: js/blocks/BooleanBlocks.js:1033
 #: js/blocks/SensorsBlocks.js:911
-#.TRANS: verdadero
+#. TRANS: verdadero
 msgid "true"
 msgstr "chiqaq"
 
@@ -981,65 +981,65 @@ msgstr "chiqaq"
 #: js/blocks/BooleanBlocks.js:849
 #: js/blocks/BooleanBlocks.js:950
 #: js/blocks/SensorsBlocks.js:913
-#.TRANS: falso
+#. TRANS: falso
 msgid "false"
 msgstr "llulla"
 
 #: js/block.js:3776
 #: js/block.js:3789
 #: js/blocks/ExtrasBlocks.js:618
-#.TRANS: Cartesiano
+#. TRANS: Cartesiano
 msgid "Cartesian"
 msgstr ""
 
 #: js/block.js:3777
 #: js/block.js:3790
 #: js/blocks/ExtrasBlocks.js:622
-#.TRANS: polar
+#. TRANS: polar
 msgid "polar"
 msgstr ""
 
 #: js/block.js:3778
 #: js/block.js:3791
 #: js/blocks/ExtrasBlocks.js:626
-#.TRANS: Cartesiano/Polar
+#. TRANS: Cartesiano/Polar
 msgid "Cartesian/Polar"
 msgstr ""
 
 #: js/block.js:3779
 #: js/block.js:3798
 #: js/blocks/ExtrasBlocks.js:655
-#.TRANS: ninguno
+#. TRANS: ninguno
 msgid "none"
 msgstr ""
 
 #: js/block.js:3792
 #: js/blocks/ExtrasBlocks.js:631
-#.TRANS: agudos
+#. TRANS: agudos
 msgid "treble"
 msgstr ""
 
 #: js/block.js:3793
 #: js/blocks/ExtrasBlocks.js:635
-#.TRANS: staff grande
+#. TRANS: staff grande
 msgid "grand staff"
 msgstr ""
 
 #: js/block.js:3794
 #: js/blocks/ExtrasBlocks.js:639
-#.TRANS: mezzo-soprano
+#. TRANS: mezzo-soprano
 msgid "mezzo-soprano"
 msgstr ""
 
 #: js/block.js:3795
 #: js/blocks/ExtrasBlocks.js:643
-#.TRANS: alto
+#. TRANS: alto
 msgid "alto"
 msgstr ""
 
 #: js/block.js:3796
 #: js/blocks/ExtrasBlocks.js:647
-#.TRANS: tenor
+#. TRANS: tenor
 msgid "tenor"
 msgstr ""
 
@@ -1047,37 +1047,37 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
-#.TRANS: bass
+#. TRANS: musical instrument
+#. TRANS: bass
 msgid "bass"
 msgstr "aynacha ira"
 
 #: js/block.js:3842
 #: js/blocks.js:2600
 #: js/blocks.js:3211
-#.TRANS: encendido
+#. TRANS: encendido
 msgid "on2"
 msgstr ""
 
 #: js/block.js:3844
 #: js/blocks.js:2602
 #: js/blocks.js:3213
-#.TRANS: apagado
+#. TRANS: apagado
 msgid "off"
 msgstr ""
 
 #: js/block.js:4411
-#.TRANS: no es un número
+#. TRANS: no es un número
 msgid "Not a number"
 msgstr ""
 
 #: js/block.js:4418
-#.TRANS: El valor de octava debe estar entre 1 y 8.
+#. TRANS: El valor de octava debe estar entre 1 y 8.
 msgid "Octave value must be between 1 and 8."
 msgstr ""
 
 #: js/block.js:4426
-#.TRANS: El bloqueo de silencio no se puede eliminar.
+#. TRANS: El bloqueo de silencio no se puede eliminar.
 msgid "Numbers can have at most 10 digits."
 msgstr ""
 
@@ -1095,19 +1095,19 @@ msgstr ""
 #: js/blocks/BoxesBlocks.js:285
 #: js/blocks/BoxesBlocks.js:405
 #: js/blocks/BoxesBlocks.js:594
-#.TRANS: caja
+#. TRANS: caja
 msgid "box"
 msgstr "tawa k'uchu"
 
 #: js/blocks.js:1713
-#.TRANS: Considera dividir esta pila en partes.
+#. TRANS: Considera dividir esta pila en partes.
 msgid "Consider breaking this stack into parts."
 msgstr ""
 
 #: js/blocks.js:2472
 #: js/palette.js:736
 #: js/blocks/MediaBlocks.js:602
-#.TRANS: abrir archivo
+#. TRANS: abrir archivo
 msgid "open file"
 msgstr ""
 
@@ -1115,7 +1115,7 @@ msgstr ""
 #: js/palette.js:657
 #: js/blocks/MediaBlocks.js:892
 #: js/blocks/MediaBlocks.js:963
-#.TRANS: texto
+#. TRANS: texto
 msgid "text"
 msgstr "qillqa"
 
@@ -1123,7 +1123,7 @@ msgstr "qillqa"
 #: js/palette.js:724
 #: js/palette.js:725
 #: js/blocks/BoxesBlocks.js:514
-#.TRANS: guardar en caja
+#. TRANS: guardar en caja
 msgid "store in box"
 msgstr "tawa k’uchupi waqaychay"
 
@@ -1134,7 +1134,7 @@ msgstr "tawa k’uchupi waqaychay"
 #: js/blocks.js:5862
 #: js/blocks.js:5883
 #: js/blocks/BoxesBlocks.js:772
-#.TRANS: caja1
+#. TRANS: caja1
 msgid "box1"
 msgstr "caja1"
 
@@ -1145,7 +1145,7 @@ msgstr "caja1"
 #: js/blocks.js:5864
 #: js/blocks.js:5885
 #: js/blocks/BoxesBlocks.js:663
-#.TRANS: caja2
+#. TRANS: caja2
 msgid "box2"
 msgstr "caja2"
 
@@ -1154,9 +1154,9 @@ msgstr "caja2"
 #: js/palette.js:727
 #: js/palette.js:1127
 #: js/blocks/BoxesBlocks.js:591
-#.TRANS: guardar en
+#. TRANS: guardar en
 msgid "store in"
-msgstr "imapi waqaychanki" "maypi waqaychanki"
+msgstr "imapi waqaychanki maypi waqaychanki"
 
 #: js/blocks.js:4122
 #: js/blocks/BoxesBlocks.js:595
@@ -1172,7 +1172,7 @@ msgstr "imapi waqaychanki" "maypi waqaychanki"
 #: js/blocks/EnsembleBlocks.js:393
 #: js/blocks/EnsembleBlocks.js:404
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: nombre
+#. TRANS: nombre
 msgid "name"
 msgstr "suti"
 
@@ -1183,32 +1183,32 @@ msgstr "suti"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/RhythmBlocks.js:1130
-#.TRANS: valor
+#. TRANS: valor
 msgid "value"
 msgstr "tupu"
 
 #: js/blocks.js:4465
-#.TRANS: Se detectó un bucle indefinido dentro de un bloque de valor de nota. Pueden ocurrir cosas inesperadas.
+#. TRANS: Se detectó un bucle indefinido dentro de un bloque de valor de nota. Pueden ocurrir cosas inesperadas.
 msgid "Forever loop detected inside a note value block. Unexpected things may happen."
 msgstr ""
 
 #: js/blocks.js:4988
-#.TRANS: No hay bloque seleccionado.
+#. TRANS: No hay bloque seleccionado.
 msgid "There is no block selected."
 msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
-#.TRANS: avatar
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: avatar
 msgid "avatar"
 msgstr "siq’isqa"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
-#.TRANS: muestra de audio
+#. TRANS: The sound sample that the user uploads.
+#. TRANS: muestra de audio
 msgid "sample"
 msgstr ""
 
@@ -1217,62 +1217,62 @@ msgstr ""
 #: js/lilypond.js:910
 #: js/lilypond.js:948
 #: js/rubrics.js:526
-#.TRANS: ratón
+#. TRANS: ratón
 msgid "mouse"
 msgstr ""
 
 #: js/lilypond.js:606
-#.TRANS: rata marrón
+#. TRANS: rata marrón
 msgid "brown rat"
 msgstr ""
 
 #: js/lilypond.js:607
-#.TRANS: topo
+#. TRANS: topo
 msgid "mole"
 msgstr ""
 
 #: js/lilypond.js:608
-#.TRANS: ardilla
+#. TRANS: ardilla
 msgid "chipmunk"
 msgstr ""
 
 #: js/lilypond.js:609
-#.TRANS: ardilla roja
+#. TRANS: ardilla roja
 msgid "red squirrel"
 msgstr ""
 
 #: js/lilypond.js:610
-#.TRANS: conejillo de indias
+#. TRANS: conejillo de indias
 msgid "guinea pig"
 msgstr ""
 
 #: js/lilypond.js:611
-#.TRANS: capybara
+#. TRANS: capybara
 msgid "capybara"
 msgstr ""
 
 #: js/lilypond.js:612
-#.TRANS: coypu
+#. TRANS: coypu
 msgid "coypu"
 msgstr ""
 
 #: js/lilypond.js:613
-#.TRANS: rata negra
+#. TRANS: rata negra
 msgid "black rat"
 msgstr ""
 
 #: js/lilypond.js:614
-#.TRANS: ardilla gris
+#. TRANS: ardilla gris
 msgid "grey squirrel"
 msgstr ""
 
 #: js/lilypond.js:615
-#.TRANS: ardilla voladora
+#. TRANS: ardilla voladora
 msgid "flying squirrel"
 msgstr ""
 
 #: js/lilypond.js:616
-#.TRANS: murciélago
+#. TRANS: murciélago
 msgid "bat"
 msgstr ""
 
@@ -1281,7 +1281,7 @@ msgstr ""
 #: js/lilypond.js:951
 #: js/blocks/ActionBlocks.js:1256
 #: js/blocks/ExtrasBlocks.js:559
-#.TRANS: iniciar tambor
+#. TRANS: iniciar tambor
 msgid "start drum"
 msgstr "tarula qhantayaña"
 
@@ -1296,15 +1296,15 @@ msgstr "tarula qhantayaña"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
-#.TRANS: ritmo
+#. TRANS: an arrangement of notes based on duration
+#. TRANS: ritmo
 msgid "rhythm"
 msgstr "taki muyuchik"
 
 #: js/rubrics.js:525
 #: js/turtledefs.js:126
 #: js/turtledefs.js:227
-#.TRANS: tono
+#. TRANS: tono
 msgid "tone"
 msgstr ""
 
@@ -1312,7 +1312,7 @@ msgstr ""
 #: js/turtledefs.js:135
 #: js/turtledefs.js:236
 #: js/widgets/phrasemaker.js:1126
-#.TRANS: pluma
+#. TRANS: pluma
 msgid "pen"
 msgstr "qillqana"
 
@@ -1322,14 +1322,14 @@ msgstr "qillqana"
 #: js/blocks/NumberBlocks.js:981
 #: js/blocks/PitchBlocks.js:1717
 #: js/blocks/PitchBlocks.js:1758
-#.TRANS: número
+#. TRANS: número
 msgid "number"
 msgstr "yupana"
 
 #: js/rubrics.js:529
 #: js/turtledefs.js:130
 #: js/turtledefs.js:231
-#.TRANS: flujo
+#. TRANS: flujo
 msgid "flow"
 msgstr ""
 
@@ -1337,8 +1337,8 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: sensores
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: sensores
 msgid "Sensors"
 msgstr "sensores"
 
@@ -1347,19 +1347,19 @@ msgstr "sensores"
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: medios
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: medios
 msgid "Media"
 msgstr "medios"
 
 #: js/rubrics.js:533
-#.TRANS: ratón
+#. TRANS: ratón
 msgid "mice"
 msgstr ""
 
 #: js/toolbar.js:48
 #: js/toolbar.js:114
-#.TRANS: Acerca de los Bloques de Música
+#. TRANS: Acerca de los Bloques de Música
 msgid "About Music Blocks"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 #: js/toolbar.js:188
 #: js/toolbar.js:249
 #: js/turtledefs.js:509
-#.TRANS: Grabar
+#. TRANS: Grabar
 msgid "Record"
 msgstr ""
 
@@ -1380,7 +1380,7 @@ msgstr ""
 #: js/toolbar.js:190
 #: js/toolbar.js:250
 #: js/toolbar.js:251
-#.TRANS: Pantalla completa
+#. TRANS: Pantalla completa
 msgid "Full screen"
 msgstr ""
 
@@ -1389,7 +1389,7 @@ msgstr ""
 #: js/toolbar.js:191
 #: js/toolbar.js:252
 #: js/turtledefs.js:516
-#.TRANS: Alternar pantalla completa
+#. TRANS: Alternar pantalla completa
 msgid "Toggle Fullscreen"
 msgstr ""
 
@@ -1400,7 +1400,7 @@ msgstr ""
 #: js/toolbar.js:1118
 #: js/turtledefs.js:522
 #: planet/js/StringHelper.js:33
-#.TRANS: Nuevo proyecto
+#. TRANS: Nuevo proyecto
 msgid "New project"
 msgstr "Nuevo proyecto"
 
@@ -1409,7 +1409,7 @@ msgstr "Nuevo proyecto"
 #: js/toolbar.js:193
 #: js/toolbar.js:254
 #: js/turtledefs.js:528
-#.TRANS: Cargar proyecto de archivo
+#. TRANS: Cargar proyecto de archivo
 msgid "Load project from file"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 #: js/turtledefs.js:535
 #: js/turtledefs.js:546
 #: js/turtledefs.js:566
-#.TRANS: Guardar proyecto
+#. TRANS: Guardar proyecto
 msgid "Save project"
 msgstr ""
 
@@ -1439,7 +1439,7 @@ msgstr ""
 #: js/toolbar.js:279
 #: js/turtledefs.js:536
 #: js/turtledefs.js:567
-#.TRANS: Guardar como HTML
+#. TRANS: Guardar como HTML
 msgid "Save project as HTML"
 msgstr ""
 
@@ -1447,7 +1447,7 @@ msgstr ""
 #: js/toolbar.js:125
 #: js/toolbar.js:196
 #: js/toolbar.js:257
-#.TRANS: Encuentra y comparte proyectos
+#. TRANS: Encuentra y comparte proyectos
 msgid "Find and share projects"
 msgstr ""
 
@@ -1455,7 +1455,7 @@ msgstr ""
 #: js/toolbar.js:126
 #: js/toolbar.js:197
 #: js/toolbar.js:258
-#.TRANS: Desconectado. Compartir no está disponible.
+#. TRANS: Desconectado. Compartir no está disponible.
 msgid "Offline. Sharing is unavailable"
 msgstr ""
 
@@ -1463,7 +1463,7 @@ msgstr ""
 #: js/toolbar.js:127
 #: js/toolbar.js:198
 #: js/toolbar.js:259
-#.TRANS: Menú auxiliar
+#. TRANS: Menú auxiliar
 msgid "Auxiliary menu"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 #: js/toolbar.js:260
 #: js/piemenus.js:3386
 #: js/turtledefs.js:592
-#.TRANS: Ayuda
+#. TRANS: Ayuda
 msgid "Help"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 #: js/toolbar.js:200
 #: js/toolbar.js:261
 #: js/turtledefs.js:598
-#.TRANS: Tocar lentamente
+#. TRANS: Tocar lentamente
 msgid "Run slowly"
 msgstr ""
 
@@ -1491,7 +1491,7 @@ msgstr ""
 #: js/toolbar.js:201
 #: js/toolbar.js:262
 #: js/turtledefs.js:604
-#.TRANS: Ejecutar paso a paso
+#. TRANS: Ejecutar paso a paso
 msgid "Run step by step"
 msgstr ""
 
@@ -1500,7 +1500,7 @@ msgstr ""
 #: js/toolbar.js:202
 #: js/toolbar.js:263
 #: js/turtledefs.js:611
-#.TRANS: Analizar
+#. TRANS: Analizar
 msgid "Display statistics"
 msgstr ""
 
@@ -1509,7 +1509,7 @@ msgstr ""
 #: js/toolbar.js:203
 #: js/toolbar.js:264
 #: js/turtledefs.js:617
-#.TRANS: Cargar plugin
+#. TRANS: Cargar plugin
 msgid "Load plugin"
 msgstr ""
 
@@ -1518,7 +1518,7 @@ msgstr ""
 #: js/toolbar.js:204
 #: js/toolbar.js:265
 #: js/turtledefs.js:625
-#.TRANS: Eliminar plugin
+#. TRANS: Eliminar plugin
 msgid "Delete plugin"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 #: js/toolbar.js:134
 #: js/toolbar.js:205
 #: js/toolbar.js:266
-#.TRANS: Habilitar desplazamiento horizontal
+#. TRANS: Habilitar desplazamiento horizontal
 msgid "Enable horizontal scrolling"
 msgstr ""
 
@@ -1534,7 +1534,7 @@ msgstr ""
 #: js/toolbar.js:135
 #: js/toolbar.js:206
 #: js/toolbar.js:267
-#.TRANS: Deshabilitar desplazamiento horizontal
+#. TRANS: Deshabilitar desplazamiento horizontal
 msgid "Disable horizontal scrolling"
 msgstr ""
 
@@ -1567,14 +1567,14 @@ msgstr ""
 #: js/turtledefs.js:648
 #: planet/js/LocalCard.js:54
 #: planet/js/StringHelper.js:71
-#.TRANS: Unir con el proyecto actual
+#. TRANS: Unir con el proyecto actual
 msgid "Merge with current project"
 msgstr "Unir con el proyecto actual"
 
 #: js/toolbar.js:74
 #: js/toolbar.js:140
 #: js/turtledefs.js:662
-#.TRANS: Establecer vista previa de tono
+#. TRANS: Establecer vista previa de tono
 msgid "Set Pitch Preview"
 msgstr ""
 
@@ -1583,7 +1583,7 @@ msgstr ""
 #: js/toolbar.js:211
 #: js/toolbar.js:272
 #: js/turtledefs.js:669
-#.TRANS: Editor de Javascript
+#. TRANS: Editor de Javascript
 msgid "JavaScript Editor"
 msgstr "JavaScript Editor"
 
@@ -1592,7 +1592,7 @@ msgstr "JavaScript Editor"
 #: js/toolbar.js:212
 #: js/toolbar.js:273
 #: js/turtledefs.js:676
-#.TRANS: Restaurar
+#. TRANS: Restaurar
 msgid "Restore"
 msgstr ""
 
@@ -1600,7 +1600,7 @@ msgstr ""
 #: js/toolbar.js:143
 #: js/toolbar.js:213
 #: js/toolbar.js:274
-#.TRANS: Cambiar al modo principiante
+#. TRANS: Cambiar al modo principiante
 msgid "Switch to beginner mode"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 #: js/toolbar.js:144
 #: js/toolbar.js:214
 #: js/toolbar.js:275
-#.TRANS: Cambiar a modo avanzado
+#. TRANS: Cambiar a modo avanzado
 msgid "Switch to advanced mode"
 msgstr ""
 
@@ -1618,7 +1618,7 @@ msgstr ""
 #: js/toolbar.js:215
 #: js/toolbar.js:276
 #: js/turtledefs.js:690
-#.TRANS: Seleccione el idioma
+#. TRANS: Seleccione el idioma
 msgid "Select language"
 msgstr ""
 
@@ -1626,37 +1626,37 @@ msgstr ""
 #: js/toolbar.js:84
 #: js/toolbar.js:148
 #: js/turtledefs.js:538
-#.TRANS: Guardar ilustraciones del ratón como PNG
+#. TRANS: Guardar ilustraciones del ratón como PNG
 msgid "Save mouse artwork as PNG"
 msgstr ""
 
 #: js/toolbar.js:83
 #: js/toolbar.js:147
-#.TRANS: Guardar ilustraciones del ratón como SVG
+#. TRANS: Guardar ilustraciones del ratón como SVG
 msgid "Save mouse artwork as SVG"
 msgstr ""
 
 #: js/toolbar.js:85
 #: js/toolbar.js:149
 #: js/turtledefs.js:569
-#.TRANS: Guarda música como WAV
+#. TRANS: Guarda música como WAV
 msgid "Save music as WAV"
 msgstr ""
 
 #: js/toolbar.js:86
 #: js/toolbar.js:150
-#.TRANS: Guardar partituras como ABC
+#. TRANS: Guardar partituras como ABC
 msgid "Save sheet music as ABC"
 msgstr ""
 
 #: js/toolbar.js:87
 #: js/toolbar.js:151
-#.TRANS: Guardar partituras como Lilypond.
+#. TRANS: Guardar partituras como Lilypond.
 msgid "Save sheet music as Lilypond"
 msgstr ""
 
 #: js/toolbar.js:88
-#.TRANS: Guardar partituras como MusicXML
+#. TRANS: Guardar partituras como MusicXML
 msgid "Save sheet music as MusicXML"
 msgstr ""
 
@@ -1666,7 +1666,7 @@ msgstr ""
 #: js/toolbar.js:221
 #: js/toolbar.js:282
 #: js/turtledefs.js:558
-#.TRANS: Guardar bloque de ilustraciones como SVG
+#. TRANS: Guardar bloque de ilustraciones como SVG
 msgid "Save block artwork as SVG"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 #: js/toolbar.js:223
 #: js/toolbar.js:284
 #: js/toolbar.js:1134
-#.TRANS: Confirmar
+#. TRANS: Confirmar
 msgid "Confirm"
 msgstr ""
 
@@ -1692,7 +1692,7 @@ msgstr ""
 #: js/toolbar.js:164
 #: js/toolbar.js:224
 #: js/toolbar.js:285
-#.TRANS: 
+#. TRANS: 
 msgid "English (United States)"
 msgstr ""
 
@@ -1700,7 +1700,7 @@ msgstr ""
 #: js/toolbar.js:165
 #: js/toolbar.js:225
 #: js/toolbar.js:286
-#.TRANS: 
+#. TRANS: 
 msgid "English (United Kingdom)"
 msgstr ""
 
@@ -1708,12 +1708,12 @@ msgstr ""
 #: js/toolbar.js:166
 #: js/toolbar.js:226
 #: js/toolbar.js:287
-#.TRANS: 
+#. TRANS: 
 msgid "日本語"
 msgstr ""
 
 #: js/toolbar.js:95
-#.TRANS: 
+#. TRANS: 
 msgid "한국어"
 msgstr ""
 
@@ -1721,7 +1721,7 @@ msgstr ""
 #: js/toolbar.js:168
 #: js/toolbar.js:228
 #: js/toolbar.js:289
-#.TRANS: 
+#. TRANS: 
 msgid "español"
 msgstr ""
 
@@ -1729,7 +1729,7 @@ msgstr ""
 #: js/toolbar.js:169
 #: js/toolbar.js:229
 #: js/toolbar.js:290
-#.TRANS: 
+#. TRANS: 
 msgid "português"
 msgstr ""
 
@@ -1737,7 +1737,7 @@ msgstr ""
 #: js/toolbar.js:170
 #: js/toolbar.js:230
 #: js/toolbar.js:291
-#.TRANS: 
+#. TRANS: 
 msgid "にほんご"
 msgstr ""
 
@@ -1745,7 +1745,7 @@ msgstr ""
 #: js/toolbar.js:171
 #: js/toolbar.js:231
 #: js/toolbar.js:292
-#.TRANS: 
+#. TRANS: 
 msgid "中文"
 msgstr ""
 
@@ -1753,7 +1753,7 @@ msgstr ""
 #: js/toolbar.js:172
 #: js/toolbar.js:232
 #: js/toolbar.js:293
-#.TRANS: 
+#. TRANS: 
 msgid "ภาษาไทย"
 msgstr ""
 
@@ -1761,7 +1761,7 @@ msgstr ""
 #: js/toolbar.js:173
 #: js/toolbar.js:233
 #: js/toolbar.js:294
-#.TRANS: 
+#. TRANS: 
 msgid "aymara"
 msgstr ""
 
@@ -1769,7 +1769,7 @@ msgstr ""
 #: js/toolbar.js:174
 #: js/toolbar.js:234
 #: js/toolbar.js:295
-#.TRANS: 
+#. TRANS: 
 msgid "quechua"
 msgstr ""
 
@@ -1777,7 +1777,7 @@ msgstr ""
 #: js/toolbar.js:175
 #: js/toolbar.js:235
 #: js/toolbar.js:296
-#.TRANS: 
+#. TRANS: 
 msgid "guarani"
 msgstr ""
 
@@ -1785,7 +1785,7 @@ msgstr ""
 #: js/toolbar.js:176
 #: js/toolbar.js:236
 #: js/toolbar.js:297
-#.TRANS: 
+#. TRANS: 
 msgid "हिंदी"
 msgstr ""
 
@@ -1793,7 +1793,7 @@ msgstr ""
 #: js/toolbar.js:178
 #: js/toolbar.js:237
 #: js/toolbar.js:299
-#.TRANS: 
+#. TRANS: 
 msgid "igbo"
 msgstr ""
 
@@ -1801,7 +1801,7 @@ msgstr ""
 #: js/toolbar.js:179
 #: js/toolbar.js:238
 #: js/toolbar.js:300
-#.TRANS: 
+#. TRANS: 
 msgid "عربى"
 msgstr ""
 
@@ -1809,7 +1809,7 @@ msgstr ""
 #: js/toolbar.js:177
 #: js/toolbar.js:239
 #: js/toolbar.js:298
-#.TRANS: 
+#. TRANS: 
 msgid "తెలుగు"
 msgstr ""
 
@@ -1817,7 +1817,7 @@ msgstr ""
 #: js/toolbar.js:180
 #: js/toolbar.js:240
 #: js/toolbar.js:301
-#.TRANS: 
+#. TRANS: 
 msgid "עִברִית"
 msgstr ""
 
@@ -1835,7 +1835,7 @@ msgstr ""
 #: js/toolbar.js:278
 #: js/toolbar.js:281
 #: js/turtledefs.js:554
-#.TRANS: Guardar la ilustración de la tortuga como PNG
+#. TRANS: Guardar la ilustración de la tortuga como PNG
 msgid "Save turtle artwork as PNG"
 msgstr ""
 
@@ -1843,55 +1843,55 @@ msgstr ""
 #: js/toolbar.js:219
 #: js/toolbar.js:280
 #: js/turtledefs.js:550
-#.TRANS: Guardar la ilustración de la tortuga como SVG
+#. TRANS: Guardar la ilustración de la tortuga como SVG
 msgid "Save turtle artwork as SVG"
 msgstr ""
 
 #: js/toolbar.js:167
 #: js/toolbar.js:227
 #: js/toolbar.js:288
-#.TRANS: 
+#. TRANS: 
 msgid "한국인"
 msgstr ""
 
 #: js/toolbar.js:185
 #: js/toolbar.js:246
-#.TRANS: Sobre TortuBloques
+#. TRANS: Sobre TortuBloques
 msgid "About Turtle Blocks"
 msgstr ""
 
 #: js/toolbar.js:494
 #: js/toolbar.js:505
 #: js/toolbar.js:545
-#.TRANS: No Envolver
+#. TRANS: No Envolver
 msgid "Turtle Wrap Off"
 msgstr ""
 
 #: js/toolbar.js:514
 #: js/toolbar.js:554
-#.TRANS: Envolver
+#. TRANS: Envolver
 msgid "Turtle Wrap On"
 msgstr ""
 
 #: js/toolbar.js:1121
-#.TRANS: Â¿Estás seguro de que deseas crear un nuevo proyecto?
+#. TRANS: Â¿Estás seguro de que deseas crear un nuevo proyecto?
 msgid "Are you sure you want to create a new project?"
 msgstr ""
 
 #: js/logo.js:61
-#.TRANS: No es un nombre de tono válido.
+#. TRANS: No es un nombre de tono válido.
 msgid "Not a valid pitch name"
 msgstr ""
 
 #: js/logo.js:507
 #: js/blocks/ProgramBlocks.js:258
 #: js/blocks/ProgramBlocks.js:427
-#.TRANS: Debe seleccionar un archivo.
+#. TRANS: Debe seleccionar un archivo.
 msgid "You must select a file."
 msgstr "Huk waqaychasqata ch’ikuy"
 
 #: js/logo.js:1688
-#.TRANS: La reproducción está preparada.
+#. TRANS: La reproducción está preparada.
 msgid "Playback is ready."
 msgstr ""
 
@@ -1901,8 +1901,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
-#.TRANS: doble agudas
+#. TRANS: double sharp is a music term related to pitch
+#. TRANS: doble agudas
 msgid "double sharp"
 msgstr "iskay ñañu kunka"
 
@@ -1914,9 +1914,9 @@ msgstr "iskay ñañu kunka"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
-#.TRANS: agudas
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
+#. TRANS: agudas
 msgid "sharp"
 msgstr "allin uyarikuy"
 
@@ -1926,8 +1926,8 @@ msgstr "allin uyarikuy"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
-#.TRANS: normal
+#. TRANS: natural is a music term related to pitch
+#. TRANS: normal
 msgid "natural"
 msgstr "purum"
 
@@ -1939,9 +1939,9 @@ msgstr "purum"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
-#.TRANS: planas
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
+#. TRANS: planas
 msgid "flat"
 msgstr "pampa"
 
@@ -1951,17 +1951,17 @@ msgstr "pampa"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
-#.TRANS: doble planas
+#. TRANS: double flat is a music term related to pitch
+#. TRANS: doble planas
 msgid "double flat"
 msgstr "iskay t’aqlla"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
-#.TRANS: unísono
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
+#. TRANS: unísono
 msgid "unison"
 msgstr "unísono"
 
@@ -1970,16 +1970,16 @@ msgstr "unísono"
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
-#.TRANS: mayor
+#. TRANS: major is a music term related to intervals and mode
+#. TRANS: mayor
 msgid "major"
 msgstr "jila"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
-#.TRANS: ionian
+#. TRANS: modal scale for music
+#. TRANS: ionian
 msgid "ionian"
 msgstr "ionian"
 
@@ -1988,33 +1988,33 @@ msgstr "ionian"
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
-#.TRANS: menor
+#. TRANS: minor is a music term related to intervals and mode
+#. TRANS: menor
 msgid "minor"
 msgstr "sullka"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
-#.TRANS: aeolian
+#. TRANS: modal scale for music
+#. TRANS: aeolian
 msgid "aeolian"
 msgstr "aeolian"
 
 #: js/piemenus.js:3373
 #: js/blocks/FlowBlocks.js:136
-#.TRANS: Duplicar
+#. TRANS: Duplicar
 msgid "Duplicate"
 msgstr ""
 
 #: js/piemenus.js:3374
 #: js/turtledefs.js:714
-#.TRANS: Extraer
+#. TRANS: Extraer
 msgid "Extract"
 msgstr ""
 
 #: js/piemenus.js:3375
-#.TRANS: Mover para recargar
+#. TRANS: Mover para recargar
 msgid "Move to trash"
 msgstr ""
 
@@ -2025,50 +2025,50 @@ msgstr ""
 #: js/widgets/temperament.js:1441
 #: js/widgets/timbre.js:962
 #: planet/js/StringHelper.js:69
-#.TRANS: Cerrar
+#. TRANS: Cerrar
 msgid "Close"
 msgstr "wisq’ay"
 
 #: js/piemenus.js:3382
-#.TRANS: Guardar pila
+#. TRANS: Guardar pila
 msgid "Save stack"
 msgstr ""
 
 #: js/piemenus.js:3412
-#.TRANS: Se detectó un bucle indefinido dentro de un bloque de valor de nota. Pueden ocurrir cosas inesperadas.
+#. TRANS: Se detectó un bucle indefinido dentro de un bloque de valor de nota. Pueden ocurrir cosas inesperadas.
 msgid "In order to copy a sample, you must reload the widget, import the sample again, and export it."
 msgstr ""
 
 #: js/piemenus.js:3801
-#.TRANS: Ha elegido la tecla para la vista previa de su tono.
+#. TRANS: Ha elegido la tecla para la vista previa de su tono.
 msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
-#.TRANS: Debe tener al menos un bloque parcial dentro de un bloque parcial ponderado.
+#. TRANS: partials are weighted components in a harmonic series
+#. TRANS: Debe tener al menos un bloque parcial dentro de un bloque parcial ponderado.
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
 #: js/turtle-singer.js:2078
-#.TRANS: Synth no puede tocar acordes.
+#. TRANS: Synth no puede tocar acordes.
 msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
-#.TRANS: https://github.com/sugarlabs/musicblocks/tree/master/guide-es/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: https://github.com/sugarlabs/musicblocks/tree/master/guide-es/README.md
 msgid "guide url"
 msgstr ""
 
 #: js/turtledefs.js:88
-#.TRANS: TortuBloques
+#. TRANS: TortuBloques
 msgid "Turtle Blocks"
 msgstr ""
 
 #: js/turtledefs.js:121
 #: js/turtledefs.js:222
-#.TRANS: buscar
+#. TRANS: buscar
 msgid "search"
 msgstr ""
 
@@ -2076,20 +2076,20 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
-#.TRANS: metro
+#. TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: metro
 msgid "meter"
 msgstr "tupuna"
 
 #: js/turtledefs.js:125
 #: js/turtledefs.js:226
-#.TRANS: intervalos
+#. TRANS: intervalos
 msgid "intervals"
 msgstr ""
 
 #: js/turtledefs.js:127
 #: js/turtledefs.js:228
-#.TRANS: ornamento
+#. TRANS: ornamento
 msgid "ornament"
 msgstr ""
 
@@ -2098,32 +2098,32 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:362
 #: js/blocks/VolumeBlocks.js:502
 #: js/blocks/VolumeBlocks.js:545
-#.TRANS: volumen
+#. TRANS: volumen
 msgid "volume"
 msgstr "volumen"
 
 #: js/turtledefs.js:132
 #: js/turtledefs.js:233
-#.TRANS: cajas
+#. TRANS: cajas
 msgid "boxes"
 msgstr ""
 
 #: js/turtledefs.js:133
 #: js/turtledefs.js:234
-#.TRANS: aparatos
+#. TRANS: aparatos
 msgid "widgets"
 msgstr ""
 
 #: js/turtledefs.js:134
 #: js/turtledefs.js:235
 #: js/widgets/phrasemaker.js:1125
-#.TRANS: gráficos
+#. TRANS: gráficos
 msgid "graphics"
 msgstr "siq’ikuna"
 
 #: js/turtledefs.js:137
 #: js/turtledefs.js:238
-#.TRANS: booleano
+#. TRANS: booleano
 msgid "boolean"
 msgstr ""
 
@@ -2131,7 +2131,7 @@ msgstr ""
 #: js/turtledefs.js:241
 #: js/blocks/HeapBlocks.js:59
 #: js/widgets/status.js:143
-#.TRANS: pila
+#. TRANS: pila
 msgid "heap"
 msgstr ""
 
@@ -2139,68 +2139,68 @@ msgstr ""
 #: js/turtledefs.js:242
 #: js/blocks/DictBlocks.js:142
 #: js/blocks/ProgramBlocks.js:495
-#.TRANS: diccionario
+#. TRANS: diccionario
 msgid "dictionary"
 msgstr ""
 
 #: js/turtledefs.js:142
 #: js/turtledefs.js:243
-#.TRANS: conjunto
+#. TRANS: conjunto
 msgid "ensemble"
 msgstr ""
 
 #: js/turtledefs.js:143
 #: js/turtledefs.js:244
-#.TRANS: extras
+#. TRANS: extras
 msgid "extras"
 msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
-#.TRANS: programa
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: programa
 msgid "program"
 msgstr ""
 
 #: js/turtledefs.js:146
 #: js/turtledefs.js:247
-#.TRANS: mis bloques
+#. TRANS: mis bloques
 msgid "my blocks"
 msgstr ""
 
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
-#.TRANS: arte
+#. TRANS: arte
 msgid "artwork"
 msgstr ""
 
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
-#.TRANS: lógica
+#. TRANS: lógica
 msgid "logic"
 msgstr ""
 
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: música
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: música
 msgid "Music"
 msgstr "música"
 
 #: js/turtledefs.js:190
-#.TRANS: Bloques de Música
+#. TRANS: Bloques de Música
 msgid "Music Blocks"
 msgstr ""
 
 #: js/turtledefs.js:438
-#.TRANS: Bienvenidos a TortuBloques
+#. TRANS: Bienvenidos a TortuBloques
 msgid "Welcome to Turtle Blocks"
 msgstr ""
 
 #: js/turtledefs.js:439
-#.TRANS: TortuBloques es una tortuga basada en Logo que dibuja imÃÂÃÂ¡genes coloridas programable de una forma visual con bloques encastrables.
+#. TRANS: TortuBloques es una tortuga basada en Logo que dibuja imÃÂÃÂ¡genes coloridas programable de una forma visual con bloques encastrables.
 msgid "Turtle Blocks is a Logo-inspired turtle that draws colorful pictures with snap-together visual-programming blocks."
 msgstr ""
 
@@ -2208,93 +2208,93 @@ msgstr ""
 #: js/turtledefs.js:467
 #: js/turtledefs.js:822
 #: js/turtledefs.js:845
-#.TRANS: La versión actual es
+#. TRANS: La versión actual es
 msgid "The current version is"
 msgstr ""
 
 #: js/turtledefs.js:448
 #: js/turtledefs.js:493
-#.TRANS: Haga clic para ejecutar el proyecto en modo rápido.
+#. TRANS: Haga clic para ejecutar el proyecto en modo rápido.
 msgid "Click the run button to run the project in fast mode."
 msgstr ""
 
 #: js/turtledefs.js:454
-#.TRANS: Detener la tortuga.
+#. TRANS: Detener la tortuga.
 msgid "Stop the turtle."
 msgstr ""
 
 #: js/turtledefs.js:456
 #: js/turtledefs.js:501
-#.TRANS: También puede escribir Alt-S para detenerse.
+#. TRANS: También puede escribir Alt-S para detenerse.
 msgid "You can also type Alt-S to stop."
 msgstr ""
 
 #: js/turtledefs.js:464
 #: js/widgets/help.js:335
-#.TRANS: Bienvenido a Bloques de Música
+#. TRANS: Bienvenido a Bloques de Música
 msgid "Welcome to Music Blocks"
 msgstr "Takiy t’aqaman allin hamunki"
 
 #: js/turtledefs.js:465
-#.TRANS: Bloques de Música es una colección de herramientas de manipulación para explorar conceptos musicales fundamentales de una manera integradora y divertido.
+#. TRANS: Bloques de Música es una colección de herramientas de manipulación para explorar conceptos musicales fundamentales de una manera integradora y divertido.
 msgid "Music Blocks is a collection of tools for exploring fundamental musical concepts in a fun way."
 msgstr ""
 
 #: js/turtledefs.js:474
 #: js/widgets/help.js:336
-#.TRANS: Conoce Sr. Ratón
+#. TRANS: Conoce Sr. Ratón
 msgid "Meet Mr. Mouse!"
 msgstr "Wiraqucha huk’uchata riqsinki"
 
 #: js/turtledefs.js:475
-#.TRANS: Sr. Ratón es nuestro conductor de Bloques de Música.
+#. TRANS: Sr. Ratón es nuestro conductor de Bloques de Música.
 msgid "Mr Mouse is our Music Blocks conductor."
 msgstr ""
 
 #: js/turtledefs.js:477
-#.TRANS: Sr. Ratón le anima a explorar los Bloques de Música.
+#. TRANS: Sr. Ratón le anima a explorar los Bloques de Música.
 msgid "Mr Mouse encourages you to explore Music Blocks."
 msgstr ""
 
 #: js/turtledefs.js:479
-#.TRANS: Vamos a empezar nuestro recorrido!
+#. TRANS: Vamos a empezar nuestro recorrido!
 msgid "Let us start our tour!"
 msgstr ""
 
 #: js/turtledefs.js:484
 #: js/turtledefs.js:807
 #: js/widgets/help.js:337
-#.TRANS: Guía
+#. TRANS: Guía
 msgid "Guide"
 msgstr "pusaq"
 
 #: js/turtledefs.js:485
-#.TRANS: Una guía detallada de Bloques de Música está disponible.
+#. TRANS: Una guía detallada de Bloques de Música está disponible.
 msgid "A detailed guide to Music Blocks is available."
 msgstr ""
 
 #: js/turtledefs.js:499
-#.TRANS: Detener la música (y los ratones)
+#. TRANS: Detener la música (y los ratones)
 msgid "Stop the music (and the mice)."
 msgstr ""
 
 #: js/turtledefs.js:510
-#.TRANS: Grabe su proyecto como video.
+#. TRANS: Grabe su proyecto como video.
 msgid "Record your project as video."
 msgstr ""
 
 #: js/turtledefs.js:517
-#.TRANS: Alternar el modo de pantalla completa
+#. TRANS: Alternar el modo de pantalla completa
 msgid "Toggle Fullscreen mode."
 msgstr ""
 
 #: js/turtledefs.js:523
-#.TRANS: Inicializar un nuevo proyecto.
+#. TRANS: Inicializar un nuevo proyecto.
 msgid "Initialize a new project."
 msgstr ""
 
 #: js/turtledefs.js:529
-#.TRANS: También puede cargar proyectos desde el sistema de archivos.
+#. TRANS: También puede cargar proyectos desde el sistema de archivos.
 msgid "You can also load projects from the file system."
 msgstr ""
 
@@ -2309,27 +2309,27 @@ msgstr ""
 #: js/widgets/temperament.js:2173
 #: js/widgets/timbre.js:750
 #: js/widgets/phrasemaker.js:561
-#.TRANS: Guardar
+#. TRANS: Guardar
 msgid "Save"
 msgstr "waqaychay"
 
 #: js/turtledefs.js:548
-#.TRANS: Guarde proyecto en archivo
+#. TRANS: Guarde proyecto en archivo
 msgid "Save your project to a file."
 msgstr ""
 
 #: js/turtledefs.js:552
-#.TRANS: Guardar gráficos de su proyecto como SVG
+#. TRANS: Guardar gráficos de su proyecto como SVG
 msgid "Save graphics from your project to as SVG."
 msgstr ""
 
 #: js/turtledefs.js:556
-#.TRANS: Guardar gráficos de su proyecto como PNG
+#. TRANS: Guardar gráficos de su proyecto como PNG
 msgid "Save graphics from your project as PNG."
 msgstr ""
 
 #: js/turtledefs.js:560
-#.TRANS: Guardar bloque de ilustraciones como un archivo de SVG
+#. TRANS: Guardar bloque de ilustraciones como un archivo de SVG
 msgid "Save block artwork as an SVG file."
 msgstr ""
 
@@ -2342,22 +2342,22 @@ msgid "Save block artwork as SVG or PNG"
 msgstr ""
 
 #: js/turtledefs.js:580
-#.TRANS: Cargar ejemplos desde el servidor
+#. TRANS: Cargar ejemplos desde el servidor
 msgid "Load samples from server"
 msgstr ""
 
 #: js/turtledefs.js:581
-#.TRANS: Este botón abre la pantalla de carga de proyectos de ejemplo.
+#. TRANS: Este botón abre la pantalla de carga de proyectos de ejemplo.
 msgid "This button opens a viewer for loading example projects."
 msgstr ""
 
 #: js/turtledefs.js:586
-#.TRANS: Expandir/colapsar la barra de opciones.
+#. TRANS: Expandir/colapsar la barra de opciones.
 msgid "Expand/collapse option toolbar"
 msgstr ""
 
 #: js/turtledefs.js:587
-#.TRANS: Haga clic en este botón para expandir o contraer la barra de herramientas auxiliar.
+#. TRANS: Haga clic en este botón para expandir o contraer la barra de herramientas auxiliar.
 msgid "Click this button to expand or collapse the auxillary toolbar."
 msgstr ""
 
@@ -2366,17 +2366,17 @@ msgid "Displays help messages for the main and auxiliary toolbar, right-click co
 msgstr ""
 
 #: js/turtledefs.js:599
-#.TRANS: Haz click para ejecutar el proyecto en modo lento.
+#. TRANS: Haz click para ejecutar el proyecto en modo lento.
 msgid "Click to run the project in slow mode."
 msgstr ""
 
 #: js/turtledefs.js:605
-#.TRANS: Haz click para ejecutar el proyecto en modo paso a paso.
+#. TRANS: Haz click para ejecutar el proyecto en modo paso a paso.
 msgid "Click to run the project step by step."
 msgstr ""
 
 #: js/turtledefs.js:612
-#.TRANS: Analizar los tipos de bloques usados.
+#. TRANS: Analizar los tipos de bloques usados.
 msgid "Display statistics about your Music project."
 msgstr ""
 
@@ -2385,17 +2385,17 @@ msgid "Load a selected plugin."
 msgstr ""
 
 #: js/turtledefs.js:626
-#.TRANS: Eliminar un plugin seleccionado.
+#. TRANS: Eliminar un plugin seleccionado.
 msgid "Delete a selected plugin."
 msgstr ""
 
 #: js/turtledefs.js:633
-#.TRANS: Activar scroll
+#. TRANS: Activar scroll
 msgid "Enable scrolling"
 msgstr ""
 
 #: js/turtledefs.js:634
-#.TRANS: Puedes mover los bloques por el área de trabajo
+#. TRANS: Puedes mover los bloques por el área de trabajo
 msgid "You can scroll the blocks on the canvas."
 msgstr ""
 
@@ -2408,12 +2408,12 @@ msgid "Click to add another project into the current one."
 msgstr ""
 
 #: js/turtledefs.js:654
-#.TRANS: Envolver tortuga
+#. TRANS: Envolver tortuga
 msgid "Wrap Turtle"
 msgstr ""
 
 #: js/turtledefs.js:655
-#.TRANS: Encender / apagar la envoltura de tortugas
+#. TRANS: Encender / apagar la envoltura de tortugas
 msgid "Turn Turtle wrapping On or Off."
 msgstr ""
 
@@ -2426,22 +2426,22 @@ msgid "Converts Music Block programs to JavaScript."
 msgstr ""
 
 #: js/turtledefs.js:677
-#.TRANS: Restaurar bloques de la papelera.
+#. TRANS: Restaurar bloques de la papelera.
 msgid "Restore blocks from the trash."
 msgstr ""
 
 #: js/turtledefs.js:684
-#.TRANS: Cambiar el modo
+#. TRANS: Cambiar el modo
 msgid "Switch mode"
 msgstr ""
 
 #: js/turtledefs.js:685
-#.TRANS: Cambia entre los modos principiante y avanzado.
+#. TRANS: Cambia entre los modos principiante y avanzado.
 msgid "Switch between beginner and advance modes."
 msgstr ""
 
 #: js/turtledefs.js:691
-#.TRANS: Seleccione su preferencia de idioma.
+#. TRANS: Seleccione su preferencia de idioma.
 msgid "Select your language preference."
 msgstr ""
 
@@ -2455,32 +2455,32 @@ msgstr ""
 
 #: js/turtledefs.js:702
 #: planet/js/StringHelper.js:46
-#.TRANS: Borrar
+#. TRANS: Borrar
 msgid "Delete"
 msgstr "Apsuña"
 
 #: js/turtledefs.js:703
-#.TRANS: Para eliminar un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de eliminar.
+#. TRANS: Para eliminar un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de eliminar.
 msgid "To delete a block, right-click on it. You will see the delete option."
 msgstr ""
 
 #: js/turtledefs.js:709
-#.TRANS: Para copiar un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de copiar.
+#. TRANS: Para copiar un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de copiar.
 msgid "To copy a block, right-click on it. You will see the copy option."
 msgstr ""
 
 #: js/turtledefs.js:715
-#.TRANS: Para extraer un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de extracción.
+#. TRANS: Para extraer un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de extracción.
 msgid "To extract a block, right-click on it. You will see the extract option."
 msgstr ""
 
 #: js/turtledefs.js:721
-#.TRANS: Atajos de teclado
+#. TRANS: Atajos de teclado
 msgid "Keyboard shortcuts"
 msgstr ""
 
 #: js/turtledefs.js:722
-#.TRANS: Puede escribir \"d\" para crear un bloque \"do\", \"r\" para crear un bloque \"re\", etc.
+#. TRANS: Puede escribir \"d\" para crear un bloque \"do\", \"r\" para crear un bloque \"re\", etc.
 msgid "You can type d to create a do block and r to create a re block etc."
 msgstr ""
 
@@ -2495,7 +2495,7 @@ msgstr ""
 #: js/turtledefs.js:736
 #: js/turtles.js:940
 #: js/palette.js:654
-#.TRANS: Cuadrícula
+#. TRANS: Cuadrícula
 msgid "Grid"
 msgstr ""
 
@@ -2519,49 +2519,49 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
-#.TRANS: Borrar
+#. TRANS: clear all subdivisions from the ruler.
+#. TRANS: Borrar
 msgid "Clear"
 msgstr "pichay"
 
 #: js/turtledefs.js:745
-#.TRANS: Borre la pantalla y devuelva los ratones a sus posiciones iniciales.
+#. TRANS: Borre la pantalla y devuelva los ratones a sus posiciones iniciales.
 msgid "Clear the screen and return the mice to their initial positions."
 msgstr ""
 
 #: js/turtledefs.js:750
 #: js/turtles.js:980
-#.TRANS: Contraer
+#. TRANS: Contraer
 msgid "Collapse"
 msgstr ""
 
 #: js/turtledefs.js:751
-#.TRANS: Contraer la ventana de gráficos.
+#. TRANS: Contraer la ventana de gráficos.
 msgid "Collapse the graphics window."
 msgstr ""
 
 #: js/turtledefs.js:757
-#.TRANS: Devolver todos los bloques para el centro de la pantalla.
+#. TRANS: Devolver todos los bloques para el centro de la pantalla.
 msgid "Return all blocks to the center of the screen."
 msgstr ""
 
 #: js/turtledefs.js:763
-#.TRANS: Ocultar o mostrar los bloques y las paletas.
+#. TRANS: Ocultar o mostrar los bloques y las paletas.
 msgid "Hide or show the blocks and the palettes."
 msgstr ""
 
 #: js/turtledefs.js:769
-#.TRANS: Expandir o colapsar los bloques colapsables, cómo por ejemplo los bloques de empezar y los de acción.
+#. TRANS: Expandir o colapsar los bloques colapsables, cómo por ejemplo los bloques de empezar y los de acción.
 msgid "Expand or collapse start and action stacks."
 msgstr ""
 
 #: js/turtledefs.js:777
-#.TRANS: Disminuye el tamaño de los bloques
+#. TRANS: Disminuye el tamaño de los bloques
 msgid "Decrease the size of the blocks."
 msgstr ""
 
 #: js/turtledefs.js:783
-#.TRANS: Incrementa el tamaño de los bloques.
+#. TRANS: Incrementa el tamaño de los bloques.
 msgid "Increase the size of the blocks."
 msgstr ""
 
@@ -2574,86 +2574,86 @@ msgid "Left-click and drag on workspace to select multiple blocks."
 msgstr ""
 
 #: js/turtledefs.js:797
-#.TRANS: Botones de paleta
+#. TRANS: Botones de paleta
 msgid "Palette buttons"
 msgstr ""
 
 #: js/turtledefs.js:798
-#.TRANS: Esta barra de herramientas contiene los botones de la paleta de Ritmo, Tono, Tortuga, y más.
+#. TRANS: Esta barra de herramientas contiene los botones de la paleta de Ritmo, Tono, Tortuga, y más.
 msgid "This toolbar contains the palette buttons including Rhythm Pitch Tone Action and more."
 msgstr ""
 
 #: js/turtledefs.js:800
-#.TRANS: Haga clic para mostrar las paletas de bloques y bloques de arrastre de las gamas de colores en el lienzo para usarlos.
+#. TRANS: Haga clic para mostrar las paletas de bloques y bloques de arrastre de las gamas de colores en el lienzo para usarlos.
 msgid "Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
 msgstr ""
 
 #: js/turtledefs.js:808
-#.TRANS: Se encuentra disponible una guía detallada de TortuBloques.
+#. TRANS: Se encuentra disponible una guía detallada de TortuBloques.
 msgid "A detailed guide to Turtle Blocks is available."
 msgstr ""
 
 #: js/turtledefs.js:812
-#.TRANS: Guía de TortuBloques
+#. TRANS: Guía de TortuBloques
 msgid "Turtle Blocks Guide"
 msgstr ""
 
 #: js/turtledefs.js:815
 #: js/turtledefs.js:838
 #: js/widgets/help.js:338
-#.TRANS: Acerca
+#. TRANS: Acerca
 msgid "About"
 msgstr "qayllampi"
 
 #: js/turtledefs.js:816
-#.TRANS: TortuBloques es una colección de herramientas de Software Libre para explorar conceptos musicales. 
+#. TRANS: TortuBloques es una colección de herramientas de Software Libre para explorar conceptos musicales. 
 msgid "Turtle Blocks is an open source collection of tools for exploring musical concepts."
 msgstr ""
 
 #: js/turtledefs.js:818
-#.TRANS: Se puede encontrar una lista completa de colaboradores en el repositorio GitHub de TortuBloques.
+#. TRANS: Se puede encontrar una lista completa de colaboradores en el repositorio GitHub de TortuBloques.
 msgid "A full list of contributors can be found in the Turtle Blocks GitHub repository."
 msgstr ""
 
 #: js/turtledefs.js:820
-#.TRANS: TortuBloques está licenciado bajo el AGPL.
+#. TRANS: TortuBloques está licenciado bajo el AGPL.
 msgid "Turtle Blocks is licensed under the AGPL."
 msgstr ""
 
 #: js/turtledefs.js:828
-#.TRANS: El repositorio de GitHub de TortuBloques
+#. TRANS: El repositorio de GitHub de TortuBloques
 msgid "Turtle Blocks GitHub repository"
 msgstr ""
 
 #: js/turtledefs.js:831
 #: js/widgets/help.js:339
 #: js/widgets/help.js:361
-#.TRANS: Felicitaciones.
+#. TRANS: Felicitaciones.
 msgid "Congratulations."
 msgstr "Jallalla"
 
 #: js/turtledefs.js:832
-#.TRANS: Ha terminado la gira. Por favor, disfrutar de TortuBloques
+#. TRANS: Ha terminado la gira. Por favor, disfrutar de TortuBloques
 msgid "You have finished the tour. Please enjoy Turtle Blocks!"
 msgstr ""
 
 #: js/turtledefs.js:839
-#.TRANS: Bloques de Música es una colección de herramientas de Software Libre para explorar conceptos musicales.
+#. TRANS: Bloques de Música es una colección de herramientas de Software Libre para explorar conceptos musicales.
 msgid "Music Blocks is an open source collection of tools for exploring musical concepts."
 msgstr ""
 
 #: js/turtledefs.js:841
-#.TRANS: Se puede encontrar una lista completa de colaboradores en el repositorio GitHub de Bloques de Música.
+#. TRANS: Se puede encontrar una lista completa de colaboradores en el repositorio GitHub de Bloques de Música.
 msgid "A full list of contributors can be found in the Music Blocks GitHub repository."
 msgstr ""
 
 #: js/turtledefs.js:843
-#.TRANS: Bloques de Música está licenciado bajo el AGPL.
+#. TRANS: Bloques de Música está licenciado bajo el AGPL.
 msgid "Music Blocks is licensed under the AGPL."
 msgstr ""
 
 #: js/turtledefs.js:851
-#.TRANS: El repositorio de GitHub de Bloques de Música
+#. TRANS: El repositorio de GitHub de Bloques de Música
 msgid "Music Blocks GitHub repository"
 msgstr ""
 
@@ -2662,39 +2662,39 @@ msgid "Congratulations!"
 msgstr ""
 
 #: js/turtledefs.js:855
-#.TRANS: Ha terminado la gira. Por favor, disfrutar de Bloques de Música!
+#. TRANS: Ha terminado la gira. Por favor, disfrutar de Bloques de Música!
 msgid "You have finished the tour. Please enjoy Music Blocks!"
 msgstr ""
 
 #: js/turtles.js:1052
-#.TRANS: Expandir
+#. TRANS: Expandir
 msgid "Expand"
 msgstr ""
 
 #: js/palette.js:663
-#.TRANS: efecto
+#. TRANS: efecto
 msgid "effect"
 msgstr ""
 
 #: js/palette.js:669
-#.TRANS: 
+#. TRANS: 
 msgid "sargam"
 msgstr ""
 
 #: js/palette.js:684
 #: js/blocks/PitchBlocks.js:1209
-#.TRANS: personalizado tono
+#. TRANS: personalizado tono
 msgid "custom pitch"
 msgstr "sapallanpa kunka"
 
 #: js/palette.js:692
-#.TRANS: accidental
+#. TRANS: accidental
 msgid "accidental"
 msgstr "yanapaqnin"
 
 #: js/palette.js:716
 #: js/blocks/PitchBlocks.js:405
-#.TRANS: convertidor de tono
+#. TRANS: convertidor de tono
 msgid "pitch converter"
 msgstr ""
 
@@ -2702,249 +2702,249 @@ msgstr ""
 #: js/utils/musicutils.js:644
 #: js/widgets/musickeyboard.js:2906
 #: js/widgets/pitchdrummatrix.js:228
-#.TRANS: descanso
+#. TRANS: descanso
 msgid "rest"
 msgstr "samay"
 
 #: js/utils/musicutils.js:687
-#.TRANS: Unísono perfecto
+#. TRANS: Unísono perfecto
 msgid "Perfect unison"
 msgstr ""
 
 #: js/utils/musicutils.js:687
-#.TRANS: Segundo disminuido
+#. TRANS: Segundo disminuido
 msgid "Diminished second"
 msgstr ""
 
 #: js/utils/musicutils.js:688
-#.TRANS: Segundo menor
+#. TRANS: Segundo menor
 msgid "Minor second"
 msgstr ""
 
 #: js/utils/musicutils.js:688
-#.TRANS: Unísono aumentado
+#. TRANS: Unísono aumentado
 msgid "Augmented unison"
 msgstr ""
 
 #: js/utils/musicutils.js:689
-#.TRANS: Segundo mayor
+#. TRANS: Segundo mayor
 msgid "Major second"
 msgstr ""
 
 #: js/utils/musicutils.js:689
-#.TRANS: Tercio disminuido
+#. TRANS: Tercio disminuido
 msgid "Diminished third"
 msgstr ""
 
 #: js/utils/musicutils.js:690
-#.TRANS: Tercio menor
+#. TRANS: Tercio menor
 msgid "Minor third"
 msgstr ""
 
 #: js/utils/musicutils.js:690
-#.TRANS: Segundo aumentado
+#. TRANS: Segundo aumentado
 msgid "Augmented second"
 msgstr ""
 
 #: js/utils/musicutils.js:691
-#.TRANS: Tercio mayor
+#. TRANS: Tercio mayor
 msgid "Major third"
 msgstr ""
 
 #: js/utils/musicutils.js:691
-#.TRANS: Cuarta disminuida
+#. TRANS: Cuarta disminuida
 msgid "Diminished fourth"
 msgstr ""
 
 #: js/utils/musicutils.js:692
-#.TRANS: Cuarta perfecta
+#. TRANS: Cuarta perfecta
 msgid "Perfect fourth"
 msgstr ""
 
 #: js/utils/musicutils.js:692
-#.TRANS: Tercio aumentado
+#. TRANS: Tercio aumentado
 msgid "Augmented third"
 msgstr ""
 
 #: js/utils/musicutils.js:693
-#.TRANS: Quinta disminuida
+#. TRANS: Quinta disminuida
 msgid "Diminished fifth"
 msgstr ""
 
 #: js/utils/musicutils.js:693
-#.TRANS: Cuarta aumentada
+#. TRANS: Cuarta aumentada
 msgid "Augmented fourth"
 msgstr ""
 
 #: js/utils/musicutils.js:694
-#.TRANS: Quinta perfecta
+#. TRANS: Quinta perfecta
 msgid "Perfect fifth"
 msgstr ""
 
 #: js/utils/musicutils.js:694
-#.TRANS: Sexto disminuido
+#. TRANS: Sexto disminuido
 msgid "Diminished sixth"
 msgstr ""
 
 #: js/utils/musicutils.js:695
-#.TRANS: Sexto menor
+#. TRANS: Sexto menor
 msgid "Minor sixth"
 msgstr ""
 
 #: js/utils/musicutils.js:695
-#.TRANS: Quinta aumentada
+#. TRANS: Quinta aumentada
 msgid "Augmented fifth"
 msgstr ""
 
 #: js/utils/musicutils.js:696
-#.TRANS: Sexto mayor
+#. TRANS: Sexto mayor
 msgid "Major sixth"
 msgstr ""
 
 #: js/utils/musicutils.js:696
-#.TRANS: Séptimo disminuido
+#. TRANS: Séptimo disminuido
 msgid "Diminished seventh"
 msgstr ""
 
 #: js/utils/musicutils.js:697
-#.TRANS: Séptimo menor
+#. TRANS: Séptimo menor
 msgid "Minor seventh"
 msgstr ""
 
 #: js/utils/musicutils.js:697
-#.TRANS: Sexto aumentado
+#. TRANS: Sexto aumentado
 msgid "Augmented sixth"
 msgstr ""
 
 #: js/utils/musicutils.js:698
-#.TRANS: Séptimo mayor
+#. TRANS: Séptimo mayor
 msgid "Major seventh"
 msgstr ""
 
 #: js/utils/musicutils.js:698
-#.TRANS: Octavo disminuido
+#. TRANS: Octavo disminuido
 msgid "Diminished octave"
 msgstr ""
 
 #: js/utils/musicutils.js:699
-#.TRANS: Octavo perfecto
+#. TRANS: Octavo perfecto
 msgid "Perfect octave"
 msgstr ""
 
 #: js/utils/musicutils.js:699
-#.TRANS: Séptimo aumentado
+#. TRANS: Séptimo aumentado
 msgid "Augmented seventh"
 msgstr ""
 
 #: js/utils/musicutils.js:700
-#.TRANS: Novena menor
+#. TRANS: Novena menor
 msgid "Minor ninth"
 msgstr ""
 
 #: js/utils/musicutils.js:700
-#.TRANS: Octavo aumentado
+#. TRANS: Octavo aumentado
 msgid "Augmented octave"
 msgstr ""
 
 #: js/utils/musicutils.js:701
-#.TRANS: Novena mayor
+#. TRANS: Novena mayor
 msgid "Major ninth"
 msgstr ""
 
 #: js/utils/musicutils.js:701
-#.TRANS: Décima disminuida
+#. TRANS: Décima disminuida
 msgid "Diminished tenth"
 msgstr ""
 
 #: js/utils/musicutils.js:702
-#.TRANS: Décima menor
+#. TRANS: Décima menor
 msgid "Minor tenth"
 msgstr ""
 
 #: js/utils/musicutils.js:702
-#.TRANS: Novena aumentada
+#. TRANS: Novena aumentada
 msgid "Augmented ninth"
 msgstr ""
 
 #: js/utils/musicutils.js:703
-#.TRANS: Décima mayor
+#. TRANS: Décima mayor
 msgid "Major tenth"
 msgstr ""
 
 #: js/utils/musicutils.js:703
-#.TRANS: Undécimo disminuido
+#. TRANS: Undécimo disminuido
 msgid "Diminished eleventh"
 msgstr ""
 
 #: js/utils/musicutils.js:704
-#.TRANS: Undécimo perfecto
+#. TRANS: Undécimo perfecto
 msgid "Perfect eleventh"
 msgstr ""
 
 #: js/utils/musicutils.js:704
-#.TRANS: Décima aumentada
+#. TRANS: Décima aumentada
 msgid "Augmented tenth"
 msgstr ""
 
 #: js/utils/musicutils.js:705
-#.TRANS: Doce disminuido
+#. TRANS: Doce disminuido
 msgid "Diminished twelfth"
 msgstr ""
 
 #: js/utils/musicutils.js:705
-#.TRANS: Undécimo aumentado
+#. TRANS: Undécimo aumentado
 msgid "Augmented eleventh"
 msgstr ""
 
 #: js/utils/musicutils.js:706
-#.TRANS: Doce perfecto
+#. TRANS: Doce perfecto
 msgid "Perfect twelfth"
 msgstr ""
 
 #: js/utils/musicutils.js:706
-#.TRANS: Decimotercero disminuido
+#. TRANS: Decimotercero disminuido
 msgid "Diminished thirteenth"
 msgstr ""
 
 #: js/utils/musicutils.js:707
-#.TRANS: Doce menor
+#. TRANS: Doce menor
 msgid "Minor thirteenth"
 msgstr ""
 
 #: js/utils/musicutils.js:707
-#.TRANS: Quinta aumentada, más una octava
+#. TRANS: Quinta aumentada, más una octava
 msgid "Augmented fifth, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:708
-#.TRANS: Decimotercero mayor
+#. TRANS: Decimotercero mayor
 msgid "Major thirteenth"
 msgstr ""
 
 #: js/utils/musicutils.js:708
-#.TRANS: Séptimo disminuido, más una octava
+#. TRANS: Séptimo disminuido, más una octava
 msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
-#.TRANS: 1ÃÂº 2ÃÂº 3ÃÂº 4ÃÂº 5ÃÂº 6ÃÂº 7ÃÂº 8ÃÂº 9ÃÂº 10ÃÂº 11ÃÂº 12ÃÂº
+#. TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: 1ÃÂº 2ÃÂº 3ÃÂº 4ÃÂº 5ÃÂº 6ÃÂº 7ÃÂº 8ÃÂº 9ÃÂº 10ÃÂº 11ÃÂº 12ÃÂº
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "1º 2º 3º 4º 5º 6º 7º 8º 9º 10º 11º 12º"
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
-#.TRANS: aumentado
+#. TRANS: augmented is a music term related to intervals
+#. TRANS: aumentado
 msgid "augmented"
 msgstr "jithxatayata"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
-#.TRANS: disminuido
+#. TRANS: diminished is a music term related to intervals and mode
+#. TRANS: disminuido
 msgid "diminished"
 msgstr "jithiqayata"
 
@@ -2953,218 +2953,218 @@ msgstr "jithiqayata"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
-#.TRANS: perfecto
+#. TRANS: perfect is a music term related to intervals
+#. TRANS: perfecto
 msgid "perfect"
 msgstr "allinpuni"
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
-#.TRANS: cromático
+#. TRANS: twelve semi-tone scale for music
+#. TRANS: cromático
 msgid "chromatic"
 msgstr "cromático"
 
 #: js/utils/musicutils.js:1013
-#.TRANS: argelino
+#. TRANS: argelino
 msgid "algerian"
 msgstr "argelino"
 
 #: js/utils/musicutils.js:1014
-#.TRANS: español
+#. TRANS: español
 msgid "spanish"
 msgstr "español"
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
-#.TRANS: octatonic
+#. TRANS: modal scale in music
+#. TRANS: octatonic
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
-#.TRANS: armónico mayor
+#. TRANS: harmonic major scale in music
+#. TRANS: armónico mayor
 msgid "harmonic major"
 msgstr "armónico mayor"
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
-#.TRANS: natural menor
+#. TRANS: natural minor scales in music
+#. TRANS: natural menor
 msgid "natural minor"
 msgstr "natural menor"
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
-#.TRANS: armónico menor
+#. TRANS: harmonic minor scale in music
+#. TRANS: armónico menor
 msgid "harmonic minor"
 msgstr "armónico menor"
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
-#.TRANS: melódico menor
+#. TRANS: melodic minor scale in music
+#. TRANS: melódico menor
 msgid "melodic minor"
 msgstr "melódico menor"
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
-#.TRANS: dorio
+#. TRANS: modal scale for music
+#. TRANS: dorio
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
-#.TRANS: frigio
+#. TRANS: modal scale for music
+#. TRANS: frigio
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
-#.TRANS: lidio
+#. TRANS: modal scale for music
+#. TRANS: lidio
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
-#.TRANS: mixolidio
+#. TRANS: modal scale for music
+#. TRANS: mixolidio
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
-#.TRANS: locrian
+#. TRANS: modal scale for music
+#. TRANS: locrian
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
-#.TRANS: jazz menor
+#. TRANS: minor jazz scale for music
+#. TRANS: jazz menor
 msgid "jazz minor"
 msgstr "jazz menor"
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
-#.TRANS: bebop
+#. TRANS: bebop scale for music
+#. TRANS: bebop
 msgid "bebop"
 msgstr ""
 
 #: js/utils/musicutils.js:1043
-#.TRANS: arábica
+#. TRANS: arábica
 msgid "arabic"
 msgstr "arábica"
 
 #: js/utils/musicutils.js:1044
-#.TRANS: bizantino
+#. TRANS: bizantino
 msgid "byzantine"
 msgstr "bizantino"
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
-#.TRANS: enigmático
+#. TRANS: musical scale for music by Verdi
+#. TRANS: enigmático
 msgid "enigmatic"
 msgstr "enigmático"
 
 #: js/utils/musicutils.js:1047
-#.TRANS: etíope
+#. TRANS: etíope
 msgid "ethiopian"
 msgstr "etíope"
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
-#.TRANS: geez
+#. TRANS: Ethiopic scale for music
+#. TRANS: geez
 msgid "geez"
 msgstr ""
 
 #: js/utils/musicutils.js:1050
-#.TRANS: hindú
+#. TRANS: hindú
 msgid "hindu"
 msgstr "hindú"
 
 #: js/utils/musicutils.js:1051
-#.TRANS: húngaro
+#. TRANS: húngaro
 msgid "hungarian"
 msgstr "húngaro"
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
-#.TRANS: romano menor
+#. TRANS: minor Romanian scale for music
+#. TRANS: romano menor
 msgid "romanian minor"
 msgstr "romano menor"
 
 #: js/utils/musicutils.js:1054
-#.TRANS: gitana española
+#. TRANS: gitana española
 msgid "spanish gypsy"
 msgstr "gitana española"
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
-#.TRANS: maqam
+#. TRANS: musical scale for Mid-Eastern music
+#. TRANS: maqam
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
-#.TRANS: blues menor
+#. TRANS: minor blues scale for music
+#. TRANS: blues menor
 msgid "minor blues"
 msgstr "blues menor"
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
-#.TRANS: blues mayor
+#. TRANS: major blues scale for music
+#. TRANS: blues mayor
 msgid "major blues"
 msgstr "blues mayor"
 
 #: js/utils/musicutils.js:1061
-#.TRANS: tono completo
+#. TRANS: tono completo
 msgid "whole tone"
 msgstr "tono completo"
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
-#.TRANS: pentatonic minor
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic minor
 msgid "minor pentatonic"
 msgstr "pentatonic minor"
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
-#.TRANS: pentatonic mayor
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic mayor
 msgid "major pentatonic"
 msgstr "pentatonic mayor"
 
 #: js/utils/musicutils.js:1066
-#.TRANS: chino
+#. TRANS: chino
 msgid "chinese"
 msgstr "chino"
 
 #: js/utils/musicutils.js:1067
-#.TRANS: egipcio
+#. TRANS: egipcio
 msgid "egyptian"
 msgstr "egipcio"
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
-#.TRANS: hirajoshi
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: hirajoshi
 msgid "hirajoshi"
 msgstr ""
 
 #: js/utils/musicutils.js:1070
-#.TRANS: Japón
+#. TRANS: Japón
 msgid "Japan"
 msgstr "Japón"
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
-#.TRANS: in
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: in
 msgid "in"
 msgstr "in"
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
-#.TRANS: minyo
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: minyo
 msgid "minyo"
 msgstr "minyo"
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
-#.TRANS: fibonacci
+#. TRANS: Italian mathematician
+#. TRANS: fibonacci
 msgid "fibonacci"
 msgstr ""
 
@@ -3181,65 +3181,65 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
-#.TRANS: personalizado
+#. TRANS: customize voice
+#. TRANS: personalizado
 msgid "custom"
 msgstr "Runachasqa"
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
-#.TRANS: highpass
+#. TRANS: highpass filter
+#. TRANS: highpass
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
-#.TRANS: 
+#. TRANS: lowpass filter
+#. TRANS: 
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
-#.TRANS: 
+#. TRANS: bandpass filter
+#. TRANS: 
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
-#.TRANS: 
+#. TRANS: high-shelf filter
+#. TRANS: 
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
-#.TRANS: 
+#. TRANS: low-shelf filter
+#. TRANS: 
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
-#.TRANS: 
+#. TRANS: notch-shelf filter
+#. TRANS: 
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
-#.TRANS: 
+#. TRANS: all-pass filter
+#. TRANS: 
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
-#.TRANS: 
+#. TRANS: peaking filter
+#. TRANS: 
 msgid "peaking"
 msgstr ""
 
@@ -3247,8 +3247,8 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
-#.TRANS: sine
+#. TRANS: sine wave
+#. TRANS: sine
 msgid "sine"
 msgstr "seno chimpu"
 
@@ -3256,8 +3256,8 @@ msgstr "seno chimpu"
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
-#.TRANS: cuadrado
+#. TRANS: square wave
+#. TRANS: cuadrado
 msgid "square"
 msgstr "tawa k’uchu"
 
@@ -3266,8 +3266,8 @@ msgstr "tawa k’uchu"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
-#.TRANS: triángulo
+#. TRANS: triangle wave
+#. TRANS: triángulo
 msgid "triangle"
 msgstr "kimsa k’uchu"
 
@@ -3275,8 +3275,8 @@ msgstr "kimsa k’uchu"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
-#.TRANS: diente de sierra
+#. TRANS: sawtooth wave
+#. TRANS: diente de sierra
 msgid "sawtooth"
 msgstr "khuchuña laka"
 
@@ -3285,9 +3285,9 @@ msgstr "khuchuña laka"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
-#.TRANS: par
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
+#. TRANS: par
 msgid "even"
 msgstr "masa"
 
@@ -3295,8 +3295,8 @@ msgstr "masa"
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
-#.TRANS: impar
+#. TRANS: odd numbers
+#. TRANS: impar
 msgid "odd"
 msgstr "sapallan"
 
@@ -3304,178 +3304,178 @@ msgstr "sapallan"
 #: js/utils/musicutils.js:1357
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:473
-#.TRANS: escalar
+#. TRANS: escalar
 msgid "scalar"
 msgstr "siqay"
 
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
-#.TRANS: piano
+#. TRANS: musical instrument
+#. TRANS: piano
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
-#.TRANS: violín
+#. TRANS: musical instrument
+#. TRANS: violín
 msgid "violin"
 msgstr "violin"
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
-#.TRANS: viola
+#. TRANS: viola musical instrument
+#. TRANS: viola
 msgid "viola"
 msgstr "viola"
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
-#.TRANS: xilófono
+#. TRANS: xylophone musical instrument
+#. TRANS: xilófono
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
-#.TRANS: vibráfono
+#. TRANS: vibraphone musical instrument
+#. TRANS: vibráfono
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
-#.TRANS: violonchelo
+#. TRANS: musical instrument
+#. TRANS: violonchelo
 msgid "cello"
 msgstr "violonchelo"
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
-#.TRANS: contrabajo
+#. TRANS: viola musical instrument
+#. TRANS: contrabajo
 msgid "double bass"
 msgstr "Viola takina waqachina"
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
-#.TRANS: guitarra
+#. TRANS: musical instrument
+#. TRANS: guitarra
 msgid "guitar"
 msgstr "guitarra"
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
-#.TRANS: guitarra acustica
+#. TRANS: musical instrument
+#. TRANS: guitarra acustica
 msgid "acoustic guitar"
 msgstr "aswan kunkayuq guitarra"
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
-#.TRANS: flauta
+#. TRANS: musical instrument
+#. TRANS: flauta
 msgid "flute"
 msgstr "flauta"
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
-#.TRANS: clarinete
+#. TRANS: musical instrument
+#. TRANS: clarinete
 msgid "clarinet"
 msgstr "clarinete"
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
-#.TRANS: saxofón
+#. TRANS: musical instrument
+#. TRANS: saxofón
 msgid "saxophone"
 msgstr "saxofón"
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
-#.TRANS: tuba
+#. TRANS: musical instrument
+#. TRANS: tuba
 msgid "tuba"
 msgstr "tuba"
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
-#.TRANS: trompeta
+#. TRANS: musical instrument
+#. TRANS: trompeta
 msgid "trumpet"
 msgstr "trompeta"
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
-#.TRANS: oboe
+#. TRANS: musical instrument
+#. TRANS: oboe
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
-#.TRANS: trombón
+#. TRANS: musical instrument
+#. TRANS: trombón
 msgid "trombone"
 msgstr "trombón"
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
-#.TRANS: sintetizador electronico
+#. TRANS: polytone synthesizer
+#. TRANS: sintetizador electronico
 msgid "electronic synth"
 msgstr "sintetizador electronico"
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
-#.TRANS: simple-1
+#. TRANS: simple monotone synthesizer
+#. TRANS: simple-1
 msgid "simple 1"
 msgstr "qasi-1"
 
 #: js/utils/musicutils.js:1123
-#.TRANS: simple 2
+#. TRANS: simple 2
 msgid "simple 2"
 msgstr ""
 
 #: js/utils/musicutils.js:1124
-#.TRANS: simple 3
+#. TRANS: simple 3
 msgid "simple 3"
 msgstr ""
 
 #: js/utils/musicutils.js:1125
-#.TRANS: simple 4
+#. TRANS: simple 4
 msgid "simple 4"
 msgstr ""
 
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
-#.TRANS: ruido blanco
+#. TRANS: white noise synthesizer
+#. TRANS: ruido blanco
 msgid "white noise"
 msgstr "Yuraq rakhaqaqaq"
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
-#.TRANS: ruido marrón
+#. TRANS: brown noise synthesizer
+#. TRANS: ruido marrón
 msgid "brown noise"
 msgstr "ch’umpi chanraray"
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
-#.TRANS: ruido rosa
+#. TRANS: pink noise synthesizer
+#. TRANS: ruido rosa
 msgid "pink noise"
 msgstr "rosa chanraray"
 
@@ -3483,249 +3483,249 @@ msgstr "rosa chanraray"
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
-#.TRANS: tambor militar pequeño
+#. TRANS: musical instrument
+#. TRANS: tambor militar pequeño
 msgid "snare drum"
 msgstr "wankar"
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
-#.TRANS: tambor de patada
+#. TRANS: musical instrument
+#. TRANS: tambor de patada
 msgid "kick drum"
 msgstr "Hayt’ana wankar"
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
-#.TRANS: tom tom
+#. TRANS: musical instrument
+#. TRANS: tom tom
 msgid "tom tom"
 msgstr "tum tum"
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
-#.TRANS: piso tom
+#. TRANS: musical instrument
+#. TRANS: piso tom
 msgid "floor tom"
 msgstr "piso tom"
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
-#.TRANS: tambor de bajo
+#. TRANS: musical instrument
+#. TRANS: tambor de bajo
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
-#.TRANS: taza de tambor
+#. TRANS: a drum made from an inverted cup
+#. TRANS: taza de tambor
 msgid "cup drum"
 msgstr "qiru wankar"
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
-#.TRANS: darbuka
+#. TRANS: musical instrument
+#. TRANS: darbuka
 msgid "darbuka drum"
 msgstr "wankar darbuka"
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
-#.TRANS: 
+#. TRANS: musical instrument
+#. TRANS: 
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
-#.TRANS: campana de paseo
+#. TRANS: a small metal bell
+#. TRANS: campana de paseo
 msgid "ride bell"
 msgstr "puriq kampana/kalanka"
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
-#.TRANS: campana de vaca
+#. TRANS: musical instrument
+#. TRANS: campana de vaca
 msgid "cow bell"
 msgstr "waka kampana/kalanka"
 
 #: js/utils/musicutils.js:1140
-#.TRANS: tambor japonés
+#. TRANS: tambor japonés
 msgid "japanese drum"
 msgstr "tambor japonés"
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
-#.TRANS: campana japonesa
+#. TRANS: musical instrument
+#. TRANS: campana japonesa
 msgid "japanese bell"
 msgstr "campana japonesa"
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
-#.TRANS: campana triangular
+#. TRANS: musical instrument
+#. TRANS: campana triangular
 msgid "triangle bell"
 msgstr "kimsa k’uchu kampana/kalanka"
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
-#.TRANS: castañuelas
+#. TRANS: musical instrument
+#. TRANS: castañuelas
 msgid "finger cymbals"
 msgstr "kastañuylas"
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
-#.TRANS: campaneo
+#. TRANS: a musically tuned set of bells
+#. TRANS: campaneo
 msgid "chime"
 msgstr "thaya suyu"
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
-#.TRANS: gong
+#. TRANS: a musical instrument
+#. TRANS: gong
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
-#.TRANS: estruendo
+#. TRANS: sound effect
+#. TRANS: estruendo
 msgid "clang"
 msgstr "q'iju"
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
-#.TRANS: choque
+#. TRANS: sound effect
+#. TRANS: choque
 msgid "crash"
 msgstr "q'axta"
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
-#.TRANS: botella
+#. TRANS: sound effect
+#. TRANS: botella
 msgid "bottle"
 msgstr "qhispillu wutilla"
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
-#.TRANS: palmada
+#. TRANS: sound effect
+#. TRANS: palmada
 msgid "clap"
 msgstr "t'axllirt'äwi"
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
-#.TRANS: bofetada
+#. TRANS: sound effect
+#. TRANS: bofetada
 msgid "slap"
 msgstr "t'axlli"
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
-#.TRANS: salpicadura
+#. TRANS: sound effect
+#. TRANS: salpicadura
 msgid "splash"
 msgstr "ch'itiqiri"
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
-#.TRANS: burbujas
+#. TRANS: sound effect
+#. TRANS: burbujas
 msgid "bubbles"
 msgstr "jupuqunaka"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
-#.TRANS: gota de agua
+#. TRANS: sound effect
+#. TRANS: gota de agua
 msgid "raindrop"
 msgstr "gota de agua"
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
-#.TRANS: gato
+#. TRANS: animal sound effect
+#. TRANS: gato
 msgid "cat"
 msgstr "phisi"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
-#.TRANS: grillo
+#. TRANS: animal sound effect
+#. TRANS: grillo
 msgid "cricket"
 msgstr "jirillu"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
-#.TRANS: perro
+#. TRANS: animal sound effect
+#. TRANS: perro
 msgid "dog"
 msgstr "anuqara"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
-#.TRANS: banjo
+#. TRANS: musical instrument
+#. TRANS: banjo
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
-#.TRANS: koto
+#. TRANS: musical instrument
+#. TRANS: koto
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
-#.TRANS: dulcimer
+#. TRANS: musical instrument
+#. TRANS: dulcimer
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
-#.TRANS: guitarra electrica
+#. TRANS: musical instrument
+#. TRANS: guitarra electrica
 msgid "electric guitar"
 msgstr "tawtinku phinchikilla"
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
-#.TRANS: fagot
+#. TRANS: musical instrument
+#. TRANS: fagot
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
-#.TRANS: celeste
+#. TRANS: musical instrument
+#. TRANS: celeste
 msgid "celeste"
 msgstr "yuraq anqhas"
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
-#.TRANS: igual
+#. TRANS: musical temperament
+#. TRANS: igual
 msgid "equal"
 msgstr "igual"
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
-#.TRANS: Pitagórico
+#. TRANS: musical temperament
+#. TRANS: Pitagórico
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
-#.TRANS: solo entonación
+#. TRANS: musical temperament
+#. TRANS: solo entonación
 msgid "just intonation"
 msgstr "solo entonación"
 
@@ -3734,285 +3734,285 @@ msgstr "solo entonación"
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
-#.TRANS: 
+#. TRANS: musical temperament
+#. TRANS: 
 msgid "Meantone"
 msgstr ""
 
 #: js/utils/musicutils.js:1188
-#.TRANS: 7mo mayor
+#. TRANS: 7mo mayor
 msgid "major 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1189
-#.TRANS: 7mo menor
+#. TRANS: 7mo menor
 msgid "minor 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1190
-#.TRANS: 7ma dominante
+#. TRANS: 7ma dominante
 msgid "dominant 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1191
-#.TRANS: 7mo menor-mayor
+#. TRANS: 7mo menor-mayor
 msgid "minor-major 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1192
-#.TRANS: 7ÃÂº completamente disminuido
+#. TRANS: 7ÃÂº completamente disminuido
 msgid "fully-diminished 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1193
-#.TRANS: 7ÃÂº medio disminuido
+#. TRANS: 7ÃÂº medio disminuido
 msgid "half-diminished 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1600
 #: js/utils/musicutils.js:1616
-#.TRANS: Igual (12EDO)
+#. TRANS: Igual (12EDO)
 msgid "Equal (12EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1601
 #: js/utils/musicutils.js:1617
-#.TRANS: Igual (5EDO)
+#. TRANS: Igual (5EDO)
 msgid "Equal (5EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1602
 #: js/utils/musicutils.js:1618
-#.TRANS: Igual (7EDO)
+#. TRANS: Igual (7EDO)
 msgid "Equal (7EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1603
 #: js/utils/musicutils.js:1619
-#.TRANS: Igual (19EDO)
+#. TRANS: Igual (19EDO)
 msgid "Equal (19EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1604
 #: js/utils/musicutils.js:1620
-#.TRANS: Igual (31EDO)
+#. TRANS: Igual (31EDO)
 msgid "Equal (31EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1605
 #: js/utils/musicutils.js:1621
-#.TRANS: 5-Límite de entonación justa
+#. TRANS: 5-Límite de entonación justa
 msgid "5-limit Just Intonation"
 msgstr ""
 
 #: js/utils/musicutils.js:1606
 #: js/utils/musicutils.js:1622
-#.TRANS: Pythagorean (3-limite EJ)
+#. TRANS: Pythagorean (3-limite EJ)
 msgid "Pythagorean (3-limit JI)"
 msgstr ""
 
 #: js/utils/musicutils.js:5631
 #: js/utils/musicutils.js:5674
-#.TRANS: actuales
+#. TRANS: actuales
 msgid "current"
 msgstr "actuales"
 
 #: js/utils/musicutils.js:5634
 #: js/utils/musicutils.js:5665
-#.TRANS: próximo
+#. TRANS: próximo
 msgid "next"
 msgstr "próximo"
 
 #: js/utils/musicutils.js:5637
 #: js/utils/musicutils.js:5670
-#.TRANS: anterior
+#. TRANS: anterior
 msgid "previous"
 msgstr "anterior"
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
-#.TRANS: simple-2
+#. TRANS: simple monotone synthesizer
+#. TRANS: simple-2
 msgid "simple-2"
 msgstr "qasi-2"
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
-#.TRANS: simple-3
+#. TRANS: simple monotone synthesizer
+#. TRANS: simple-3
 msgid "simple-3"
 msgstr "qasi-3"
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
-#.TRANS: simple-4
+#. TRANS: simple monotone synthesizer
+#. TRANS: simple-4
 msgid "simple-4"
 msgstr "qasi-4"
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
-#.TRANS: taiko
+#. TRANS: musical instrument
+#. TRANS: taiko
 msgid "taiko"
 msgstr "chakiyuq wankar"
 
 #: js/blocks/BooleanBlocks.js:44
-#.TRANS: El bloque No es el operador lógico no.
+#. TRANS: El bloque No es el operador lógico no.
 msgid "The Not block is the logical not operator."
 msgstr "El bloque No es el operador lógico no."
 
 #: js/blocks/BooleanBlocks.js:62
-#.TRANS: no
+#. TRANS: no
 msgid "not"
 msgstr "mana"
 
 #: js/blocks/BooleanBlocks.js:134
-#.TRANS: El bloque Y es el lógico y el operador.
+#. TRANS: El bloque Y es el lógico y el operador.
 msgid "The And block is the logical and operator."
 msgstr "El bloque Y es el lógico y el operador."
 
 #: js/blocks/BooleanBlocks.js:152
-#.TRANS: y
+#. TRANS: y
 msgid "and"
 msgstr "hinallataq"
 
 #: js/blocks/BooleanBlocks.js:218
-#.TRANS: El bloque O es el lógico o el operador.
+#. TRANS: El bloque O es el lógico o el operador.
 msgid "The Or block is the logical or operator."
 msgstr "El bloque O es el lógico o el operador."
 
 #: js/blocks/BooleanBlocks.js:236
-#.TRANS: o
+#. TRANS: o
 msgid "or"
 msgstr "utaq"
 
 #: js/blocks/BooleanBlocks.js:302
-#.TRANS: El bloque XOR es el lógico XOR el operador.
+#. TRANS: El bloque XOR es el lógico XOR el operador.
 msgid "The XOR block is the logical XOR operator."
 msgstr "El bloque XOR es el lógico XOR el operador."
 
 #: js/blocks/BooleanBlocks.js:320
-#.TRANS: xor
+#. TRANS: xor
 msgid "xor"
 msgstr ""
 
 #: js/blocks/BooleanBlocks.js:808
-#.TRANS: El bloque Igual devuelve verdadero si los dos números son iguales.
+#. TRANS: El bloque Igual devuelve verdadero si los dos números son iguales.
 msgid "The Equal block returns True if the two numbers are equal."
 msgstr "El bloque Igual devuelve verdadero si los dos números son iguales."
 
 #: js/blocks/BooleanBlocks.js:909
-#.TRANS: El bloque No igual a devuelve Verdadero si los dos números no son iguales entre sí.
+#. TRANS: El bloque No igual a devuelve Verdadero si los dos números no son iguales entre sí.
 msgid "The Not-equal-to block returns True if the two numbers are not equal to each other."
 msgstr ""
 
 #: js/blocks/BooleanBlocks.js:1008
-#.TRANS: El bloque Booleano se utiliza para especificar verdadero o falso.
+#. TRANS: El bloque Booleano se utiliza para especificar verdadero o falso.
 msgid "The Boolean block is used to specify true or false."
 msgstr "El bloque Booleano se utiliza para especificar verdadero o falso."
 
 #: js/blocks/BoxesBlocks.js:53
 #: js/blocks/BoxesBlocks.js:59
-#.TRANS: El bloque Agregar a se usa para agregar al valor almacenado en un cuadro.
+#. TRANS: El bloque Agregar a se usa para agregar al valor almacenado en un cuadro.
 msgid "The Add-to block is used to add to the value stored in a box."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:61
-#.TRANS: También se puede utilizar con otros bloques, como el color, el tamaño de la pluma.
+#. TRANS: También se puede utilizar con otros bloques, como el color, el tamaño de la pluma.
 msgid "It can also be used with other blocks such as Color and Pen size."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:73
-#.TRANS: sumar
+#. TRANS: sumar
 msgid "add"
 msgstr "yapay"
 
 #: js/blocks/BoxesBlocks.js:75
 #: js/widgets/temperament.js:825
-#.TRANS: para
+#. TRANS: para
 msgid "to"
 msgstr "sayay"
 
 #: js/blocks/BoxesBlocks.js:75
 #: js/blocks/BoxesBlocks.js:595
 #: js/blocks/HeapBlocks.js:544
-#.TRANS: valor
+#. TRANS: valor
 msgid "value1"
 msgstr "chanin"
 
 #: js/blocks/BoxesBlocks.js:118
-#.TRANS: Bloque no soporta incremento.
+#. TRANS: Bloque no soporta incremento.
 msgid "Block does not support incrementing."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:152
-#.TRANS: El bloque Sumar-1-a agrega uno al valor almacenado en un cuadro.
+#. TRANS: El bloque Sumar-1-a agrega uno al valor almacenado en un cuadro.
 msgid "The Add-1-to block adds one to the value stored in a box."
 msgstr "Yapay-1 t’aqa hukta tawa k’uchu wayqaychasqaman yapan"
 
 #: js/blocks/BoxesBlocks.js:163
-#.TRANS: sumar 1 a
+#. TRANS: sumar 1 a
 msgid "add 1 to"
-msgstr "1 yapay" "hukta yapay"
+msgstr "1 yapay hukta yapay"
 
 #: js/blocks/BoxesBlocks.js:211
-#.TRANS: El bloque restar-1-de resta uno al valor almacenado en un cuadro.
+#. TRANS: El bloque restar-1-de resta uno al valor almacenado en un cuadro.
 msgid "The Subtract-1-from block subtracts one from the value stored in a box."
 msgstr "El bloque restar-1-de resta uno al valor almacenado en un cuadro."
 
 #: js/blocks/BoxesBlocks.js:222
-#.TRANS: restar 1 de
+#. TRANS: restar 1 de
 msgid "subtract 1 from"
-msgstr "1 qichuy" "hukta qichuy"
+msgstr "1 qichuy hukta qichuy"
 
 #: js/blocks/BoxesBlocks.js:270
 #: js/blocks/BoxesBlocks.js:387
-#.TRANS: El bloque Caja devuelve el valor almacenado en una caja .
+#. TRANS: El bloque Caja devuelve el valor almacenado en una caja .
 msgid "The Box block returns the value stored in a box."
 msgstr "El bloque Caja devuelve el valor almacenado en una caja ."
 
 #: js/blocks/BoxesBlocks.js:500
 #: js/blocks/BoxesBlocks.js:576
-#.TRANS: El bloque Guardar en caja se utiliza para almacenar un valor en una caja.
+#. TRANS: El bloque Guardar en caja se utiliza para almacenar un valor en una caja.
 msgid "The Store in block will store a value in a box."
 msgstr "El bloque Guardar en caja se utiliza para almacenar un valor en una caja."
 
 #: js/blocks/BoxesBlocks.js:595
 #: js/blocks/EnsembleBlocks.js:393
 #: js/blocks/EnsembleBlocks.js:404
-#.TRANS: nombre
+#. TRANS: nombre
 msgid "name1"
 msgstr "Suti"
 
 #: js/blocks/BoxesBlocks.js:652
-#.TRANS: El bloque Caja 2 devuelve el valor almacenado en caja 2.
+#. TRANS: El bloque Caja 2 devuelve el valor almacenado en caja 2.
 msgid "The Box2 block returns the value stored in Box2."
 msgstr "El bloque Caja 2 devuelve el valor almacenado en caja 2."
 
 #: js/blocks/BoxesBlocks.js:703
-#.TRANS: El bloque Guardar en caja2 se utiliza para almacenar un valor en caja2.
+#. TRANS: El bloque Guardar en caja2 se utiliza para almacenar un valor en caja2.
 msgid "The Store in Box2 block is used to store a value in Box2."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:715
-#.TRANS: guardar en caja 2
+#. TRANS: guardar en caja 2
 msgid "store in box2"
 msgstr "guardar en caja 2"
 
 #: js/blocks/BoxesBlocks.js:761
-#.TRANS: El bloque Caja 1 devuelve el valor almacenado en caja 1.
+#. TRANS: El bloque Caja 1 devuelve el valor almacenado en caja 1.
 msgid "The Box1 block returns the value stored in Box1."
 msgstr "El bloque Caja 1 devuelve el valor almacenado en caja 1."
 
 #: js/blocks/BoxesBlocks.js:812
-#.TRANS: El bloque Guardar en caja1 se utiliza para almacenar un valor en caja1.
+#. TRANS: El bloque Guardar en caja1 se utiliza para almacenar un valor en caja1.
 msgid "The Store in Box1 block is used to store a value in Box1."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:826
-#.TRANS: guardar en caja 1
+#. TRANS: guardar en caja 1
 msgid "store in box1"
 msgstr "guardar en caja 1"
 
 #: js/blocks/DictBlocks.js:77
-#.TRANS: mostrar diccionario
+#. TRANS: mostrar diccionario
 msgid "show dictionary"
 msgstr ""
 
@@ -4023,25 +4023,25 @@ msgstr ""
 #: js/blocks/ProgramBlocks.js:396
 #: js/blocks/ProgramBlocks.js:501
 #: js/blocks/ProgramBlocks.js:664
-#.TRANS: mi diccionario
+#. TRANS: mi diccionario
 msgid "My Dictionary"
 msgstr ""
 
 #: js/blocks/DictBlocks.js:129
-#.TRANS: El bloque Diccionario devuelve un diccionario.
+#. TRANS: El bloque Diccionario devuelve un diccionario.
 msgid "The Dictionary block returns a dictionary."
 msgstr ""
 
 #: js/blocks/DictBlocks.js:197
 #: js/blocks/DictBlocks.js:339
-#.TRANS: El bloque obtener-valor devuelve un valor en el diccionario para una clave especificada.
+#. TRANS: El bloque obtener-valor devuelve un valor en el diccionario para una clave especificada.
 msgid "The Get-dict block returns a value in the dictionary for a specified key."
 msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
-#.TRANS: obtener valor
+#. TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: obtener valor
 msgid "get value"
 msgstr ""
 
@@ -4052,7 +4052,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:357
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
-#.TRANS: clave
+#. TRANS: clave
 msgid "key2"
 msgstr ""
 
@@ -4064,143 +4064,143 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
-#.TRANS: clave
+#. TRANS: key, e.g., C in C Major
+#. TRANS: clave
 msgid "key"
 msgstr "kichanapaq"
 
 #: js/blocks/DictBlocks.js:271
 #: js/blocks/DictBlocks.js:411
-#.TRANS: El bloque valor-adjusto establece un valor en el diccionario para una clave específica.
+#. TRANS: El bloque valor-adjusto establece un valor en el diccionario para una clave específica.
 msgid "The Set-dict block sets a value in the dictionary for a specified key."
 msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
-#.TRANS: valor ajustado
+#. TRANS: set a value in the dictionary for a given key
+#. TRANS: valor ajustado
 msgid "set value"
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:59
-#.TRANS: El bloque Nombre de ruido se utiliza para seleccionar un sintetizador de ruido.
+#. TRANS: El bloque Nombre de ruido se utiliza para seleccionar un sintetizador de ruido.
 msgid "The Noise name block is used to select a noise synthesizer."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:102
-#.TRANS: El bloque nombre del tambor se utiliza para seleccionar un tambor.
+#. TRANS: El bloque nombre del tambor se utiliza para seleccionar un tambor.
 msgid "The Drum name block is used to select a drum."
 msgstr "Tambor sayaq sutinqa, tambor akllanapaqmi"
 
 #: js/blocks/DrumBlocks.js:146
-#.TRANS: El bloque nombre de efectos se utiliza para seleccionar un efecto de sonido.
+#. TRANS: El bloque nombre de efectos se utiliza para seleccionar un efecto de sonido.
 msgid "The Effects name block is used to select a sound effect."
 msgstr "El bloque nombre de efectos se utiliza para seleccionar un efecto de sonido."
 
 #: js/blocks/DrumBlocks.js:163
-#.TRANS: ruido
+#. TRANS: ruido
 msgid "noise"
 msgstr "rakhaqaqaq"
 
 #: js/blocks/DrumBlocks.js:177
-#.TRANS: El bloque Ruido de reproducción generará ruido blanco, rosa o marrón.
+#. TRANS: El bloque Ruido de reproducción generará ruido blanco, rosa o marrón.
 msgid "The Play noise block will generate white, pink, or brown noise."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:317
-#.TRANS: Reemplace cada instancia de un tono con un sonido de tambor.
+#. TRANS: Reemplace cada instancia de un tono con un sonido de tambor.
 msgid "Replace every instance of a pitch with a drum sound."
 msgstr "Reemplace cada instancia de un tono con un sonido de tambor."
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
-#.TRANS: mapa de tono al tambor
+#. TRANS: map a pitch to a drum sound
+#. TRANS: mapa de tono al tambor
 msgid "map pitch to drum"
 msgstr "saywa"
 
 #: js/blocks/DrumBlocks.js:395
-#.TRANS: En el ejemplo anterior, se reproducirá un sonido de bombo en lugar de sol.
+#. TRANS: En el ejemplo anterior, se reproducirá un sonido de bombo en lugar de sol.
 msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
-#.TRANS: fijar tambor
+#. TRANS: set the current drum sound for playback
+#. TRANS: fijar tambor
 msgid "set drum"
 msgstr "tarula chimpuña"
 
 #: js/blocks/DrumBlocks.js:451
-#.TRANS: efecto de sonido
+#. TRANS: efecto de sonido
 msgid "sound effect"
 msgstr "t’uqyaq pantachiq"
 
 #: js/blocks/DrumBlocks.js:489
-#.TRANS: Puede utilizar varios bloques de percusión dentro de un bloque de notas.
+#. TRANS: Puede utilizar varios bloques de percusión dentro de un bloque de notas.
 msgid "You can use multiple Drum blocks within a Note block."
 msgstr "Sayaq uhpi atiwaqmi achka kunkakunaq takaykunanpi"
 
 #: js/blocks/HeapBlocks.js:49
-#.TRANS: El bloque Pila devuelve la pila.
+#. TRANS: El bloque Pila devuelve la pila.
 msgid "The Heap block returns the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:133
-#.TRANS: mostrar pila
+#. TRANS: mostrar pila
 msgid "show heap"
 msgstr "qutu rikuchiy"
 
 #: js/blocks/HeapBlocks.js:181
-#.TRANS: El bloque Longitud de la pila devuelve la longitud de la pila.
+#. TRANS: El bloque Longitud de la pila devuelve la longitud de la pila.
 msgid "The Heap-length block returns the length of the heap."
 msgstr "El bloque Longitud de la pila devuelve la longitud de la pila."
 
 #: js/blocks/HeapBlocks.js:195
-#.TRANS: tamaño de la pila
+#. TRANS: tamaño de la pila
 msgid "heap length"
 msgstr "qutuq sunin"
 
 #: js/blocks/HeapBlocks.js:254
-#.TRANS: El bloque Pila-vacío? devuelve verdadero si la pila está vacío.
+#. TRANS: El bloque Pila-vacío? devuelve verdadero si la pila está vacío.
 msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "El bloque Pila-vacío? devuelve verdadero si la pila está vacío."
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
-#.TRANS: ÃÂ¿pila vacía?
+#. TRANS: Is the heap empty?
+#. TRANS: ÃÂ¿pila vacía?
 msgid "heap empty?"
 msgstr "Llapan qutupi mana kanchu?"
 
 #: js/blocks/HeapBlocks.js:317
-#.TRANS: El bloque Vacío pila vacía la pila.
+#. TRANS: El bloque Vacío pila vacía la pila.
 msgid "The Empty-heap block empties the heap."
 msgstr "El bloque Vacío pila vacía la pila."
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
-#.TRANS: vaciar pila
+#. TRANS: empty the heap
+#. TRANS: vaciar pila
 msgid "empty heap"
 msgstr "ch’usaq qutu"
 
 #: js/blocks/HeapBlocks.js:371
-#.TRANS: El bloque Pila inversa invierte el orden de la pila.
+#. TRANS: El bloque Pila inversa invierte el orden de la pila.
 msgid "The Reverse-heap block reverses the order of the heap."
 msgstr "El bloque Pila inversa invierte el orden de la pila."
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
-#.TRANS: revertir la pila
+#. TRANS: reverse the order of the heap
+#. TRANS: revertir la pila
 msgid "reverse heap"
 msgstr "Qutu tikray"
 
 #: js/blocks/HeapBlocks.js:428
-#.TRANS: El bloque ÃÂndice de pila devuelve un valor en la pila en una ubicación especificada.
+#. TRANS: El bloque ÃÂndice de pila devuelve un valor en la pila en una ubicación especificada.
 msgid "The Index-heap block returns a value in the heap at a specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
-#.TRANS: valor en la pila
+#. TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: valor en la pila
 msgid "index heap"
 msgstr "nayrïri qutu"
 
@@ -4208,60 +4208,60 @@ msgstr "nayrïri qutu"
 #: js/blocks/HeapBlocks.js:572
 #: js/blocks/EnsembleBlocks.js:124
 #: js/blocks/EnsembleBlocks.js:1200
-#.TRANS: El índice debe ser > 0.
+#. TRANS: El índice debe ser > 0.
 msgid "Index must be > 0."
 msgstr "Wakichata > 0 chimputa jilañapawa"
 
 #: js/blocks/HeapBlocks.js:479
 #: js/blocks/HeapBlocks.js:577
 #: js/blocks/EnsembleBlocks.js:129
-#.TRANS: El tamaño máximo de pilas es 1000.
+#. TRANS: El tamaño máximo de pilas es 1000.
 msgid "Maximum heap size is 1000."
 msgstr "El tamaño máximo de pilas es 1000."
 
 #: js/blocks/HeapBlocks.js:523
-#.TRANS: El bloque Fijar entrada de pila establece un valor en la pila en la ubicación especificada.
+#. TRANS: El bloque Fijar entrada de pila establece un valor en la pila en la ubicación especificada.
 msgid "The Set-heap entry block sets a value in he heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
-#.TRANS: fijar pila
+#. TRANS: load the heap from a JSON encoding
+#. TRANS: fijar pila
 msgid "set heap"
 msgstr "Qutu kutichiy"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
-#.TRANS: posición en la pila
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: posición en la pila
 msgid "index"
 msgstr "wakichatanaka"
 
 #: js/blocks/HeapBlocks.js:619
-#.TRANS: El bloque Pop elimina el valor en la parte superior del pila.
+#. TRANS: El bloque Pop elimina el valor en la parte superior del pila.
 msgid "The Pop block removes the value at the top of the heap."
 msgstr "El bloque Pop elimina el valor en la parte superior del pila."
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
-#.TRANS: sacar
+#. TRANS: pop a value off the top of the heap
+#. TRANS: sacar
 msgid "pop"
 msgstr "hurquy"
 
 #: js/blocks/HeapBlocks.js:680
-#.TRANS: El bloque Push agrega un valor a la parte superior del pila.
+#. TRANS: El bloque Push agrega un valor a la parte superior del pila.
 msgid "The Push block adds a value to the top of the heap."
 msgstr "El bloque Push agrega un valor a la parte superior del pila."
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
-#.TRANS: apilar
+#. TRANS: push a value onto the top of the heap
+#. TRANS: apilar
 msgid "push"
 msgstr "tawqay"
 
 #: js/blocks/IntervalsBlocks.js:45
-#.TRANS: fijar temperamento
+#. TRANS: fijar temperamento
 msgid "set temperament"
 msgstr "q’uñipi k’askachiy"
 
@@ -4277,510 +4277,510 @@ msgstr "q’uñipi k’askachiy"
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
-#.TRANS: octava
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: octava
 msgid "octave"
 msgstr "pusaq pata"
 
 #: js/blocks/IntervalsBlocks.js:99
-#.TRANS: El bloque Nombre Temperamento se utiliza para seleccionar un método de ajuste.
+#. TRANS: El bloque Nombre Temperamento se utiliza para seleccionar un método de ajuste.
 msgid "The Temperament name block is used to select a tuning method."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:161
-#.TRANS: doble
+#. TRANS: doble
 msgid "doubly"
 msgstr "iskaycha"
 
 #: js/blocks/IntervalsBlocks.js:166
-#.TRANS: El bloque doble duplicará el tamaño de un intervalo.
+#. TRANS: El bloque doble duplicará el tamaño de un intervalo.
 msgid "The Doubly block will double the size of an interval."
 msgstr "iskaycha t’aqata iskaychanqa sayayninta unaymanta"
 
 #: js/blocks/IntervalsBlocks.js:262
-#.TRANS: número de intervalo
+#. TRANS: número de intervalo
 msgid "interval number"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:317
-#.TRANS: intervalo actua
+#. TRANS: intervalo actua
 msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
-#.TRANS: medida de intervalo semitono
+#. TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: medida de intervalo semitono
 msgid "semi-tone interval measure"
 msgstr "tupuy unaymanta kuskan kunka"
 
 #: js/blocks/IntervalsBlocks.js:454
 #: js/blocks/IntervalsBlocks.js:570
-#.TRANS: Debe usar dos bloques de tono cuando mida un intervalo.
+#. TRANS: Debe usar dos bloques de tono cuando mida un intervalo.
 msgid "You must use two pitch blocks when measuring an interval."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:496
-#.TRANS: El bloque Intervalo escalar mide la distancia entre dos notas en la clave y el modo actuales.
+#. TRANS: El bloque Intervalo escalar mide la distancia entre dos notas en la clave y el modo actuales.
 msgid "The Scalar interval block measures the distance between two notes in the current key and mode."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
-#.TRANS: medida de intervalo escalar
+#. TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: medida de intervalo escalar
 msgid "scalar interval measure"
 msgstr "tupuy unaymanta siqaq"
 
 #: js/blocks/IntervalsBlocks.js:678
-#.TRANS: En la figura, agregamos sol# a sol.
+#. TRANS: En la figura, agregamos sol# a sol.
 msgid "In the figure, we add sol# to sol."
 msgstr "En la figura, agregamos sol# a sol."
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
-#.TRANS: intervalo semitono
+#. TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: intervalo semitono
 msgid "semi-tone interval"
 msgstr "intervalo semitono"
 
 #: js/blocks/IntervalsBlocks.js:733
-#.TRANS: La salida del ejemplo es: do, mi, sol, sol, ti, mi
+#. TRANS: La salida del ejemplo es: do, mi, sol, sol, ti, mi
 msgid "The output of the example is: do, mi, sol, sol, ti, mi"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:740
 #: js/blocks/WidgetBlocks.js:768
-#.TRANS: arpegio
+#. TRANS: arpegio
 msgid "arpeggio"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:931
-#.TRANS: El bloque Acordes calcula acordes comunes.
+#. TRANS: El bloque Acordes calcula acordes comunes.
 msgid "The Chord block calculates common chords."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:933
-#.TRANS: En la figura generamos un acorde de C-mayor.
+#. TRANS: En la figura generamos un acorde de C-mayor.
 msgid "In the figure, we generate a C-major chord."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:938
-#.TRANS: acorde
+#. TRANS: acorde
 msgid "chord"
 msgstr "tinkuq kunka"
 
 #: js/blocks/IntervalsBlocks.js:990
-#.TRANS: El bloque intervalo de razón calcula un intervalo basado en una razón
+#. TRANS: El bloque intervalo de razón calcula un intervalo basado en una razón
 msgid "The Ratio Interval block calculates an interval based on a ratio."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:995
-#.TRANS: intervalo de razón
+#. TRANS: intervalo de razón
 msgid "ratio interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1064
-#.TRANS: En la figura, sumamos la a sol.
+#. TRANS: En la figura, sumamos la a sol.
 msgid "In the figure, we add la to sol."
 msgstr "En la figura, sumamos la a sol."
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
-#.TRANS: definir el modo
+#. TRANS: define a custom mode
+#. TRANS: definir el modo
 msgid "define mode"
 msgstr "definir el modo"
 
 #: js/blocks/IntervalsBlocks.js:1173
-#.TRANS: movible Do
+#. TRANS: movible Do
 msgid "movable Do"
 msgstr "movible Do"
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
-#.TRANS: longitud de modo
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: longitud de modo
 msgid "mode length"
 msgstr "Hina kay sunin"
 
 #: js/blocks/IntervalsBlocks.js:1233
-#.TRANS: El bloque Longitud de modo es el número de notas en la escala actual.
+#. TRANS: El bloque Longitud de modo es el número de notas en la escala actual.
 msgid "The Mode length block is the number of notes in the current scale."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1235
-#.TRANS: La mayoría de las escalas occidentales tienen 7 notas.
+#. TRANS: La mayoría de las escalas occidentales tienen 7 notas.
 msgid "Most Western scales have 7 notes."
 msgstr "La mayoría de las escalas occidentales tienen 7 notas."
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
-#.TRANS: modo actual
+#. TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: modo actual
 msgid "current mode"
 msgstr "Chaynalla kunka"
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
-#.TRANS: clave actual
+#. TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: clave actual
 msgid "current key"
 msgstr "kunan kichaq"
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
-#.TRANS: fijar clave
+#. TRANS: set the key and mode, e.g. C Major
+#. TRANS: fijar clave
 msgid "set key"
 msgstr "imañanaka wakichata limt'aña"
 
 #: js/blocks/IntervalsBlocks.js:1443
 #: js/blocks/IntervalsBlocks.js:1449
-#.TRANS: El bloque Fijar tecla se usa para configurar la tecla y el modo,
+#. TRANS: El bloque Fijar tecla se usa para configurar la tecla y el modo,
 msgid "The Set key block is used to set the key and mode,"
 msgstr "El bloque Fijar tecla se usa para configurar la tecla y el modo,"
 
 #: js/blocks/IntervalsBlocks.js:1449
-#.TRANS: por ejemplo, C Mayor
+#. TRANS: por ejemplo, C Mayor
 msgid "eg C Major"
 msgstr "C kuraq"
 
 #: js/blocks/NumberBlocks.js:28
-#.TRANS: El bloque Int devuelve un entero.
+#. TRANS: El bloque Int devuelve un entero.
 msgid "The Int block returns an integer."
 msgstr "El bloque Int devuelve un entero."
 
 #: js/blocks/NumberBlocks.js:34
-#.TRANS: int
+#. TRANS: int
 msgid "int"
 msgstr "int chimpu"
 
 #: js/blocks/NumberBlocks.js:73
-#.TRANS: El bloque Mod devuelve el resto de una división.
+#. TRANS: El bloque Mod devuelve el resto de una división.
 msgid "The Mod block returns the remainder from a division."
 msgstr "El bloque Mod devuelve el resto de una división."
 
 #: js/blocks/NumberBlocks.js:79
-#.TRANS: módulo
+#. TRANS: módulo
 msgid "mod"
 msgstr "kunka tupachiy"
 
 #: js/blocks/NumberBlocks.js:141
-#.TRANS: El bloque de potencia calcula una función de potencia.
+#. TRANS: El bloque de potencia calcula una función de potencia.
 msgid "The Power block calculates a power function."
 msgstr "El bloque de potencia calcula una función de potencia."
 
 #: js/blocks/NumberBlocks.js:196
-#.TRANS: El bloque Sqrt devuelve la raíz cuadrada.
+#. TRANS: El bloque Sqrt devuelve la raíz cuadrada.
 msgid "The Sqrt block returns the square root."
 msgstr "El bloque Sqrt devuelve la raíz cuadrada."
 
 #: js/blocks/NumberBlocks.js:202
-#.TRANS: raíz
+#. TRANS: raíz
 msgid "sqrt"
 msgstr "saphi"
 
 #: js/blocks/NumberBlocks.js:248
-#.TRANS: El bloque Abs devuelve el valor absoluto.
+#. TRANS: El bloque Abs devuelve el valor absoluto.
 msgid "The Abs block returns the absolute value."
 msgstr "El bloque Abs devuelve el valor absoluto."
 
 #: js/blocks/NumberBlocks.js:254
-#.TRANS: abs
+#. TRANS: abs
 msgid "abs"
 msgstr "abs chimpu"
 
 #: js/blocks/NumberBlocks.js:295
-#.TRANS: El bloque Distancia devuelve la distancia entre dos puntos. Por ejemplo, entre el ratón y el centro de la pantalla.
+#. TRANS: El bloque Distancia devuelve la distancia entre dos puntos. Por ejemplo, entre el ratón y el centro de la pantalla.
 msgid "The Distance block returns the distance between two points. For example, between the mouse and the center of the screen."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:301
 #: plugins/rodi.rtp:310
-#.TRANS: distancia
+#. TRANS: distancia
 msgid "distance"
 msgstr "karukay"
 
 #: js/blocks/NumberBlocks.js:361
-#.TRANS: El bloque División se usa para dividir.
+#. TRANS: El bloque División se usa para dividir.
 msgid "The Divide block is used to divide."
 msgstr "rakiy t’aqaqa rakinapaq apaykachakun"
 
 #: js/blocks/NumberBlocks.js:441
-#.TRANS: El bloque Multiplicar se usa para multiplicar.
+#. TRANS: El bloque Multiplicar se usa para multiplicar.
 msgid "The Multiply block is used to multiply."
 msgstr "Mirachiy t’aqaqa mirachinapaq apaykachay"
 
 #: js/blocks/NumberBlocks.js:612
-#.TRANS: El bloque Minus se usa para restar.
+#. TRANS: El bloque Minus se usa para restar.
 msgid "The Minus block is used to subtract."
 msgstr "Qichuy/minus t’aqaqa qichunapaq apaykachakun"
 
 #: js/blocks/NumberBlocks.js:723
-#.TRANS: El bloque Plus se utiliza para agregar.
+#. TRANS: El bloque Plus se utiliza para agregar.
 msgid "The Plus block is used to add."
 msgstr "Plus t’aqaqa yapanapaq apaykachakun"
 
 #: js/blocks/NumberBlocks.js:849
-#.TRANS: El bloque Uno de estos devuelve una de dos opciones.
+#. TRANS: El bloque Uno de estos devuelve una de dos opciones.
 msgid "The One-of block returns one of two choices."
 msgstr "El bloque Uno de estos devuelve una de dos opciones."
 
 #: js/blocks/NumberBlocks.js:856
 #: js/blocks/PitchBlocks.js:616
-#.TRANS: uno de estos
+#. TRANS: uno de estos
 msgid "one of"
 msgstr "huk kaykunamanta"
 
 #: js/blocks/NumberBlocks.js:858
-#.TRANS: éste
+#. TRANS: éste
 msgid "this"
 msgstr "kay"
 
 #: js/blocks/NumberBlocks.js:858
-#.TRANS: ése
+#. TRANS: ése
 msgid "that"
 msgstr "chay"
 
 #: js/blocks/NumberBlocks.js:913
-#.TRANS: El bloque Aleatorio devuelve un número aleatorio.
+#. TRANS: El bloque Aleatorio devuelve un número aleatorio.
 msgid "The Random block returns a random number."
 msgstr "El bloque Aleatorio devuelve un número aleatorio."
 
 #: js/blocks/NumberBlocks.js:920
-#.TRANS: aleatorio
+#. TRANS: aleatorio
 msgid "random"
 msgstr "chaqrusqa"
 
 #: js/blocks/NumberBlocks.js:922
-#.TRANS: min
+#. TRANS: min
 msgid "min"
 msgstr "pisi"
 
 #: js/blocks/NumberBlocks.js:922
-#.TRANS: max
+#. TRANS: max
 msgid "max"
 msgstr "achkha"
 
 #: js/blocks/NumberBlocks.js:986
-#.TRANS: El bloque Numérico contiene un número.
+#. TRANS: El bloque Numérico contiene un número.
 msgid "The Number block holds a number."
 msgstr "Yupay t’aqaqa huk yupayniyuq"
 
 #: js/blocks/OrnamentBlocks.js:32
-#.TRANS: factor de staccato
+#. TRANS: factor de staccato
 msgid "staccato factor"
 msgstr "staccato wakichata chimpu"
 
 #: js/blocks/OrnamentBlocks.js:108
-#.TRANS: factor de legato
+#. TRANS: factor de legato
 msgid "slur factor"
 msgstr "jist'thapiña wakichata chimpu"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
-#.TRANS: vecino
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: vecino
 msgid "neighbor"
 msgstr "wasimasi"
 
 #: js/blocks/OrnamentBlocks.js:293
-#.TRANS: El bloque Vecino cambia rápidamente entre los tonos vecinos.
+#. TRANS: El bloque Vecino cambia rápidamente entre los tonos vecinos.
 msgid "The Neighbor block rapidly switches between neighboring pitches."
 msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:364
-#.TRANS: deslizarse
+#. TRANS: deslizarse
 msgid "glide"
 msgstr "deslizarse"
 
 #: js/blocks/OrnamentBlocks.js:479
 #: js/blocks/OrnamentBlocks.js:643
-#.TRANS: legato
+#. TRANS: legato
 msgid "slur"
 msgstr "Jaquntäwi"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
-#.TRANS: staccato
+#. TRANS: play each note sharply detached from the others
+#. TRANS: staccato
 msgid "staccato"
 msgstr "staccato wakichata"
 
 #: js/blocks/ProgramBlocks.js:33
-#.TRANS: El bloque Cargar-pila-en-app carga la pila en una página web.
+#. TRANS: El bloque Cargar-pila-en-app carga la pila en una página web.
 msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
-#.TRANS: cargar pila desde aplicación
+#. TRANS: load the heap contents from a URL
+#. TRANS: cargar pila desde aplicación
 msgid "load heap from App"
 msgstr "App taypita kunaymana wakichaña"
 
 #: js/blocks/ProgramBlocks.js:95
-#.TRANS: Error de análisis de datos JSON.
+#. TRANS: Error de análisis de datos JSON.
 msgid "Error parsing JSON data:"
 msgstr "JSON wakichatanaka uñakipäwina pantjäwi"
 
 #: js/blocks/ProgramBlocks.js:100
-#.TRANS: 404: Página no encontrada.
+#. TRANS: 404: Página no encontrada.
 msgid "404: Page not found"
 msgstr "mana tarisqa p’anqa"
 
 #: js/blocks/ProgramBlocks.js:133
-#.TRANS: El bloque Guardar-pila-en-app guarda la pila en una página web.
+#. TRANS: El bloque Guardar-pila-en-app guarda la pila en una página web.
 msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr "El bloque Guardar-pila-en-app guarda la pila en una página web."
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
-#.TRANS: guardar pila a aplicación
+#. TRANS: save the heap contents to a URL
+#. TRANS: guardar pila a aplicación
 msgid "save heap to App"
 msgstr "Llapanta kay qutupi waqaychana"
 
 #: js/blocks/ProgramBlocks.js:189
-#.TRANS: Pilas tortuga no contiene un montón válida para
+#. TRANS: Pilas tortuga no contiene un montón válida para
 msgid "Cannot find a valid heap for"
 msgstr "Manam llapan qutupi tarikunchu"
 
 #: js/blocks/ProgramBlocks.js:206
-#.TRANS: El bloque Cargar pila carga la pila de un archivo.
+#. TRANS: El bloque Cargar pila carga la pila de un archivo.
 msgid "The Load-heap block loads the heap from a file."
 msgstr "El bloque Cargar pila carga la pila de un archivo."
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
-#.TRANS: cargar pila
+#. TRANS: load the heap from a file
+#. TRANS: cargar pila
 msgid "load heap"
 msgstr "Qututa apachiy"
 
 #: js/blocks/ProgramBlocks.js:270
-#.TRANS: El archivo seleccionado no contiene un pila válida.
+#. TRANS: El archivo seleccionado no contiene un pila válida.
 msgid "The file you selected does not contain a valid heap."
 msgstr "Wakichata chhijllata yaqha wakichataniwa"
 
 #: js/blocks/ProgramBlocks.js:275
-#.TRANS: El bloque Pila de carga necesita un bloque de archivo de carga.
+#. TRANS: El bloque Pila de carga necesita un bloque de archivo de carga.
 msgid "The loadHeap block needs a loadFile block."
 msgstr "wakichata siqi qhantayañataki maya qhantayaña wakichata mayi"
 
 #: js/blocks/ProgramBlocks.js:291
-#.TRANS: El bloque fijar pila carga la pila.
+#. TRANS: El bloque fijar pila carga la pila.
 msgid "The Set-heap block loads the heap."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:340
-#.TRANS: El bloque que seleccionó no contiene una pila válido.
+#. TRANS: El bloque que seleccionó no contiene una pila válido.
 msgid "The block you selected does not contain a valid heap."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:343
-#.TRANS: El bloque fija pila necesita una pila.
+#. TRANS: El bloque fija pila necesita una pila.
 msgid "The Set heap block needs a heap."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:360
-#.TRANS: El bloque Carga-diccionario carga un diccionario desde un archivo.
+#. TRANS: El bloque Carga-diccionario carga un diccionario desde un archivo.
 msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
-#.TRANS: carga diccionario
+#. TRANS: load a dictionary from a file
+#. TRANS: carga diccionario
 msgid "load dictionary"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:390
 #: js/blocks/ProgramBlocks.js:658
 #: js/blocks/ToneBlocks.js:1025
-#.TRANS: archivo
+#. TRANS: archivo
 msgid "file"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:444
-#.TRANS: El archivo que seleccionó no contiene un diccionario válido.
+#. TRANS: El archivo que seleccionó no contiene un diccionario válido.
 msgid "The file you selected does not contain a valid dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:449
-#.TRANS: El bloque de diccionario de carga necesita un bloque de archivo
+#. TRANS: El bloque de diccionario de carga necesita un bloque de archivo
 msgid "The load dictionary block needs a load file block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:466
-#.TRANS: El bloque fijar diccionario carga un diccionario.
+#. TRANS: El bloque fijar diccionario carga un diccionario.
 msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
-#.TRANS: fijar diccionario
+#. TRANS: load a dictionary from a JSON
+#. TRANS: fijar diccionario
 msgid "set dictionary"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:546
-#.TRANS: El bloque que seleccionó no contiene un diccionario válido.
+#. TRANS: El bloque que seleccionó no contiene un diccionario válido.
 msgid "The block you selected does not contain a valid dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:550
-#.TRANS: El bloque Fijar dictionario necesita un diccionario.
+#. TRANS: El bloque Fijar dictionario necesita un diccionario.
 msgid "The set dictionary block needs a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:567
-#.TRANS: El bloque Guardar pila guarda la pila en un archivo.
+#. TRANS: El bloque Guardar pila guarda la pila en un archivo.
 msgid "The Save-heap block saves the heap to a file."
 msgstr "El bloque Guardar pila guarda la pila en un archivo."
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
-#.TRANS: guardar pila
+#. TRANS: save the heap to a file
+#. TRANS: guardar pila
 msgid "save heap"
 msgstr "Qutupi waqaychay"
 
 #: js/blocks/ProgramBlocks.js:629
-#.TRANS: El bloque Guardar diccionario guarda el diccionario en un archivo
+#. TRANS: El bloque Guardar diccionario guarda el diccionario en un archivo
 msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
-#.TRANS: guardar diccionario
+#. TRANS: save a dictionary to a file
+#. TRANS: guardar diccionario
 msgid "save dictionary"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:720
-#.TRANS: El bloque abrir la paleta abre una paleta
+#. TRANS: El bloque abrir la paleta abre una paleta
 msgid "The Open palette block opens a palette."
 msgstr "El bloque abrir la paleta abre una paleta"
 
 #: js/blocks/ProgramBlocks.js:727
-#.TRANS: abrir la paleta
+#. TRANS: abrir la paleta
 msgid "open palette"
 msgstr "llimp’ipa taqinta kichay"
 
 #: js/blocks/ProgramBlocks.js:785
-#.TRANS: El bloque eliminar bloque elimina un bloque
+#. TRANS: El bloque eliminar bloque elimina un bloque
 msgid "The Delete block block removes a block."
 msgstr "El bloque eliminar bloque elimina un bloque"
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
-#.TRANS: eliminar bloque
+#. TRANS: Move this block to the trash.
+#. TRANS: eliminar bloque
 msgid "delete block"
 msgstr "kay chiqasta chanqapuy"
 
 #: js/blocks/ProgramBlocks.js:861
-#.TRANS: El bloque mover bloque mueve un bloque.
+#. TRANS: El bloque mover bloque mueve un bloque.
 msgid "The Move block block moves a block."
 msgstr "El bloque mover bloque mueve un bloque."
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
-#.TRANS: mover bloque
+#. TRANS: Move the position of a block on the screen.
+#. TRANS: mover bloque
 msgid "move block"
 msgstr "kay chiqasta kuyuchiy"
 
 #: js/blocks/ProgramBlocks.js:881
 #: js/blocks/ProgramBlocks.js:1048
-#.TRANS: número de bloque
+#. TRANS: número de bloque
 msgid "block number"
 msgstr "kay chiqaspa payupaynin"
 
@@ -4793,7 +4793,7 @@ msgstr "kay chiqaspa payupaynin"
 #: js/blocks/GraphicsBlocks.js:478
 #: js/blocks/GraphicsBlocks.js:525
 #: js/blocks/GraphicsBlocks.js:741
-#.TRANS: x
+#. TRANS: x
 msgid "x"
 msgstr "x"
 
@@ -4806,45 +4806,45 @@ msgstr "x"
 #: js/blocks/GraphicsBlocks.js:478
 #: js/blocks/GraphicsBlocks.js:525
 #: js/blocks/GraphicsBlocks.js:741
-#.TRANS: y
+#. TRANS: y
 msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
-#.TRANS: ejecutar bloque
+#. TRANS: Run program beginning at this block.
+#. TRANS: ejecutar bloque
 msgid "run block"
 msgstr "kay chiqasta ruray"
 
 #: js/blocks/ProgramBlocks.js:1025
-#.TRANS: El bloque connectar conecta dos bloques
+#. TRANS: El bloque connectar conecta dos bloques
 msgid "The Dock block block connections two blocks."
 msgstr "El bloque connectar conecta dos bloques"
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
-#.TRANS: connectar block
+#. TRANS: We can connect a block to another block.
+#. TRANS: connectar block
 msgid "connect blocks"
 msgstr "chiqasta hap’ichiy"
 
 #: js/blocks/ProgramBlocks.js:1048
-#.TRANS: bloque de destino
+#. TRANS: bloque de destino
 msgid "target block"
 msgstr "mayman chiqas riq "
 
 #: js/blocks/ProgramBlocks.js:1048
-#.TRANS: número de conexion
+#. TRANS: número de conexion
 msgid "connection number"
 msgstr "hap’ichiypa yupaynin"
 
 #: js/blocks/ProgramBlocks.js:1140
-#.TRANS: El bloque crear bloque crea un bloque.
+#. TRANS: El bloque crear bloque crea un bloque.
 msgid "The Make block block creates a new block."
 msgstr "El bloque crear bloque crea un bloque."
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
-#.TRANS: crear bloque
+#. TRANS: Create a new block
+#. TRANS: crear bloque
 msgid "make block"
 msgstr " chiqasta paqarichiy"
 
@@ -4859,152 +4859,152 @@ msgstr " chiqasta paqarichiy"
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
-#.TRANS: nota
+#. TRANS: a musical note consisting of pitch and duration
+#. TRANS: nota
 msgid "note"
 msgstr "kunka"
 
 #: js/blocks/ProgramBlocks.js:1285
-#.TRANS: No se puede encontrar el bloque.
+#. TRANS: No se puede encontrar el bloque.
 msgid "Cannot find block"
 msgstr "Manam chiqas tarikunchu"
 
 #: js/blocks/ProgramBlocks.js:1304
 #: js/blocks/ProgramBlocks.js:1313
-#.TRANS: Advertencia: el tipo de argumento de bloque no coincide
+#. TRANS: Advertencia: el tipo de argumento de bloque no coincide
 msgid "Warning: block argument type mismatch"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1347
-#.TRANS: El bloque Abrir proyecto se utiliza para abrir un proyecto desde una página web.
+#. TRANS: El bloque Abrir proyecto se utiliza para abrir un proyecto desde una página web.
 msgid "The Open project block is used to open a project from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1357
-#.TRANS: abierto proyecto
+#. TRANS: abierto proyecto
 msgid "open project"
 msgstr "rurana kichasqa"
 
 #: js/blocks/ProgramBlocks.js:1410
-#.TRANS: Por favor introduzca un URL válido.
+#. TRANS: Por favor introduzca un URL válido.
 msgid "Please enter a valid URL."
 msgstr "Ama hina waliq URLta haykuchiy"
 
 #: js/blocks/RhythmBlocks.js:182
 #: js/blocks/RhythmBlocks.js:1086
 #: js/blocks/RhythmBlocks.js:1162
-#.TRANS: Valor de la nota debe ser mayor que 0.
+#. TRANS: Valor de la nota debe ser mayor que 0.
 msgid "Note value must be greater than 0."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
-#.TRANS: swing
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing
 msgid "swing"
 msgstr "jiwalachi"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
-#.TRANS: valor de swing
+#. TRANS: the amount to shift to the offbeat note
+#. TRANS: valor de swing
 msgid "swing value"
 msgstr "swing wakichata chanipa"
 
 #: js/blocks/RhythmBlocks.js:419
-#.TRANS: El bloque Omitir notas hará que las notas se omitan.
+#. TRANS: El bloque Omitir notas hará que las notas se omitan.
 msgid "The Skip notes block will cause notes to be skipped."
 msgstr "El bloque Omitir notas hará que las notas se omitan."
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
-#.TRANS: saltar notas
+#. TRANS: substitute rests on notes being skipped
+#. TRANS: saltar notas
 msgid "skip notes"
 msgstr "kunkakuna p’itay"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
-#.TRANS: ritmo multiplican
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: ritmo multiplican
 msgid "multiply note value"
 msgstr "Muyuq miracchiq"
 
 #: js/blocks/RhythmBlocks.js:542
-#.TRANS: El bloque Atar funciona en pares de notas, combinándolas en una sola nota.
+#. TRANS: El bloque Atar funciona en pares de notas, combinándolas en una sola nota.
 msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
-#.TRANS: atar
+#. TRANS: tie notes together into one longer note
+#. TRANS: atar
 msgid "tie"
 msgstr "Watay"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
-#.TRANS: punto
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: punto
 msgid "dot"
 msgstr "Ch’iku)"
 
 #: js/blocks/RhythmBlocks.js:619
 #: js/turtleactions/RhythmActions.js:221
-#.TRANS: Un argumento de -1 da como resultado un valor de nota de 0.
+#. TRANS: Un argumento de -1 da como resultado un valor de nota de 0.
 msgid "An argument of -1 results in a note value of 0."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:661
-#.TRANS: El bloque Punto extiende la duración de una nota en un 50%.
+#. TRANS: El bloque Punto extiende la duración de una nota en un 50%.
 msgid "The Dot block extends the duration of a note by 50%."
 msgstr "El bloque Punto extiende la duración de una nota en un 50%."
 
 #: js/blocks/RhythmBlocks.js:663
-#.TRANS: Por ejemplo, una nota de un cuarto de puntos se reproducirá a 3/8 (1/4 + 1/8) de un tiempo.
+#. TRANS: Por ejemplo, una nota de un cuarto de puntos se reproducirá a 3/8 (1/4 + 1/8) de un tiempo.
 msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
-#.TRANS: Valor de nota tambor
+#. TRANS: Japanese only: note value block for drum
+#. TRANS: Valor de nota tambor
 msgid "note value drum"
 msgstr "Valor de nota tambor"
 
 #: js/blocks/RhythmBlocks.js:829
-#.TRANS: 392 hertz
+#. TRANS: 392 hertz
 msgid "392 hertz"
 msgstr "329 kaparina"
 
 #: js/blocks/RhythmBlocks.js:1119
-#.TRANS: El bloque Nota es un contenedor para uno o más bloques de tono.
+#. TRANS: El bloque Nota es un contenedor para uno o más bloques de tono.
 msgid "The Note block is a container for one or more Pitch blocks."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:1121
-#.TRANS: El bloque Notas especifica la duración (valor de la nota) de su contenido.
+#. TRANS: El bloque Notas especifica la duración (valor de la nota) de su contenido.
 msgid "The Note block specifies the duration (note value) of its contents."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:1130
-#.TRANS: valor
+#. TRANS: valor
 msgid "value2"
 msgstr "valor"
 
 #: js/blocks/RhythmBlocks.js:1200
-#.TRANS: definir frecuencia
+#. TRANS: definir frecuencia
 msgid "define frequency"
 msgstr "definir frecuencia"
 
 #: js/blocks/RhythmBlocks.js:1218
 #: js/widgets/temperament.js:757
 #: js/widgets/temperament.js:1522
-#.TRANS: espacio de octava
+#. TRANS: espacio de octava
 msgid "octave space"
 msgstr "pusaqpa pachan"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
-#.TRANS: ritmo
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
+#. TRANS: ritmo
 msgid "rhythm1"
 msgstr "ritmo"
 
@@ -5013,177 +5013,177 @@ msgstr "ritmo"
 #: js/blocks/RhythmBlockPaletteBlocks.js:517
 #: js/blocks/RhythmBlockPaletteBlocks.js:586
 #: js/blocks/RhythmBlockPaletteBlocks.js:907
-#.TRANS: número de notas
+#. TRANS: número de notas
 msgid "number of notes"
 msgstr "Yupay waqaykuna"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:126
-#.TRANS: ritmo polifónico
+#. TRANS: ritmo polifónico
 msgid "polyphonic rhythm"
 msgstr "Achka waqaykunap Munay muyuchik"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:219
-#.TRANS: El bloque Ritmo se utiliza para generar patrones de ritmo.
+#. TRANS: El bloque Ritmo se utiliza para generar patrones de ritmo.
 msgid "The Rhythm block is used to generate rhythm patterns."
 msgstr "Munay purichiqa kinkinman hina qatipaq"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:281
 #: js/blocks/RhythmBlockPaletteBlocks.js:286
-#.TRANS: 1/64 nota
+#. TRANS: 1/64 nota
 msgid "1/64 note"
 msgstr "1/64 kunka"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:312
 #: js/blocks/RhythmBlockPaletteBlocks.js:317
-#.TRANS: 1/32 nota
+#. TRANS: 1/32 nota
 msgid "1/32 note"
 msgstr "Kunkaq tahasqan"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:346
 #: js/blocks/RhythmBlockPaletteBlocks.js:351
-#.TRANS: 1/16 nota
+#. TRANS: 1/16 nota
 msgid "1/16 note"
 msgstr "1/6 kunka"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:380
-#.TRANS: 1/8 nota
+#. TRANS: 1/8 nota
 msgid "eighth note"
 msgstr "1/8 kunka"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:408
-#.TRANS: 1/4 nota
+#. TRANS: 1/4 nota
 msgid "quarter note"
 msgstr "1/4 kunka"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:436
 #: js/blocks/RhythmBlockPaletteBlocks.js:441
-#.TRANS: 1/2 nota
+#. TRANS: 1/2 nota
 msgid "half note"
 msgstr "1/2 kunka"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:470
 #: js/blocks/RhythmBlockPaletteBlocks.js:475
-#.TRANS: nota completa
+#. TRANS: nota completa
 msgid "whole note"
 msgstr "hunt’asqa kunka"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
-#.TRANS: tuplet
+#. TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: tuplet
 msgid "tuplet"
 msgstr "tupla chimpu"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:800
-#.TRANS: septeto
+#. TRANS: septeto
 msgid "septuplet"
 msgstr "Qanchikmanta"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:828
-#.TRANS: quinteto
+#. TRANS: quinteto
 msgid "quintuplet"
 msgstr "Phisqamanta"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:856
-#.TRANS: trillizo
+#. TRANS: trillizo
 msgid "triplet"
 msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:883
-#.TRANS: tuplet simple
+#. TRANS: tuplet simple
 msgid "simple tuplet"
 msgstr "tuplet simple"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:893
-#.TRANS: Tuplets son una colección de notas que se escalan a una duración específica.
+#. TRANS: Tuplets son una colección de notas que se escalan a una duración específica.
 msgid "Tuplets are a collection of notes that get scaled to a specific duration."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:41
-#.TRANS: El bloque Atrás ejecuta el código en orden inverso (retrógrado en la música).
+#. TRANS: El bloque Atrás ejecuta el código en orden inverso (retrógrado en la música).
 msgid "The Backward block runs code in reverse order (Musical retrograde)."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:48
-#.TRANS: hacia atrás
+#. TRANS: hacia atrás
 msgid "backward"
 msgstr "Qhipaman"
 
 #: js/blocks/FlowBlocks.js:124
-#.TRANS: El bloque Duplicado ejecutará cada bloque varias veces.
+#. TRANS: El bloque Duplicado ejecutará cada bloque varias veces.
 msgid "The Duplicate block will run each block multiple times."
 msgstr "Iskay kikinyachiq sayaq, ruranqa sapanka sayaqta achka kutita"
 
 #: js/blocks/FlowBlocks.js:334
-#.TRANS: El bloque predeterminado se usa dentro de un bloque de switch para definir la acción predeterminada.
+#. TRANS: El bloque predeterminado se usa dentro de un bloque de switch para definir la acción predeterminada.
 msgid "The Default block is used inside of a Switch to define the default action."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:342
-#.TRANS: el caso de forma predeterminada
+#. TRANS: el caso de forma predeterminada
 msgid "default"
 msgstr "Chhaynapaq rurasqa"
 
 #: js/blocks/FlowBlocks.js:361
 #: js/blocks/FlowBlocks.js:418
-#.TRANS: El bloque Caso debe utilizarse dentro de un bloque de switch.
+#. TRANS: El bloque Caso debe utilizarse dentro de un bloque de switch.
 msgid "The Case Block must be used inside of a Switch Block."
 msgstr "El bloque Caso debe utilizarse dentro de un bloque de switch."
 
 #: js/blocks/FlowBlocks.js:389
-#.TRANS: El bloque Caso se utiliza dentro de un interruptor para definir coincidencias.
+#. TRANS: El bloque Caso se utiliza dentro de un interruptor para definir coincidencias.
 msgid "The Case block is used inside of a Switch to define matches."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:397
-#.TRANS: caso
+#. TRANS: caso
 msgid "case"
 msgstr "uka chimpu"
 
 #: js/blocks/FlowBlocks.js:446
-#.TRANS: El bloque Switch ejecutará el código en el caso correspondiente.
+#. TRANS: El bloque Switch ejecutará el código en el caso correspondiente.
 msgid "The Switch block will run the code in the matching Case."
 msgstr "El bloque Switch ejecutará el código en el caso correspondiente."
 
 #: js/blocks/FlowBlocks.js:454
-#.TRANS: switch
+#. TRANS: switch
 msgid "switch"
 msgstr "tinkuchiy"
 
 #: js/blocks/FlowBlocks.js:595
-#.TRANS: El bloque Parar detendrá un bucle.
+#. TRANS: El bloque Parar detendrá un bucle.
 msgid "The Stop block will stop a loop"
 msgstr "El bloque Parar detendrá un bucle."
 
 #: js/blocks/FlowBlocks.js:597
-#.TRANS: Por siempre, Repetir, Mientras o Hasta.
+#. TRANS: Por siempre, Repetir, Mientras o Hasta.
 msgid "Forever, Repeat, While, or Until."
 msgstr "Por siempre, Repetir, Mientras o Hasta."
 
 #: js/blocks/FlowBlocks.js:653
-#.TRANS: El bloque Esperar esperará hasta que la condición sea verdadera.
+#. TRANS: El bloque Esperar esperará hasta que la condición sea verdadera.
 msgid "The Waitfor block will wait until the condition is true."
 msgstr "El bloque Esperar esperará hasta que la condición sea verdadera."
 
 #: js/blocks/FlowBlocks.js:661
-#.TRANS: esperar hasta
+#. TRANS: esperar hasta
 msgid "wait for"
 msgstr "ukakama suyt’aña"
 
 #: js/blocks/FlowBlocks.js:732
-#.TRANS: El bloque Hasta se repetirá hasta que la condición sea verdadera.
+#. TRANS: El bloque Hasta se repetirá hasta que la condición sea verdadera.
 msgid "The Until block will repeat until the condition is true."
 msgstr "El bloque Hasta se repetirá hasta que la condición sea verdadera."
 
 #: js/blocks/FlowBlocks.js:740
-#.TRANS: hasta
+#. TRANS: hasta
 msgid "until"
 msgstr "kay kama"
 
 #: js/blocks/FlowBlocks.js:742
 #: js/blocks/FlowBlocks.js:822
-#.TRANS: hacer
+#. TRANS: hacer
 msgid "do2"
 msgstr "hacer"
 
@@ -5194,96 +5194,96 @@ msgstr "hacer"
 #: js/blocks/ActionBlocks.js:610
 #: js/blocks/ActionBlocks.js:959
 #: js/blocks/ActionBlocks.js:1048
-#.TRANS: hacer
+#. TRANS: hacer
 msgid "do"
 msgstr "Ruray"
 
 #: js/blocks/FlowBlocks.js:812
-#.TRANS: El bloque Mientras se repetirá mientras la condición sea verdadera.
+#. TRANS: El bloque Mientras se repetirá mientras la condición sea verdadera.
 msgid "The While block will repeat while the condition is true."
 msgstr "El bloque Mientras se repetirá mientras la condición sea verdadera."
 
 #: js/blocks/FlowBlocks.js:820
-#.TRANS: mientras
+#. TRANS: mientras
 msgid "while"
 msgstr "chaykamataq"
 
 #: js/blocks/FlowBlocks.js:903
 #: js/blocks/FlowBlocks.js:968
 #: js/blocks/FlowBlocks.js:979
-#.TRANS: En este ejemplo, si se presiona el botón del mouse, se reproducirá una caja.
+#. TRANS: En este ejemplo, si se presiona el botón del mouse, se reproducirá una caja.
 msgid "In this example if the mouse button is pressed a snare drum will play."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:925
 #: js/blocks/FlowBlocks.js:988
-#.TRANS: si
+#. TRANS: si
 msgid "if"
 msgstr "arí"
 
 #: js/blocks/FlowBlocks.js:927
 #: js/blocks/FlowBlocks.js:990
-#.TRANS: entonces
+#. TRANS: entonces
 msgid "then"
 msgstr "chaynaqa"
 
 #: js/blocks/FlowBlocks.js:927
-#.TRANS: sino
+#. TRANS: sino
 msgid "else"
 msgstr "mana chayqa"
 
 #: js/blocks/FlowBlocks.js:1025
-#.TRANS: El bloque Por siempre repetirá los bloques contenidos para siempre.
+#. TRANS: El bloque Por siempre repetirá los bloques contenidos para siempre.
 msgid "The Forever block will repeat the contained blocks forever."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:1037
-#.TRANS: por siempre
+#. TRANS: por siempre
 msgid "forever"
 msgstr "wiñaypaq"
 
 #: js/blocks/FlowBlocks.js:1073
-#.TRANS: El bloque Repetir repetirá los bloques contenidos.
+#. TRANS: El bloque Repetir repetirá los bloques contenidos.
 msgid "The Repeat block will repeat the contained blocks."
 msgstr "El bloque Repetir repetirá los bloques contenidos."
 
 #: js/blocks/FlowBlocks.js:1075
-#.TRANS: En este ejemplo la nota se tocará 4 veces.
+#. TRANS: En este ejemplo la nota se tocará 4 veces.
 msgid "In this example the note will be played 4 times."
 msgstr "En este ejemplo la nota se tocará 4 veces."
 
 #: js/blocks/FlowBlocks.js:1083
-#.TRANS: repetir
+#. TRANS: repetir
 msgid "repeat"
 msgstr "huktawan"
 
 #: js/blocks/FlowBlocks.js:1123
-#.TRANS: duplicar factor
+#. TRANS: duplicar factor
 msgid "duplicate factor"
 msgstr "panichiri chimpu"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
-#.TRANS: meter actuale
+#. TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: meter actuale
 msgid "current meter"
 msgstr "actualita haykuchiy"
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
-#.TRANS: factor de ritmo
+#. TRANS: number of beats per minute
+#. TRANS: factor de ritmo
 msgid "beat factor"
 msgstr "p’ullpuqiy"
 
 #: js/blocks/MeterBlocks.js:161
-#.TRANS: El bloque de latidos por minuto devuelve los latidos actuales por minuto.
+#. TRANS: El bloque de latidos por minuto devuelve los latidos actuales por minuto.
 msgid "The Beats per minute block returns the current beats per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
-#.TRANS: pulsaciones por minuto
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: pulsaciones por minuto
 msgid "beats per minute2"
 msgstr "minutupi p’ullpuqiy"
 
@@ -5291,25 +5291,25 @@ msgstr "minutupi p’ullpuqiy"
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
-#.TRANS: pulsaciones por minuto
+#. TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: pulsaciones por minuto
 msgid "beats per minute"
 msgstr "minutupi p’ullpuqiy"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
-#.TRANS: cuenta de medidas
+#. TRANS: count of current musical measure in meter
+#. TRANS: cuenta de medidas
 msgid "measure count"
 msgstr "tupusqakunapa yupaynin"
 
 #: js/blocks/MeterBlocks.js:242
-#.TRANS: El bloque de conteo de medidas devuelve la medida actual.
+#. TRANS: El bloque de conteo de medidas devuelve la medida actual.
 msgid "The Measure count block returns the current measure."
 msgstr "tupunakuna yupay chiqasqa kunan tupunata kutichipun"
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
-#.TRANS: cuenta de latidos
+#. TRANS: count of current beat in the meter
+#. TRANS: cuenta de latidos
 msgid "beat count"
 msgstr "p’ullpuqiyta yupay"
 
@@ -5317,85 +5317,85 @@ msgstr "p’ullpuqiyta yupay"
 #: js/blocks/MeterBlocks.js:312
 #: js/blocks/MeterBlocks.js:566
 #: js/blocks/MeterBlocks.js:577
-#.TRANS: El bloque Conteo de tiempos es el número del tiempo actual,
+#. TRANS: El bloque Conteo de tiempos es el número del tiempo actual,
 msgid "The Beat count block is the number of the current beat,"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:314
 #: js/blocks/MeterBlocks.js:579
-#.TRANS: por ejemplo, 1, 2, 3, o 4.
+#. TRANS: por ejemplo, 1, 2, 3, o 4.
 msgid "eg 1, 2, 3, or 4."
 msgstr "kanman huk, iskay, kimsa, kallanmantaq tawa"
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
-#.TRANS: cuenta las notas
+#. TRANS: count the number of notes
+#. TRANS: cuenta las notas
 msgid "sum note values"
 msgstr "nota yupay"
 
 #: js/blocks/MeterBlocks.js:377
 #: js/blocks/MeterBlocks.js:441
-#.TRANS: El bloque Contador de notas se puede usar para contar el número de notas contenidas.
+#. TRANS: El bloque Contador de notas se puede usar para contar el número de notas contenidas.
 msgid "The Note counter block can be used to count the number of contained notes."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
-#.TRANS: cuenta las notas
+#. TRANS: count the number of notes
+#. TRANS: cuenta las notas
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
-#.TRANS: notas completa jugadas
+#. TRANS: number of whole notes that have been played
+#. TRANS: notas completa jugadas
 msgid "whole notes played"
 msgstr "hunt’asqa nota pukllasqakuna"
 
 #: js/blocks/MeterBlocks.js:506
-#.TRANS: El bloque Nota completa reproducidas devuelve el número total de notas completas reproducidas.
+#. TRANS: El bloque Nota completa reproducidas devuelve el número total de notas completas reproducidas.
 msgid "The Whole notes played block returns the total number of whole notes played."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
-#.TRANS: notas jugadas
+#. TRANS: number of notes that have been played
+#. TRANS: notas jugadas
 msgid "notes played"
 msgstr "notakuna pukllasqakuna"
 
 #: js/blocks/MeterBlocks.js:654
-#.TRANS: El bloque Sin reloj desacopla las notas del reloj maestro.
+#. TRANS: El bloque Sin reloj desacopla las notas del reloj maestro.
 msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
-#.TRANS: sin reloj
+#. TRANS: don't lock notes to master clock
+#. TRANS: sin reloj
 msgid "no clock"
 msgstr "mana intiwatanayuq"
 
 #: js/blocks/MeterBlocks.js:701
-#.TRANS: en latido débil hacer
+#. TRANS: en latido débil hacer
 msgid "on weak beat do"
 msgstr "mana kallpayuq p’ullpuqiypi rurana"
 
 #: js/blocks/MeterBlocks.js:706
-#.TRANS: El bloque En-latido-débil-hacer te permite especificar acciones a realizar en latido débiles.
+#. TRANS: El bloque En-latido-débil-hacer te permite especificar acciones a realizar en latido débiles.
 msgid "The On-weak-beat block lets you specify actions to take on weak (off) beats."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:751
-#.TRANS: en latido fuerte hacer
+#. TRANS: en latido fuerte hacer
 msgid "on strong beat"
 msgstr "kallpayuq p’ullpuqiypi rurana"
 
 #: js/blocks/MeterBlocks.js:759
-#.TRANS: El bloque En-latido-fuerte-hacer le permite especificar acciones a realizar en latido específicos.
+#. TRANS: El bloque En-latido-fuerte-hacer le permite especificar acciones a realizar en latido específicos.
 msgid "The On-strong-beat block lets you specify actions to take on specified beats."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:770
-#.TRANS: latidos
+#. TRANS: latidos
 msgid "beat"
 msgstr "p’ullpuqiy"
 
@@ -5404,123 +5404,123 @@ msgstr "p’ullpuqiy"
 #: js/blocks/ActionBlocks.js:610
 #: js/blocks/ActionBlocks.js:959
 #: js/blocks/ActionBlocks.js:1048
-#.TRANS: do
+#. TRANS: do
 msgid "do1"
 msgstr "do"
 
 #: js/blocks/MeterBlocks.js:814
-#.TRANS: en cado latodo hacer
+#. TRANS: en cado latodo hacer
 msgid "on every beat do"
 msgstr "en cada latodo hacer"
 
 #: js/blocks/MeterBlocks.js:822
-#.TRANS: El bloque En-cado-latido-hacer le permite especificar acciones a realizar en cado latado.
+#. TRANS: El bloque En-cado-latido-hacer le permite especificar acciones a realizar en cado latado.
 msgid "The On-every-beat block lets you specify actions to take on every beat."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:875
-#.TRANS: en cada nota hacer
+#. TRANS: en cada nota hacer
 msgid "on every note do"
 msgstr "en cada nota hacer"
 
 #: js/blocks/MeterBlocks.js:883
-#.TRANS: El bloque En-cada-nota-hacer le permite especificar acciones a realizar en cada nota.
+#. TRANS: El bloque En-cada-nota-hacer le permite especificar acciones a realizar en cada nota.
 msgid "The On-every-note block lets you specify actions to take on every note."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
-#.TRANS: latidos por minuto de dominar
+#. TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: latidos por minuto de dominar
 msgid "master beats per minute"
 msgstr "minutupi p’ullpuqiy hap’iy"
 
 #: js/blocks/MeterBlocks.js:953
 #: js/blocks/MeterBlocks.js:1079
 #: js/blocks/MeterBlocks.js:1136
-#.TRANS: lpm
+#. TRANS: lpm
 msgid "bpm"
 msgstr "bmp"
 
 #: js/blocks/MeterBlocks.js:953
 #: js/blocks/MeterBlocks.js:1079
 #: js/blocks/MeterBlocks.js:1136
-#.TRANS: valor de latidos
+#. TRANS: valor de latidos
 msgid "beat value"
 msgstr "p’ullpuqiypa kaqnin"
 
 #: js/blocks/MeterBlocks.js:1025
 #: js/blocks/MeterBlocks.js:1168
 #: js/blocks/MeterBlocks.js:1242
-#.TRANS: Latidos por minuto debe ser > 30.
+#. TRANS: Latidos por minuto debe ser > 30.
 msgid "Beats per minute must be > 30."
 msgstr "minutupi p’ullpuqiyniqa 30 kurakmi kanan"
 
 #: js/blocks/MeterBlocks.js:1028
 #: js/blocks/MeterBlocks.js:1171
 #: js/blocks/MeterBlocks.js:1245
-#.TRANS: Los latidos por minuto como máximo es de 1000.
+#. TRANS: Los latidos por minuto como máximo es de 1000.
 msgid "Maximum beats per minute is 1000."
 msgstr " minutupi p’ullpuqiyniqa may tukupunankamaqa waranqan (1000) kanan"
 
 #: js/blocks/MeterBlocks.js:1069
-#.TRANS: El bloque Pulsaciones por minuto establece el número de 1/4 notas por minuto.
+#. TRANS: El bloque Pulsaciones por minuto establece el número de 1/4 notas por minuto.
 msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
-#.TRANS: 
+#. TRANS: anacrusis
+#. TRANS: 
 msgid "pickup"
 msgstr "pallay"
 
 #: js/blocks/MeterBlocks.js:1368
-#.TRANS: número de latidos
+#. TRANS: número de latidos
 msgid "number of beats"
 msgstr "p’ullpuqiypa yupanan"
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
-#.TRANS: transposición
+#. TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: transposición
 msgid "transposition"
 msgstr "haywapuynin"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
-#.TRANS: escalar bajar
+#. TRANS: step down one note in current musical scale
+#. TRANS: escalar bajar
 msgid "scalar step down"
 msgstr "wichay uraqay"
 
 #: js/blocks/PitchBlocks.js:172
-#.TRANS: El bloque Escalar bajar devuelve el número de semitonos a la nota anterior en la tecla y modo actuales.
+#. TRANS: El bloque Escalar bajar devuelve el número de semitonos a la nota anterior en la tecla y modo actuales.
 msgid "The Scalar step down block returns the number of semi-tones down to the previous note in the current key and mode."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
-#.TRANS: escalar aumentar
+#. TRANS: step up one note in current musical scale
+#. TRANS: escalar aumentar
 msgid "scalar step up"
 msgstr "wichay yapaykuy"
 
 #: js/blocks/PitchBlocks.js:194
-#.TRANS: El bloque Escalar aumentar devuelve el número de semitonos hasta la siguiente nota en la tecla y modo actuales.
+#. TRANS: El bloque Escalar aumentar devuelve el número de semitonos hasta la siguiente nota en la tecla y modo actuales.
 msgid "The Scalar step up block returns the number of semi-tones up to the next note in the current key and mode."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
-#.TRANS: cambio en tono
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: cambio en tono
 msgid "change in pitch"
 msgstr "kunkan t’ikrasqa"
 
 #: js/blocks/PitchBlocks.js:216
-#.TRANS: El cambio en el bloque de tono es la diferencia (en medio pasos) entre el tono actual que se está reproduciendo y el tono anterior.
+#. TRANS: El cambio en el bloque de tono es la diferencia (en medio pasos) entre el tono actual que se está reproduciendo y el tono anterior.
 msgid "The Change in pitch block is the difference (in half steps) between the current pitch being played and the previous pitch played."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
-#.TRANS: cambio en tono escalar
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: cambio en tono escalar
 msgid "scalar change in pitch"
 msgstr "cambio en tono escalar"
 
@@ -5531,111 +5531,111 @@ msgstr "cambio en tono escalar"
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
-#.TRANS: número de tono
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: número de tono
 msgid "pitch number"
 msgstr "kunkapa yupaynin"
 
 #: js/blocks/PitchBlocks.js:256
-#.TRANS: El bloque Número de tono es el valor del tono de la nota que se está reproduciendo actualmente.
+#. TRANS: El bloque Número de tono es el valor del tono de la nota que se está reproduciendo actualmente.
 msgid "The Pitch number block is the value of the pitch of the note currently being played."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
-#.TRANS: tono en hertz
+#. TRANS: the current pitch expressed in Hertz
+#. TRANS: tono en hertz
 msgid "pitch in hertz"
 msgstr "hertzpi kunkan"
 
 #: js/blocks/PitchBlocks.js:334
-#.TRANS: El bloque Tono en Hertz es el valor en hercios del tono de la nota que se está reproduciendo actualmente.
+#. TRANS: El bloque Tono en Hertz es el valor en hercios del tono de la nota que se está reproduciendo actualmente.
 msgid "The Pitch in Hertz block is the value in Hertz of the pitch of the note currently being played."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:367
 #: js/turtleactions/DictActions.js:87
-#.TRANS: tono actual
+#. TRANS: tono actual
 msgid "current pitch"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:373
-#.TRANS: El bloque de tono actual se utiliza con el bloque convertidor de tono. En el ejemplo anterior, el tono actual, sol 4, se muestra como 392 hercios.
+#. TRANS: El bloque de tono actual se utiliza con el bloque convertidor de tono. En el ejemplo anterior, el tono actual, sol 4, se muestra como 392 hercios.
 msgid "The Current Pitch block is used with the Pitch Converter block. In the example above, current pitch, sol 4, is displayed as 392 hertz."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:410
-#.TRANS: Este bloque convierte el valor de tono de la última nota tocada en diferentes formatos como hertz, nombre de letra, número de tono, etc.
+#. TRANS: Este bloque convierte el valor de tono de la última nota tocada en diferentes formatos como hertz, nombre de letra, número de tono, etc.
 msgid "This block converts the pitch value of the last note played into different formats such as hertz, letter name, pitch number, et al."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:434
-#.TRANS: alfabeto
+#. TRANS: alfabeto
 msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
-#.TRANS: clase de alfabeto
+#. TRANS: Translate as "alphabet class"
+#. TRANS: clase de alfabeto
 msgid "letter class"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:437
-#.TRANS: clase de solfege
+#. TRANS: clase de solfege
 msgid "solfege class"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:438
-#.TRANS: musical y
+#. TRANS: musical y
 msgid "staff y"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:439
-#.TRANS: sílaba solfege
+#. TRANS: sílaba solfege
 msgid "solfege syllable"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:440
-#.TRANS: clase de tono
+#. TRANS: clase de tono
 msgid "pitch class"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:441
-#.TRANS: clase de escala
+#. TRANS: clase de escala
 msgid "scalar class"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:443
-#.TRANS: nth grado
+#. TRANS: nth grado
 msgid "nth degree"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:444
-#.TRANS: tono a la sombra
+#. TRANS: tono a la sombra
 msgid "pitch to shade"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:445
-#.TRANS: tono a color
+#. TRANS: tono a color
 msgid "pitch to color"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
-#.TRANS: MIDI
+#. TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI
 msgid "MIDI"
 msgstr "MIDI"
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
-#.TRANS: fijar offset del número de tono
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: fijar offset del número de tono
 msgid "set pitch number offset"
 msgstr "kunkapa yupayninta watapuna "
 
 #: js/blocks/PitchBlocks.js:645
-#.TRANS: El bloque Fijar del número de tono establecido se usa para establecer el desplazamiento para asignar números de tono a tono y octava.
+#. TRANS: El bloque Fijar del número de tono establecido se usa para establecer el desplazamiento para asignar números de tono a tono y octava.
 msgid "The Set pitch number offset block is used to set the offset for mapping pitch numbers to pitch and octave."
 msgstr ""
 
@@ -5643,213 +5643,213 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
-#.TRANS: nombre
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: nombre
 msgid "name2"
 msgstr "suti"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
-#.TRANS: número a tono
+#. TRANS: convert piano key number (1-88) to pitch
+#. TRANS: número a tono
 msgid "number to pitch"
 msgstr "yupay kunkaman"
 
 #: js/blocks/PitchBlocks.js:682
-#.TRANS: El bloque Número a tono convertirá un número de tono en un nombre pich.
+#. TRANS: El bloque Número a tono convertirá un número de tono en un nombre pich.
 msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
-#.TRANS: número a octava
+#. TRANS: convert piano key number (1-88) to octave
+#. TRANS: número a octava
 msgid "number to octave"
 msgstr "yupay pusaq pataman"
 
 #: js/blocks/PitchBlocks.js:717
-#.TRANS: El bloque Número a octava convertirá un número de tono en una octava.
+#. TRANS: El bloque Número a octava convertirá un número de tono en una octava.
 msgid "The Number to octave block will convert a pitch number to an octave."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:726
-#.TRANS: y para tono
+#. TRANS: y para tono
 msgid "y to pitch"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:729
-#.TRANS: El bloque Y a tono convertirá una posición de pentagrama y a la notación de tono correspondiente.
+#. TRANS: El bloque Y a tono convertirá una posición de pentagrama y a la notación de tono correspondiente.
 msgid "Y to pitch block will convert a staff y position to corresponding pitch notation."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:841
-#.TRANS: selector accidental
+#. TRANS: selector accidental
 msgid "accidental selector"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:844
-#.TRANS: El bloque Selector de accidental se usa para elegir entre doble filo, agudo, natural, plano y doble plano.
+#. TRANS: El bloque Selector de accidental se usa para elegir entre doble filo, agudo, natural, plano y doble plano.
 msgid "The Accidental selector block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:858
-#.TRANS: El tono puede especificarse en términos de ni dha pa ma ga re sa.
+#. TRANS: El tono puede especificarse en términos de ni dha pa ma ga re sa.
 msgid "Pitch can be specified in terms of ni dha pa ma ga re sa."
 msgstr "kunkaqa kay tukuykunapi ni dha pa ma ga re sa alayrichikun "
 
 #: js/blocks/PitchBlocks.js:872
-#.TRANS: El tono puede especificarse en términos de C D E F G A B.
+#. TRANS: El tono puede especificarse en términos de C D E F G A B.
 msgid "Pitch can be specified in terms of C D E F G A B."
 msgstr " kunkaqa kay tukuykunapi C D E F G A B alayrichikun "
 
 #: js/blocks/PitchBlocks.js:884
-#.TRANS: 
+#. TRANS: 
 msgid "solfege"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:887
-#.TRANS: El tono puede especificarse en términos de do re mi fa sol la si.
+#. TRANS: El tono puede especificarse en términos de do re mi fa sol la si.
 msgid "Pitch can be specified in terms of do re mi fa sol la ti."
 msgstr " kunkaqa kay tukuykunapi do re mi fa sol la si alayrichikun "
 
 #: js/blocks/PitchBlocks.js:922
-#.TRANS: El bloque Invertir gira cualquier nota contenida alrededor de una nota de destino.
+#. TRANS: El bloque Invertir gira cualquier nota contenida alrededor de una nota de destino.
 msgid "The Invert block rotates any contained notes around a target note."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
-#.TRANS: Invertir
+#. TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: Invertir
 msgid "Invert"
 msgstr "Tikray"
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
-#.TRANS: invertir (impar)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: invertir (impar)
 msgid "invert (odd)"
 msgstr "t’ikray (sapallan"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
-#.TRANS: invertir (par)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: invertir (par)
 msgid "invert (even)"
 msgstr "t’ikray (masantin)"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
-#.TRANS: registro
+#. TRANS: register is the octave of the current pitch
+#. TRANS: registro
 msgid "register"
 msgstr "waqaychasqa"
 
 #: js/blocks/PitchBlocks.js:1026
-#.TRANS: El bloque Registro proporciona una manera fácil de modificar el registro (octava) de las notas que lo siguen.
+#. TRANS: El bloque Registro proporciona una manera fácil de modificar el registro (octava) de las notas que lo siguen.
 msgid "The Register block provides an easy way to modify the register (octave) of the notes that follow it."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
-#.TRANS: 50 centavos
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: 50 centavos
 msgid "50 cents"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1102
-#.TRANS: El bloque de transposición de semitono desplazará los pasos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) medio pasos.
+#. TRANS: El bloque de transposición de semitono desplazará los pasos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) medio pasos.
 msgid "The Semi-tone transposition block will shift the pitches contained inside Note blocks up (or down) by half steps."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1104
-#.TRANS: En el ejemplo que se muestra arriba, sol se desplaza hasta sol#.
+#. TRANS: En el ejemplo que se muestra arriba, sol se desplaza hasta sol#.
 msgid "In the example shown above, sol is shifted up to sol#."
 msgstr "wichaypi qhawachisqapi hina, solqa solkama purin"
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
-#.TRANS: transposición semitono
+#. TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: transposición semitono
 msgid "semi-tone transpose"
 msgstr "kuskan kunka Haywapuynin"
 
 #: js/blocks/PitchBlocks.js:1143
-#.TRANS: El bloque transponer por razón cambiará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) en una proporción
+#. TRANS: El bloque transponer por razón cambiará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) en una proporción
 msgid "The Transpose by Ratio block will shift the pitches contained inside Note blocks up (or down) by a ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
-#.TRANS: transponer por razón
+#. TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: transponer por razón
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
-#.TRANS: sexto abajo
+#. TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: sexto abajo
 msgid "down sixth"
 msgstr "uraypi suqta pata"
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
-#.TRANS: tercero abajo
+#. TRANS: down third means the note is two scale degrees below current note
+#. TRANS: tercero abajo
 msgid "down third"
 msgstr "uraypi kimsa pata"
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
-#.TRANS: séptimo
+#. TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: séptimo
 msgid "seventh"
 msgstr "qanchis pata"
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
-#.TRANS: sexto
+#. TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sexto
 msgid "sixth"
 msgstr "suqta pata"
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
-#.TRANS: quinto
+#. TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: quinto
 msgid "fifth"
 msgstr "phichqa pata"
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
-#.TRANS: cuarto
+#. TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: cuarto
 msgid "fourth"
 msgstr "tawa pata"
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
-#.TRANS: tercio
+#. TRANS: third means the note is two scale degrees above current note
+#. TRANS: tercio
 msgid "third"
 msgstr "kimsa pata"
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
-#.TRANS: segundo
+#. TRANS: second means the note is one scale degree above current note
+#. TRANS: segundo
 msgid "second"
 msgstr "iskay pata"
 
 #: js/blocks/PitchBlocks.js:1407
-#.TRANS: El bloque Transposición escalar desplazará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) de la escala.
+#. TRANS: El bloque Transposición escalar desplazará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) de la escala.
 msgid "The Scalar transposition block will shift the pitches contained inside Note blocks up (or down) the scale."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1409
-#.TRANS: En el ejemplo que se muestra arriba, el sol se desplaza hacia arriba a la.
+#. TRANS: En el ejemplo que se muestra arriba, el sol se desplaza hacia arriba a la.
 msgid "In the example shown above, sol is shifted up to la."
 msgstr "En el ejemplo que se muestra arriba, el sol se desplaza hacia arriba a la."
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
-#.TRANS: transposición escalar
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: transposición escalar
 msgid "scalar transpose"
 msgstr "  sayayninta  tupachiy haywapuynin"
 
 #: js/blocks/PitchBlocks.js:1451
-#.TRANS: El bloque Accidental se utiliza para crear objetos punzantes y pisos.
+#. TRANS: El bloque Accidental se utiliza para crear objetos punzantes y pisos.
 msgid "The Accidental block is used to create sharps and flats"
 msgstr "Yanapaqnin chiqasqa chhukuna hinallataq saruna imakunapas paqarichiy llamk’anam"
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
-#.TRANS: anular accidental
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: anular accidental
 msgid "accidental override"
 msgstr ""
 
@@ -5857,83 +5857,83 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
-#.TRANS: hertz
+#. TRANS: a measure of frequency: one cycle per second
+#. TRANS: hertz
 msgid "hertz"
 msgstr "hertz"
 
 #: js/blocks/PitchBlocks.js:1581
-#.TRANS: El bloque Hertz (en combinación con un bloque numérico) reproducirá un sonido a la frecuencia especificada.
+#. TRANS: El bloque Hertz (en combinación con un bloque numérico) reproducirá un sonido a la frecuencia especificada.
 msgid "The Hertz block (in combination with a Number block) will play a sound at the specified frequency."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1671
-#.TRANS: El bloque de número de tono reproducirá un tono asociado por su número, p. 0 para C y 7 para G.
+#. TRANS: El bloque de número de tono reproducirá un tono asociado por su número, p. 0 para C y 7 para G.
 msgid "The Pitch Number block will play a pitch associated by its number, e.g. 0 for C and 7 for G."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: nth tono modal
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: nth tono modal
 msgid "nth modal pitch"
 msgstr "nth tono modal"
 
 #: js/blocks/PitchBlocks.js:1706
-#.TRANS: Nth Modal Pitch toma el patrón de tonos en semitonos para un modo y hace que cada punto sea un grado del modo,
+#. TRANS: Nth Modal Pitch toma el patrón de tonos en semitonos para un modo y hace que cada punto sea un grado del modo,
 msgid "nth Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1708
-#.TRANS: comenzando desde 1 e independientemente del marco tonal (es decir, no siempre 8 notas en la octava)
+#. TRANS: comenzando desde 1 e independientemente del marco tonal (es decir, no siempre 8 notas en la octava)
 msgid "starting from 1 and regardless of tonal framework (i.e. not always 8 notes in the octave)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
-#.TRANS: Nth modal tono un número como entrada como el nth grado para el modo dado. 0 es la primera posición, 1 es la segunda, -1 es la nota anterior a la primera, etc.
+#. TRANS: Nth modal tono un número como entrada como el nth grado para el modo dado. 0 es la primera posición, 1 es la segunda, -1 es la nota anterior a la primera, etc.
 msgid "Nth Modal Pitch takes a number as an input as the nth degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1751
-#.TRANS: Los tonos cambian según el modo especificado sin necesidad de grafías.
+#. TRANS: Los tonos cambian según el modo especificado sin necesidad de grafías.
 msgid "The pitches change according to the mode specified without any need for respellings."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1790
-#.TRANS: El grado de escala es una convención común en la música. El grado de ecala ofrece siete posiciones posibles en la escala (1-7) y puede modificarse mediante alteraciones.
+#. TRANS: El grado de escala es una convención común en la música. El grado de ecala ofrece siete posiciones posibles en la escala (1-7) y puede modificarse mediante alteraciones.
 msgid "Scale Degree is a common convention in music. Scale Degree offers seven possible positions in the scale (1-7) and can be modified via accidentals."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1792
-#.TRANS: El grado de la escala de 1 es siempre el primer tono de una escala determinada, independientemente de la octava.
+#. TRANS: El grado de la escala de 1 es siempre el primer tono de una escala determinada, independientemente de la octava.
 msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of octave."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
-#.TRANS: paso escalar
+#. TRANS: step some number of notes in current musical scale
+#. TRANS: paso escalar
 msgid "scalar step"
 msgstr "wichayman challqa"
 
 #: js/blocks/PitchBlocks.js:1819
-#.TRANS: El bloque Paso escalar (en combinación con un bloque numérico) reproducirá el siguiente tono en una escala,
+#. TRANS: El bloque Paso escalar (en combinación con un bloque numérico) reproducirá el siguiente tono en una escala,
 msgid "The Scalar Step block (in combination with a Number block) will play the next pitch in a scale,"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1821
-#.TRANS: por ejemplo, si la última nota tocada fue sol, el paso escalar 1 tocará la.
+#. TRANS: por ejemplo, si la última nota tocada fue sol, el paso escalar 1 tocará la.
 msgid "eg if the last note played was sol, Scalar Step 1 will play la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1857
-#.TRANS: The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note.
+#. TRANS: The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note.
 msgid "The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 #: js/widgets/timbre.js:783
-#.TRANS: Oscilador
+#. TRANS: Oscilador
 msgid "Oscillator"
 msgstr "Tikraq"
 
@@ -5941,131 +5941,131 @@ msgstr "Tikraq"
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
-#.TRANS: typo
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: typo
 msgid "type"
 msgstr "typo"
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
-#.TRANS: parciales
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: parciales
 msgid "partials"
 msgstr "chawakuna"
 
 #: js/blocks/ToneBlocks.js:76
-#.TRANS: Está agregando varios bloques de oscilador.
+#. TRANS: Está agregando varios bloques de oscilador.
 msgid "You are adding multiple oscillator blocks."
 msgstr "maymikuqmanmi achka chiqasta yapachkan"
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
-#.TRANS: duo sintetizador
+#. TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: duo sintetizador
 msgid "duo synth"
 msgstr "iskayman pisiyachiqnin"
 
 #: js/blocks/ToneBlocks.js:149
-#.TRANS: El bloque Sintetizador Duo es un modulador de frecuencia doble usado para definir un timbre.
+#. TRANS: El bloque Sintetizador Duo es un modulador de frecuencia doble usado para definir un timbre.
 msgid "The Duo synth block is a duo-frequency modulator used to define a timbre."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:157
 #: js/widgets/timbre.js:1468
-#.TRANS: velocidad del vibrato
+#. TRANS: velocidad del vibrato
 msgid "vibrato rate"
 msgstr "vibratupa usqhachiq"
 
 #: js/blocks/ToneBlocks.js:157
-#.TRANS: intensidad de vibrato
+#. TRANS: intensidad de vibrato
 msgid "vibrato intensity"
 msgstr "vibratupa kallpachaynin"
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
-#.TRANS: AM sintetizador
+#. TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM sintetizador
 msgid "AM synth"
 msgstr "AM pisiyachiqnin"
 
 #: js/blocks/ToneBlocks.js:189
-#.TRANS: El bloque Sintetizador AM es un modulador de amplitud usado para definir un timbre.
+#. TRANS: El bloque Sintetizador AM es un modulador de amplitud usado para definir un timbre.
 msgid "The AM synth block is an amplitude modulator used to define a timbre."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
-#.TRANS: FM sintetizador
+#. TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM sintetizador
 msgid "FM synth"
 msgstr "FM pisiyachiqnin "
 
 #: js/blocks/ToneBlocks.js:228
-#.TRANS: El bloque Sintetizador de FM es un modulador de frecuencia utilizado para definir un timbre.
+#. TRANS: El bloque Sintetizador de FM es un modulador de frecuencia utilizado para definir un timbre.
 msgid "The FM synth block is a frequency modulator used to define a timbre."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:262
-#.TRANS: parcial
+#. TRANS: parcial
 msgid "partial"
 msgstr "chawa"
 
 #: js/blocks/ToneBlocks.js:265
-#.TRANS: El bloque Parcial se utiliza para especificar un peso para un armónico parcial específico.
+#. TRANS: El bloque Parcial se utiliza para especificar un peso para un armónico parcial específico.
 msgid "The Partial block is used to specify a weight for a specific partial harmonic."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
-#.TRANS: El peso parcial debe estar entre 0 y 1.
+#. TRANS: partials are weighted components in a harmonic series
+#. TRANS: El peso parcial debe estar entre 0 y 1.
 msgid "Partial weight must be between 0 and 1."
 msgstr "chawapa llasayninqa chúsaqpi hinallataq huk chawpipin kanan"
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
-#.TRANS: El bloque Parcial debe usarse dentro de un bloque de parciales ponderados.
+#. TRANS: partials are weighted components in a harmonic series
+#. TRANS: El bloque Parcial debe usarse dentro de un bloque de parciales ponderados.
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
-#.TRANS: parcial ponderada
+#. TRANS: partials are weighted components in a harmonic series
+#. TRANS: parcial ponderada
 msgid "weighted partials"
 msgstr "chawa chaninchasqa"
 
 #: js/blocks/ToneBlocks.js:383
-#.TRANS: El bloque Armónicos agregará armónicos a las notas contenidas.
+#. TRANS: El bloque Armónicos agregará armónicos a las notas contenidas.
 msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
-#.TRANS: armónico
+#. TRANS: A harmonic is an overtone.
+#. TRANS: armónico
 msgid "harmonic"
 msgstr "armónico"
 
 #: js/blocks/ToneBlocks.js:431
-#.TRANS: El bloque Distorsión agrega distorsión al tono.
+#. TRANS: El bloque Distorsión agrega distorsión al tono.
 msgid "The Distortion block adds distortion to the pitch."
 msgstr "q’iwiy chiqasqa kunkaman q’iwiyninta yapam"
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
-#.TRANS: distorsión
+#. TRANS: distortion is an alteration in the sound
+#. TRANS: distorsión
 msgid "distortion"
 msgstr "q’íwiy"
 
 #: js/blocks/ToneBlocks.js:487
-#.TRANS: El bloque Tremolo añade un efecto de vacilación.
+#. TRANS: El bloque Tremolo añade un efecto de vacilación.
 msgid "The Tremolo block adds a wavering effect."
 msgstr "Thalay chiqasqa iskayananpaq yapaykun"
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
-#.TRANS: tremolo
+#. TRANS: a wavering effect in a musical tone
+#. TRANS: tremolo
 msgid "tremolo"
 msgstr "Thalay"
 
@@ -6077,8 +6077,8 @@ msgstr "Thalay"
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
-#.TRANS: velocidad
+#. TRANS: rate at which tremolo wavers
+#. TRANS: velocidad
 msgid "rate"
 msgstr "utqay"
 
@@ -6086,135 +6086,135 @@ msgstr "utqay"
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
-#.TRANS: intensidad
+#. TRANS: amplitude of tremolo waver
+#. TRANS: intensidad
 msgid "depth"
 msgstr "kallpa"
 
 #: js/blocks/ToneBlocks.js:559
-#.TRANS: El bloque Phaser añade un sonido de barrido.
+#. TRANS: El bloque Phaser añade un sonido de barrido.
 msgid "The Phaser block adds a sweeping sound."
 msgstr "Phaser chiqasqa pichana kunkatan yapan"
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
-#.TRANS: phaser
+#. TRANS: alter the phase of the sound
+#. TRANS: phaser
 msgid "phaser"
 msgstr "phaser"
 
 #: js/blocks/ToneBlocks.js:569
 #: js/turtleactions/IntervalsActions.js:114
 #: js/widgets/timbre.js:2410
-#.TRANS: octavas
+#. TRANS: octavas
 msgid "octaves"
 msgstr "pusaq patakuna"
 
 #: js/blocks/ToneBlocks.js:569
 #: js/widgets/timbre.js:2413
-#.TRANS: frecuencia de base
+#. TRANS: frecuencia de base
 msgid "base frequency"
 msgstr "tiyananpi sapakuti ruranan "
 
 #: js/blocks/ToneBlocks.js:619
-#.TRANS: El bloque Chorus añade un efecto chorus.
+#. TRANS: El bloque Chorus añade un efecto chorus.
 msgid "The Chorus block adds a chorus effect."
 msgstr "takich’unku chiqasqa takich’unku kayninta yapan"
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
-#.TRANS: coro
+#. TRANS: musical effect to simulate a choral sound
+#. TRANS: coro
 msgid "chorus"
 msgstr "takich’unku"
 
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2310
-#.TRANS: retraso (MS)
+#. TRANS: retraso (MS)
 msgid "delay (MS)"
 msgstr "qhipariy"
 
 #: js/blocks/ToneBlocks.js:678
-#.TRANS: El bloque Vibrato agrega una variación rápida y leve en el tono.
+#. TRANS: El bloque Vibrato agrega una variación rápida y leve en el tono.
 msgid "The Vibrato block adds a rapid, slight variation in pitch."
 msgstr "Khatatay chiqasqa utqay chaninchayninta hinallataq pisi kunkanta yapan"
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
-#.TRANS: vibrato
+#. TRANS: a rapid, slight variation in pitch
+#. TRANS: vibrato
 msgid "vibrato"
 msgstr "khatatay"
 
 #: js/blocks/ToneBlocks.js:689
 #: js/widgets/timbre.js:2209
-#.TRANS: intensidad
+#. TRANS: intensidad
 msgid "intensity"
 msgstr "kallpa"
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
-#.TRANS: fijar synth
+#. TRANS: select synthesizer
+#. TRANS: fijar synth
 msgid "set synth"
 msgstr "synth watay"
 
 #: js/blocks/ToneBlocks.js:804
-#.TRANS: nombre del sintetizador
+#. TRANS: nombre del sintetizador
 msgid "synth name"
 msgstr " pisiyachiqninpa sutin"
 
 #: js/blocks/ToneBlocks.js:842
-#.TRANS: fijar instrumento predeterminado
+#. TRANS: fijar instrumento predeterminado
 msgid "set default instrument"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
-#.TRANS: fijar instrumento
+#. TRANS: set the characteristics of a custom instrument
+#. TRANS: fijar instrumento
 msgid "set instrument"
 msgstr "ruk’awita churana"
 
 #: js/blocks/ToneBlocks.js:898
 #: js/blocks/ToneBlocks.js:926
 #: js/blocks/ToneBlocks.js:932
-#.TRANS: El bloque Fijar Instrumentos selecciona una voz para el sintetizador,
+#. TRANS: El bloque Fijar Instrumentos selecciona una voz para el sintetizador,
 msgid "The Set instrument block selects a voice for the synthesizer,"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:900
 #: js/blocks/ToneBlocks.js:934
-#.TRANS: Por ejemplo, guitarra, piano, violín o cello
+#. TRANS: Por ejemplo, guitarra, piano, violín o cello
 msgid "eg guitar piano violin or cello."
 msgstr "kitara, piyanu, wiyulin kallamanta wiyula hina"
 
 #: js/blocks/ToneBlocks.js:1015
-#.TRANS: Importe un archivo de sonido para usarlo como instrumento y establezca su centro de tono.
+#. TRANS: Importe un archivo de sonido para usarlo como instrumento y establezca su centro de tono.
 msgid "Import a sound file to use as an instrument and set its pitch center."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:1110
-#.TRANS: Cargue un archivo de sonido para conectarlo con el bloque de muestra.
+#. TRANS: Cargue un archivo de sonido para conectarlo con el bloque de muestra.
 msgid "Upload a sound file to connect with the sample block."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:58
-#.TRANS: El bloque Volver (Return) devolverá un valor de una acción.
+#. TRANS: El bloque Volver (Return) devolverá un valor de una acción.
 msgid "The Return block will return a value from an action."
 msgstr "Kutiq Saya, kutichinqa huk  rurayta "
 
 #: js/blocks/ActionBlocks.js:75
-#.TRANS: retorno
+#. TRANS: retorno
 msgid "return"
 msgstr "kuti"
 
 #: js/blocks/ActionBlocks.js:128
-#.TRANS: El bloque Volver a URL devolverá un valor a una página web.
+#. TRANS: El bloque Volver a URL devolverá un valor a una página web.
 msgid "The Return to URL block will return a value to a webpage."
 msgstr "Kutichiq Saya URLman qupunqa huk chaninta web qhawanaman"
 
 #: js/blocks/ActionBlocks.js:145
-#.TRANS: retorno a URL
+#. TRANS: retorno a URL
 msgid "return to URL"
 msgstr "Kutichimuy URLman"
 
@@ -6222,14 +6222,14 @@ msgstr "Kutichimuy URLman"
 #: js/blocks/ActionBlocks.js:290
 #: js/blocks/ActionBlocks.js:501
 #: js/blocks/ActionBlocks.js:688
-#.TRANS: El bloque Calcular devuelve un valor calculado por una acción.
+#. TRANS: El bloque Calcular devuelve un valor calculado por una acción.
 msgid "The Calculate block returns a value calculated by an action."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:251
 #: js/blocks/ActionBlocks.js:517
 #: js/blocks/ActionBlocks.js:707
-#.TRANS: calcular
+#. TRANS: calcular
 msgid "calculate"
 msgstr "Yuyakukuy"
 
@@ -6237,100 +6237,100 @@ msgstr "Yuyakukuy"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
-#.TRANS: El bloque Hacer se utiliza para iniciar una acción.
+#. TRANS: do is the do something or take an action.
+#. TRANS: El bloque Hacer se utiliza para iniciar una acción.
 msgid "The Do block is used to initiate an action."
 msgstr "El bloque Hacer se utiliza para iniciar una acción."
 
 #: js/blocks/ActionBlocks.js:791
 #: js/blocks/ActionBlocks.js:865
-#.TRANS: El bloque Arg contiene el valor de un argumento pasado a una acción.
+#. TRANS: El bloque Arg contiene el valor de un argumento pasado a una acción.
 msgid "The Arg block contains the value of an argument passed to an action."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:806
 #: js/blocks/ActionBlocks.js:878
-#.TRANS: arg
+#. TRANS: arg
 msgid "arg"
 msgstr "ruray"
 
 #: js/blocks/ActionBlocks.js:836
 #: js/blocks/ActionBlocks.js:900
 #: js/blocks/ActionBlocks.js:908
-#.TRANS: argumento no válido
+#. TRANS: argumento no válido
 msgid "Invalid argument"
 msgstr "Mana chaninniyuq rimay"
 
 #: js/blocks/ActionBlocks.js:944
-#.TRANS: En el ejemplo, se usa con el bloque Uno para elegir una fase aleatoria.
+#. TRANS: En el ejemplo, se usa con el bloque Uno para elegir una fase aleatoria.
 msgid "In the example, it is used with the One of block to choose a random phase."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:1019
 #: js/blocks/ActionBlocks.js:1026
-#.TRANS: El bloque de escucha se usa para escuchar un evento como un clic del ratón.
+#. TRANS: El bloque de escucha se usa para escuchar un evento como un clic del ratón.
 msgid "The Listen block is used to listen for an event such as a mouse click."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:1028
-#.TRANS: Cuando ocurre el evento, se realiza una acción.
+#. TRANS: Cuando ocurre el evento, se realiza una acción.
 msgid "When the event happens, an action is taken."
 msgstr "Sichus kanqa ruray, chayqa kuyukachay kanqa"
 
 #: js/blocks/ActionBlocks.js:1045
-#.TRANS: cuando
+#. TRANS: cuando
 msgid "on"
 msgstr "on qhantayaña"
 
 #: js/blocks/ActionBlocks.js:1048
 #: js/blocks/ActionBlocks.js:1049
 #: js/blocks/ActionBlocks.js:1153
-#.TRANS: señal
+#. TRANS: señal
 msgid "event"
-msgstr "riqsichi""
+msgstr "riqsichi"
 
 #: js/blocks/ActionBlocks.js:1133
-#.TRANS: El bloque Emitir se utiliza para desencadenar un evento.
+#. TRANS: El bloque Emitir se utiliza para desencadenar un evento.
 msgid "The Broadcast block is used to trigger an event."
 msgstr "El bloque Emitir se utiliza para desencadenar un evento."
 
 #: js/blocks/ActionBlocks.js:1151
-#.TRANS: emitir
+#. TRANS: emitir
 msgid "broadcast"
 msgstr "lluqsichiy"
 
 #: js/blocks/ActionBlocks.js:1208
-#.TRANS: Cada bloque de inicio es una voz separada.
+#. TRANS: Cada bloque de inicio es una voz separada.
 msgid "Each Start block is a separate voice."
 msgstr "Cada bloque de inicio es una voz separada."
 
 #: js/blocks/ActionBlocks.js:1304
-#.TRANS: A menudo se utiliza para almacenar una frase de música que se repite.
+#. TRANS: A menudo se utiliza para almacenar una frase de música que se repite.
 msgid "It is often used for storing a phrase of music that is repeated."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:1495
-#.TRANS: definir el temperamento
+#. TRANS: definir el temperamento
 msgid "define temperament"
 msgstr "akllay"
 
 #: js/blocks/EnsembleBlocks.js:87
-#.TRANS: valor en la pila de ratón
+#. TRANS: valor en la pila de ratón
 msgid "mouse index heap"
 msgstr "Huk’ucha /qillqa purichina"
 
 #: js/blocks/EnsembleBlocks.js:87
-#.TRANS: valor en la pila de tortuga
+#. TRANS: valor en la pila de tortuga
 msgid "turtle index heap"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:89
-#.TRANS: El bloque de valor en la pila de ratón devuelve un valor en el almacenamiento dinámico en una ubicación específica para un mouse específico.
+#. TRANS: El bloque de valor en la pila de ratón devuelve un valor en el almacenamiento dinámico en una ubicación específica para un mouse específico.
 msgid "The Mouse index heap block returns a value in the heap at a specified location for a specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:90
-#.TRANS: El bloque de valor en la pila de tortuga devuelve un valor en el almacenamiento dinámico en una ubicación específica para un mouse específico.
+#. TRANS: El bloque de valor en la pila de tortuga devuelve un valor en el almacenamiento dinámico en una ubicación específica para un mouse específico.
 msgid "The Turtle index heap block returns a value in the heap at a specified location for a specified turtle."
 msgstr ""
 
@@ -6351,39 +6351,39 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:957
 #: js/blocks/EnsembleBlocks.js:1222
 #: js/blocks/EnsembleBlocks.js:1296
-#.TRANS: 
+#. TRANS: 
 msgid "Yertle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:96
 #: js/blocks/EnsembleBlocks.js:1083
-#.TRANS: renombrar ratón
+#. TRANS: renombrar ratón
 msgid "mouse name"
 msgstr "Sutichay huk’uchata"
 
 #: js/blocks/EnsembleBlocks.js:96
 #: js/blocks/EnsembleBlocks.js:1092
-#.TRANS: renombrar tortuga
+#. TRANS: renombrar tortuga
 msgid "turtle name"
 msgstr "Tortuga wakichatampi mayachasiña"
 
 #: js/blocks/EnsembleBlocks.js:147
-#.TRANS: parar ratón
+#. TRANS: parar ratón
 msgid "stop mouse"
 msgstr "jithiyaña sayt'ayaña"
 
 #: js/blocks/EnsembleBlocks.js:149
-#.TRANS: El bloque parar ratón parar el ratón especificado.
+#. TRANS: El bloque parar ratón parar el ratón especificado.
 msgid "The Stop mouse block stops the specified mouse."
 msgstr "El bloque parar ratón parar el ratón especificado."
 
 #: js/blocks/EnsembleBlocks.js:160
-#.TRANS: detener tortuga
+#. TRANS: detener tortuga
 msgid "stop turtle"
 msgstr "tortuga wakichata sayt'ayaña"
 
 #: js/blocks/EnsembleBlocks.js:162
-#.TRANS: El bloque parar tortuga parar el ratón especificado.
+#. TRANS: El bloque parar tortuga parar el ratón especificado.
 msgid "The Stop turtle block stops the specified turtle."
 msgstr ""
 
@@ -6396,7 +6396,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:872
 #: js/blocks/EnsembleBlocks.js:1193
 #: js/blocks/EnsembleBlocks.js:1256
-#.TRANS: No se puede encontrar ratón
+#. TRANS: No se puede encontrar ratón
 msgid "Cannot find mouse"
 msgstr "Manan huk’uchata tarikunchu"
 
@@ -6409,470 +6409,470 @@ msgstr "Manan huk’uchata tarikunchu"
 #: js/blocks/EnsembleBlocks.js:874
 #: js/blocks/EnsembleBlocks.js:1195
 #: js/blocks/EnsembleBlocks.js:1258
-#.TRANS: No se puede encontrar tortuga.
+#. TRANS: No se puede encontrar tortuga.
 msgid "Cannot find turtle"
 msgstr "No se puede encontrar tortuga."
 
 #: js/blocks/EnsembleBlocks.js:208
-#.TRANS: comenzar ratón
+#. TRANS: comenzar ratón
 msgid "start mouse"
 msgstr "jithuyaña qalltaña"
 
 #: js/blocks/EnsembleBlocks.js:211
-#.TRANS: El bloque comenzar ratón inicia el ratón especificado.
+#. TRANS: El bloque comenzar ratón inicia el ratón especificado.
 msgid "The Start mouse block starts the specified mouse."
 msgstr "El bloque comenzar ratón inicia el ratón especificado."
 
 #: js/blocks/EnsembleBlocks.js:222
-#.TRANS: iniciar tortuga
+#. TRANS: iniciar tortuga
 msgid "start turtle"
 msgstr "tortuga wakichata qalltaña"
 
 #: js/blocks/EnsembleBlocks.js:225
-#.TRANS: El bloque comenzar tortuga inicia el ratón especificado.
+#. TRANS: El bloque comenzar tortuga inicia el ratón especificado.
 msgid "The Start turtle block starts the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:258
-#.TRANS: Ratón ya ha comenzado.
+#. TRANS: Ratón ya ha comenzado.
 msgid "Mouse is already running."
 msgstr "Huk’ucha qallarinña"
 
 #: js/blocks/EnsembleBlocks.js:260
-#.TRANS: Tortuga ya ha comenzado.
+#. TRANS: Tortuga ya ha comenzado.
 msgid "Turtle is already running."
 msgstr "Tortuga ya ha comenzado."
 
 #: js/blocks/EnsembleBlocks.js:284
-#.TRANS: No se puede encontrar el bloque de inicar.
+#. TRANS: No se puede encontrar el bloque de inicar.
 msgid "Cannot find start block"
 msgstr "Manan qallariq saya tarikunchu"
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
-#.TRANS: color de ratón
+#. TRANS: pen color for this mouse
+#. TRANS: color de ratón
 msgid "mouse color"
 msgstr "Llimp’iyniyuq huk’ucha"
 
 #: js/blocks/EnsembleBlocks.js:296
-#.TRANS: El bloque de color del ratón devuelve el color del lápiz del ratón especificado.
+#. TRANS: El bloque de color del ratón devuelve el color del lápiz del ratón especificado.
 msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
-#.TRANS: color de tortuga
+#. TRANS: pen color for this turtle
+#. TRANS: color de tortuga
 msgid "turtle color"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:310
-#.TRANS: El bloque de color de la tortuga devuelve el color del lápiz de la tortuga especificado.
+#. TRANS: El bloque de color de la tortuga devuelve el color del lápiz de la tortuga especificado.
 msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
-#.TRANS: rumbo de ratón
+#. TRANS: heading (compass direction) for this mouse
+#. TRANS: rumbo de ratón
 msgid "mouse heading"
 msgstr "jithiyaña wakichata suti"
 
 #: js/blocks/EnsembleBlocks.js:342
-#.TRANS: El bloque de rumbo del ratón devuelve el rumbo del lápiz del ratón especificado.
+#. TRANS: El bloque de rumbo del ratón devuelve el rumbo del lápiz del ratón especificado.
 msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
-#.TRANS: rumbo de tortuga
+#. TRANS: heading (compass direction) for this turtle
+#. TRANS: rumbo de tortuga
 msgid "turtle heading"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:356
-#.TRANS: El bloque de rumbo de la tortuga devuelve el rumbo del lápiz de la tortuga especificado.
+#. TRANS: El bloque de rumbo de la tortuga devuelve el rumbo del lápiz de la tortuga especificado.
 msgid "The Turtle heading block returns the heading of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
-#.TRANS: fijar ratón
+#. TRANS: set xy position for this mouse
+#. TRANS: fijar ratón
 msgid "set mouse"
 msgstr "fijar ratón"
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
-#.TRANS: fijar tortuga
+#. TRANS: set xy position for this turtle
+#. TRANS: fijar tortuga
 msgid "set turtle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:435
-#.TRANS: El bloque de ratón establecer envía una pila de bloques para que los ejecute el ratón especificado.
+#. TRANS: El bloque de ratón establecer envía una pila de bloques para que los ejecute el ratón especificado.
 msgid "The Set mouse block sends a stack of blocks to be run by the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:448
-#.TRANS: El bloque de tortuga establecer envía una pila de bloques para que los ejecute el tortuga especificado.
+#. TRANS: El bloque de tortuga establecer envía una pila de bloques para que los ejecute el tortuga especificado.
 msgid "The Set turtle block sends a stack of blocks to be run by the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
-#.TRANS: ratón y
+#. TRANS: y position for this mouse
+#. TRANS: ratón y
 msgid "mouse y"
 msgstr "puripaq Y"
 
 #: js/blocks/EnsembleBlocks.js:484
-#.TRANS: El bloque del ratón Y devuelve la posición Y del ratón especificado.
+#. TRANS: El bloque del ratón Y devuelve la posición Y del ratón especificado.
 msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
-#.TRANS: tortuga y
+#. TRANS: y position for this turtle
+#. TRANS: tortuga y
 msgid "turtle y"
 msgstr "tortuga Y wakichata"
 
 #: js/blocks/EnsembleBlocks.js:498
-#.TRANS: El bloque de la tortuga Y devuelve la posición Y de la tortuga especificado.
+#. TRANS: El bloque de la tortuga Y devuelve la posición Y de la tortuga especificado.
 msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
-#.TRANS: ratón x
+#. TRANS: x position for this mouse
+#. TRANS: ratón x
 msgid "mouse x"
 msgstr "puripaq X"
 
 #: js/blocks/EnsembleBlocks.js:530
-#.TRANS: El bloque del ratón X devuelve la posición X del ratón especificado.
+#. TRANS: El bloque del ratón X devuelve la posición X del ratón especificado.
 msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
-#.TRANS: tortuga x
+#. TRANS: x position for this turtle
+#. TRANS: tortuga x
 msgid "turtle x"
 msgstr "tortuga X wakichata"
 
 #: js/blocks/EnsembleBlocks.js:544
-#.TRANS: El bloque de la tortuga X devuelve la posición X de la tortuga especificado.
+#. TRANS: El bloque de la tortuga X devuelve la posición X de la tortuga especificado.
 msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
-#.TRANS: notas jugadas de ratón
+#. TRANS: notes played by this mouse
+#. TRANS: notas jugadas de ratón
 msgid "mouse notes played"
 msgstr "notas jugadas de ratón"
 
 #: js/blocks/EnsembleBlocks.js:577
-#.TRANS: El bloque de notas jugadas del ratón devuelve el número de notas tocadas por el ratón especificado.
+#. TRANS: El bloque de notas jugadas del ratón devuelve el número de notas tocadas por el ratón especificado.
 msgid "The Mouse elapse notes block returns the number of notes played by the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
-#.TRANS: notas jugadas de tortuga
+#. TRANS: notes played by this turtle
+#. TRANS: notas jugadas de tortuga
 msgid "turtle notes played"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:591
-#.TRANS: El bloque de notas jugadas de la tortuga devuelve el número de notas tocadas por la tortuga especificado.
+#. TRANS: El bloque de notas jugadas de la tortuga devuelve el número de notas tocadas por la tortuga especificado.
 msgid "The Turtle elapse notes block returns the number of notes played by the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
-#.TRANS: número de tono de ratón
+#. TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: número de tono de ratón
 msgid "mouse pitch number"
 msgstr "jithiyaña wairsu jakhu chimpu"
 
 #: js/blocks/EnsembleBlocks.js:631
-#.TRANS: El bloque de tono del ratón devuelve el número de tono actual que está reproduciendo el ratón especificado.
+#. TRANS: El bloque de tono del ratón devuelve el número de tono actual que está reproduciendo el ratón especificado.
 msgid "The Mouse pitch block returns the current pitch number being played by the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
-#.TRANS: número de tono de tortuga
+#. TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: número de tono de tortuga
 msgid "turtle pitch number"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:645
-#.TRANS: El bloque de tono de la tortuga devuelve el número de tono actual que está reproduciendo la tortuga especificado.
+#. TRANS: El bloque de tono de la tortuga devuelve el número de tono actual que está reproduciendo la tortuga especificado.
 msgid "The Turtle pitch block returns the current pitch number being played by the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
-#.TRANS: valor de la nota del ratón
+#. TRANS: note value is the duration of the note played by this mouse
+#. TRANS: valor de la nota del ratón
 msgid "mouse note value"
 msgstr "jithiyäwi wakichata qillqata chani"
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
-#.TRANS: valor de la nota de la tortuga
+#. TRANS: note value is the duration of the note played by this turtle
+#. TRANS: valor de la nota de la tortuga
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
-#.TRANS: sincronizar
+#. TRANS: sync is short for synchronization
+#. TRANS: sincronizar
 msgid "mouse sync"
 msgstr "jithiyaña wakichata mayachaña"
 
 #: js/blocks/EnsembleBlocks.js:834
-#.TRANS: El bloque sincronizar alinea el conteo de latidos entre ratones.
+#. TRANS: El bloque sincronizar alinea el conteo de latidos entre ratones.
 msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "El bloque sincronizar alinea el conteo de latidos entre ratones."
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
-#.TRANS: sincronizar
+#. TRANS: sync is short for synchronization
+#. TRANS: sincronizar
 msgid "turtle sync"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:848
-#.TRANS: El bloque sincronizar alinea el conteo de latidos entre tortugas.
+#. TRANS: El bloque sincronizar alinea el conteo de latidos entre tortugas.
 msgid "The Turtle sync block aligns the beat count between turtles."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:889
-#.TRANS: El bloque de ratón encontrado devolverá verdadero si se puede encontrar el ratón especificado.
+#. TRANS: El bloque de ratón encontrado devolverá verdadero si se puede encontrar el ratón especificado.
 msgid "The Found mouse block will return true if the specified mouse can be found."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:895
-#.TRANS: encontré el raton
+#. TRANS: encontré el raton
 msgid "found mouse"
 msgstr "Huk’uchata tarini"
 
 #: js/blocks/EnsembleBlocks.js:905
-#.TRANS: El bloque de tortuga encontrado devolverá verdadero si se puede encontrar el tortuga especificado.
+#. TRANS: El bloque de tortuga encontrado devolverá verdadero si se puede encontrar el tortuga especificado.
 msgid "The Found turtle block will return true if the specified turtle can be found."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:911
-#.TRANS: encontré la tortuga
+#. TRANS: encontré la tortuga
 msgid "found turtle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:934
-#.TRANS: nuevo ratón
+#. TRANS: nuevo ratón
 msgid "new mouse"
 msgstr "Musuq huk’ucha"
 
 #: js/blocks/EnsembleBlocks.js:936
-#.TRANS: El bloque nuevo ratón crea un nuevo ratón.
+#. TRANS: El bloque nuevo ratón crea un nuevo ratón.
 msgid "The New mouse block will create a new mouse."
 msgstr "El bloque nuevo ratón crea un nuevo ratón."
 
 #: js/blocks/EnsembleBlocks.js:947
-#.TRANS: nuevo tortuga
+#. TRANS: nuevo tortuga
 msgid "new turtle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:949
-#.TRANS: El bloque nuevo ratón crea un nuevo tortuga.
+#. TRANS: El bloque nuevo ratón crea un nuevo tortuga.
 msgid "The New turtle block will create a new turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1013
-#.TRANS: fijar color del ratón
+#. TRANS: fijar color del ratón
 msgid "set mouse color"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1016
-#.TRANS: El bloque fijar color del ratón se usa para fijar el color de un ratón.
+#. TRANS: El bloque fijar color del ratón se usa para fijar el color de un ratón.
 msgid "The Set-mouse-color block is used to set the color of a mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1022
-#.TRANS: fijar color de la tortuga
+#. TRANS: fijar color de la tortuga
 msgid "set turtle color"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1025
-#.TRANS: El bloque fijar color de la tortuga se usa para fijar el color de una tortuga.
+#. TRANS: El bloque fijar color de la tortuga se usa para fijar el color de una tortuga.
 msgid "The Set-turtle-color block is used to set the color of a turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1086
-#.TRANS: El bloque Nombre del ratón devuelve el nombre de un ratón.
+#. TRANS: El bloque Nombre del ratón devuelve el nombre de un ratón.
 msgid "The Mouse-name block returns the name of a mouse."
 msgstr "Huk’uha sayaq kutichin huk’ucha  sutiman"
 
 #: js/blocks/EnsembleBlocks.js:1095
-#.TRANS: El bloque Nombre de la tortuga devuelve el nombre de una tortuga.
+#. TRANS: El bloque Nombre de la tortuga devuelve el nombre de una tortuga.
 msgid "The Turtle-name block returns the name of a turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1118
-#.TRANS: recuento de ratones
+#. TRANS: recuento de ratones
 msgid "mouse count"
 msgstr "recuento de ratones"
 
 #: js/blocks/EnsembleBlocks.js:1121
-#.TRANS: El bloque recuento de ratones devuelve el número de ratones.
+#. TRANS: El bloque recuento de ratones devuelve el número de ratones.
 msgid "The Mouse-count block returns the number of mice."
 msgstr "El bloque recuento de ratones devuelve el número de ratones."
 
 #: js/blocks/EnsembleBlocks.js:1127
-#.TRANS: recuento de tortuga
+#. TRANS: recuento de tortuga
 msgid "turtle count"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1130
-#.TRANS: El bloque recuento de tortugas devuelve el número de tortugas.
+#. TRANS: El bloque recuento de tortugas devuelve el número de tortugas.
 msgid "The Turtle-count block returns the number of turtles."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1152
-#.TRANS: nombre de nth ratón
+#. TRANS: nombre de nth ratón
 msgid "nth mouse name"
 msgstr "nombre de nth ratón"
 
 #: js/blocks/EnsembleBlocks.js:1155
-#.TRANS: El bloque de nombre Nth-ratón devuelve el nombre del enésimo ratón.
+#. TRANS: El bloque de nombre Nth-ratón devuelve el nombre del enésimo ratón.
 msgid "The Nth-Mouse name block returns the name of the nth mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1161
-#.TRANS: nombre de nth tortuga
+#. TRANS: nombre de nth tortuga
 msgid "nth turtle name"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1164
-#.TRANS: El bloque de nombre Nth-tortuga devuelve el nombre del enésimo tortuga.
+#. TRANS: El bloque de nombre Nth-tortuga devuelve el nombre del enésimo tortuga.
 msgid "The Nth-Turtle name block returns the name of the nth turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1208
 #: js/blocks/EnsembleBlocks.js:1268
-#.TRANS: fijar nombre
+#. TRANS: fijar nombre
 msgid "set name"
 msgstr "Sutita tahachik"
 
 #: js/blocks/EnsembleBlocks.js:1217
 #: js/blocks/EnsembleBlocks.js:1224
-#.TRANS: origen
+#. TRANS: origen
 msgid "source"
 msgstr "paqarina"
 
 #: js/blocks/EnsembleBlocks.js:1217
 #: js/blocks/EnsembleBlocks.js:1224
-#.TRANS: destino
+#. TRANS: destino
 msgid "target"
 msgstr "chayana"
 
 #: js/blocks/EnsembleBlocks.js:1274
-#.TRANS: El bloque Fijar nombre se usa para nombrar un ratón.
+#. TRANS: El bloque Fijar nombre se usa para nombrar un ratón.
 msgid "The Set-name block is used to name a mouse."
 msgstr "El bloque Fijar nombre se usa para nombrar un ratón."
 
 #: js/blocks/EnsembleBlocks.js:1287
-#.TRANS: El bloque Fijar nombre se usa para nombrar una tortuga.
+#. TRANS: El bloque Fijar nombre se usa para nombrar una tortuga.
 msgid "The Set-name block is used to name a turtle."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:33
-#.TRANS: fracción
+#. TRANS: fracción
 msgid "fraction"
 msgstr "phatmi"
 
 #: js/blocks/ExtrasBlocks.js:36
-#.TRANS: convertir un número racional en fracción
+#. TRANS: convertir un número racional en fracción
 msgid "Convert a float to a fraction"
 msgstr "convertir un número racional en fracción"
 
 #: js/blocks/ExtrasBlocks.js:93
-#.TRANS: guardar como ABC
+#. TRANS: guardar como ABC
 msgid "save as ABC"
 msgstr "ABC hinaman waqaychay"
 
 #: js/blocks/ExtrasBlocks.js:96
 #: js/blocks/ExtrasBlocks.js:132
 #: js/blocks/ExtrasBlocks.js:168
-#.TRANS: título
+#. TRANS: título
 msgid "title"
 msgstr "umalliq suti"
 
 #: js/blocks/ExtrasBlocks.js:129
-#.TRANS: guardar como Lilypond
+#. TRANS: guardar como Lilypond
 msgid "save as Lilypond"
 msgstr "Lilypondtahina waqaychay"
 
 #: js/blocks/ExtrasBlocks.js:165
-#.TRANS: guardar como SVG
+#. TRANS: guardar como SVG
 msgid "save as SVG"
 msgstr "SVGtahina waqaychay"
 
 #: js/blocks/ExtrasBlocks.js:216
-#.TRANS: sin fondo
+#. TRANS: sin fondo
 msgid "no background"
 msgstr "Mana imayuq"
 
 #: js/blocks/ExtrasBlocks.js:219
-#.TRANS: El bloque Sin fondo elimina el fondo de la salida SVG guardada.
+#. TRANS: El bloque Sin fondo elimina el fondo de la salida SVG guardada.
 msgid "The No background block eliminates the background from the saved SVG output."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:247
-#.TRANS: mostrar bloques
+#. TRANS: mostrar bloques
 msgid "show blocks"
 msgstr " chiqaskunata qhawachiy"
 
 #: js/blocks/ExtrasBlocks.js:249
-#.TRANS: El bloque mostrar bloques muestra los bloques.
+#. TRANS: El bloque mostrar bloques muestra los bloques.
 msgid "The Show blocks block shows the blocks."
 msgstr "El bloque mostrar bloques muestra los bloques."
 
 #: js/blocks/ExtrasBlocks.js:276
-#.TRANS: El bloque ocultar esconde los bloques.
+#. TRANS: El bloque ocultar esconde los bloques.
 msgid "The Hide blocks block hides the blocks."
 msgstr "El bloque ocultar esconde los bloques."
 
 #: js/blocks/ExtrasBlocks.js:305
 #: js/blocks/ExtrasBlocks.js:338
-#.TRANS: El bloque Espacio se utiliza para agregar espacio entre bloques.
+#. TRANS: El bloque Espacio se utiliza para agregar espacio entre bloques.
 msgid "The Space block is used to add space between blocks."
 msgstr " Qaylla chiqasqa chiqaspurakuna qayllayuq kanankupaq yapaq yapanapaq"
 
 #: js/blocks/ExtrasBlocks.js:376
-#.TRANS: esperar
+#. TRANS: esperar
 msgid "wait"
 msgstr "suyay"
 
 #: js/blocks/ExtrasBlocks.js:379
-#.TRANS: El bloque Espera detiene el programa durante un número específico de segundos.
+#. TRANS: El bloque Espera detiene el programa durante un número específico de segundos.
 msgid "The Wait block pauses the program for a specified number of seconds."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:433
 #: plugins/facebook.rtp:30
-#.TRANS: comentar
+#. TRANS: comentar
 msgid "comment"
 msgstr "rimariy"
 
 #: js/blocks/ExtrasBlocks.js:469
-#.TRANS: imprimir
+#. TRANS: imprimir
 msgid "print"
 msgstr "ñit'iy"
 
 #: js/blocks/ExtrasBlocks.js:476
-#.TRANS: El bloque Imprimir muestra texto en la parte superior de la pantalla.
+#. TRANS: El bloque Imprimir muestra texto en la parte superior de la pantalla.
 msgid "The Print block displays text at the top of the screen."
 msgstr "Nit’iy chiqasqa pantallapa hawanpi qillqata qhawachikun"
 
 #: js/blocks/ExtrasBlocks.js:585
-#.TRANS: mostrar cuadrícula
+#. TRANS: mostrar cuadrícula
 msgid "display grid"
 msgstr "mostrar cuadrícula"
 
 #: js/blocks/ExtrasBlocks.js:590
-#.TRANS: Mostrar el bloque de cuadrícula cambia el tipo de cuadrícula
+#. TRANS: Mostrar el bloque de cuadrícula cambia el tipo de cuadrícula
 msgid "The Display Grid Block changes the grid type"
 msgstr "Mostrar el bloque de cuadrícula cambia el tipo de cuadrícula"
 
@@ -6884,7 +6884,7 @@ msgstr "Mostrar el bloque de cuadrícula cambia el tipo de cuadrícula"
 #: js/blocks/ExtrasBlocks.js:794
 #: js/blocks/ExtrasBlocks.js:813
 #: js/blocks/ExtrasBlocks.js:832
-#.TRANS: desconocido
+#. TRANS: desconocido
 msgid "unknown"
 msgstr "Mana riqsisqa"
 
@@ -6892,77 +6892,77 @@ msgstr "Mana riqsisqa"
 #: js/turtleactions/DictActions.js:77
 #: js/turtleactions/DictActions.js:144
 #: js/turtleactions/DictActions.js:173
-#.TRANS: rumbo
+#. TRANS: rumbo
 msgid "heading"
 msgstr "mayman"
 
 #: js/blocks/GraphicsBlocks.js:56
-#.TRANS: El bloque rumbo devuelve la orientación del ratón.
+#. TRANS: El bloque rumbo devuelve la orientación del ratón.
 msgid "The Heading block returns the orientation of the mouse."
 msgstr "El bloque rumbo devuelve la orientación del ratón."
 
 #: js/blocks/GraphicsBlocks.js:62
-#.TRANS: El bloque rumbo devuelve la orientación de la tortuga.
+#. TRANS: El bloque rumbo devuelve la orientación de la tortuga.
 msgid "The Heading block returns the orientation of the turtle."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:133
-#.TRANS: El bloque Y devuelve la posición horizontal del ratón.
+#. TRANS: El bloque Y devuelve la posición horizontal del ratón.
 msgid "The Y block returns the vertical position of the mouse."
 msgstr "chiqasqa huk’ucha pampallanpi kasqanta kutichipun"
 
 #: js/blocks/GraphicsBlocks.js:140
-#.TRANS: El bloque Y devuelve la posición horizontal de la tortuga.
+#. TRANS: El bloque Y devuelve la posición horizontal de la tortuga.
 msgid "The Y block returns the vertical position of the turtle."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:149
-#.TRANS: y
+#. TRANS: y
 msgid "y3"
 msgstr "y3"
 
 #: js/blocks/GraphicsBlocks.js:219
-#.TRANS: El bloque X devuelve la posición horizontal del ratón.
+#. TRANS: El bloque X devuelve la posición horizontal del ratón.
 msgid "The X block returns the horizontal position of the mouse."
 msgstr "X chiqasqa huk’ucha pampallanpi kasqanta kutichipun"
 
 #: js/blocks/GraphicsBlocks.js:226
-#.TRANS: El bloque X devuelve la posición horizontal de la tortuga.
+#. TRANS: El bloque X devuelve la posición horizontal de la tortuga.
 msgid "The X block returns the horizontal position of the turtle."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:235
-#.TRANS: x
+#. TRANS: x
 msgid "x3"
 msgstr "x3"
 
 #: js/blocks/GraphicsBlocks.js:295
-#.TRANS: desplazar xy
+#. TRANS: desplazar xy
 msgid "scroll xy"
 msgstr "xy purichiy"
 
 #: js/blocks/GraphicsBlocks.js:303
-#.TRANS: El bloque Desplazar XY mueve el lienzo.
+#. TRANS: El bloque Desplazar XY mueve el lienzo.
 msgid "The Scroll XY block moves the canvas."
 msgstr "Purichiy chiqasqa XY llikata kuyuchin"
 
 #: js/blocks/GraphicsBlocks.js:313
-#.TRANS: x
+#. TRANS: x
 msgid "x2"
 msgstr "x2"
 
 #: js/blocks/GraphicsBlocks.js:313
-#.TRANS: y
+#. TRANS: y
 msgid "y2"
 msgstr "y2"
 
 #: js/blocks/GraphicsBlocks.js:417
-#.TRANS: El bloque Control-point 2 establece el segundo punto de control para la curva Bezier.
+#. TRANS: El bloque Control-point 2 establece el segundo punto de control para la curva Bezier.
 msgid "The Control-point 2 block sets the second control point for the Bezier curve."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:424
-#.TRANS: punto de control 2
+#. TRANS: punto de control 2
 msgid "control point 2"
 msgstr "arariwaq 2"
 
@@ -6970,7 +6970,7 @@ msgstr "arariwaq 2"
 #: js/blocks/GraphicsBlocks.js:478
 #: js/blocks/GraphicsBlocks.js:525
 #: js/blocks/GraphicsBlocks.js:741
-#.TRANS: x
+#. TRANS: x
 msgid "x1"
 msgstr "x1"
 
@@ -6978,47 +6978,47 @@ msgstr "x1"
 #: js/blocks/GraphicsBlocks.js:478
 #: js/blocks/GraphicsBlocks.js:525
 #: js/blocks/GraphicsBlocks.js:741
-#.TRANS: y
+#. TRANS: y
 msgid "y1"
 msgstr "y1"
 
 #: js/blocks/GraphicsBlocks.js:468
-#.TRANS: El bloque Control-point 1 establece el segundo punto de control para la curva Bezier.
+#. TRANS: El bloque Control-point 1 establece el segundo punto de control para la curva Bezier.
 msgid "The Control-point 1 block sets the first control point for the Bezier curve."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:475
-#.TRANS: punto de control 1
+#. TRANS: punto de control 1
 msgid "control point 1"
 msgstr "arariwaq 1"
 
 #: js/blocks/GraphicsBlocks.js:518
-#.TRANS: El bloque bezier dibuja una curva bezier.
+#. TRANS: El bloque bezier dibuja una curva bezier.
 msgid "The Bezier block draws a Bezier curve."
 msgstr "El bloque bezier dibuja una curva bezier."
 
 #: js/blocks/GraphicsBlocks.js:522
-#.TRANS: bezier
+#. TRANS: bezier
 msgid "bezier"
 msgstr "bezier wakichata"
 
 #: js/blocks/GraphicsBlocks.js:583
-#.TRANS: El bloque Arco mueve la tortuga en un arco.
+#. TRANS: El bloque Arco mueve la tortuga en un arco.
 msgid "The Arc block moves the turtle in an arc."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:591
-#.TRANS: arco
+#. TRANS: arco
 msgid "arc"
 msgstr "k’umu"
 
 #: js/blocks/GraphicsBlocks.js:594
-#.TRANS: ángulo
+#. TRANS: ángulo
 msgid "angle"
 msgstr "k'uchu"
 
 #: js/blocks/GraphicsBlocks.js:594
-#.TRANS: radio
+#. TRANS: radio
 msgid "radius"
 msgstr "illwa"
 
@@ -7026,7 +7026,7 @@ msgstr "illwa"
 #: js/blocks/GraphicsBlocks.js:758
 #: js/blocks/GraphicsBlocks.js:1001
 #: js/blocks/GraphicsBlocks.js:1084
-#.TRANS: El valor debe estar entre -5000 y 5000 cuando el modo Wrap está desactivado.
+#. TRANS: El valor debe estar entre -5000 y 5000 cuando el modo Wrap está desactivado.
 msgid "Value must be within -5000 to 5000 when Wrap Mode is off."
 msgstr ""
 
@@ -7034,47 +7034,49 @@ msgstr ""
 #: js/blocks/GraphicsBlocks.js:760
 #: js/blocks/GraphicsBlocks.js:1003
 #: js/blocks/GraphicsBlocks.js:1086
-#.TRANS: El valor debe estar entre -20000 y 20000 cuando el modo Wrap está activado.
+#. TRANS: El valor debe estar entre -20000 y 20000 cuando el modo Wrap está activado.
 msgid "Value must be within -20000 to 20000 when Wrap Mode is on."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:651
-#.TRANS: fijar rumbo
+#. TRANS: fijar rumbo
 msgid "set heading"
 msgstr "mayman rinantam churay"
 
 #: js/blocks/GraphicsBlocks.js:664
-#.TRANS: El bloque fijar rumbo establece el rumbo de la tortuga.
+#. TRANS: El bloque fijar rumbo establece el rumbo de la tortuga.
 msgid "The Set heading block sets the heading of the turtle."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:724
-#.TRANS: El bloque Fijar XY mueve el ratón a una posición específica en la pantalla.
+#. TRANS: El bloque Fijar XY mueve el ratón a una posición específica en la pantalla.
 msgid "The Set XY block moves the mouse to a specific position on the screen."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:730
-#.TRANS: El bloque Fijar XY mueve la tortuga a una posición específica en la pantalla.
+#. TRANS: El bloque Fijar XY mueve la tortuga a una posición específica en la pantalla.
 msgid "The Set XY block moves the turtle to a specific position on the screen."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:738
-#.TRANS: fijar xy
+#. TRANS: fijar xy
 msgid "set xy"
-msgstr "xy nisqata churay" "xy k’askachiy"
+msgstr ""
+"xy nisqata churay "
+"xy k’askachiy"
 
 #: js/blocks/GraphicsBlocks.js:810
-#.TRANS: El bloque Derecha gira el ratón hacia la derecha.
+#. TRANS: El bloque Derecha gira el ratón hacia la derecha.
 msgid "The Right block turns the mouse to the right."
 msgstr "El bloque Derecha gira el ratón hacia la derecha."
 
 #: js/blocks/GraphicsBlocks.js:817
-#.TRANS: El bloque Derecha gira la tortuga hacia la derecha.
+#. TRANS: El bloque Derecha gira la tortuga hacia la derecha.
 msgid "The Right block turns the turtle to the right."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:826
-#.TRANS: derecha
+#. TRANS: derecha
 msgid "right1"
 msgstr "paña"
 
@@ -7082,22 +7084,22 @@ msgstr "paña"
 #: plugins/rodi.rtp:77
 #: plugins/rodi.rtp:340
 #: plugins/rodi.rtp:375
-#.TRANS: derecha
+#. TRANS: derecha
 msgid "right"
 msgstr "paña"
 
 #: js/blocks/GraphicsBlocks.js:890
-#.TRANS: El bloque izquierdo gira el ratón hacia la izquierda.
+#. TRANS: El bloque izquierdo gira el ratón hacia la izquierda.
 msgid "The Left block turns the mouse to the left."
 msgstr "lluq’i t’aqa huk’uchawan lluq’iman muyun"
 
 #: js/blocks/GraphicsBlocks.js:897
-#.TRANS: El bloque izquierdo gira la tortuga hacia la izquierda.
+#. TRANS: El bloque izquierdo gira la tortuga hacia la izquierda.
 msgid "The Left block turns the turtle to the left."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:906
-#.TRANS: izquierda
+#. TRANS: izquierda
 msgid "left1"
 msgstr "lluq’i"
 
@@ -7105,7 +7107,7 @@ msgstr "lluq’i"
 #: plugins/rodi.rtp:79
 #: plugins/rodi.rtp:339
 #: plugins/rodi.rtp:362
-#.TRANS: izquierda
+#. TRANS: izquierda
 msgid "left"
 msgstr "lluq’i"
 
@@ -7114,174 +7116,174 @@ msgstr "lluq’i"
 #: js/widgets/temperament.js:1033
 #: plugins/rodi.rtp:69
 #: plugins/rodi.rtp:387
-#.TRANS: atrás
+#. TRANS: atrás
 msgid "back"
 msgstr "qhipa"
 
 #: js/blocks/GraphicsBlocks.js:967
-#.TRANS: El bloque Atrás mueve el ratón hacia atrás.
+#. TRANS: El bloque Atrás mueve el ratón hacia atrás.
 msgid "The Back block moves the mouse backward."
 msgstr "qhipa t’aqa huk’uchawan qhipaman muyun"
 
 #: js/blocks/GraphicsBlocks.js:974
-#.TRANS: El bloque Atrás mueve la tortuga hacia atrás.
+#. TRANS: El bloque Atrás mueve la tortuga hacia atrás.
 msgid "The Back block moves the turtle backward."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:1041
 #: plugins/rodi.rtp:71
 #: plugins/rodi.rtp:400
-#.TRANS: adelante
+#. TRANS: adelante
 msgid "forward"
 msgstr "ñawpaq"
 
 #: js/blocks/GraphicsBlocks.js:1050
-#.TRANS: El bloque Adelante mueve el ratón hacia adelante.
+#. TRANS: El bloque Adelante mueve el ratón hacia adelante.
 msgid "The Forward block moves the mouse forward."
 msgstr "ñawpaq t’aqa huk’uchawan ñawpaqman muyun"
 
 #: js/blocks/GraphicsBlocks.js:1057
-#.TRANS: El bloque Adelante mueve la tortuga hacia adelante.
+#. TRANS: El bloque Adelante mueve la tortuga hacia adelante.
 msgid "The Forward block moves the turtle forward."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:1145
 #: js/blocks/GraphicsBlocks.js:1163
-#.TRANS: envolver
+#. TRANS: envolver
 msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
-#.TRANS: derecha
+#. TRANS: right side of the screen
+#. TRANS: derecha
 msgid "right (screen)"
 msgstr "pantallapa pañanpi"
 
 #: js/blocks/MediaBlocks.js:45
 #: js/blocks/MediaBlocks.js:56
-#.TRANS: El bloque Derecha devuelve la posición de la derecha del lienzo.
+#. TRANS: El bloque Derecha devuelve la posición de la derecha del lienzo.
 msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
-#.TRANS: izquierdo
+#. TRANS: left side of the screen
+#. TRANS: izquierdo
 msgid "left (screen)"
 msgstr "pantallapa lluq’ínpi"
 
 #: js/blocks/MediaBlocks.js:107
 #: js/blocks/MediaBlocks.js:118
-#.TRANS: El bloque Izquierdo devuelve la posición de la izquierda del lienzo.
+#. TRANS: El bloque Izquierdo devuelve la posición de la izquierda del lienzo.
 msgid "The Left block returns the position of the left of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:158
-#.TRANS: superior
+#. TRANS: superior
 msgid "top (screen)"
 msgstr "hanan"
 
 #: js/blocks/MediaBlocks.js:168
 #: js/blocks/MediaBlocks.js:179
-#.TRANS: El bloque superior devuelve la posición de la parte superior del lienzo.
+#. TRANS: El bloque superior devuelve la posición de la parte superior del lienzo.
 msgid "The Top block returns the position of the top of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:219
-#.TRANS: inferior
+#. TRANS: inferior
 msgid "bottom (screen)"
 msgstr "uran"
 
 #: js/blocks/MediaBlocks.js:229
 #: js/blocks/MediaBlocks.js:240
-#.TRANS: El bloque Inferior devuelve la posición de la parte inferior del lienzo.
+#. TRANS: El bloque Inferior devuelve la posición de la parte inferior del lienzo.
 msgid "The Bottom block returns the position of the bottom of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:282
-#.TRANS: anchura
+#. TRANS: anchura
 msgid "width"
 msgstr "chutariynin"
 
 #: js/blocks/MediaBlocks.js:291
-#.TRANS: El bloque ancho devuelve el ancho del lienzo.
+#. TRANS: El bloque ancho devuelve el ancho del lienzo.
 msgid "The Width block returns the width of the canvas."
 msgstr "chutariynin chiqasqa qillqana llikapa chutariyninta kutichin"
 
 #: js/blocks/MediaBlocks.js:325
-#.TRANS: altura
+#. TRANS: altura
 msgid "height"
 msgstr "sayaynin"
 
 #: js/blocks/MediaBlocks.js:334
-#.TRANS: El bloque altura devuelve la altura del lienzo.
+#. TRANS: El bloque altura devuelve la altura del lienzo.
 msgid "The Height block returns the height of the canvas."
 msgstr "sayaynin chiqasqa qillqana llikapa sayayninta kutichin"
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
-#.TRANS: detener
+#. TRANS: stops playback of an audio recording
+#. TRANS: detener
 msgid "stop play"
 msgstr "sayachiy"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
-#.TRANS: borrar medios
+#. TRANS: Erases the images and text
+#. TRANS: borrar medios
 msgid "erase media"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:409
-#.TRANS: El bloque Erase Media borra texto e imágenes.
+#. TRANS: El bloque Erase Media borra texto e imágenes.
 msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
-#.TRANS: reproducir
+#. TRANS: play an audio recording
+#. TRANS: reproducir
 msgid "play back"
 msgstr "puririchiy"
 
 #: js/blocks/MediaBlocks.js:487
-#.TRANS: hablar
+#. TRANS: hablar
 msgid "speak"
 msgstr "rimay"
 
 #: js/blocks/MediaBlocks.js:495
-#.TRANS: El bloque Habla emite al sintetizador de texto a voz.
+#. TRANS: El bloque Habla emite al sintetizador de texto a voz.
 msgid "The Speak block outputs to the text-to-speech synthesizer"
 msgstr "Rimay chiqasqa kunkawan rimasqa pisiyachisqanmanta riman "
 
 #: js/blocks/MediaBlocks.js:546
-#.TRANS: 
+#. TRANS: 
 msgid "camera"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:551
-#.TRANS: El bloque cámara conecta una cámara web al bloque mostrar.
+#. TRANS: El bloque cámara conecta una cámara web al bloque mostrar.
 msgid "The Camera block connects a webcam to the Show block."
 msgstr "Cámarata webman hap’ichiy"
 
 #: js/blocks/MediaBlocks.js:574
-#.TRANS: 
+#. TRANS: 
 msgid "video"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:579
-#.TRANS: El bloque video selecciona video para al bloque mostrar.
+#. TRANS: El bloque video selecciona video para al bloque mostrar.
 msgid "The Video block selects video for use with the Show block."
 msgstr "El bloque video selecciona video para al bloque mostrar."
 
 #: js/blocks/MediaBlocks.js:607
-#.TRANS: El bloque Abrir archivo abre un archivo para usar con el bloque Mostrar.
+#. TRANS: El bloque Abrir archivo abre un archivo para usar con el bloque Mostrar.
 msgid "The Open file block opens a file for use with the Show block."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:645
-#.TRANS: detener medios
+#. TRANS: detener medios
 msgid "stop media"
 msgstr "ruranakunata sayachiy"
 
 #: js/blocks/MediaBlocks.js:650
-#.TRANS: El bloque detener medios detiene la reproducción de audio o video.
+#. TRANS: El bloque detener medios detiene la reproducción de audio o video.
 msgid "The Stop media block stops audio or video playback."
 msgstr "El bloque detener medios detiene la reproducción de audio o video."
 
@@ -7293,136 +7295,136 @@ msgstr "El bloque detener medios detiene la reproducción de audio o video."
 #: js/widgets/temperament.js:590
 #: js/widgets/temperament.js:1446
 #: js/widgets/timbre.js:1834
-#.TRANS: frecuencia
+#. TRANS: frecuencia
 msgid "frequency"
 msgstr "Kutipayaq"
 
 #: js/blocks/MediaBlocks.js:692
 #: plugins/rodi.rtp:193
-#.TRANS: 
+#. TRANS: 
 msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
-#.TRANS: nota a frecuencia
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: nota a frecuencia
 msgid "note to frequency"
 msgstr "kuti kuti ruranaman huch’uy willakuy"
 
 #: js/blocks/MediaBlocks.js:736
-#.TRANS: El bloque A frecuencia convierte un nombre de tono y una octava a Hertz.
+#. TRANS: El bloque A frecuencia convierte un nombre de tono y una octava a Hertz.
 msgid "The To frequency block converts a pitch name and octave to Hertz."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:812
-#.TRANS: El bloque Avatar se usa para cambiar la apariencia del ratón.
+#. TRANS: El bloque Avatar se usa para cambiar la apariencia del ratón.
 msgid "The Avatar block is used to change the appearance of the mouse."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:819
-#.TRANS: El bloque Avatar se usa para cambiar la apariencia de la tortuga.
+#. TRANS: El bloque Avatar se usa para cambiar la apariencia de la tortuga.
 msgid "The Avatar block is used to change the appearance of the turtle."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
-#.TRANS: tamaño
+#. TRANS: a media object
+#. TRANS: tamaño
 msgid "size"
 msgstr "sayay"
 
 #: js/blocks/MediaBlocks.js:831
-#.TRANS: imagen
+#. TRANS: imagen
 msgid "image"
 msgstr "rikch’aynin"
 
 #: js/blocks/MediaBlocks.js:880
-#.TRANS: El bloque Mostrar se utiliza para mostrar texto o imágenes en el lienzo.
+#. TRANS: El bloque Mostrar se utiliza para mostrar texto o imágenes en el lienzo.
 msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
-#.TRANS: mostrar
+#. TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: mostrar
 msgid "show1"
 msgstr "qhawachiy"
 
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: objeto
+#. TRANS: objeto
 msgid "obj"
 msgstr "ima"
 
 #: js/blocks/MediaBlocks.js:938
-#.TRANS: El bloque Medios se utiliza para importar una imagen.
+#. TRANS: El bloque Medios se utiliza para importar una imagen.
 msgid "The Media block is used to import an image."
 msgstr "Kaqkuna chiqastaqa llimp’ita apamunapaq hap’ikun"
 
 #: js/blocks/MediaBlocks.js:973
-#.TRANS: El bloque Texto contiene una cadena de texto.
+#. TRANS: El bloque Texto contiene una cadena de texto.
 msgid "The Text block holds a text string."
 msgstr "Qillqa t’aqaqa watuchasqa qillqakuna kaqniyuqmi"
 
 #: js/blocks/PenBlocks.js:30
-#.TRANS: morado
+#. TRANS: morado
 msgid "purple"
 msgstr "Kulli"
 
 #: js/blocks/PenBlocks.js:48
 #: js/blocks/SensorsBlocks.js:521
 #: plugins/rodi.rtp:219
-#.TRANS: azur
+#. TRANS: azur
 msgid "blue"
 msgstr "Anqas"
 
 #: js/blocks/PenBlocks.js:64
 #: js/blocks/SensorsBlocks.js:577
 #: plugins/rodi.rtp:218
-#.TRANS: verde
+#. TRANS: verde
 msgid "green"
 msgstr "Qunir"
 
 #: js/blocks/PenBlocks.js:80
-#.TRANS: amarillo
+#. TRANS: amarillo
 msgid "yellow"
 msgstr "Q’illu"
 
 #: js/blocks/PenBlocks.js:96
 #: plugins/nutrition.rtp:164
-#.TRANS: naranja
+#. TRANS: naranja
 msgid "orange"
 msgstr "q'illmu"
 
 #: js/blocks/PenBlocks.js:112
 #: js/blocks/SensorsBlocks.js:633
 #: plugins/rodi.rtp:217
-#.TRANS: rojo
+#. TRANS: rojo
 msgid "red"
 msgstr "Puka"
 
 #: js/blocks/PenBlocks.js:128
-#.TRANS: blanco
+#. TRANS: blanco
 msgid "white"
 msgstr "Yuraq"
 
 #: js/blocks/PenBlocks.js:144
-#.TRANS: negro
+#. TRANS: negro
 msgid "black"
 msgstr "Yana"
 
 #: js/blocks/PenBlocks.js:163
-#.TRANS: iniciar relleno
+#. TRANS: iniciar relleno
 msgid "begin fill"
 msgstr "Hunt’achiyta qallariy"
 
 #: js/blocks/PenBlocks.js:188
-#.TRANS: Cargar proyecto desde archivo
+#. TRANS: Cargar proyecto desde archivo
 msgid "end fill"
 msgstr "pusariqta waqaychanamanta hunt’achimuy"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
-#.TRANS: rellenar pantalla
+#. TRANS: set the background color
+#. TRANS: rellenar pantalla
 msgid "background"
 msgstr " qhawanata hunt’achiy"
 
@@ -7430,12 +7432,12 @@ msgstr " qhawanata hunt’achiy"
 #: js/turtleactions/DictActions.js:71
 #: js/turtleactions/DictActions.js:138
 #: js/turtleactions/DictActions.js:170
-#.TRANS: gris
+#. TRANS: gris
 msgid "grey"
 msgstr "uqi"
 
 #: js/blocks/PenBlocks.js:261
-#.TRANS: El bloque gris devuelve el valor gris actual de la pluma.
+#. TRANS: El bloque gris devuelve el valor gris actual de la pluma.
 msgid "The Grey block returns the current pen grey value."
 msgstr "El bloque gris devuelve el valor gris actual de la pluma."
 
@@ -7443,12 +7445,12 @@ msgstr "El bloque gris devuelve el valor gris actual de la pluma."
 #: js/turtleactions/DictActions.js:69
 #: js/turtleactions/DictActions.js:136
 #: js/turtleactions/DictActions.js:169
-#.TRANS: sombra
+#. TRANS: sombra
 msgid "shade"
 msgstr "llanthu"
 
 #: js/blocks/PenBlocks.js:326
-#.TRANS: El bloque sombra devuelve la sombra actual de la pluma.
+#. TRANS: El bloque sombra devuelve la sombra actual de la pluma.
 msgid "The Shade block returns the current pen shade value."
 msgstr "El bloque sombra devuelve la sombra actual de la pluma."
 
@@ -7456,12 +7458,12 @@ msgstr "El bloque sombra devuelve la sombra actual de la pluma."
 #: js/turtleactions/DictActions.js:67
 #: js/turtleactions/DictActions.js:134
 #: js/turtleactions/DictActions.js:168
-#.TRANS: color
+#. TRANS: color
 msgid "color"
 msgstr "llimp'i"
 
 #: js/blocks/PenBlocks.js:394
-#.TRANS: El bloque color devuelve el color actual de la pluma.
+#. TRANS: El bloque color devuelve el color actual de la pluma.
 msgid "The Color block returns the current pen color."
 msgstr "sayaq llimp’i kutichin llimp’ita kunan llimp’qman"
 
@@ -7469,541 +7471,541 @@ msgstr "sayaq llimp’i kutichin llimp’ita kunan llimp’qman"
 #: js/turtleactions/DictActions.js:73
 #: js/turtleactions/DictActions.js:140
 #: js/turtleactions/DictActions.js:171
-#.TRANS: tamaño de la pluma
+#. TRANS: tamaño de la pluma
 msgid "pen size"
 msgstr "Qillqanq sayayanin"
 
 #: js/blocks/PenBlocks.js:453
-#.TRANS: El bloque tamaño de la pluma devuelve el tamaño actual de la pluma.
+#. TRANS: El bloque tamaño de la pluma devuelve el tamaño actual de la pluma.
 msgid "The Pen size block returns the current pen size value."
 msgstr "El bloque tamaño de la pluma devuelve el tamaño actual de la pluma."
 
 #: js/blocks/PenBlocks.js:492
-#.TRANS: fijar font
+#. TRANS: fijar font
 msgid "set font"
 msgstr "tahachiy font"
 
 #: js/blocks/PenBlocks.js:497
-#.TRANS: El bloque fijar font establece el font utilizada por el bloque mostrar.
+#. TRANS: El bloque fijar font establece el font utilizada por el bloque mostrar.
 msgid "The Set font block sets the font used by the Show block."
 msgstr "El bloque fijar font establece el font utilizada por el bloque mostrar."
 
 #: js/blocks/PenBlocks.js:544
-#.TRANS: El bloque Fondo establece el color de fondo de la ventana.
+#. TRANS: El bloque Fondo establece el color de fondo de la ventana.
 msgid "The Background block sets the window background color."
 msgstr "El bloque Fondo establece el color de fondo de la ventana."
 
 #: js/blocks/PenBlocks.js:575
-#.TRANS: El bloque de línea sin relleno crea una línea con un centro hueco.
+#. TRANS: El bloque de línea sin relleno crea una línea con un centro hueco.
 msgid "The Hollow line block creates a line with a hollow center."
 msgstr "El bloque de línea sin relleno crea una línea con un centro hueco."
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
-#.TRANS: linea sin relleno
+#. TRANS: draw a line logo has a hollow space down its center
+#. TRANS: linea sin relleno
 msgid "hollow line"
 msgstr "Hunt’achina siq’i"
 
 #: js/blocks/PenBlocks.js:652
-#.TRANS: El bloque relleno rellena una forma con un color.
+#. TRANS: El bloque relleno rellena una forma con un color.
 msgid "The Fill block fills in a shape with a color."
 msgstr "El bloque relleno rellena una forma con un color."
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
-#.TRANS: relleno
+#. TRANS: fill in as a solid color
+#. TRANS: relleno
 msgid "fill"
 msgstr "Hunt’achina"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
-#.TRANS: subir pluma
+#. TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: subir pluma
 msgid "pen up"
 msgstr "qillqanata uqariy"
 
 #: js/blocks/PenBlocks.js:745
-#.TRANS: El bloque Subir pluma levanta la pluma para que no dibuje.
+#. TRANS: El bloque Subir pluma levanta la pluma para que no dibuje.
 msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "Sayaqpi, qillqanata uqariy mana siq’inanpaq"
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
-#.TRANS: bajar pluma
+#. TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: bajar pluma
 msgid "pen down"
 msgstr "qillqanata urayachiy"
 
 #: js/blocks/PenBlocks.js:787
-#.TRANS: El bloque de Haciar pluma abajo baja la pluma para que dibuje.
+#. TRANS: El bloque de Haciar pluma abajo baja la pluma para que dibuje.
 msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "El bloque de Haciar pluma abajo baja la pluma para que dibuje."
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
-#.TRANS: fijar pluma
+#. TRANS: set the width of the line drawn by the pen
+#. TRANS: fijar pluma
 msgid "set pen size"
 msgstr "Qillqanata tahachiy"
 
 #: js/blocks/PenBlocks.js:831
-#.TRANS: El bloque Fijar tamaño de la pluma de ajuste cambia el tamaño de la pluma.
+#. TRANS: El bloque Fijar tamaño de la pluma de ajuste cambia el tamaño de la pluma.
 msgid "The Set-pen-size block changes the size of the pen."
 msgstr "Sayaq, qillqanaq tahachinanmi kutichin qillqaqa rakhuyanata, ñañuyachinata"
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
-#.TRANS: fijar translucidez
+#. TRANS: set degree of translucence of the pen color
+#. TRANS: fijar translucidez
 msgid "set translucency"
 msgstr " K’anchayninta tahachiy "
 
 #: js/blocks/PenBlocks.js:898
-#.TRANS: El bloque fijar translucidez cambia la opacidad de la pluma.
+#. TRANS: El bloque fijar translucidez cambia la opacidad de la pluma.
 msgid "The Set translucency block changes the opacity of the pen."
 msgstr "El bloque fijar translucidez cambia la opacidad de la pluma."
 
 #: js/blocks/PenBlocks.js:958
-#.TRANS: fijar matiz
+#. TRANS: fijar matiz
 msgid "set hue"
 msgstr " Llimp’inta tahachiy "
 
 #: js/blocks/PenBlocks.js:966
-#.TRANS: El bloque fijar matiz cambia la color de la pluma.
+#. TRANS: El bloque fijar matiz cambia la color de la pluma.
 msgid "The Set hue block changes the color of the pen."
 msgstr "El bloque fijar matiz cambia la color de la pluma."
 
 #: js/blocks/PenBlocks.js:1024
-#.TRANS: fijar sombra
+#. TRANS: fijar sombra
 msgid "set shade"
 msgstr " Llanthunta tahachiy "
 
 #: js/blocks/PenBlocks.js:1034
-#.TRANS: El bloque Fijar sombra cambia el color de la pluma de oscuro a claro.
+#. TRANS: El bloque Fijar sombra cambia el color de la pluma de oscuro a claro.
 msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
-#.TRANS: fijar gris
+#. TRANS: set the level of vividness of the pen color
+#. TRANS: fijar gris
 msgid "set grey"
 msgstr " Uqinta tahachiy "
 
 #: js/blocks/PenBlocks.js:1096
-#.TRANS: El bloque fijar gris cambia la intensidad de la pluma.
+#. TRANS: El bloque fijar gris cambia la intensidad de la pluma.
 msgid "The Set grey block changes the vividness of the pen color."
 msgstr "El bloque fijar gris cambia la intensidad de la pluma."
 
 #: js/blocks/PenBlocks.js:1149
-#.TRANS: fijar color
+#. TRANS: fijar color
 msgid "set color"
 msgstr "Llinpinta tahachiy"
 
 #: js/blocks/PenBlocks.js:1159
-#.TRANS: El bloque fijar color cambia el color de la pluma.
+#. TRANS: El bloque fijar color cambia el color de la pluma.
 msgid "The Set-color block changes the pen color."
 msgstr "Sayaq, tahachiy llmp’iyta qillqanaq llimp’iynita kutichin"
 
 #: js/blocks/SensorsBlocks.js:36
-#.TRANS: El bloque de entrada solicita la entrada del teclado.
+#. TRANS: El bloque de entrada solicita la entrada del teclado.
 msgid "The Input block prompts for keyboard input."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:46
-#.TRANS: el input
+#. TRANS: el input
 msgid "input"
 msgstr "haykuna"
 
 #: js/blocks/SensorsBlocks.js:64
-#.TRANS: ingrese un valor
+#. TRANS: ingrese un valor
 msgid "Input a value"
 msgstr "ingrese un valor"
 
 #: js/blocks/SensorsBlocks.js:126
-#.TRANS: valor de entrada
+#. TRANS: valor de entrada
 msgid "input value"
 msgstr "chaninchaqta haykuchiy"
 
 #: js/blocks/SensorsBlocks.js:131
-#.TRANS: El bloque de valor de entrada almacena la entrada.
+#. TRANS: El bloque de valor de entrada almacena la entrada.
 msgid "The Input-value block stores the input."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:238
-#.TRANS: volumen
+#. TRANS: volumen
 msgid "loudness"
 msgstr "p’ulin"
 
 #: js/blocks/SensorsBlocks.js:245
-#.TRANS: El bloque Volumen devuelve el volumen detectado por el micrófono.
+#. TRANS: El bloque Volumen devuelve el volumen detectado por el micrófono.
 msgid "The Loudness block returns the volume detected by the microphone."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:300
-#.TRANS: click
+#. TRANS: click
 msgid "click"
 msgstr "liq"
 
 #: js/blocks/SensorsBlocks.js:306
-#.TRANS: El bloque Click activa un evento si se ha hecho clic en un ratón.
+#. TRANS: El bloque Click activa un evento si se ha hecho clic en un ratón.
 msgid "The Click block triggers an event if a mouse has been clicked."
 msgstr "El bloque Click activa un evento si se ha hecho clic en un mouse."
 
 #: js/blocks/SensorsBlocks.js:313
-#.TRANS: El bloque Click activa un evento si se ha hecho clic en una tortuga.
+#. TRANS: El bloque Click activa un evento si se ha hecho clic en una tortuga.
 msgid "The Click block triggers an event if a turtle has been clicked."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:342
-#.TRANS: cursor sobre
+#. TRANS: cursor sobre
 msgid "cursor over"
 msgstr "cursor sobre"
 
 #: js/blocks/SensorsBlocks.js:387
-#.TRANS: cursor fuera
+#. TRANS: cursor fuera
 msgid "cursor out"
 msgstr "cursor fuera"
 
 #: js/blocks/SensorsBlocks.js:433
-#.TRANS: el botón presionado
+#. TRANS: el botón presionado
 msgid "cursor button down"
-msgstr "el botón presionado" "
+msgstr "el botón presionado"
 
 #: js/blocks/SensorsBlocks.js:477
-#.TRANS: el botón arriba
+#. TRANS: el botón arriba
 msgid "cursor button up"
 msgstr "el botón arriba"
 
 #: js/blocks/SensorsBlocks.js:638
-#.TRANS: El bloque Obtener rojo devuelve el componente rojo del píxel debajo del ratón.
+#. TRANS: El bloque Obtener rojo devuelve el componente rojo del píxel debajo del ratón.
 msgid "The Get red block returns the red component of the pixel under the mouse."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:644
-#.TRANS: El bloque Obtener rojo devuelve el componente rojo del píxel debajo de la tortuga.
+#. TRANS: El bloque Obtener rojo devuelve el componente rojo del píxel debajo de la tortuga.
 msgid "The Get red block returns the red component of the pixel under the turtle."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:685
 #: plugins/rodi.rtp:216
-#.TRANS: color del pixel
+#. TRANS: color del pixel
 msgid "pixel color"
 msgstr " llimp’iy k’anchaypa phatmin"
 
 #: js/blocks/SensorsBlocks.js:690
-#.TRANS: El bloque Obtener píxel devuelve el color del píxel debajo del ratón.
+#. TRANS: El bloque Obtener píxel devuelve el color del píxel debajo del ratón.
 msgid "The Get pixel block returns the color of the pixel under the mouse."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:696
-#.TRANS: El bloque Obtener píxel devuelve el color del píxel debajo de la tortuga.
+#. TRANS: El bloque Obtener píxel devuelve el color del píxel debajo de la tortuga.
 msgid "The Get pixel block returns the color of the pixel under the turtle."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:759
-#.TRANS: tiempo
+#. TRANS: tiempo
 msgid "time"
 msgstr "pacha"
 
 #: js/blocks/SensorsBlocks.js:805
-#.TRANS: cursor y
+#. TRANS: cursor y
 msgid "cursor y"
 msgstr "y t’uqpina"
 
 #: js/blocks/SensorsBlocks.js:810
-#.TRANS: El bloque Cursor Y devuelve la posición vertical del cursor.
+#. TRANS: El bloque Cursor Y devuelve la posición vertical del cursor.
 msgid "The Cursor Y block returns the vertical position of the mouse."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:846
-#.TRANS: cursor x
+#. TRANS: cursor x
 msgid "cursor x"
 msgstr "t’uqpina"
 
 #: js/blocks/SensorsBlocks.js:851
-#.TRANS: El bloque Cursor X devuelve la posición horizontal del ratón.
+#. TRANS: El bloque Cursor X devuelve la posición horizontal del ratón.
 msgid "The Cursor X block returns the horizontal position of the mouse."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:887
-#.TRANS: botón del ratón
+#. TRANS: botón del ratón
 msgid "mouse button"
 msgstr "Huk’uchapa ñup’unan"
 
 #: js/blocks/SensorsBlocks.js:889
-#.TRANS: El bloque Botón del ratón devuelve Verdadero si se presiona el botón del ratón.
+#. TRANS: El bloque Botón del ratón devuelve Verdadero si se presiona el botón del ratón.
 msgid "The Mouse-button block returns True if the mouse button is pressed."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:935
-#.TRANS: a ASCII
+#. TRANS: a ASCII
 msgid "to ASCII"
 msgstr "ASCIIman"
 
 #: js/blocks/SensorsBlocks.js:939
-#.TRANS: El bloque a ASCII convierte números a letras.
+#. TRANS: El bloque a ASCII convierte números a letras.
 msgid "The To ASCII block converts numbers to letters."
 msgstr "El bloque a ASCII convierte números a letras."
 
 #: js/blocks/SensorsBlocks.js:1006
-#.TRANS: El bloque teclado devuelve entrada de teclado.
+#. TRANS: El bloque teclado devuelve entrada de teclado.
 msgid "The Keyboard block returns computer keyboard input."
 msgstr "El bloque teclado devuelve entrada de teclado."
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
-#.TRANS: Envolvente
+#. TRANS: sound envelope (ADSR)
+#. TRANS: Envolvente
 msgid "Envelope"
 msgstr "patapi"
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
-#.TRANS: atacar
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: atacar
 msgid "attack"
 msgstr "atacar"
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
-#.TRANS: decaer
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: decaer
 msgid "decay"
 msgstr "Pisipayay"
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
-#.TRANS: sostener
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: sostener
 msgid "sustain"
 msgstr "hap’ipay"
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
-#.TRANS: liberar
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: liberar
 msgid "release"
 msgstr " waqmanta ñawinchay"
 
 #: js/blocks/WidgetBlocks.js:113
-#.TRANS: El valor de atacar debe estar entre 0 y 100.
+#. TRANS: El valor de atacar debe estar entre 0 y 100.
 msgid "Attack value should be from 0 to 100."
 msgstr "El valor de atacar debe estar entre 0 y 100."
 
 #: js/blocks/WidgetBlocks.js:116
-#.TRANS: El valor de decaer debe estar entre 0 y 100.
+#. TRANS: El valor de decaer debe estar entre 0 y 100.
 msgid "Decay value should be from 0 to 100."
 msgstr "Pisipayachiyqa 0 – 100 kaman kanan"
 
 #: js/blocks/WidgetBlocks.js:119
-#.TRANS: El valor de sostener debe estar entre 0 y 100.
+#. TRANS: El valor de sostener debe estar entre 0 y 100.
 msgid "Sustain value should be from 0 to 100."
 msgstr "Hap’paypa tupuynin ch’usaqmanta pachaqkamann kanan"
 
 #: js/blocks/WidgetBlocks.js:122
-#.TRANS: El valor de liberar debe estar entre 0 y 100.
+#. TRANS: El valor de liberar debe estar entre 0 y 100.
 msgid "Release value should be from 0-100."
 msgstr "Kachariya tupun kanan 0 – 100 kama"
 
 #: js/blocks/WidgetBlocks.js:140
-#.TRANS: Está agregando varios bloques de envolvente.
+#. TRANS: Está agregando varios bloques de envolvente.
 msgid "You are adding multiple envelope blocks."
 msgstr "Está agregando varios bloques de envolvente."
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
-#.TRANS: Filtrar
+#. TRANS: a filter removes some unwanted components from a signal
+#. TRANS: Filtrar
 msgid "Filter"
 msgstr "ch’uyay"
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
-#.TRANS: rodar
+#. TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rodar
 msgid "rolloff"
 msgstr "rolloff jithtayaña"
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
-#.TRANS: Roll off valor debe ser -12, -24, -48, o -96 decibelios.
+#. TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: Roll off valor debe ser -12, -24, -48, o -96 decibelios.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:252
-#.TRANS: La Herramienta temperamento se utiliza para definir la afinación personalizada.
+#. TRANS: La Herramienta temperamento se utiliza para definir la afinación personalizada.
 msgid "The Temperament tool is used to define custom tuning."
 msgstr "La Herramienta temperamento se utiliza para definir la afinación personalizada."
 
 #: js/blocks/WidgetBlocks.js:332
 #: js/blocks/WidgetBlocks.js:1574
 #: js/widgets/sampler.js:501
-#.TRANS: Sube una muestra de audio y ajusta su centro de tono.
+#. TRANS: Sube una muestra de audio y ajusta su centro de tono.
 msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
-#.TRANS: muestreador de audio
+#. TRANS: the speed at music is should be played.
+#. TRANS: muestreador de audio
 msgid "sampler"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:517
-#.TRANS: El bloque Meter abre una herramienta para seleccionar golpes fuertes para el metro.
+#. TRANS: El bloque Meter abre una herramienta para seleccionar golpes fuertes para el metro.
 msgid "The Meter block opens a tool to select strong beats for the meter."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:573
-#.TRANS: El bloque del osciloscopio abre una herramienta para visualizar formas de onda.
+#. TRANS: El bloque del osciloscopio abre una herramienta para visualizar formas de onda.
 msgid "The oscilloscope block opens a tool to visualize waveforms."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:578
-#.TRANS: osciloscopio
+#. TRANS: osciloscopio
 msgid "oscilloscope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:645
-#.TRANS: El bloque Modo personalizado abre una herramienta para explorar el modo musical (el espaciado de las notas en una escala).
+#. TRANS: El bloque Modo personalizado abre una herramienta para explorar el modo musical (el espaciado de las notas en una escala).
 msgid "The Custom mode block opens a tool to explore musical mode (the spacing of the notes in a scale)."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
-#.TRANS: modo personalizado
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: modo personalizado
 msgid "custom mode"
 msgstr "huk hinayuq runachasqa"
 
 #: js/blocks/WidgetBlocks.js:700
-#.TRANS: El bloque Tempo abre un metrónomo para visualizar el ritmo.
+#. TRANS: El bloque Tempo abre un metrónomo para visualizar el ritmo.
 msgid "The Tempo block opens a metronome to visualize the beat."
 msgstr "El bloque Tempo abre un metrónomo para visualizar el ritmo."
 
 #: js/blocks/WidgetBlocks.js:762
-#.TRANS: El Arpegio Widget se usa para componer secuencias de acordes.
+#. TRANS: El Arpegio Widget se usa para componer secuencias de acordes.
 msgid "The Arpeggio Widget is used to compose chord sequences."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:837
-#.TRANS: La Matriz de percusión de tono se utiliza para asignar tonos a los sonidos de tambor.
+#. TRANS: La Matriz de percusión de tono se utiliza para asignar tonos a los sonidos de tambor.
 msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
-#.TRANS: matriz de tono en tambor
+#. TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: matriz de tono en tambor
 msgid "pitch-drum mapper"
 msgstr "taki purihiq"
 
 #: js/blocks/WidgetBlocks.js:891
-#.TRANS: Debe tener al menos un bloque de tono y un bloque de tambor en la matriz.
+#. TRANS: Debe tener al menos un bloque de tono y un bloque de tambor en la matriz.
 msgid "You must have at least one pitch block and one drum block in the matrix."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:920
-#.TRANS: La Herramienta de control deslizante tono se utiliza para generar tonos en las frecuencias seleccionadas.
+#. TRANS: La Herramienta de control deslizante tono se utiliza para generar tonos en las frecuencias seleccionadas.
 msgid "The Pitch slider tool to is used to generate pitches at selected frequencies."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
-#.TRANS: deslizante de tono
+#. TRANS: widget to generate pitches using a slider
+#. TRANS: deslizante de tono
 msgid "pitch slider"
 msgstr "Kunka lluskhachik"
 
 #: js/blocks/WidgetBlocks.js:977
-#.TRANS: teclado cromático
+#. TRANS: teclado cromático
 msgid "chromatic keyboard"
 msgstr "teclado cromático"
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
-#.TRANS: teclado musical
+#. TRANS: widget to generate pitches using a slider
+#. TRANS: teclado musical
 msgid "music keyboard"
 msgstr "taki t’upuna"
 
 #: js/blocks/WidgetBlocks.js:1062
 #: js/blocks/WidgetBlocks.js:1069
-#.TRANS: El bloque Teclado de música abre un teclado de piano que puede usarse para crear notas.
+#. TRANS: El bloque Teclado de música abre un teclado de piano que puede usarse para crear notas.
 msgid "The Music keyboard block opens a piano keyboard that can be used to create notes."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1128
-#.TRANS: La Herramienta escalera de tono se utiliza para generar tonos a partir de una relación dada.
+#. TRANS: La Herramienta escalera de tono se utiliza para generar tonos a partir de una relación dada.
 msgid "The Pitch staircase tool to is used to generate pitches from a given ratio."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
-#.TRANS: escalera de tono
+#. TRANS: generate a progressive sequence of pitches
+#. TRANS: escalera de tono
 msgid "pitch staircase"
 msgstr "Kunka siqachina"
 
 #: js/blocks/WidgetBlocks.js:1222
-#.TRANS: El bloque Hacer un ritmo abre una herramienta para crear cajas de ritmos.
+#. TRANS: El bloque Hacer un ritmo abre una herramienta para crear cajas de ritmos.
 msgid "The Rhythm Maker block opens a tool to create drum machines."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1291
-#.TRANS: escala mayor G
+#. TRANS: escala mayor G
 msgid "G major scale"
 msgstr "Kuraq G wichachina"
 
 #: js/blocks/WidgetBlocks.js:1326
-#.TRANS: escala mayor C
+#. TRANS: escala mayor C
 msgid "C major scale"
 msgstr "Kuraq C wichachina"
 
 #: js/blocks/WidgetBlocks.js:1366
-#.TRANS: El bloque Matriz de tono y tiempo abre una herramienta para crear frases musicales.
+#. TRANS: El bloque Matriz de tono y tiempo abre una herramienta para crear frases musicales.
 msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
-#.TRANS: matriz de tono en tiempo
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: matriz de tono en tiempo
 msgid "phrase maker"
 msgstr "Kunka pachapi paqarichiq "
 
 #: js/blocks/WidgetBlocks.js:1445
-#.TRANS: Debe tener al menos un bloque de tono y un bloque de ritmo en la matriz.
+#. TRANS: Debe tener al menos un bloque de tono y un bloque de ritmo en la matriz.
 msgid "You must have at least one pitch block and one rhythm block in the matrix."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1504
-#.TRANS: El bloque Estado abre una herramienta para inspeccionar el estado de Bloques de Música mientras se ejecuta.
+#. TRANS: El bloque Estado abre una herramienta para inspeccionar el estado de Bloques de Música mientras se ejecuta.
 msgid "The Status block opens a tool for inspecting the status of Music Blocks as it is running."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
-#.TRANS: Música de IA
+#. TRANS: AI-generated music
+#. TRANS: Música de IA
 msgid "AI Music"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:35
-#.TRANS: volumen del sintetizador
+#. TRANS: volumen del sintetizador
 msgid "synth volume"
 msgstr "volumen del sintetizador"
 
 #: js/blocks/VolumeBlocks.js:39
-#.TRANS: El bloque de volumen sintetizador devuelve el volumen actual del sintetizador actual.
+#. TRANS: El bloque de volumen sintetizador devuelve el volumen actual del sintetizador actual.
 msgid "The Synth volume block returns the current volume of the current synthesizer."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:105
-#.TRANS: volumen maestro
+#. TRANS: volumen maestro
 msgid "master volume"
 msgstr "t’uqya kamay"
 
 #: js/blocks/VolumeBlocks.js:109
-#.TRANS: El bloque volumen maestro devuelve nivel de volumen maestro.
+#. TRANS: El bloque volumen maestro devuelve nivel de volumen maestro.
 msgid "The Master volume block returns the master volume."
 msgstr "El bloque volumen maestro devuelve nivel de volumen maestro."
 
 #: js/blocks/VolumeBlocks.js:355
 #: js/blocks/VolumeBlocks.js:524
-#.TRANS: fijar volumen del sintetizador
+#. TRANS: fijar volumen del sintetizador
 msgid "set synth volume"
 msgstr "fijar volumen del sintetizador"
 
 #: js/blocks/VolumeBlocks.js:362
 #: js/blocks/VolumeBlocks.js:545
-#.TRANS: sintetizador
+#. TRANS: sintetizador
 msgid "synth"
 msgstr "sintetizador"
 
@@ -8011,209 +8013,209 @@ msgstr "sintetizador"
 #: js/blocks/VolumeBlocks.js:577
 #: js/blocks/VolumeBlocks.js:740
 #: js/turtleactions/VolumeActions.js:173
-#.TRANS: Ajuste el volumen a 0
+#. TRANS: Ajuste el volumen a 0
 msgid "Setting volume to 0."
 msgstr "Ajuste el volumen a 0"
 
 #: js/blocks/VolumeBlocks.js:440
-#.TRANS: No se encuentra el sintetizador.
+#. TRANS: No se encuentra el sintetizador.
 msgid "Synth not found"
 msgstr "No se encuentra el sintetizador."
 
 #: js/blocks/VolumeBlocks.js:494
-#.TRANS: filar volumen del tambor
+#. TRANS: filar volumen del tambor
 msgid "set drum volume"
 msgstr "filar volumen del tambor"
 
 #: js/blocks/VolumeBlocks.js:530
-#.TRANS: El bloque Ajuste volumen del sintetizador cambiará el volumen de un sintetizador particular,
+#. TRANS: El bloque Ajuste volumen del sintetizador cambiará el volumen de un sintetizador particular,
 msgid "The Set synth volume block will change the volume of a particular synth,"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:532
-#.TRANS: por ejemplo, guitarra, violín, tambor
+#. TRANS: por ejemplo, guitarra, violín, tambor
 msgid "eg guitar violin snare drum etc."
 msgstr "por ejemplo, guitarra, violín, tambor"
 
 #: js/blocks/VolumeBlocks.js:534
-#.TRANS: El volumen predeterminado es 50.
+#. TRANS: El volumen predeterminado es 50.
 msgid "The default volume is 50."
 msgstr "El volumen predeterminado es 50."
 
 #: js/blocks/VolumeBlocks.js:536
-#.TRANS: El rango es de 0 para el silencio a 100 para el volumen completo.
+#. TRANS: El rango es de 0 para el silencio a 100 para el volumen completo.
 msgid "The range is 0 for silence to 100 for full volume."
 msgstr "El rango es de 0 para el silencio a 100 para el volumen completo."
 
 #: js/blocks/VolumeBlocks.js:597
-#.TRANS: establecer panorámica
+#. TRANS: establecer panorámica
 msgid "set panning"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:603
-#.TRANS: El bloque Establecer Panorámica establece el panorama para todos los sintetizadores.
+#. TRANS: El bloque Establecer Panorámica establece el panorama para todos los sintetizadores.
 msgid "The Set Panning block sets the panning for all synthesizers."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:625
-#.TRANS: Advertencia: El sonido sale solo del lado izquierdo o derecho.
+#. TRANS: Advertencia: El sonido sale solo del lado izquierdo o derecho.
 msgid "Warning: Sound is coming out from only the left or right side."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:647
 #: js/blocks/VolumeBlocks.js:695
-#.TRANS: filar volumen maestro
+#. TRANS: filar volumen maestro
 msgid "set master volume"
 msgstr "filar volumen maestro"
 
 #: js/blocks/VolumeBlocks.js:653
-#.TRANS: El bloque Ajuste volumen maestro establece el volumen para todos los sintetizadores.
+#. TRANS: El bloque Ajuste volumen maestro establece el volumen para todos los sintetizadores.
 msgid "The Set master volume block sets the volume for all synthesizers."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:784
-#.TRANS: El bloque Fijar volumen relativo cambia el volumen de las notas contenidas.
+#. TRANS: El bloque Fijar volumen relativo cambia el volumen de las notas contenidas.
 msgid "The Set relative volume block changes the volume of the contained notes."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:791
-#.TRANS: fijar volumen relativo
+#. TRANS: fijar volumen relativo
 msgid "set relative volume"
 msgstr "jach'ata maya k'ata arsuyaña"
 
 #: js/blocks/VolumeBlocks.js:857
-#.TRANS: decrescendo
+#. TRANS: decrescendo
 msgid "decrescendo"
 msgstr "decrescendo"
 
 #: js/blocks/VolumeBlocks.js:921
-#.TRANS: crescendo
+#. TRANS: crescendo
 msgid "crescendo"
 msgstr "wiñachkan"
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: uno
+#. TRANS: uno
 msgid "one"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: dos
+#. TRANS: dos
 msgid "two"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: tres
+#. TRANS: tres
 msgid "three"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: cuatro
+#. TRANS: cuatro
 msgid "four"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: cinco
+#. TRANS: cinco
 msgid "five"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: seis
+#. TRANS: seis
 msgid "six"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: siete
+#. TRANS: siete
 msgid "seven"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: ocho
+#. TRANS: ocho
 msgid "eight"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: nueve
+#. TRANS: nueve
 msgid "nine"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:140
-#.TRANS: abajo
+#. TRANS: abajo
 msgid "below"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: arriba
+#. TRANS: arriba
 msgid "above"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:131
-#.TRANS: más
+#. TRANS: más
 msgid "plus"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:258
-#.TRANS: Agregar el número de tono que falta 0.
+#. TRANS: Agregar el número de tono que falta 0.
 msgid "Adding missing pitch number 0."
 msgstr "Agregar el número de tono que falta 0."
 
 #: js/turtleactions/IntervalsActions.js:266
-#.TRANS: Ignorando los números de tono menos de cero o más de once.
+#. TRANS: Ignorando los números de tono menos de cero o más de once.
 msgid "Ignoring pitch numbers less than zero or greater than eleven."
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:272
-#.TRANS: Ignorando números de tono duplicados.
+#. TRANS: Ignorando números de tono duplicados.
 msgid "Ignoring duplicate pitch numbers."
 msgstr "Ignorando números de tono duplicados."
 
 #: js/turtleactions/DictActions.js:75
 #: js/turtleactions/DictActions.js:142
 #: js/turtleactions/DictActions.js:172
-#.TRANS: fuente
+#. TRANS: fuente
 msgid "font"
 msgstr ""
 
 #: js/turtleactions/DictActions.js:255
-#.TRANS: No existe diccionario con este nombre
+#. TRANS: No existe diccionario con este nombre
 msgid "Dictionary with this name does not exist"
 msgstr ""
 
 #: js/turtleactions/DictActions.js:259
-#.TRANS: La clave con este nombre no existe en 
+#. TRANS: La clave con este nombre no existe en 
 msgid "Key with this name does not exist in "
 msgstr ""
 
 #: js/turtleactions/DrumActions.js:227
-#.TRANS: Bloque de ruido: Quizás quiso decir utilizar un bloque de nota?
+#. TRANS: Bloque de ruido: Quizás quiso decir utilizar un bloque de nota?
 msgid "Noise Block: Did you mean to use a Note block?"
 msgstr "Bloque de ruido: Quizás quiso decir utilizar un bloque de nota?"
 
 #: js/turtleactions/ToneActions.js:134
-#.TRANS: La intensidad del vibrato debe estar entre 1 y 100.
+#. TRANS: La intensidad del vibrato debe estar entre 1 y 100.
 msgid "Vibrato intensity must be between 1 and 100."
 msgstr " khatataypa kallpanqa huk hinallataq pachakpi kachkanan"
 
 #: js/turtleactions/ToneActions.js:139
-#.TRANS: La velocidad del vibrato debe ser mayor que 0.
+#. TRANS: La velocidad del vibrato debe ser mayor que 0.
 msgid "Vibrato rate must be greater than 0."
 msgstr " khatataypa utqayninqa ch’usaqpa kurakninmi kanan"
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
-#.TRANS: El valor de profundidad está fuera de rango.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: El valor de profundidad está fuera de rango.
 msgid "Depth is out of range."
 msgstr "ukhunchasqa chaninninqa manam t’aqanpichu kachkan"
 
 #: js/turtleactions/ToneActions.js:301
-#.TRANS: El valor de distorsión debe ser de 0 a 100.
+#. TRANS: El valor de distorsión debe ser de 0 a 100.
 msgid "Distortion must be from 0 to 100."
 msgstr "q’iwisqapa chaninninqa ch’usaqmanta pachakkama kanan"
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
-#.TRANS: Parcial debe ser mayor o igual a 0.
+#. TRANS: partials components in a harmonic series
+#. TRANS: Parcial debe ser mayor o igual a 0.
 msgid "Partial must be greater than or equal to 0."
 msgstr "chawaqa ch’usaqamanta kurakpas kikinpas kanan"
 
@@ -8221,31 +8223,31 @@ msgstr "chawaqa ch’usaqamanta kurakpas kikinpas kanan"
 #: js/turtleactions/ToneActions.js:417
 #: js/turtleactions/ToneActions.js:456
 #: js/widgets/timbre.js:776
-#.TRANS: No se puede usar el sintetizador debido al bloqueo del oscilador.
+#. TRANS: No se puede usar el sintetizador debido al bloqueo del oscilador.
 msgid "Unable to use synth due to existing oscillator"
 msgstr "Manam pisiyachiqta hap’ikunmanchu imaraykuchus maymikuq hark’asqa kaptin"
 
 #: js/turtleactions/ToneActions.js:388
 #: js/turtleactions/ToneActions.js:427
-#.TRANS: La entrada no puede ser negativa.
+#. TRANS: La entrada no puede ser negativa.
 msgid "The input cannot be negative."
 msgstr "haykunanqa manam manaqa kanmanchu"
 
 #: js/turtleactions/MeterActions.js:101
 #: js/turtleactions/MeterActions.js:139
-#.TRANS: latidos por minuto deben ser mayores que
+#. TRANS: latidos por minuto deben ser mayores que
 msgid "beats per minute must be greater than"
 msgstr "minutupi p’ullpuqiyqa kurak kanan"
 
 #: js/turtleactions/MeterActions.js:111
 #: js/turtleactions/MeterActions.js:149
-#.TRANS: máximo
+#. TRANS: máximo
 msgid "maximum"
 msgstr "tukupunankama"
 
 #: js/turtleactions/MeterActions.js:117
 #: js/turtleactions/MeterActions.js:155
-#.TRANS: latidos por minuto es
+#. TRANS: latidos por minuto es
 msgid "beats per minute is"
 msgstr "minutupi p’ullpuqiyninqa"
 
@@ -8255,7 +8257,7 @@ msgstr "minutupi p’ullpuqiyninqa"
 #: js/widgets/help.js:158
 #: js/widgets/help.js:378
 #: js/widgets/help.js:393
-#.TRANS: Hacer un recorrido
+#. TRANS: Hacer un recorrido
 msgid "Take a tour"
 msgstr "pusay"
 
@@ -8270,40 +8272,40 @@ msgstr "pusay"
 #: js/widgets/tempo.js:78
 #: js/widgets/tempo.js:97
 #: js/widgets/tempo.js:98
-#.TRANS: Pausa
+#. TRANS: Pausa
 msgid "Pause"
 msgstr "sayay"
 
 #: js/widgets/aiwidget.js:179
 #: js/widgets/sampler.js:225
-#.TRANS: Advertencia: la muestra es más grande que 1 MB.
+#. TRANS: Advertencia: la muestra es más grande que 1 MB.
 msgid "Warning: Sample is bigger than 1MB."
 msgstr ""
 
 #: js/widgets/aiwidget.js:538
-#.TRANS: Nuevo bloque de inicio generado
+#. TRANS: Nuevo bloque de inicio generado
 msgid "New start block generated"
 msgstr ""
 
 #: js/widgets/aiwidget.js:540
-#.TRANS: Carga MIDI. Esto puede tardar un tiempo dependiendo de la cantidad de notas en la pista.
+#. TRANS: Carga MIDI. Esto puede tardar un tiempo dependiendo de la cantidad de notas en la pista.
 msgid "MIDI loading. This may take some time depending upon the number of notes in the track"
 msgstr ""
 
 #: js/widgets/aiwidget.js:550
 #: js/widgets/sampler.js:252
-#.TRANS: Error en la carga: la muestra no es un archivo .WAV.
+#. TRANS: Error en la carga: la muestra no es un archivo .WAV.
 msgid "Upload failed: Sample is not a .wav file."
 msgstr ""
 
 #: js/widgets/aiwidget.js:677
 #: js/widgets/sampler.js:430
-#.TRANS: Guardar muestra de audio
+#. TRANS: Guardar muestra de audio
 msgid "Save sample"
 msgstr ""
 
 #: js/widgets/arpeggio.js:241
-#.TRANS: Haga clic en la cuadrícula para agregar pasos al arpegio.
+#. TRANS: Haga clic en la cuadrícula para agregar pasos al arpegio.
 msgid "Click in the grid to add steps to the arpeggio."
 msgstr ""
 
@@ -8321,27 +8323,27 @@ msgstr ""
 #: js/widgets/rhythmruler.js:1809
 #: js/widgets/rhythmruler.js:1810
 #: js/widgets/temperament.js:2165
-#.TRANS: Jugar todo
+#. TRANS: Jugar todo
 msgid "Play all"
 msgstr "llapanta pukllay"
 
 #: js/widgets/meterwidget.js:269
-#.TRANS: Reiniciar
+#. TRANS: Reiniciar
 msgid "Reset"
 msgstr ""
 
 #: js/widgets/meterwidget.js:295
-#.TRANS: Haga clic en el círculo para seleccionar ritmos fuertes para el medidor.
+#. TRANS: Haga clic en el círculo para seleccionar ritmos fuertes para el medidor.
 msgid "Click in the circle to select strong beats for the meter."
 msgstr "Haga clic en el círculo para seleccionar ritmos fuertes para el medidor."
 
 #: js/widgets/modewidget.js:125
-#.TRANS: Girar en sentido antihorario
+#. TRANS: Girar en sentido antihorario
 msgid "Rotate counter clockwise"
 msgstr "Girar en sentido antihorario"
 
 #: js/widgets/modewidget.js:131
-#.TRANS: Girar en sentido horario
+#. TRANS: Girar en sentido horario
 msgid "Rotate clockwise"
 msgstr "lluq’iman muyuy"
 
@@ -8349,13 +8351,13 @@ msgstr "lluq’iman muyuy"
 #: js/widgets/pitchstaircase.js:676
 #: js/widgets/rhythmruler.js:578
 #: js/widgets/timbre.js:957
-#.TRANS: Deshacer
+#. TRANS: Deshacer
 msgid "Undo"
 msgstr "paskay"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
-#.TRANS: Haga clic en el círculo para seleccionar notas para el modo.
+#. TRANS: A circle of notes represents the musical mode.
+#. TRANS: Haga clic en el círculo para seleccionar notas para el modo.
 msgid "Click in the circle to select notes for the mode."
 msgstr "Haga clic en el círculo para seleccionar notas para el modo."
 
@@ -8367,18 +8369,18 @@ msgstr "Haga clic en el círculo para seleccionar notas para el modo."
 #: js/widgets/temperament.js:1862
 #: js/widgets/tempo.js:412
 #: js/widgets/phrasemaker.js:5467
-#.TRANS: Nuevo bloque de acción creado.
+#. TRANS: Nuevo bloque de acción creado.
 msgid "New action block generated."
 msgstr ""
 
 #: js/widgets/musickeyboard.js:743
 #: js/widgets/phrasemaker.js:595
-#.TRANS: Agrega una nota
+#. TRANS: Agrega una nota
 msgid "Add note"
 msgstr "Agrega una nota"
 
 #: js/widgets/musickeyboard.js:762
-#.TRANS: Metrónomo
+#. TRANS: Metrónomo
 msgid "Metronome"
 msgstr ""
 
@@ -8387,80 +8389,80 @@ msgid "Note value"
 msgstr ""
 
 #: js/widgets/musickeyboard.js:3209
-#.TRANS: Nuevo bloques de acción creado.
+#. TRANS: Nuevo bloques de acción creado.
 msgid "New action blocks generated."
 msgstr ""
 
 #: js/widgets/musickeyboard.js:3393
 #: js/widgets/musickeyboard.js:3401
-#.TRANS: Dispositivo MIDI presente.
+#. TRANS: Dispositivo MIDI presente.
 msgid "MIDI device present."
 msgstr ""
 
 #: js/widgets/musickeyboard.js:3404
-#.TRANS: No se encontró ningún dispositivo MIDI.
+#. TRANS: No se encontró ningún dispositivo MIDI.
 msgid "No MIDI device found."
 msgstr ""
 
 #: js/widgets/musickeyboard.js:3414
-#.TRANS: Error al obtener acceso MIDI en el navegador.
+#. TRANS: Error al obtener acceso MIDI en el navegador.
 msgid "Failed to get MIDI access in browser."
 msgstr ""
 
 #: js/widgets/pitchdrummatrix.js:356
 #: js/widgets/pitchdrummatrix.js:741
-#.TRANS: Haga clic en la cuadrícula para asignar notas a sonidos de tambors
+#. TRANS: Haga clic en la cuadrícula para asignar notas a sonidos de tambors
 msgid "Click in the grid to map notes to drums."
 msgstr "Haga clic en la cuadrícula para asignar notas a sonidos de tambors"
 
 #: js/widgets/pitchslider.js:103
-#.TRANS: Ascender
+#. TRANS: Ascender
 msgid "Move up"
 msgstr "wichay"
 
 #: js/widgets/pitchslider.js:114
-#.TRANS: Descender
+#. TRANS: Descender
 msgid "Move down"
 msgstr "uraqay"
 
 #: js/widgets/pitchslider.js:136
-#.TRANS: Haga clic en el control deslizante para crear un bloque de notas.
+#. TRANS: Haga clic en el control deslizante para crear un bloque de notas.
 msgid "Click on the slider to create a note block."
 msgstr "Haga clic en el control deslizante para crear un bloque de notas."
 
 #: js/widgets/pitchstaircase.js:622
-#.TRANS: Tocar un acorde
+#. TRANS: Tocar un acorde
 msgid "Play chord"
 msgstr "Tocar un acorde"
 
 #: js/widgets/pitchstaircase.js:630
-#.TRANS: Tocar una escala
+#. TRANS: Tocar una escala
 msgid "Play scale"
 msgstr "Tocar una escala"
 
 #: js/widgets/pitchstaircase.js:694
-#.TRANS: Haga clic en una nota para crear un nuevo paso.
+#. TRANS: Haga clic en una nota para crear un nuevo paso.
 msgid "Click on a note to create a new step."
 msgstr "Haga clic en una nota para crear un nuevo paso."
 
 #: js/widgets/rhythmruler.js:486
-#.TRANS: Guardar ritmos
+#. TRANS: Guardar ritmos
 msgid "Save rhythms"
 msgstr "T’impuchisqata waqaychay"
 
 #: js/widgets/rhythmruler.js:512
-#.TRANS: Guardar la caja de ritmos
+#. TRANS: Guardar la caja de ritmos
 msgid "Save drum machine"
 msgstr "tawa k’uchu t’impumusqakuna waqaychana"
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
-#.TRANS: Toca un ritmo
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: Toca un ritmo
 msgid "Tap a rhythm"
 msgstr "Toca un ritmo"
 
 #: js/widgets/rhythmruler.js:813
-#.TRANS: Haga clic en la regla para dividirla.
+#. TRANS: Haga clic en la regla para dividirla.
 msgid "Click on the ruler to divide it."
 msgstr "Haga clic en la regla para dividirla."
 
@@ -8470,63 +8472,63 @@ msgstr "Haga clic en la regla para dividirla."
 #: js/widgets/rhythmruler.js:1149
 #: js/widgets/rhythmruler.js:1760
 #: js/widgets/rhythmruler.js:1761
-#.TRANS: tocar un ritmo
+#. TRANS: tocar un ritmo
 msgid "tap a rhythm"
 msgstr "maya wirsu arsuyaña"
 
 #: js/widgets/rhythmruler.js:1453
-#.TRANS: Se ha superado el valor máximo de 256.
+#. TRANS: Se ha superado el valor máximo de 256.
 msgid "Maximum value of 256 has been exceeded."
 msgstr "Se ha superado el valor máximo de 256."
 
 #: js/widgets/sampler.js:235
-#.TRANS: grabación comenzada
+#. TRANS: grabación comenzada
 msgid "Recording started"
 msgstr ""
 
 #: js/widgets/sampler.js:243
-#.TRANS: grabación completa
+#. TRANS: grabación completa
 msgid "Recording complete"
 msgstr ""
 
 #: js/widgets/sampler.js:281
-#.TRANS: Se generó un nuevo bloque de muestra de audio.
+#. TRANS: Se generó un nuevo bloque de muestra de audio.
 msgid "A new sample block was generated."
 msgstr ""
 
 #: js/widgets/sampler.js:376
-#.TRANS: Subir muestra de audio
+#. TRANS: Subir muestra de audio
 msgid "Upload sample"
 msgstr ""
 
 #: js/widgets/sampler.js:397
-#.TRANS: Advertencia: Su muestra no se puede cargar porque es >1 MB.
+#. TRANS: Advertencia: Su muestra no se puede cargar porque es >1 MB.
 msgid "Warning: Your sample cannot be loaded because it is >1MB."
 msgstr ""
 
 #: js/widgets/sampler.js:446
-#.TRANS: Alternar el micrófono
+#. TRANS: Alternar el micrófono
 msgid "Toggle Mic"
 msgstr ""
 
 #: js/widgets/sampler.js:453
-#.TRANS: Reproducir
+#. TRANS: Reproducir
 msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
-#.TRANS: tono de referencia
+#. TRANS: The reference tone is a sound used for comparison.
+#. TRANS: tono de referencia
 msgid "reference tone"
 msgstr ""
 
 #: js/widgets/temperament.js:319
-#.TRANS: volver al espacio de octava 2: 1
+#. TRANS: volver al espacio de octava 2: 1
 msgid "back to 2:1 octave space"
 msgstr ""
 
 #: js/widgets/temperament.js:445
-#.TRANS: editar
+#. TRANS: editar
 msgid "edit"
 msgstr ""
 
@@ -8540,39 +8542,39 @@ msgstr ""
 #: js/widgets/temperament.js:1379
 #: js/widgets/temperament.js:1448
 #: js/widgets/temperament.js:1529
-#.TRANS: terminado
+#. TRANS: terminado
 msgid "done"
 msgstr ""
 
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:587
 #: js/widgets/temperament.js:1021
-#.TRANS: proporción
+#. TRANS: proporción
 msgid "ratio"
 msgstr ""
 
 #: js/widgets/temperament.js:588
-#.TRANS: intervalo
+#. TRANS: intervalo
 msgid "interval"
 msgstr ""
 
 #: js/widgets/temperament.js:716
-#.TRANS: no escalar
+#. TRANS: no escalar
 msgid "non scalar"
 msgstr ""
 
 #: js/widgets/temperament.js:757
-#.TRANS: proporcións
+#. TRANS: proporcións
 msgid "ratios"
 msgstr ""
 
 #: js/widgets/temperament.js:757
-#.TRANS: arbitrario
+#. TRANS: arbitrario
 msgid "arbitrary"
 msgstr ""
 
 #: js/widgets/temperament.js:828
-#.TRANS: número de divisiones
+#. TRANS: número de divisiones
 msgid "number of divisions"
 msgstr ""
 
@@ -8580,278 +8582,278 @@ msgstr ""
 #: js/widgets/temperament.js:958
 #: js/widgets/temperament.js:1037
 #: js/widgets/temperament.js:1128
-#.TRANS: preestreno
+#. TRANS: preestreno
 msgid "preview"
 msgstr ""
 
 #: js/widgets/temperament.js:888
-#.TRANS: El número de divisiones es demasiado grande.
+#. TRANS: El número de divisiones es demasiado grande.
 msgid "The Number of divisions is too large."
 msgstr ""
 
 #: js/widgets/temperament.js:1023
-#.TRANS: recursividad
+#. TRANS: recursividad
 msgid "recursion"
 msgstr ""
 
 #: js/widgets/temperament.js:1549
-#.TRANS: La proporción de octavas ha cambiado. Esto cambia el temperamento de manera significativa.
+#. TRANS: La proporción de octavas ha cambiado. Esto cambia el temperamento de manera significativa.
 msgid "The octave ratio has changed. This changes temperament significantly."
 msgstr ""
 
 #: js/widgets/temperament.js:2177
-#.TRANS: Tabla
+#. TRANS: Tabla
 msgid "Table"
 msgstr "tawla"
 
 #: js/widgets/temperament.js:2285
-#.TRANS: añadir tonos
+#. TRANS: añadir tonos
 msgid "Add pitches"
 msgstr "kunkakuna yapay"
 
 #: js/widgets/tempo.js:111
-#.TRANS: Guardar tempo
+#. TRANS: Guardar tempo
 msgid "Save tempo"
 msgstr "Pacha waqaychay"
 
 #: js/widgets/tempo.js:142
-#.TRANS: acelerar
+#. TRANS: acelerar
 msgid "speed up"
 msgstr "utqhaychay"
 
 #: js/widgets/tempo.js:148
-#.TRANS: retardar
+#. TRANS: retardar
 msgid "slow down"
 msgstr "qhipariy"
 
 #: js/widgets/tempo.js:192
-#.TRANS: Ajusta el tempo con los botones.
+#. TRANS: Ajusta el tempo con los botones.
 msgid "Adjust the tempo with the buttons."
 msgstr "Ajusta el tempo con los botones."
 
 #: js/widgets/tempo.js:259
-#.TRANS: Por favor, introduzca un número entre 30 y 1000.
+#. TRANS: Por favor, introduzca un número entre 30 y 1000.
 msgid "Please enter a number between 30 and 1000"
 msgstr ""
 
 #: js/widgets/tempo.js:266
 #: js/widgets/tempo.js:269
-#.TRANS: Los latidos por minuto deben estar entre 30 y 1000.
+#. TRANS: Los latidos por minuto deben estar entre 30 y 1000.
 msgid "The beats per minute must be between 30 and 1000."
 msgstr "Los latidos por minuto deben estar entre 30 y 1000."
 
 #: js/widgets/tempo.js:285
-#.TRANS: Los latidos por minuto deben estar por debajo de 1000.
+#. TRANS: Los latidos por minuto deben estar por debajo de 1000.
 msgid "The beats per minute must be below 1000."
 msgstr ""
 
 #: js/widgets/tempo.js:301
-#.TRANS: Los latidos por minuto deben ser superiores a 30.
+#. TRANS: Los latidos por minuto deben ser superiores a 30.
 msgid "The beats per minute must be above 30"
 msgstr ""
 
 #: js/widgets/timbre.js:760
-#.TRANS: Sintetizador
+#. TRANS: Sintetizador
 msgid "Synthesizer"
 msgstr "Huch’uyachispa tikraq"
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: Efectos
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: Efectos
 msgid "Effects"
 msgstr "Tikrasqa kunka"
 
 #: js/widgets/timbre.js:940
-#.TRANS: Agregar un filtro
+#. TRANS: Agregar un filtro
 msgid "Add filter"
 msgstr "Ch’uyaqta churay"
 
 #: js/widgets/timbre.js:981
-#.TRANS: Haga clic en los botones para abrir las herramientas de diseño de timbre.
+#. TRANS: Haga clic en los botones para abrir las herramientas de diseño de timbre.
 msgid "Click on buttons to open the timbre design tools."
 msgstr "Haga clic en los botones para abrir las herramientas de diseño de timbre."
 
 #: js/widgets/timbre.js:1265
-#.TRANS: armonía
+#. TRANS: armonía
 msgid "harmonicity"
 msgstr "tupasqa"
 
 #: js/widgets/timbre.js:1332
 #: js/widgets/timbre.js:1398
-#.TRANS: índice de modulación
+#. TRANS: índice de modulación
 msgid "modulation index"
 msgstr "imanas kunka tupasqa"
 
 #: js/widgets/timbre.js:1476
-#.TRANS: cantidad de vibrato
+#. TRANS: cantidad de vibrato
 msgid "vibrato amount"
 msgstr "kunkachasqa"
 
 #: js/widgets/timbre.js:1911
-#.TRANS: filtro ya presente
+#. TRANS: filtro ya presente
 msgid "Filter already present."
 msgstr "filtro ya presente"
 
 #: js/widgets/timbre.js:2495
-#.TRANS: cantidad de distorsión
+#. TRANS: cantidad de distorsión
 msgid "distortion amount"
 msgstr "cantidad de distorsión"
 
 #: js/widgets/oscilloscope.js:79
-#.TRANS: Hacer zoom
+#. TRANS: Hacer zoom
 msgid "Zoom In"
 msgstr ""
 
 #: js/widgets/oscilloscope.js:88
-#.TRANS: Alejar
+#. TRANS: Alejar
 msgid "Zoom Out"
 msgstr ""
 
 #: js/widgets/phrasemaker.js:585
-#.TRANS: Exportar
+#. TRANS: Exportar
 msgid "Export"
 msgstr "hurquy"
 
 #: js/widgets/phrasemaker.js:592
-#.TRANS: Ordenar
+#. TRANS: Ordenar
 msgid "Sort"
 msgstr "ñiq’ichay"
 
 #: js/widgets/phrasemaker.js:1061
-#.TRANS: Haga clic en la tabla para agregar notas.
+#. TRANS: Haga clic en la tabla para agregar notas.
 msgid "Click on the table to add notes."
 msgstr "Haga clic en la tabla para agregar notas."
 
 #: js/widgets/phrasemaker.js:2755
 #: js/widgets/phrasemaker.js:2891
-#.TRANS: valor del tuplet
+#. TRANS: valor del tuplet
 msgid "tuplet value"
 msgstr "tupla chimpu chani"
 
 #: planet/js/GlobalCard.js:68
-#.TRANS: Compartir
+#. TRANS: Compartir
 msgid "Share"
 msgstr "Apakipaña"
 
 #: planet/js/GlobalCard.js:74
-#.TRANS: Banderas
+#. TRANS: Banderas
 msgid "Flags"
 msgstr "Banderas"
 
 #: planet/js/GlobalPlanet.js:35
-#.TRANS: No se han encontrado resultados.
+#. TRANS: No se han encontrado resultados.
 msgid "No results found."
 msgstr "No se han encontrado resultados."
 
 #: planet/js/GlobalPlanet.js:51
-#.TRANS: Remix de
+#. TRANS: Remix de
 msgid "Remix of"
 msgstr "Remix de"
 
 #: planet/js/GlobalPlanet.js:509
-#.TRANS: No es posible conectar con el servidor.
+#. TRANS: No es posible conectar con el servidor.
 msgid "Cannot connect to server"
 msgstr "No es posible conectar con el servidor."
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: todos los proyectos
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: todos los proyectos
 msgid "All Projects"
 msgstr "todos los proyectos"
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: Mis proyectos
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: Mis proyectos
 msgid "My Projects"
 msgstr "Mis proyectos"
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: ejemplos
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: ejemplos
 msgid "Examples"
 msgstr "ejemplos"
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: arte
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: arte
 msgid "Art"
 msgstr "arte"
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: mates
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: mates
 msgid "Math"
 msgstr "mates"
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: interactivo
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: interactivo
 msgid "Interactive"
 msgstr "interactivo"
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: diseño
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: diseño
 msgid "Design"
 msgstr "diseño"
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: juego
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: juego
 msgid "Game"
 msgstr "juego"
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: fragmento de código
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: fragmento de código
 msgid "Code Snippet"
 msgstr ""
 
 #: planet/js/LocalCard.js:36
-#.TRANS: Ver proyecto publicado
+#. TRANS: Ver proyecto publicado
 msgid "View published project"
 msgstr "Ver proyecto publicado"
 
 #: planet/js/LocalCard.js:42
 #: planet/js/StringHelper.js:38
-#.TRANS: Publicar proyecto
+#. TRANS: Publicar proyecto
 msgid "Publish project"
 msgstr "Publicar proyecto"
 
 #: planet/js/LocalCard.js:51
-#.TRANS: Editar proyecto
+#. TRANS: Editar proyecto
 msgid "Edit project"
 msgstr "Editar proyecto"
 
 #: planet/js/LocalCard.js:52
-#.TRANS: Borrar proyecto
+#. TRANS: Borrar proyecto
 msgid "Delete project"
 msgstr "Borrar proyecto"
 
 #: planet/js/LocalCard.js:53
-#.TRANS: Descargar proyecto
+#. TRANS: Descargar proyecto
 msgid "Download project"
 msgstr "Descargar proyecto"
 
 #: planet/js/LocalCard.js:55
-#.TRANS: Duplucar proyecto
+#. TRANS: Duplucar proyecto
 msgid "Duplicate project"
 msgstr "Duplucar proyecto"
 
 #: planet/js/ProjectStorage.js:243
-#.TRANS: anónimo
+#. TRANS: anónimo
 msgid "anonymous"
 msgstr "anónimo"
 
 #: planet/js/ProjectViewer.js:30
-#.TRANS: Error: No se pudo enviar el informe. Inténtalo de nuevo más tarde.
+#. TRANS: Error: No se pudo enviar el informe. Inténtalo de nuevo más tarde.
 msgid "Error: Report could not be submitted. Try again later."
 msgstr "Error: No se pudo enviar el informe. Inténtalo de nuevo más tarde."
 
 #: planet/js/ProjectViewer.js:31
-#.TRANS: Gracias por reportar este proyecto. Un moderador revisará el proyecto en breve para verificar la violación del Código de conducta de Sugar Labs.
+#. TRANS: Gracias por reportar este proyecto. Un moderador revisará el proyecto en breve para verificar la violación del Código de conducta de Sugar Labs.
 msgid "Thank you for reporting this project. A moderator will review the project shortly, to verify violation of the Sugar Labs Code of Conduct."
 msgstr "Gracias por reportar este proyecto. Un moderador revisará el proyecto en breve para verificar la violación del Código de conducta de Sugar Labs."
 
@@ -8859,527 +8861,527 @@ msgstr "Gracias por reportar este proyecto. Un moderador revisará el proyecto e
 #: planet/js/StringHelper.js:62
 #: planet/js/StringHelper.js:64
 #: planet/js/StringHelper.js:68
-#.TRANS: Informe de proyecto
+#. TRANS: Informe de proyecto
 msgid "Report Project"
 msgstr "Informe de proyecto"
 
 #: planet/js/ProjectViewer.js:33
 #: planet/js/StringHelper.js:63
-#.TRANS: Proyecto informado
+#. TRANS: Proyecto informado
 msgid "Project Reported"
 msgstr "Proyecto informado"
 
 #: planet/js/ProjectViewer.js:34
-#.TRANS: Descripción requerida
+#. TRANS: Descripción requerida
 msgid "Report description required"
 msgstr "Descripción requerida"
 
 #: planet/js/ProjectViewer.js:35
-#.TRANS: La descripción es demasiado larga.
+#. TRANS: La descripción es demasiado larga.
 msgid "Report description too long"
 msgstr "La descripción es demasiado larga."
 
 #: planet/js/Publisher.js:30
-#.TRANS: Característica no disponible: no se puede conectar al servidor. Vuelve a cargar Bloques de Música para intentarlo de nuevo.
+#. TRANS: Característica no disponible: no se puede conectar al servidor. Vuelve a cargar Bloques de Música para intentarlo de nuevo.
 msgid "Feature unavailable - cannot connect to server. Reload Music Blocks to try again."
 msgstr "Característica no disponible: no se puede conectar al servidor. Vuelve a cargar Music Blocks para intentarlo de nuevo."
 
 #: planet/js/Publisher.js:220
 #: planet/js/Publisher.js:237
-#.TRANS: Este campo es requerido.
+#. TRANS: Este campo es requerido.
 msgid "This field is required"
 msgstr "Este campo es requerido."
 
 #: planet/js/Publisher.js:227
-#.TRANS: Título es demasiado largo.
+#. TRANS: Título es demasiado largo.
 msgid "Title too long"
 msgstr "Título es demasiado largo."
 
 #: planet/js/Publisher.js:244
-#.TRANS: La descripción es demasiado largo.
+#. TRANS: La descripción es demasiado largo.
 msgid "Description too long"
 msgstr "La descripción es demasiado largo."
 
 #: planet/js/Publisher.js:341
-#.TRANS: Error del Servidor
+#. TRANS: Error del Servidor
 msgid "Server Error"
 msgstr "Error del Servidor"
 
 #: planet/js/Publisher.js:341
-#.TRANS: Inténtalo de nuevo
+#. TRANS: Inténtalo de nuevo
 msgid "Try Again"
 msgstr "Inténtalo de nuevo"
 
 #: planet/js/SaveInterface.js:34
-#.TRANS: Abrir en Bloques de Música
+#. TRANS: Abrir en Bloques de Música
 msgid "Open in Music Blocks"
 msgstr "Abrir en bloques de música"
 
 #: planet/js/SaveInterface.js:35
-#.TRANS: Abierto en TortuBloques
+#. TRANS: Abierto en TortuBloques
 msgid "Open in Turtle Blocks"
 msgstr ""
 
 #: planet/js/helper.js:149
 #: planet/js/StringHelper.js:49
-#.TRANS: Mostrar más etiquetas
+#. TRANS: Mostrar más etiquetas
 msgid "Show more tags"
 msgstr "Mostrar más etiquetas"
 
 #: planet/js/helper.js:150
-#.TRANS: Mostrar menos etiquetas
+#. TRANS: Mostrar menos etiquetas
 msgid "Show fewer tags"
 msgstr "Mostrar menos etiquetas"
 
 #: planet/js/StringHelper.js:30
-#.TRANS: Planeta
+#. TRANS: Planeta
 msgid "Planet"
 msgstr "Uraqi"
 
 #: planet/js/StringHelper.js:31
-#.TRANS: Cerrar Planeta
+#. TRANS: Cerrar Planeta
 msgid "Close Planet"
 msgstr "Cerrar Planeta"
 
 #: planet/js/StringHelper.js:32
-#.TRANS: Abrir proyecto desde archivo
+#. TRANS: Abrir proyecto desde archivo
 msgid "Open project from file"
 msgstr "Abrir proyecto desde archivo"
 
 #: planet/js/StringHelper.js:34
-#.TRANS: Local
+#. TRANS: Local
 msgid "Local"
 msgstr ""
 
 #: planet/js/StringHelper.js:35
-#.TRANS: Global
+#. TRANS: Global
 msgid "Global"
 msgstr ""
 
 #: planet/js/StringHelper.js:36
-#.TRANS: Buscar un proyecto
+#. TRANS: Buscar un proyecto
 msgid "Search for a project"
 msgstr "Buscar un proyecto"
 
 #: planet/js/StringHelper.js:40
-#.TRANS: Etiquetas (max 5)
+#. TRANS: Etiquetas (max 5)
 msgid "Tags (max 5)"
 msgstr "Etiquetas (max 5)"
 
 #: planet/js/StringHelper.js:41
 #: planet/js/StringHelper.js:61
-#.TRANS: Descripción
+#. TRANS: Descripción
 msgid "Description"
 msgstr "Descripción"
 
 #: planet/js/StringHelper.js:42
 #: planet/js/StringHelper.js:67
-#.TRANS: Presentar
+#. TRANS: Presentar
 msgid "Submit"
 msgstr "Presentar"
 
 #: planet/js/StringHelper.js:43
 #: planet/js/StringHelper.js:47
-#.TRANS: Cancelar
+#. TRANS: Cancelar
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: planet/js/StringHelper.js:44
-#.TRANS: Borrar \\"<span id=\\"deleter-title\\"></span>\\"?
+#. TRANS: Borrar \\"<span id=\\"deleter-title\\"></span>\\"?
 msgid "Delete \\"<span id=\\"deleter-title\\"></span>\\"?"
 msgstr "Borrar \\"<span id=\\"deleter-title\\"></span>\\"?"
 
 #: planet/js/StringHelper.js:45
-#.TRANS: Eliminar permanentemente el proyecto \\"<span id=\\"deleter-name\\"></span>\\"?
+#. TRANS: Eliminar permanentemente el proyecto \\"<span id=\\"deleter-name\\"></span>\\"?
 msgid "Permanently delete project \\"<span id=\\"deleter-name\\"></span>\\"?"
 msgstr "Eliminar permanentemente el proyecto \\"<span id=\\"deleter-name\\"></span>\\"?"
 
 #: planet/js/StringHelper.js:48
-#.TRANS: Explorar proyectos
+#. TRANS: Explorar proyectos
 msgid "Explore Projects"
 msgstr "Explorar proyectos"
 
 #: planet/js/StringHelper.js:50
-#.TRANS: Más reciente
+#. TRANS: Más reciente
 msgid "Most recent"
 msgstr "Más reciente"
 
 #: planet/js/StringHelper.js:51
-#.TRANS: Más gustado
+#. TRANS: Más gustado
 msgid "Most liked"
 msgstr "Más gustado"
 
 #: planet/js/StringHelper.js:52
-#.TRANS: Más descargados
+#. TRANS: Más descargados
 msgid "Most downloaded"
 msgstr "Más descargados"
 
 #: planet/js/StringHelper.js:53
-#.TRANS: A-Z
+#. TRANS: A-Z
 msgid "A-Z"
 msgstr ""
 
 #: planet/js/StringHelper.js:54
-#.TRANS: Ordenar por
+#. TRANS: Ordenar por
 msgid "Sort by"
 msgstr "Ordenar por"
 
 #: planet/js/StringHelper.js:55
-#.TRANS: Cargar más proyectos
+#. TRANS: Cargar más proyectos
 msgid "Load More Projects"
 msgstr "Cargar más proyectos"
 
 #: planet/js/StringHelper.js:56
-#.TRANS: ÃÂltima actualización
+#. TRANS: ÃÂltima actualización
 msgid "Last Updated"
 msgstr "Última actualización"
 
 #: planet/js/StringHelper.js:57
-#.TRANS: Fecha de creación
+#. TRANS: Fecha de creación
 msgid "Creation Date"
 msgstr "Fecha de creación"
 
 #: planet/js/StringHelper.js:58
-#.TRANS: Numero de descargas:
+#. TRANS: Numero de descargas:
 msgid "Number of Downloads:"
 msgstr "Numero de descargas:"
 
 #: planet/js/StringHelper.js:59
-#.TRANS: Número de me gusta:
+#. TRANS: Número de me gusta:
 msgid "Number of Likes:"
 msgstr "Número de me gusta:"
 
 #: planet/js/StringHelper.js:60
-#.TRANS: Etiquetas:
+#. TRANS: Etiquetas:
 msgid "Tags:"
 msgstr "Etiquetas:"
 
 #: planet/js/StringHelper.js:65
-#.TRANS: Reportar proyectos que violen <a href=\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">el código de conducta de Sugar Labs</a>.
+#. TRANS: Reportar proyectos que violen <a href=\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">el código de conducta de Sugar Labs</a>.
 msgid "Report projects which violate the <a href=\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">Sugar Labs Code of Conduct</a>."
 msgstr "Reportar proyectos que violen <a href=\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">el código de conducta de Sugar Labs</a>."
 
 #: planet/js/StringHelper.js:66
-#.TRANS: Razón para informar el proyecto
+#. TRANS: Razón para informar el proyecto
 msgid "Reason for reporting project"
 msgstr "Razón para informar el proyecto"
 
 #: planet/js/StringHelper.js:70
-#.TRANS: Descargar como archivo
+#. TRANS: Descargar como archivo
 msgid "Download as File"
 msgstr "Descargar como archivo"
 
 #: plugins/accelerometer.rtp:48
-#.TRANS: x del acelerómetro
+#. TRANS: x del acelerómetro
 msgid "motion x"
 msgstr "X unxtäwi"
 
 #: plugins/accelerometer.rtp:56
-#.TRANS: y del acelerómetro
+#. TRANS: y del acelerómetro
 msgid "motion y"
 msgstr "Y unxtäwi"
 
 #: plugins/accelerometer.rtp:64
-#.TRANS: z del acelerómetro
+#. TRANS: z del acelerómetro
 msgid "motion z"
 msgstr "Z unxtäwi"
 
 #: plugins/facebook.rtp:27
-#.TRANS: publicar
+#. TRANS: publicar
 msgid "publish"
 msgstr "Facebook taypita yatiyaña"
 
 #: plugins/maths.rtp:62
-#.TRANS: poder
+#. TRANS: poder
 msgid "power"
 msgstr "kankaña"
 
 #: plugins/maths.rtp:62
-#.TRANS: base
+#. TRANS: base
 msgid "base"
 msgstr "chillpa"
 
 #: plugins/maths.rtp:62
-#.TRANS: exp
+#. TRANS: exp
 msgid "exp"
 msgstr "exponente chimpu"
 
 #: plugins/maths.rtp:99
-#.TRANS: piso
+#. TRANS: piso
 msgid "floor"
 msgstr "uraqi"
 
 #: plugins/maths.rtp:104
-#.TRANS: techo
+#. TRANS: techo
 msgid "ceiling"
 msgstr "pillu"
 
 #: plugins/maths.rtp:109
-#.TRANS: a grados
+#. TRANS: a grados
 msgid "to degrees"
 msgstr "jukha chaniru"
 
 #: plugins/maths.rtp:114
-#.TRANS: a radianes
+#. TRANS: a radianes
 msgid "to radians"
 msgstr "radianes wakichataru"
 
 #: plugins/nutrition.rtp:104
-#.TRANS: obtener calorías
+#. TRANS: obtener calorías
 msgid "get calories"
 msgstr "ch'amanchirinaka katuña"
 
 #: plugins/nutrition.rtp:107
-#.TRANS: obtener proteínas
+#. TRANS: obtener proteínas
 msgid "get protein"
 msgstr "ch’amanchirinaka katuña"
 
 #: plugins/nutrition.rtp:110
-#.TRANS: obtener carbohidratos
+#. TRANS: obtener carbohidratos
 msgid "get carbs"
 msgstr "carbohidratos ch’amanchirinaka katuña"
 
 #: plugins/nutrition.rtp:113
-#.TRANS: obtener fibra
+#. TRANS: obtener fibra
 msgid "get fiber"
 msgstr "llika wakichata katuña"
 
 #: plugins/nutrition.rtp:116
-#.TRANS: obtener grasas
+#. TRANS: obtener grasas
 msgid "get fat"
 msgstr "lik’intaña"
 
 #: plugins/nutrition.rtp:119
-#.TRANS: obtener nombre
+#. TRANS: obtener nombre
 msgid "get name"
 msgstr "suti jakiña"
 
 #: plugins/nutrition.rtp:122
-#.TRANS: calorías
+#. TRANS: calorías
 msgid "calories"
 msgstr "junt’u manq’anaka"
 
 #: plugins/nutrition.rtp:128
-#.TRANS: proteína
+#. TRANS: proteína
 msgid "protein"
 msgstr "ch’amanchiri juyra"
 
 #: plugins/nutrition.rtp:134
-#.TRANS: carbohidratos
+#. TRANS: carbohidratos
 msgid "carbs"
 msgstr "carbohidratos ch’amanchirinakata wakichata"
 
 #: plugins/nutrition.rtp:140
-#.TRANS: fibra
+#. TRANS: fibra
 msgid "fiber"
 msgstr "llika"
 
 #: plugins/nutrition.rtp:146
-#.TRANS: grasa
+#. TRANS: grasa
 msgid "fat"
 msgstr "ch'islli"
 
 #: plugins/nutrition.rtp:152
-#.TRANS: comer
+#. TRANS: comer
 msgid "eat"
 msgstr "manq’aña"
 
 #: plugins/nutrition.rtp:155
-#.TRANS: digerir
+#. TRANS: digerir
 msgid "digest meal"
 msgstr "qhatjayaña"
 
 #: plugins/nutrition.rtp:158
-#.TRANS: manzana
+#. TRANS: manzana
 msgid "apple"
 msgstr "manzana puquta"
 
 #: plugins/nutrition.rtp:161
-#.TRANS: banana
+#. TRANS: banana
 msgid "banana"
 msgstr "latanusa puquta"
 
 #: plugins/nutrition.rtp:167
-#.TRANS: pan
+#. TRANS: pan
 msgid "wheat bread"
 msgstr "tiriwu t’ant’a"
 
 #: plugins/nutrition.rtp:170
-#.TRANS: maíz
+#. TRANS: maíz
 msgid "corn"
 msgstr "tunqu"
 
 #: plugins/nutrition.rtp:173
-#.TRANS: papa
+#. TRANS: papa
 msgid "potato"
 msgstr "ch’uqi juyra"
 
 #: plugins/nutrition.rtp:176
-#.TRANS: boñato
+#. TRANS: boñato
 msgid "sweet potato"
 msgstr "kamuti juyra"
 
 #: plugins/nutrition.rtp:179
-#.TRANS: tomate
+#. TRANS: tomate
 msgid "tomato"
 msgstr "tomate juyra"
 
 #: plugins/nutrition.rtp:182
-#.TRANS: brócoli
+#. TRANS: brócoli
 msgid "broccoli"
 msgstr "broccoli juyra"
 
 #: plugins/nutrition.rtp:185
-#.TRANS: arroz y frijoles
+#. TRANS: arroz y frijoles
 msgid "rice and beans"
 msgstr "arroz ukata frijoles juyranaka"
 
 #: plugins/nutrition.rtp:188
-#.TRANS: tamal
+#. TRANS: tamal
 msgid "tamale"
 msgstr "tamal manq’a"
 
 #: plugins/nutrition.rtp:191
-#.TRANS: queso
+#. TRANS: queso
 msgid "cheese"
 msgstr "kisulla"
 
 #: plugins/nutrition.rtp:194
-#.TRANS: pollo
+#. TRANS: pollo
 msgid "chicken"
 msgstr "chhiwchhi"
 
 #: plugins/nutrition.rtp:197
-#.TRANS: pescado
+#. TRANS: pescado
 msgid "fish"
 msgstr "chawlla"
 
 #: plugins/nutrition.rtp:200
-#.TRANS: carne de res
+#. TRANS: carne de res
 msgid "beef"
 msgstr "waka aycha"
 
 #: plugins/nutrition.rtp:203
-#.TRANS: pastel
+#. TRANS: pastel
 msgid "cake"
 msgstr "llamp’u t’ant’a"
 
 #: plugins/nutrition.rtp:206
-#.TRANS: galleta
+#. TRANS: galleta
 msgid "cookie"
 msgstr "khapu t’ant’a"
 
 #: plugins/nutrition.rtp:209
-#.TRANS: agua
+#. TRANS: agua
 msgid "water"
 msgstr "uma"
 
 #: plugins/weather.rtp:68
 #: plugins/weather.rtp:97
-#.TRANS: Los días siguientes deben estar en el rango de -1 a 5.
+#. TRANS: Los días siguientes deben estar en el rango de -1 a 5.
 msgid "Days ahead must be in the range of -1 to 5."
 msgstr "Jutiri urunakaxa -1 ukata 5 jakhu chimpunkañapawa"
 
 #: plugins/weather.rtp:122
-#.TRANS: pronóstico
+#. TRANS: pronóstico
 msgid "forecast"
 msgstr "watiqaña"
 
 #: plugins/weather.rtp:123
 #: plugins/weather.rtp:137
 #: plugins/weather.rtp:150
-#.TRANS: ciudad
+#. TRANS: ciudad
 msgid "city"
 msgstr "marka"
 
 #: plugins/weather.rtp:124
 #: plugins/weather.rtp:138
 #: plugins/weather.rtp:151
-#.TRANS: día
+#. TRANS: día
 msgid "day"
 msgstr "uru"
 
 #: plugins/weather.rtp:136
-#.TRANS: alta
+#. TRANS: alta
 msgid "high"
 msgstr "jach’a"
 
 #: plugins/weather.rtp:149
-#.TRANS: baja
+#. TRANS: baja
 msgid "low"
 msgstr "jisk’a"
 
 #: plugins/rodi.rtp:172
-#.TRANS: parpadear
+#. TRANS: parpadear
 msgid "blink"
 msgstr "lliphiqi"
 
 #: plugins/rodi.rtp:246
-#.TRANS: LED
+#. TRANS: LED
 msgid "led"
 msgstr "irpata"
 
 #: plugins/rodi.rtp:265
-#.TRANS: intensidad de luz
+#. TRANS: intensidad de luz
 msgid "light intensity"
 msgstr "qhana lliphi ch'ama"
 
 #: plugins/rodi.rtp:282
-#.TRANS: luz infrarroja (izquierda)
+#. TRANS: luz infrarroja (izquierda)
 msgid "infrared light (left)"
 msgstr "Surump'iyasiri qhana (ch'iqäxa)"
 
 #: plugins/rodi.rtp:296
-#.TRANS: luz infrarroja (derecha)
+#. TRANS: luz infrarroja (derecha)
 msgid "infrared light (right)"
 msgstr "Surump'iyasiri qhana (Kupïxa)"
 
 #: plugins/rodi.rtp:338
-#.TRANS: mover
+#. TRANS: mover
 msgid "move"
 msgstr "unxtayaña"
 
 #: js/activity.js:3323
 
-#.TRANS: Nada en la basura para restaurar.
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#. TRANS: Nada en la basura para restaurar.
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#.TRANS: Guarda audio de tu proyecto como WAV.
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#. TRANS: Guarda audio de tu proyecto como WAV.
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#.TRANS: Guarda tu proyecto como un archivo ABC.
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#. TRANS: Guarda tu proyecto como un archivo ABC.
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#.TRANS: Guarde el proyecto como un archivo de LilyPond.
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#. TRANS: Guarde el proyecto como un archivo de LilyPond.
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#.TRANS: Mostrar u ocultar las rejillas de coordenadas.
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#. TRANS: Mostrar u ocultar las rejillas de coordenadas.
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#.TRANS: Expandir/contraer los bloques
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#. TRANS: Expandir/contraer los bloques
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#.TRANS: Mostrar estos mensajes.
-#~msgid "Show these messages."
-#~msgstr ""
+#. TRANS: Mostrar estos mensajes.
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9387,8 +9389,8 @@ msgstr "unxtayaña"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -9398,8 +9400,8 @@ msgstr "unxtayaña"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -9411,35 +9413,35 @@ msgstr "unxtayaña"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "qhawachiy"
+#~ msgid "show"
+#~ msgstr "qhawachiy"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -9453,69 +9455,69 @@ msgstr "unxtayaña"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr " chiqaskunata pakay"
+#~ msgid "hide blocks"
+#~ msgstr " chiqaskunata pakay"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr "iskay kikiyachiy"
+#~ msgid "duplicate"
+#~ msgstr "iskay kikiyachiy"
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -9535,13 +9537,13 @@ msgstr "unxtayaña"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "sayachiy"
+#~ msgid "stop"
+#~ msgstr "sayachiy"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "kawsapakuy"
+#~ msgid "duration (ms)"
+#~ msgstr "kawsapakuy"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -9549,58 +9551,58 @@ msgstr "unxtayaña"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "pichay"
+#~ msgid "clear"
+#~ msgstr "pichay"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "t’ikray"
+#~ msgid "invert"
+#~ msgstr "t’ikray"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr "maymikuynin"
+#~ msgid "oscillator"
+#~ msgstr "maymikuynin"
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr "qhipay"
+#~ msgid "delay"
+#~ msgstr "qhipay"
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr "envolventes"
+#~ msgid "envelope"
+#~ msgstr "envolventes"
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr "suysuy"
+#~ msgid "filter"
+#~ msgstr "suysuy"
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -9616,25 +9618,25 @@ msgstr "unxtayaña"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr "Nuevo bloque de acción creado!"
+#~ msgid "New action block generated!"
+#~ msgstr "Nuevo bloque de acción creado!"
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "unaykachiy"
+#~ msgid "duration"
+#~ msgstr "unaykachiy"
 
 #: js/widgets/temperament.js:454
 
@@ -9644,46 +9646,46 @@ msgstr "unxtayaña"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr "wisq’ay"
+#~ msgid "close"
+#~ msgstr "wisq’ay"
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr "Publicar el proyecto"
+#~ msgid "Publish Project"
+#~ msgstr "Publicar el proyecto"
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr "qhantayaña"
+#~ msgid "play"
+#~ msgstr "qhantayaña"
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
-#~msgid ""Toggle Fullscreen"
-#~msgstr ""Ajarka pantalla sarnaqapxana"
+#~ msgid "Toggle Fullscreen"
+#~ msgstr "Ajarka pantalla sarnaqapxana"
 
 #: js/toolbar.js:70
 
@@ -9693,190 +9695,190 @@ msgstr "unxtayaña"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr "video llamk’ana"
+#~ msgid "video material"
+#~ msgstr "video llamk’ana"
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -9886,394 +9888,394 @@ msgstr "unxtayaña"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr "El bloque Arco mueve el ratón en un arco."
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr "El bloque Arco mueve el ratón en un arco."
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr "El bloque fijar rumbo establece el rumbo del mouse."
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr "El bloque fijar rumbo establece el rumbo del mouse."
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr "kaqpuni kasqan, cuartopa notan yupay"
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr "kaqpuni kasqan, cuartopa notan yupay"
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr "El cursor sobre el bloque activa un evento cuando el cursor se mueve sobre un ratón."
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr "El cursor sobre el bloque activa un evento cuando el cursor se mueve sobre un ratón."
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr "El bloque de salida del cursor desencadena un evento cuando el cursor se mueve fuera de un ratón."
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr "El bloque de salida del cursor desencadena un evento cuando el cursor se mueve fuera de un ratón."
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr "El bloque hacia abajo del botón del cursor activa un evento cuando se presiona el botón del cursor en un ratón."
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr "El bloque hacia abajo del botón del cursor activa un evento cuando se presiona el botón del cursor en un ratón."
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr "El bloque del botón del cursor hacia arriba desencadena un evento cuando se suelta el botón del cursor sobre un ratón."
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr "El bloque del botón del cursor hacia arriba desencadena un evento cuando se suelta el botón del cursor sobre un ratón."
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr "Más detalles"
+#~ msgid "More Details"
+#~ msgstr "Más detalles"
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr "Compartir proyecto"
+#~ msgid "Share project"
+#~ msgstr "Compartir proyecto"
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr "Copiar enlace al portapapeles"
+#~ msgid "Copy link to clipboard"
+#~ msgstr "Copiar enlace al portapapeles"
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr "Ejecutar código al inicio."
+#~ msgid "Run project on startup."
+#~ msgstr "Ejecutar código al inicio."
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr "Mostrar código al inicio."
+#~ msgid "Show code blocks on startup."
+#~ msgstr "Mostrar código al inicio."
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr "Contraer bloques al inicio."
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr "Contraer bloques al inicio."
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr "Opciones avanzadas"
+#~ msgid "Advanced Options"
+#~ msgstr "Opciones avanzadas"
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr "Hertz chiqas: ¿yaqapas huch’uy willakuy chiqaspi llamk’ayta munawaq karqan "
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr "Hertz chiqas: ¿yaqapas huch’uy willakuy chiqaspi llamk’ayta munawaq karqan "
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr "Proyecto \"No me gusta\""
+#~ msgid "Unlike project"
+#~ msgstr "Proyecto \"No me gusta\""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr "Proyecto \"Me gusta\""
+#~ msgid "Like project"
+#~ msgstr "Proyecto \"Me gusta\""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr "Volver a publicar el proyecto"
+#~ msgid "Republish Project"
+#~ msgstr "Volver a publicar el proyecto"
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr "5 tinkuq kunka"
+#~ msgid "chord5"
+#~ msgstr "5 tinkuq kunka"
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr "4 tinkuq kunka"
+#~ msgid "chord4"
+#~ msgstr "4 tinkuq kunka"
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr "1 tinkuq kunka"
+#~ msgid "chord1"
+#~ msgstr "1 tinkuq kunka"
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr "El bloque nombre de nth ratón devuelve el nombre de nth ratón"
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr "El bloque nombre de nth ratón devuelve el nombre de nth ratón"
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "qullqi"
+#~ msgid "currency"
+#~ msgstr "qullqi"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "ukatpacha"
+#~ msgid "from"
+#~ msgstr "ukatpacha"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "qhatu alapa"
+#~ msgid "stock price"
+#~ msgstr "qhatu alapa"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "jaqukipaña"
+#~ msgid "translate"
+#~ msgstr "jaqukipaña"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "kamisaraki"
+#~ msgid "hello"
+#~ msgstr "kamisaraki"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "aru katjaña"
+#~ msgid "detect lang"
+#~ msgstr "aru katjaña"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "aru jaqukipaña"
+#~ msgid "set lang"
+#~ msgstr "aru jaqukipaña"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "Marka sayt’u taña "
+#~ msgid "city latitude"
+#~ msgstr "Marka sayt’u taña "
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "marka sayt’u tañapa"
+#~ msgid "city longitude"
+#~ msgstr "marka sayt’u tañapa"
 
 #: plugins/gmap.rtp:71
 
@@ -10283,144 +10285,144 @@ msgstr "unxtayaña"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "Jani jakiña yatiyäwinaka tuqita aruskipaña"
+#~ msgid "Coordinate data not available."
+#~ msgstr "Jani jakiña yatiyäwinaka tuqita aruskipaña"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "Google pacha rixipa wakichata"
+#~ msgid "Google map"
+#~ msgstr "Google pacha rixipa wakichata"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "coordenadas wakichata"
+#~ msgid "coordinates"
+#~ msgstr "coordenadas wakichata"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "jach’aptayaña wakisiripa"
+#~ msgid "zoom factor"
+#~ msgstr "jach’aptayaña wakisiripa"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "jach'aptayaña"
+#~ msgid "zoom"
+#~ msgstr "jach'aptayaña"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "ampsta"
+#~ msgid "latitude"
+#~ msgstr "ampsta"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "sara taña"
+#~ msgid "longitude"
+#~ msgstr "sara taña"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "muyta taña chimpu"
+#~ msgid "degrees"
+#~ msgstr "muyta taña chimpu"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "radianes wakichata"
+#~ msgid "radians"
+#~ msgstr "radianes wakichata"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "amtaña"
+#~ msgid "define"
+#~ msgstr "amtaña"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "bitcoin wakichata"
+#~ msgid "bitcoin"
+#~ msgstr "bitcoin wakichata"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr "Maya wakichata imata chhijllañamawa"
+#~ msgid "You need to select a file."
+#~ msgstr "Maya wakichata imata chhijllañamawa"
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -10430,15 +10432,15 @@ msgstr "unxtayaña"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -10448,23 +10450,23 @@ msgstr "unxtayaña"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr "Tarula siqi: Qillqata maya siqi wakichata sañcha munta"
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr "Tarula siqi: Qillqata maya siqi wakichata sañcha munta"
 
 #: js/pitchtracker.js:181
 
@@ -10474,8 +10476,8 @@ msgstr "unxtayaña"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -10483,57 +10485,57 @@ msgstr "unxtayaña"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr "iranaka imaña"
+#~ msgid "save rhythms"
+#~ msgstr "iranaka imaña"
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr "arrastrar"
+#~ msgid "drag"
+#~ msgstr "arrastrar"
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr "kunka chiqas: ¿yaqapas huch’uy willakuy chiqaspi llamk’ayta munawaq karqan?"
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr "kunka chiqas: ¿yaqapas huch’uy willakuy chiqaspi llamk’ayta munawaq karqan?"
 
-#~msgid " he Effects name block is used to select a sound effect."
-#~msgstr "Pantanchina Sayaqa, pantachina akllanapaqmi "
+#~ msgid " he Effects name block is used to select a sound effect."
+#~ msgstr "Pantanchina Sayaqa, pantachina akllanapaqmi "
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr "Huk’uchaman liqta churarqunki chayqa,  liq chiqasqa chiqaq nisqantan kutichin "
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr "Huk’uchaman liqta churarqunki chayqa,  liq chiqasqa chiqaq nisqantan kutichin "
 
-#~msgid "The Box 2 block returns the value stored in Box 2."
-#~msgstr "2 tawa k’uchu t’aqa  2 tawa k’uchu waqaychasqaman chaninta kutichin"
+#~ msgid "The Box 2 block returns the value stored in Box 2."
+#~ msgstr "2 tawa k’uchu t’aqa  2 tawa k’uchu waqaychasqaman chaninta kutichin"
 
-#~msgid "box 2"
-#~msgstr "2 tawa k’uchu"
+#~ msgid "box 2"
+#~ msgstr "2 tawa k’uchu"
 
-#~msgid "store in box 2"
-#~msgstr "2 tawa k’uchupi waqaychay"
+#~ msgid "store in box 2"
+#~ msgstr "2 tawa k’uchupi waqaychay"
 
-#~msgid "The Box 1 block returns the value stored in Box 1."
-#~msgstr "1 tawa k’uchu t’aqa 1 tawa k’uchuta chanin waqaychasqata kutichin"
+#~ msgid "The Box 1 block returns the value stored in Box 1."
+#~ msgstr "1 tawa k’uchu t’aqa 1 tawa k’uchuta chanin waqaychasqata kutichin"
 
-#~msgid "box 1"
-#~msgstr "1 tawa k’uchu"
+#~ msgid "box 1"
+#~ msgstr "1 tawa k’uchu"
 
-#~msgid "store in box 1"
-#~msgstr "1 tawa k’uchupi waqaychay"
+#~ msgid "store in box 1"
+#~ msgstr "1 tawa k’uchupi waqaychay"
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr "El bloque Caja 2 devuelve el valor almacenado en caja 2."
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr "El bloque Caja 2 devuelve el valor almacenado en caja 2."
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr "El bloque Caja 1 devuelve el valor almacenado en caja 1."
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr "El bloque Caja 1 devuelve el valor almacenado en caja 1."
 
-#~msgid "This block converts the pitch value of the last note played into differ"
-#~msgstr "Este bloque convierte el valor de tono de la última nota tocada en dif"
+#~ msgid "This block converts the pitch value of the last note played into differ"
+#~ msgstr "Este bloque convierte el valor de tono de la última nota tocada en dif"
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -2215,7 +2215,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2296,33 +2296,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2422,7 +2422,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2651,8 +2651,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2821,14 +2821,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2859,7 +2859,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2884,7 +2884,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2893,7 +2893,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2914,7 +2914,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2932,8 +2932,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3035,7 +3035,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3169,14 +3169,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3251,7 +3251,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3287,7 +3287,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3296,7 +3296,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3787,7 +3787,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3799,8 +3799,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3810,7 +3810,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3822,8 +3822,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3833,15 +3833,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3850,14 +3850,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3866,14 +3866,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3923,7 +3923,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3940,7 +3940,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4009,8 +4009,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4032,7 +4032,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4318,7 +4318,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4649,21 +4649,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4672,12 +4672,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4690,62 +4690,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4758,7 +4758,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4767,7 +4767,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4780,7 +4780,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4789,17 +4789,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4808,12 +4808,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4835,17 +4835,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4862,56 +4862,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4927,7 +4927,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4936,7 +4936,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4944,7 +4944,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4953,8 +4953,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4962,7 +4962,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4976,116 +4976,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5104,19 +5104,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5124,61 +5124,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5188,149 +5188,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5339,7 +5339,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5418,22 +5418,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5590,7 +5590,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5612,7 +5612,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5623,7 +5623,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5652,7 +5652,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5661,7 +5661,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5694,7 +5694,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5704,7 +5704,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5713,7 +5713,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5722,7 +5722,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5745,13 +5745,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5760,7 +5760,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5769,7 +5769,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5789,7 +5789,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5814,7 +5814,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5828,7 +5828,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5838,7 +5838,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5876,7 +5876,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5885,7 +5885,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5898,18 +5898,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6030,7 +6030,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6049,7 +6049,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6058,7 +6058,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6075,7 +6075,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6088,7 +6088,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6117,7 +6117,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6140,7 +6140,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6157,7 +6157,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6166,7 +6166,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6183,7 +6183,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6192,7 +6192,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6226,7 +6226,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6235,7 +6235,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6252,7 +6252,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6267,7 +6267,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6301,12 +6301,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6315,12 +6315,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6329,13 +6329,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6353,7 +6353,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6385,8 +6385,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6442,7 +6442,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6599,12 +6599,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6614,8 +6614,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6623,12 +6623,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6637,7 +6637,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6654,7 +6654,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6664,12 +6664,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6679,7 +6679,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6688,7 +6688,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6738,7 +6738,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6771,7 +6771,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6780,12 +6780,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6794,7 +6794,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6803,7 +6803,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6812,7 +6812,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6823,8 +6823,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6834,7 +6834,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6860,7 +6860,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6898,12 +6898,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6915,12 +6915,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6929,7 +6929,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6975,22 +6975,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7012,7 +7012,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7021,47 +7021,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7074,7 +7074,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7083,7 +7083,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7091,7 +7091,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7105,8 +7105,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7135,7 +7135,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7160,14 +7160,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7177,7 +7177,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7196,7 +7196,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7206,7 +7206,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7223,17 +7223,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7242,7 +7242,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7252,7 +7252,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7262,7 +7262,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7274,7 +7274,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7292,7 +7292,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7313,7 +7313,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7328,7 +7328,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7352,7 +7352,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7408,7 +7408,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7586,7 +7586,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7595,7 +7595,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7604,7 +7604,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7613,7 +7613,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7623,13 +7623,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7642,7 +7642,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7651,7 +7651,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7660,7 +7660,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7669,7 +7669,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7678,7 +7678,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7687,7 +7687,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7696,7 +7696,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7705,7 +7705,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7715,17 +7715,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7734,7 +7734,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8161,7 +8161,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8171,7 +8171,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8215,12 +8215,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8229,7 +8229,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8286,7 +8286,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8304,7 +8304,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8317,7 +8317,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8382,7 +8382,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8447,7 +8447,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8456,12 +8456,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8470,7 +8470,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8479,7 +8479,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8488,7 +8488,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8513,7 +8513,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8648,27 +8648,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8694,18 +8694,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8720,7 +8720,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8741,7 +8741,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8758,7 +8758,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8771,7 +8771,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8781,7 +8781,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8795,7 +8795,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8816,7 +8816,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8830,7 +8830,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9017,7 +9017,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9026,7 +9026,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9148,7 +9148,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9231,7 +9231,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9281,7 +9281,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9398,7 +9398,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9477,48 +9477,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9951,38 +9951,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9990,8 +9990,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10001,8 +10001,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10014,35 +10014,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10056,69 +10056,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10138,13 +10138,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10152,58 +10152,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10219,25 +10219,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10247,43 +10247,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10293,190 +10293,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10486,305 +10486,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10794,97 +10794,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10894,144 +10894,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11041,15 +11041,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11059,23 +11059,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11085,8 +11085,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11094,224 +11094,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11327,37 +11327,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11365,28 +11365,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11400,8 +11400,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11411,65 +11411,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11477,8 +11477,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11488,127 +11488,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11616,608 +11616,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12227,165 +12227,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12399,28 +12399,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12428,133 +12428,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12562,136 +12562,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12701,127 +12701,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12829,397 +12829,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13231,196 +13231,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13428,155 +13428,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13584,257 +13584,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13848,223 +13848,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14074,144 +14074,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14219,57 +14219,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14279,30 +14279,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14310,112 +14310,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14423,287 +14423,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14711,13 +14711,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14725,86 +14725,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/bi.po
+++ b/po/bi.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "খালি heap"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "বের করো"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "প্রবেশ করাও"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "কলম ওঠাও"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "কলম নামাও"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "কলমের আকার নির্ধারণ করো"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "ঝাঁজরি"
+#~ msgid "grid"
+#~ msgstr "ঝাঁজরি"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "পরিষ্কার করো"
+#~ msgid "Clean"
+#~ msgstr "পরিষ্কার করো"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "ব্লক লুকিয়ে রাখো"
+#~ msgid "hide blocks"
+#~ msgstr "ব্লক লুকিয়ে রাখো"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "ধাপ"
+#~ msgid "stop"
+#~ msgstr "ধাপ"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "টার্টেল"
+#~ msgid "turtle"
+#~ msgstr "টার্টেল"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/br.po
+++ b/po/br.po
@@ -2215,7 +2215,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2296,33 +2296,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2422,7 +2422,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2651,8 +2651,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2821,14 +2821,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2859,7 +2859,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2884,7 +2884,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2893,7 +2893,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2914,7 +2914,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2932,8 +2932,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3035,7 +3035,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3169,14 +3169,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3251,7 +3251,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3287,7 +3287,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3296,7 +3296,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3787,7 +3787,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3799,8 +3799,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3810,7 +3810,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3822,8 +3822,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3833,15 +3833,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3850,14 +3850,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3866,14 +3866,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3923,7 +3923,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3940,7 +3940,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4009,8 +4009,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4032,7 +4032,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4318,7 +4318,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4649,21 +4649,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4672,12 +4672,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4690,62 +4690,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4758,7 +4758,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4767,7 +4767,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4780,7 +4780,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4789,17 +4789,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4808,12 +4808,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4835,17 +4835,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4862,56 +4862,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4927,7 +4927,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4936,7 +4936,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4944,7 +4944,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4953,8 +4953,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4962,7 +4962,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4976,116 +4976,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5104,19 +5104,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5124,61 +5124,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5188,149 +5188,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5339,7 +5339,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5418,22 +5418,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5590,7 +5590,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5612,7 +5612,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5623,7 +5623,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5652,7 +5652,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5661,7 +5661,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5694,7 +5694,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5704,7 +5704,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5713,7 +5713,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5722,7 +5722,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5745,13 +5745,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5760,7 +5760,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5769,7 +5769,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5789,7 +5789,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5814,7 +5814,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5828,7 +5828,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5838,7 +5838,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5876,7 +5876,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5885,7 +5885,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5898,18 +5898,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6030,7 +6030,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6049,7 +6049,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6058,7 +6058,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6075,7 +6075,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6088,7 +6088,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6117,7 +6117,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6140,7 +6140,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6157,7 +6157,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6166,7 +6166,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6183,7 +6183,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6192,7 +6192,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6226,7 +6226,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6235,7 +6235,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6252,7 +6252,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6267,7 +6267,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6301,12 +6301,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6315,12 +6315,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6329,13 +6329,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6353,7 +6353,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6385,8 +6385,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6442,7 +6442,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6599,12 +6599,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6614,8 +6614,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6623,12 +6623,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6637,7 +6637,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6654,7 +6654,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6664,12 +6664,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6679,7 +6679,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6688,7 +6688,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6738,7 +6738,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6771,7 +6771,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6780,12 +6780,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6794,7 +6794,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6803,7 +6803,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6812,7 +6812,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6823,8 +6823,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6834,7 +6834,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6860,7 +6860,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6898,12 +6898,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6915,12 +6915,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6929,7 +6929,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6975,22 +6975,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7012,7 +7012,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7021,47 +7021,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7074,7 +7074,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7083,7 +7083,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7091,7 +7091,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7105,8 +7105,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7135,7 +7135,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7160,14 +7160,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7177,7 +7177,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7196,7 +7196,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7206,7 +7206,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7223,17 +7223,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7242,7 +7242,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7252,7 +7252,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7262,7 +7262,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7274,7 +7274,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7292,7 +7292,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7313,7 +7313,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7328,7 +7328,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7352,7 +7352,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7408,7 +7408,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7586,7 +7586,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7595,7 +7595,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7604,7 +7604,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7613,7 +7613,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7623,13 +7623,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7642,7 +7642,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7651,7 +7651,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7660,7 +7660,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7669,7 +7669,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7678,7 +7678,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7687,7 +7687,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7696,7 +7696,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7705,7 +7705,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7715,17 +7715,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7734,7 +7734,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8161,7 +8161,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8171,7 +8171,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8215,12 +8215,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8229,7 +8229,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8286,7 +8286,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8304,7 +8304,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8317,7 +8317,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8382,7 +8382,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8447,7 +8447,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8456,12 +8456,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8470,7 +8470,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8479,7 +8479,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8488,7 +8488,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8513,7 +8513,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8648,27 +8648,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8694,18 +8694,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8720,7 +8720,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8741,7 +8741,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8758,7 +8758,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8771,7 +8771,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8781,7 +8781,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8795,7 +8795,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8816,7 +8816,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8830,7 +8830,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9017,7 +9017,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9026,7 +9026,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9148,7 +9148,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9231,7 +9231,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9281,7 +9281,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9398,7 +9398,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9477,48 +9477,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9951,38 +9951,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9990,8 +9990,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10001,8 +10001,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10014,35 +10014,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10056,69 +10056,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10138,13 +10138,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10152,58 +10152,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10219,25 +10219,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10247,43 +10247,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10293,190 +10293,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10486,305 +10486,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10794,97 +10794,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10894,144 +10894,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11041,15 +11041,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11059,23 +11059,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11085,8 +11085,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11094,224 +11094,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11327,37 +11327,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11365,28 +11365,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11400,8 +11400,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11411,65 +11411,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11477,8 +11477,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11488,127 +11488,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11616,608 +11616,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12227,165 +12227,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12399,28 +12399,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12428,133 +12428,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12562,136 +12562,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12701,127 +12701,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12829,397 +12829,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13231,196 +13231,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13428,155 +13428,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13584,257 +13584,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13848,223 +13848,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14074,144 +14074,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14219,57 +14219,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14279,30 +14279,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14310,112 +14310,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14423,287 +14423,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14711,13 +14711,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14725,86 +14725,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "buidar la pila"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "treure"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "netejar"
+#~ msgid "Clean"
+#~ msgstr "netejar"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "Tortuga"
+#~ msgid "turtle"
+#~ msgstr "Tortuga"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "bouchnout"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "tlačit"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "zapnout pero"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "vypnout pero"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "nastavit velikost pera"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "ukázat"
+#~ msgid "show"
+#~ msgstr "ukázat"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Smazat"
+#~ msgid "Clean"
+#~ msgstr "Smazat"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "skrýt bloky"
+#~ msgid "hide blocks"
+#~ msgstr "skrýt bloky"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "Krok"
+#~ msgid "stop"
+#~ msgstr "Krok"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "Želva"
+#~ msgid "turtle"
+#~ msgstr "Želva"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Otevřít"
+#~ msgid "Open"
+#~ msgstr "Otevřít"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -2216,7 +2216,7 @@ msgstr "handling"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr "flyd"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr "ekstramateriale"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "tom hób"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "pop"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "skub"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "mus y"
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "skildpadde y"
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "mus x"
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "skildpadde x"
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr "slut udfyld"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "pen oppe"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "pen nede"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "indstil størrelse på pen"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "medie"
+#~ msgid "media"
+#~ msgstr "medie"
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "vis"
+#~ msgid "show"
+#~ msgstr "vis"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Rens"
+#~ msgid "Clean"
+#~ msgstr "Rens"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "skjul blokke"
+#~ msgid "hide blocks"
+#~ msgstr "skjul blokke"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "stop"
+#~ msgid "stop"
+#~ msgstr "stop"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "varighed"
+#~ msgid "duration"
+#~ msgstr "varighed"
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "hej"
+#~ msgid "hello"
+#~ msgstr "hej"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "skildpadde"
+#~ msgid "turtle"
+#~ msgstr "skildpadde"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Åbn"
+#~ msgid "Open"
+#~ msgstr "Åbn"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr "blokke"
+#~ msgid "blocks"
+#~ msgstr "blokke"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -2215,7 +2215,7 @@ msgstr "Aktion"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr "Ente"
 
@@ -2282,7 +2282,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "Mein Projekt"
 
@@ -2296,33 +2296,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2422,7 +2422,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2651,8 +2651,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr "Lineal"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2821,14 +2821,14 @@ msgstr "Treppe"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "Geschwindigkeit"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "Modus"
 
@@ -2859,7 +2859,7 @@ msgstr "Trommel"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2884,7 +2884,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "Notenwert"
 
@@ -2893,7 +2893,7 @@ msgstr "Notenwert"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2914,7 +2914,7 @@ msgid "silence"
 msgstr "Stille"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2932,8 +2932,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "Tonlage"
 
@@ -3035,7 +3035,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3169,14 +3169,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3251,7 +3251,7 @@ msgstr "Starte Trommel"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "Rhythmus"
 
@@ -3287,7 +3287,7 @@ msgstr "Programmfluss"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3296,7 +3296,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3787,7 +3787,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3799,8 +3799,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "Um einen Halbton erhöht"
 
@@ -3810,7 +3810,7 @@ msgstr "Um einen Halbton erhöht"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3822,8 +3822,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "Um einen Halbton erniedrigt"
 
@@ -3833,15 +3833,15 @@ msgstr "Um einen Halbton erniedrigt"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3850,14 +3850,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "Dur"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3866,14 +3866,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "Moll"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3923,7 +3923,7 @@ msgid "synth cannot play chords."
 msgstr "Der Syntheziser kann keine Akkorde spielen"
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3940,7 +3940,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "Meter"
 
@@ -4009,8 +4009,8 @@ msgstr "Extras"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4032,7 +4032,7 @@ msgstr "Logik"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4318,7 +4318,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4649,21 +4649,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "übermäßig"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "vermindert"
 
@@ -4672,12 +4672,12 @@ msgstr "vermindert"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "rein"
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4690,62 +4690,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4758,7 +4758,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4767,7 +4767,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4780,7 +4780,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4789,17 +4789,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4808,12 +4808,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4835,17 +4835,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4862,56 +4862,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr "Benutzerdefiniert"
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "Sinus"
 
@@ -4927,7 +4927,7 @@ msgstr "Sinus"
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "Quadrat"
 
@@ -4936,7 +4936,7 @@ msgstr "Quadrat"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "Dreieck"
 
@@ -4944,7 +4944,7 @@ msgstr "Dreieck"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "Sägezahn"
 
@@ -4953,8 +4953,8 @@ msgstr "Sägezahn"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4962,7 +4962,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4976,116 +4976,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr "Geige"
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr "Cello"
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5104,19 +5104,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5124,61 +5124,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr "Snare"
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr "Basstrommel"
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr "Tomtom"
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr "Tomtom"
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "Bechertrommel"
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr "Darbuka"
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr "Hi-Hat"
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr "Ride-Becken"
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr "Kuhglocke"
 
@@ -5188,149 +5188,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr "Triangel"
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr "Zimbel"
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "Glockenspiel"
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr "Klang"
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr "Krachen"
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr "Flasche"
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr "Klatschen"
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr "Schlag"
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr "Spritzen"
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr "Blasen"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr "Katze"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr "Grille"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr "Hund"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5339,7 +5339,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5418,22 +5418,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5590,7 +5590,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5612,7 +5612,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "Schlüssel"
 
@@ -5623,7 +5623,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5652,7 +5652,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5661,7 +5661,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "Trommel Auswahlen"
 
@@ -5694,7 +5694,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "Leerer Stapel?"
 
@@ -5704,7 +5704,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "leere Stapel"
 
@@ -5713,7 +5713,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5722,7 +5722,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "Stapel abrufen"
 
@@ -5745,13 +5745,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "Stapel bestimmen"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "Index"
 
@@ -5760,7 +5760,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "Nimm auf"
 
@@ -5769,7 +5769,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "Lege ab"
 
@@ -5789,7 +5789,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "Oktave"
 
@@ -5814,7 +5814,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5828,7 +5828,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5838,7 +5838,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5876,7 +5876,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5885,7 +5885,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5898,18 +5898,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "Notenschlüssel auswählen"
 
@@ -6030,7 +6030,7 @@ msgstr "Legato-Faktor"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6049,7 +6049,7 @@ msgstr "Legato"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "Staccato"
 
@@ -6058,7 +6058,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr "Lade Stapel aus der App"
 
@@ -6075,7 +6075,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr "Speichere Stapel in der App"
 
@@ -6088,7 +6088,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "Lade Stapel"
 
@@ -6117,7 +6117,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6140,7 +6140,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6157,7 +6157,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "Speichere Stapel"
 
@@ -6166,7 +6166,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6183,7 +6183,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6192,7 +6192,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6226,7 +6226,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6235,7 +6235,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6252,7 +6252,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6267,7 +6267,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "Note"
 
@@ -6301,12 +6301,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "Swing"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "Swing-Wert"
 
@@ -6315,12 +6315,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "Noten überspringen"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "Schläge erhöhen"
 
@@ -6329,13 +6329,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "Zusammenführen"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "Punkt"
 
@@ -6353,7 +6353,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6385,8 +6385,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6442,7 +6442,7 @@ msgstr "Ganze Note"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "Triplet"
 
@@ -6599,12 +6599,12 @@ msgid "duplicate factor"
 msgstr "Faktor verdoppeln"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "Anzahl der Schläge pro Minute"
 
@@ -6614,8 +6614,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6623,12 +6623,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "Schläge pro Minute (BPM)"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6637,7 +6637,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6654,7 +6654,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6664,12 +6664,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6679,7 +6679,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6688,7 +6688,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "Freizeit"
 
@@ -6738,7 +6738,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr "Schläge pro Minute (BPM)"
 
@@ -6771,7 +6771,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6780,12 +6780,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "Versetzung"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6794,7 +6794,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6803,7 +6803,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6812,7 +6812,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6823,8 +6823,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6834,7 +6834,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6860,7 +6860,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6898,12 +6898,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6915,12 +6915,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "Taste für Tonlage festlegen"
 
@@ -6929,7 +6929,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "Taste für oktave festlegen"
 
@@ -6975,22 +6975,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "Umkehren (ungerade)"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "Umkehren (gerade)"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7012,7 +7012,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7021,47 +7021,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7074,7 +7074,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7083,7 +7083,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7091,7 +7091,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr "Hertz"
 
@@ -7105,8 +7105,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7135,7 +7135,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7160,14 +7160,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7177,7 +7177,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7196,7 +7196,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7206,7 +7206,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7223,17 +7223,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7242,7 +7242,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7252,7 +7252,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7262,7 +7262,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7274,7 +7274,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7292,7 +7292,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7313,7 +7313,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7328,7 +7328,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7352,7 +7352,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7408,7 +7408,7 @@ msgstr "Berechne"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7586,7 +7586,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7595,7 +7595,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7604,7 +7604,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7613,7 +7613,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7623,13 +7623,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7642,7 +7642,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "Maus-y"
 
@@ -7651,7 +7651,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "Schildkröten-y"
 
@@ -7660,7 +7660,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "Maus-x"
 
@@ -7669,7 +7669,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "Schildkröten-x"
 
@@ -7678,7 +7678,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7687,7 +7687,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7696,7 +7696,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7705,7 +7705,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "Nummer für Tonlage der Schildkröte festlegen"
 
@@ -7715,17 +7715,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "Schildkröten-Noten-Wert"
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7734,7 +7734,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8161,7 +8161,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8171,7 +8171,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8215,12 +8215,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "Anhalten"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8229,7 +8229,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "Playback"
 
@@ -8286,7 +8286,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "Note in Frequenz umwandeln"
 
@@ -8304,7 +8304,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "Größe"
 
@@ -8317,7 +8317,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8382,7 +8382,7 @@ msgstr "Beende Füllung"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "Hintergrund"
 
@@ -8447,7 +8447,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "Bogen"
 
@@ -8456,12 +8456,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "Füllen"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "Stift aus"
 
@@ -8470,7 +8470,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "Stift an"
 
@@ -8479,7 +8479,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "Setze Stiftdicke"
 
@@ -8488,7 +8488,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "Transparenz bestimmen"
 
@@ -8513,7 +8513,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "Intensität bestimmen"
 
@@ -8648,27 +8648,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8694,18 +8694,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8720,7 +8720,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8741,7 +8741,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "Bearbeitungsmodus"
 
@@ -8758,7 +8758,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "Tonlage-Trommel-Matrix"
 
@@ -8771,7 +8771,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8781,7 +8781,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8795,7 +8795,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "Tonleiter"
 
@@ -8816,7 +8816,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8830,7 +8830,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9017,7 +9017,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9026,7 +9026,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9148,7 +9148,7 @@ msgid "Undo"
 msgstr "Rückgängig machen"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9231,7 +9231,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9281,7 +9281,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9398,7 +9398,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9477,48 +9477,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9951,38 +9951,38 @@ msgstr "Roboter bewegen"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "Speichere dein Projekt als Lilypond Datei"
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "Speichere dein Projekt als Lilypond Datei"
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "Diese Meldungen anzeigen"
+#~ msgid "Show these messages."
+#~ msgstr "Diese Meldungen anzeigen"
 
 #: js/rubrics.js:531
 
@@ -9990,8 +9990,8 @@ msgstr "Roboter bewegen"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "Sensoren"
+#~ msgid "sensors"
+#~ msgstr "Sensoren"
 
 #: js/rubrics.js:532
 
@@ -10001,8 +10001,8 @@ msgstr "Roboter bewegen"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "Medien"
+#~ msgid "media"
+#~ msgstr "Medien"
 
 #: js/block-verbose.js:3837
 
@@ -10014,35 +10014,35 @@ msgstr "Roboter bewegen"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "Zeige"
+#~ msgid "show"
+#~ msgstr "Zeige"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10056,69 +10056,69 @@ msgstr "Roboter bewegen"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr "Speichern"
+#~ msgid "save"
+#~ msgstr "Speichern"
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Alles löschen"
+#~ msgid "Clean"
+#~ msgstr "Alles löschen"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "Langsam abspielen"
+#~ msgid "Run slow"
+#~ msgstr "Langsam abspielen"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr "benutzerdefiniert"
+#~ msgid "Custom"
+#~ msgstr "benutzerdefiniert"
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "Blöcke verbergen"
+#~ msgid "hide blocks"
+#~ msgstr "Blöcke verbergen"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr "Noten verdoppeln"
+#~ msgid "duplicate"
+#~ msgstr "Noten verdoppeln"
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10138,13 +10138,13 @@ msgstr "Roboter bewegen"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "Anhalten"
+#~ msgid "stop"
+#~ msgstr "Anhalten"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "Laufzeit (ms)"
+#~ msgid "duration (ms)"
+#~ msgstr "Laufzeit (ms)"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10152,58 +10152,58 @@ msgstr "Roboter bewegen"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "löschen"
+#~ msgid "clear"
+#~ msgstr "löschen"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "Umdrehen"
+#~ msgid "invert"
+#~ msgstr "Umdrehen"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10219,25 +10219,25 @@ msgstr "Roboter bewegen"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "Dauer"
+#~ msgid "duration"
+#~ msgstr "Dauer"
 
 #: js/widgets/temperament.js:454
 
@@ -10247,43 +10247,43 @@ msgstr "Roboter bewegen"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr "Schließen"
+#~ msgid "close"
+#~ msgstr "Schließen"
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr "Abspielen"
+#~ msgid "play"
+#~ msgstr "Abspielen"
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10293,190 +10293,190 @@ msgstr "Roboter bewegen"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10486,305 +10486,305 @@ msgstr "Roboter bewegen"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr "Hertz Block: Willst du einen Notenblock benutzen?"
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr "Hertz Block: Willst du einen Notenblock benutzen?"
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "Schnell abspielen"
+#~ msgid "Run fast"
+#~ msgstr "Schnell abspielen"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "Klappbare Blöcke ausklappen/einklappen "
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "Klappbare Blöcke ausklappen/einklappen "
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10794,97 +10794,97 @@ msgstr "Roboter bewegen"
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "Währung"
+#~ msgid "currency"
+#~ msgstr "Währung"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "von"
+#~ msgid "from"
+#~ msgstr "von"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr " Wahrenpreis "
+#~ msgid "stock price"
+#~ msgstr " Wahrenpreis "
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "Übersetze"
+#~ msgid "translate"
+#~ msgstr "Übersetze"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "Hallo"
+#~ msgid "hello"
+#~ msgstr "Hallo"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "Sprache erkennen"
+#~ msgid "detect lang"
+#~ msgstr "Sprache erkennen"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "Sprache einstellen"
+#~ msgid "set lang"
+#~ msgstr "Sprache einstellen"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "Breitengrad der Stadt"
+#~ msgid "city latitude"
+#~ msgstr "Breitengrad der Stadt"
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "Längengrad der Stadt"
+#~ msgid "city longitude"
+#~ msgstr "Längengrad der Stadt"
 
 #: plugins/gmap.rtp:71
 
@@ -10894,144 +10894,144 @@ msgstr "Roboter bewegen"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "Koordinaten nicht verfügbar"
+#~ msgid "Coordinate data not available."
+#~ msgstr "Koordinaten nicht verfügbar"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "Google maps"
+#~ msgid "Google map"
+#~ msgstr "Google maps"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "Koordinaten"
+#~ msgid "coordinates"
+#~ msgstr "Koordinaten"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "vergrößerung"
+#~ msgid "zoom factor"
+#~ msgstr "vergrößerung"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "Zoom"
+#~ msgid "zoom"
+#~ msgstr "Zoom"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "Breitengrad"
+#~ msgid "latitude"
+#~ msgstr "Breitengrad"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "Längengrad"
+#~ msgid "longitude"
+#~ msgstr "Längengrad"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "Grad"
+#~ msgid "degrees"
+#~ msgstr "Grad"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "Radiant"
+#~ msgid "radians"
+#~ msgstr "Radiant"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "Definiere"
+#~ msgid "define"
+#~ msgstr "Definiere"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "Bitcoin"
+#~ msgid "bitcoin"
+#~ msgstr "Bitcoin"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr "Wähle eine Datei aus"
+#~ msgid "You need to select a file."
+#~ msgstr "Wähle eine Datei aus"
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11041,15 +11041,15 @@ msgstr "Roboter bewegen"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr "Verbergen"
+#~ msgid "hide"
+#~ msgstr "Verbergen"
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11059,23 +11059,23 @@ msgstr "Roboter bewegen"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr "Pop up"
+#~ msgid "popout"
+#~ msgstr "Pop up"
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr "Trommelblock: Willst du einen Notenblock benutzen?"
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr "Trommelblock: Willst du einen Notenblock benutzen?"
 
 #: js/pitchtracker.js:181
 
@@ -11085,8 +11085,8 @@ msgstr "Roboter bewegen"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11094,224 +11094,224 @@ msgstr "Roboter bewegen"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr "Rhythmus speichern"
+#~ msgid "save rhythms"
+#~ msgstr "Rhythmus speichern"
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr "Tonlagen-Block: Willst du einen Notenblock benutzen?"
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr "Tonlagen-Block: Willst du einen Notenblock benutzen?"
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr "Auswerten"
+#~ msgid "eval"
+#~ msgstr "Auswerten"
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr "100"
+#~ msgid "100"
+#~ msgstr "100"
 
 #: js/playback.js:87
 
@@ -11327,37 +11327,37 @@ msgstr "Roboter bewegen"
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11365,28 +11365,28 @@ msgstr "Roboter bewegen"
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11400,8 +11400,8 @@ msgstr "Roboter bewegen"
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11411,65 +11411,65 @@ msgstr "Roboter bewegen"
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr "Crescendo-Faktor"
+#~ msgid "crescendo factor"
+#~ msgstr "Crescendo-Faktor"
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11477,8 +11477,8 @@ msgstr "Roboter bewegen"
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11488,127 +11488,127 @@ msgstr "Roboter bewegen"
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr "Rückgängig machen"
+#~ msgid "undo"
+#~ msgstr "Rückgängig machen"
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr "Lautstärke"
+#~ msgid "set volume"
+#~ msgstr "Lautstärke"
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr "Vor Stunden"
+#~ msgid "hours ago"
+#~ msgstr "Vor Stunden"
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr "Tonleiter abspielen"
+#~ msgid "play scale"
+#~ msgstr "Tonleiter abspielen"
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr " Diese Toolbar enthält Matrix, Noten, Töne, Schildkröten und mehr. Klicke um die Paletten der Blöcke anzuzeigen und ziehe die Blöcke von der Palette auf die Arbeitsfläche "
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr " Diese Toolbar enthält Matrix, Noten, Töne, Schildkröten und mehr. Klicke um die Paletten der Blöcke anzuzeigen und ziehe die Blöcke von der Palette auf die Arbeitsfläche "
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr "rätselhaft"
+#~ msgid "Enigmatic"
+#~ msgstr "rätselhaft"
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr "Fünftel"
+#~ msgid "fifths"
+#~ msgstr "Fünftel"
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr "E"
+#~ msgid "mi"
+#~ msgstr "E"
 
 #: js/turtledefs.js:251
 
@@ -11616,603 +11616,603 @@ msgstr "Roboter bewegen"
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr "Japanisch"
+#~ msgid "Japanese"
+#~ msgstr "Japanisch"
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr " Herr Maus ist der Dirigent bei „Music Blocks“ Herr Maus will, dass du „Music Blocks“ kennenlernst. Lass uns die Tour beginnen"
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr " Herr Maus ist der Dirigent bei „Music Blocks“ Herr Maus will, dass du „Music Blocks“ kennenlernst. Lass uns die Tour beginnen"
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr "D"
+#~ msgid "re"
+#~ msgstr "D"
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr "Zigeunertonleiter"
+#~ msgid "Spanish Gypsy"
+#~ msgstr "Zigeunertonleiter"
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr "Schläge erniedrigen"
+#~ msgid "divide note value"
+#~ msgstr "Schläge erniedrigen"
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr "Trommelsyntheziser speichern"
+#~ msgid "save drum machine"
+#~ msgstr "Trommelsyntheziser speichern"
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "Öffne ein … um „Music Blocks“ zu konfigurieren"
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "Öffne ein … um „Music Blocks“ zu konfigurieren"
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr "Stapel speichern speichert Stapel in der benutzerdefinierten Palette"
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr "Stapel speichern speichert Stapel in der benutzerdefinierten Palette"
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr "Ägyptisch"
+#~ msgid "Egyptian"
+#~ msgstr "Ägyptisch"
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr "Einfügen ist möglich, wenn du Blöcke in die Zwischenablage kopiert hast"
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr "Einfügen ist möglich, wenn du Blöcke in die Zwischenablage kopiert hast"
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr "Algerisch"
+#~ msgid "Algerian"
+#~ msgstr "Algerisch"
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr "Nenner"
+#~ msgid "denominator"
+#~ msgstr "Nenner"
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr "Drittel"
+#~ msgid "thirds"
+#~ msgstr "Drittel"
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "Du kannst neue Blocks aus den Dateien laden"
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "Du kannst neue Blocks aus den Dateien laden"
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr "Einstellungen"
+#~ msgid "Settings"
+#~ msgstr "Einstellungen"
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr "Nach unten"
+#~ msgid "move down"
+#~ msgstr "Nach unten"
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr "Eine Note höher"
+#~ msgid "consonant step up"
+#~ msgstr "Eine Note höher"
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr "Tonlagen-Schieber"
+#~ msgid "pitchslider"
+#~ msgstr "Tonlagen-Schieber"
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr "Fibonacci"
+#~ msgid "Fibonacci"
+#~ msgstr "Fibonacci"
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr "Noten-Latstärke"
+#~ msgid "note volume"
+#~ msgstr "Noten-Latstärke"
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr "Triplet-Block: Willst du einen Matrix-Block benutzen?"
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr "Triplet-Block: Willst du einen Matrix-Block benutzen?"
 
-#~msgid "set beats per minute"
-#~msgstr "Bestimme die Schläge pro Minute (BPM)"
+#~ msgid "set beats per minute"
+#~ msgstr "Bestimme die Schläge pro Minute (BPM)"
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr "Alles löschen"
+#~ msgid "Delete all"
+#~ msgstr "Alles löschen"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr "farbig"
+#~ msgid "Chromatic"
+#~ msgstr "farbig"
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr "Mit dem Uhrzeigersinn drehen"
+#~ msgid "rotate clockwise"
+#~ msgstr "Mit dem Uhrzeigersinn drehen"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr "Eingabe im Moll-Block muss 2, 3, 6 oder 7 sein"
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr "Eingabe im Moll-Block muss 2, 3, 6 oder 7 sein"
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr "Zähler"
+#~ msgid "numerator"
+#~ msgstr "Zähler"
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12222,160 +12222,160 @@ msgstr "Roboter bewegen"
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr "G"
+#~ msgid "sol"
+#~ msgstr "G"
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr "Phrygisch"
+#~ msgid "Phrygian"
+#~ msgstr "Phrygisch"
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr "A"
+#~ msgid "la"
+#~ msgstr "A"
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr "Strecke anzeigen"
+#~ msgid "see distance"
+#~ msgstr "Strecke anzeigen"
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr "vorraussichtliches Intervall"
+#~ msgid "relative interval"
+#~ msgstr "vorraussichtliches Intervall"
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr "Musik anhalten (auch die Schildkröten)"
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr "Musik anhalten (auch die Schildkröten)"
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr "Schildkrötennote"
+#~ msgid "turtle note"
+#~ msgstr "Schildkrötennote"
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12389,28 +12389,28 @@ msgstr "Roboter bewegen"
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr "Ungarisch"
+#~ msgid "Hungarian"
+#~ msgstr "Ungarisch"
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr "Akkord abspielen"
+#~ msgid "play chord"
+#~ msgstr "Akkord abspielen"
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12418,128 +12418,128 @@ msgstr "Roboter bewegen"
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr "Viertel"
+#~ msgid "fourths"
+#~ msgstr "Viertel"
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr "Projekt auf dem Server speichern"
+#~ msgid "Save your project to a server."
+#~ msgstr "Projekt auf dem Server speichern"
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr "Gnazer Ton"
+#~ msgid "Whole Tone"
+#~ msgstr "Gnazer Ton"
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr "Klicke hier um die Musik langsam abzuspielen"
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr "Klicke hier um die Musik langsam abzuspielen"
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "Eingabe im erweiterten Block muss 1, 2, 3, 4, 5, 6, 7 oder 8 sein"
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "Eingabe im erweiterten Block muss 1, 2, 3, 4, 5, 6, 7 oder 8 sein"
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr "Speichere als"
+#~ msgid "save as lilypond"
+#~ msgstr "Speichere als"
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr "Vermindert"
+#~ msgid "Diminished"
+#~ msgstr "Vermindert"
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr "Toolbar aus-/einklappen"
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr "Toolbar aus-/einklappen"
 
 #: js/turtledefs.js:187
 
@@ -12547,136 +12547,136 @@ msgstr "Roboter bewegen"
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:104
 
-#~msgid "turtle"
-#~msgstr "Schildkröte"
+#~ msgid "turtle"
+#~ msgstr "Schildkröte"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr "Vorspulen"
+#~ msgid "play forward"
+#~ msgstr "Vorspulen"
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr "Bass"
+#~ msgid "basse"
+#~ msgstr "Bass"
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:562
 
-#~msgid "440 hertz"
-#~msgstr "440 Hertz"
+#~ msgid "440 hertz"
+#~ msgstr "440 Hertz"
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12686,127 +12686,127 @@ msgstr "Roboter bewegen"
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr "Alles abspielen"
+#~ msgid "play all"
+#~ msgstr "Alles abspielen"
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr "Eine Note tiefer"
+#~ msgid "consonant step down"
+#~ msgstr "Eine Note tiefer"
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr "Lydisch"
+#~ msgid "Lydian"
+#~ msgstr "Lydisch"
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr "Veröffentlichen"
+#~ msgid "Publish"
+#~ msgstr "Veröffentlichen"
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr "Mi Sheberach"
+#~ msgid "Romanian Minor"
+#~ msgstr "Mi Sheberach"
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12814,397 +12814,397 @@ msgstr "Roboter bewegen"
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr "Weltweit"
+#~ msgid "Worldwide"
+#~ msgstr "Weltweit"
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr "Saite schlagen"
+#~ msgid "pluck"
+#~ msgstr "Saite schlagen"
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr "Faktor überspringen"
+#~ msgid "skip factor"
+#~ msgstr "Faktor überspringen"
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Öffnen"
+#~ msgid "Open"
+#~ msgstr "Öffnen"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:686
 
-#~msgid "set voice"
-#~msgstr "Stimme"
+#~ msgid "set voice"
+#~ msgstr "Stimme"
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr "Ionisch"
+#~ msgid "Ionian"
+#~ msgstr "Ionisch"
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr "Klicke hier um deine Musik Note für Note abzuspielen"
+#~ msgid "Click to run the music note by note."
+#~ msgstr "Klicke hier um deine Musik Note für Note abzuspielen"
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr "Mehrstimmiger Synthesizer"
+#~ msgid "poly"
+#~ msgstr "Mehrstimmiger Synthesizer"
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr "Nach oben"
+#~ msgid "move up"
+#~ msgstr "Nach oben"
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr "Bestätigen"
+#~ msgid "confirm"
+#~ msgstr "Bestätigen"
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr "Maqam"
+#~ msgid "Maqam"
+#~ msgstr "Maqam"
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr "Äolisch"
+#~ msgid "Aeolian"
+#~ msgstr "Äolisch"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr "Lokrisch"
+#~ msgid "Locrian"
+#~ msgstr "Lokrisch"
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr "Blues"
+#~ msgid "Blues"
+#~ msgstr "Blues"
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr "Feld"
+#~ msgid "field"
+#~ msgstr "Feld"
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr "Feld nicht gefunden"
+#~ msgid "Impact field not found."
+#~ msgstr "Feld nicht gefunden"
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr "Moll"
+#~ msgid "Minor"
+#~ msgstr "Moll"
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr "Byzantinisch"
+#~ msgid "Byzantine"
+#~ msgstr "Byzantinisch"
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr "melodisch Moll aufwärts"
+#~ msgid "Jazz Minor"
+#~ msgstr "melodisch Moll aufwärts"
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13216,191 +13216,191 @@ msgstr "Roboter bewegen"
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "Verberge/zeige die Block-Paletten"
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "Verberge/zeige die Block-Paletten"
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr "Okatonisch"
+#~ msgid "Octatonic"
+#~ msgstr "Okatonisch"
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr "Linker Sensor"
+#~ msgid "sense left"
+#~ msgstr "Linker Sensor"
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr "Essen"
+#~ msgid "food"
+#~ msgstr "Essen"
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr "Pendelzeit"
+#~ msgid "osctime"
+#~ msgstr "Pendelzeit"
 
 #: js/turtledefs.js:187
 
@@ -13408,155 +13408,155 @@ msgstr "Roboter bewegen"
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr "Mathe"
+#~ msgid "maths"
+#~ msgstr "Mathe"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr "Dorisch"
+#~ msgid "Dorian"
+#~ msgstr "Dorisch"
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr "Diese Toolbar enthält die Paletten Matrix, Notenschildkröte and more"
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr "Diese Toolbar enthält die Paletten Matrix, Notenschildkröte and more"
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr " Stapel speichern speichert Stapel in der benutzerdefinierten Palette "
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr " Stapel speichern speichert Stapel in der benutzerdefinierten Palette "
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr " Um einen Stapel in die Zwischenablage zu kopieren, halte ihn gedrückt "
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr " Um einen Stapel in die Zwischenablage zu kopieren, halte ihn gedrückt "
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13564,257 +13564,257 @@ msgstr "Roboter bewegen"
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr "Aktionen"
+#~ msgid "actions"
+#~ msgstr "Aktionen"
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr "Der Notenwert muss größer als 0 sein"
+#~ msgid "Note value must be greater than 0"
+#~ msgstr "Der Notenwert muss größer als 0 sein"
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr "Tonlage-Zeit-Matrix"
+#~ msgid "pitch-time matrix"
+#~ msgstr "Tonlage-Zeit-Matrix"
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "Zeige oder verberge das Polarkoordinartensystem"
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "Zeige oder verberge das Polarkoordinartensystem"
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "Lösche den Bildschirm und bring die Schildkröten in ihre Ausgangsposition zurück"
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "Lösche den Bildschirm und bring die Schildkröten in ihre Ausgangsposition zurück"
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr "Der … Block muss im Notenblock genutzt werden"
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr "Der … Block muss im Notenblock genutzt werden"
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr "Blinke (ms)"
+#~ msgid "blink (ms)"
+#~ msgstr "Blinke (ms)"
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr "Geez"
+#~ msgid "Geez"
+#~ msgstr "Geez"
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr "Rhythmus-Block: Wollten Sie einen Noten-Block benutzen?"
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr "Rhythmus-Block: Wollten Sie einen Noten-Block benutzen?"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr "Diese Toolbar enthält Matrix, Noten, Töne, Schildkröten und mehr. Klicke um die Paletten der Blöcke anzuzeigen und ziehe die Blöcke von der Palette auf die Arbeitsfläche."
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr "Diese Toolbar enthält Matrix, Noten, Töne, Schildkröten und mehr. Klicke um die Paletten der Blöcke anzuzeigen und ziehe die Blöcke von der Palette auf die Arbeitsfläche."
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr "Veralteter Notenwert"
+#~ msgid "deprecated note value"
+#~ msgstr "Veralteter Notenwert"
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr "Arabisch"
+#~ msgid "Arabic"
+#~ msgstr "Arabisch"
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr "Hinduistisch"
+#~ msgid "Hindu"
+#~ msgstr "Hinduistisch"
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr "Noten in einer Tonlage gehen"
+#~ msgid "step pitch"
+#~ msgstr "Noten in einer Tonlage gehen"
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr "Rückwärts abspielen"
+#~ msgid "play backward"
+#~ msgstr "Rückwärts abspielen"
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13828,223 +13828,223 @@ msgstr "Roboter bewegen"
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr " H A G F E D C "
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr " H A G F E D C "
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr "Gegen den Uhrzeigersinn drehen"
+#~ msgid "rotate counter clockwise"
+#~ msgstr "Gegen den Uhrzeigersinn drehen"
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr "Sortieren"
+#~ msgid "sort"
+#~ msgstr "Sortieren"
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr "Polar"
+#~ msgid "Polar"
+#~ msgstr "Polar"
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr "Name der aktuellen Tonlage"
+#~ msgid "current pitch name"
+#~ msgstr "Name der aktuellen Tonlage"
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "Zeige oder verberge das kartesische Koordinatensystem"
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "Zeige oder verberge das kartesische Koordinatensystem"
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr "Mixolydisch"
+#~ msgid "Mixolydian"
+#~ msgstr "Mixolydisch"
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr "Plug-In aus Datei laden"
+#~ msgid "Load plugin from file"
+#~ msgstr "Plug-In aus Datei laden"
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr "Singe"
+#~ msgid "sing"
+#~ msgstr "Singe"
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr "Chinesisch"
+#~ msgid "Chinese"
+#~ msgstr "Chinesisch"
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14054,144 +14054,144 @@ msgstr "Roboter bewegen"
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr "Herunterladen"
+#~ msgid "Download"
+#~ msgstr "Herunterladen"
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr "Wolke"
+#~ msgid "cloud"
+#~ msgstr "Wolke"
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr "nicht gefunden"
+#~ msgid "Impact UID not found."
+#~ msgstr "nicht gefunden"
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr "Solfeggio"
+#~ msgid "Solfa"
+#~ msgstr "Solfeggio"
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr "TurtleHeaps beinhaltet keinen zulässigen Stapel für"
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr "TurtleHeaps beinhaltet keinen zulässigen Stapel für"
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr "Paletten zeigen/verbergen"
+#~ msgid "Show/hide palettes"
+#~ msgstr "Paletten zeigen/verbergen"
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr "Blöcke"
+#~ msgid "blocks"
+#~ msgstr "Blöcke"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14199,57 +14199,57 @@ msgstr "Roboter bewegen"
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr "Rhythmus-Lineal"
+#~ msgid "rhythm ruler"
+#~ msgstr "Rhythmus-Lineal"
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr "Pentatonisch"
+#~ msgid "Pentatonic"
+#~ msgstr "Pentatonisch"
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr "Eingabe im Dur-Block muss 2, 3, 6 oder 7 sein"
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr "Eingabe im Dur-Block muss 2, 3, 6 oder 7 sein"
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:695
 
-#~msgid "articulation"
-#~msgstr "Artikulation"
+#~ msgid "articulation"
+#~ msgstr "Artikulation"
 
 #: js/turtledefs.js:387
 
@@ -14259,30 +14259,30 @@ msgstr "Roboter bewegen"
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14290,112 +14290,112 @@ msgstr "Roboter bewegen"
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr "Notenblätter speichern"
+#~ msgid "Save sheet music"
+#~ msgstr "Notenblätter speichern"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr "Versetzung anpassen"
+#~ msgid "adjust transposition"
+#~ msgstr "Versetzung anpassen"
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "Klicke hier um dein Projekt abzuspielen"
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "Klicke hier um dein Projekt abzuspielen"
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr "Note für Note abspielen"
+#~ msgid "Run note by note"
+#~ msgstr "Note für Note abspielen"
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr "Panzer"
+#~ msgid "shell"
+#~ msgstr "Panzer"
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr "Bitte schließe die aktuelle Matrix, bevor du eine Neue öffnest."
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr "Bitte schließe die aktuelle Matrix, bevor du eine Neue öffnest."
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14403,282 +14403,282 @@ msgstr "Roboter bewegen"
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr "Pause"
+#~ msgid "pause"
+#~ msgstr "Pause"
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr "Hier kannst du die Haupt-Toolbar öffnen und schließen"
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr "Hier kannst du die Haupt-Toolbar öffnen und schließen"
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr "Äthopisch"
+#~ msgid "Ethiopian"
+#~ msgstr "Äthopisch"
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr "Stapel speichern wird nach einem langen Klick auf einen Stapel angezeigt"
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr "Stapel speichern wird nach einem langen Klick auf einen Stapel angezeigt"
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr "Eingabe im Perfekt-Block muss 1, 4, 5 oder 8 sein"
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr "Eingabe im Perfekt-Block muss 1, 4, 5 oder 8 sein"
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr "Rechter Sensor"
+#~ msgid "sense right"
+#~ msgstr "Rechter Sensor"
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr "Bebop"
+#~ msgid "Bebop"
+#~ msgstr "Bebop"
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr "Einfügen wird aufzeigen"
+#~ msgid "The Paste Button will highlight."
+#~ msgstr "Einfügen wird aufzeigen"
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "Inhalt der Arbeitsfläche löschen, das beinhaltet auch alle Blöcke"
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "Inhalt der Arbeitsfläche löschen, das beinhaltet auch alle Blöcke"
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr "Speichere "
+#~ msgid "save svg"
+#~ msgstr "Speichere "
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr "Auf meinem Gerät"
+#~ msgid "On my device"
+#~ msgstr "Auf meinem Gerät"
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "Eingabe im verminderten Block muss 1, 2, 3, 4, 5, 6, 7 oder 8 sein"
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "Eingabe im verminderten Block muss 1, 2, 3, 4, 5, 6, 7 oder 8 sein"
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr "Musik langsam abspielen"
+#~ msgid "Run music slow"
+#~ msgstr "Musik langsam abspielen"
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr "Um einen Stapel in die Zwischenablage zu kopieren, halte ihn gedrückt"
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr "Um einen Stapel in die Zwischenablage zu kopieren, halte ihn gedrückt"
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr "Exportieren"
+#~ msgid "export"
+#~ msgstr "Exportieren"
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14686,13 +14686,13 @@ msgstr "Roboter bewegen"
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:644
 
@@ -14700,81 +14700,81 @@ msgstr "Roboter bewegen"
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr "Dur"
+#~ msgid "Major"
+#~ msgstr "Dur"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr "Scrollen deaktivieren"
+#~ msgid "Disable scrolling"
+#~ msgstr "Scrollen deaktivieren"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr "Rhythmus-Block: Willst du einen Matrix-Block benutzen?"
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr "Rhythmus-Block: Willst du einen Matrix-Block benutzen?"
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr "Oktave der aktuellen Tonlage"
+#~ msgid "current pitch octave"
+#~ msgstr "Oktave der aktuellen Tonlage"
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr "Spanisch"
+#~ msgid "Spanish"
+#~ msgstr "Spanisch"
 

--- a/po/dz.po
+++ b/po/dz.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -2216,7 +2216,7 @@ msgstr "ενέργεια"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "κενός σωρός"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "απώθηση"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "ώθηση"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "συντεταγμένη y του ποντικιού"
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "συντεταγμένη x του ποντικιού"
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr "τέλος γεμίσματος"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "στιλό πάνω"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "στιλό κάτω"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "ορισμός μεγέθους στιλό"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "εμφάνιση"
+#~ msgid "show"
+#~ msgstr "εμφάνιση"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "Πλέγμα"
+#~ msgid "grid"
+#~ msgstr "Πλέγμα"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Καθαρισμός"
+#~ msgid "Clean"
+#~ msgstr "Καθαρισμός"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "απόκρυψη εντολών"
+#~ msgid "hide blocks"
+#~ msgstr "απόκρυψη εντολών"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "διακοπή"
+#~ msgid "stop"
+#~ msgstr "διακοπή"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "διάρκεια"
+#~ msgid "duration"
+#~ msgstr "διάρκεια"
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "γεια"
+#~ msgid "hello"
+#~ msgstr "γεια"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "χελώνα"
+#~ msgid "turtle"
+#~ msgstr "χελώνα"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Άνοιγμα"
+#~ msgid "Open"
+#~ msgstr "Άνοιγμα"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -2220,7 +2220,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2287,7 +2287,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2301,33 +2301,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2349,7 +2349,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2427,7 +2427,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2656,8 +2656,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2816,7 +2816,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2826,14 +2826,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2864,7 +2864,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2889,7 +2889,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2898,7 +2898,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2919,7 +2919,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2937,8 +2937,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3040,7 +3040,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3174,14 +3174,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3256,7 +3256,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3292,7 +3292,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3301,7 +3301,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3792,7 +3792,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3804,8 +3804,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3815,7 +3815,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3827,8 +3827,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3838,15 +3838,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3855,14 +3855,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3871,14 +3871,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3919,7 +3919,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3928,7 +3928,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3945,7 +3945,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4014,8 +4014,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4037,7 +4037,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4323,7 +4323,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4654,21 +4654,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4677,12 +4677,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4695,62 +4695,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4763,7 +4763,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4785,7 +4785,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4794,17 +4794,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4813,12 +4813,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4831,7 +4831,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4840,17 +4840,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4867,56 +4867,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4924,7 +4924,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4932,7 +4932,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4941,7 +4941,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4949,7 +4949,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4958,8 +4958,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4981,116 +4981,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5109,19 +5109,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5129,61 +5129,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5193,149 +5193,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5344,7 +5344,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5423,22 +5423,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5595,7 +5595,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5617,7 +5617,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5657,7 +5657,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5666,7 +5666,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5699,7 +5699,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5709,7 +5709,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5718,7 +5718,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5727,7 +5727,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5750,13 +5750,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5765,7 +5765,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5774,7 +5774,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5794,7 +5794,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5819,7 +5819,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5833,7 +5833,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5843,7 +5843,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5881,7 +5881,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5890,7 +5890,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5903,18 +5903,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6054,7 +6054,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6063,7 +6063,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6080,7 +6080,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6093,7 +6093,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6122,7 +6122,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6162,7 +6162,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6171,7 +6171,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6188,7 +6188,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6197,7 +6197,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6231,7 +6231,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6240,7 +6240,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6257,7 +6257,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6306,12 +6306,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6320,12 +6320,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6334,13 +6334,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6358,7 +6358,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6390,8 +6390,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "rhythm"
 
@@ -6447,7 +6447,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6604,12 +6604,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6619,8 +6619,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "beats per minute"
 
@@ -6628,12 +6628,12 @@ msgstr "beats per minute"
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6642,7 +6642,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6659,7 +6659,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6669,12 +6669,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6684,7 +6684,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6743,7 +6743,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6776,7 +6776,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6785,12 +6785,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6799,7 +6799,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6808,7 +6808,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6817,7 +6817,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6828,8 +6828,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6839,7 +6839,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6865,7 +6865,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6903,12 +6903,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6920,12 +6920,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "name"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6934,7 +6934,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6980,22 +6980,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7004,7 +7004,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7017,7 +7017,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7026,47 +7026,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7079,7 +7079,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7088,7 +7088,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7096,7 +7096,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7110,8 +7110,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7140,7 +7140,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7165,14 +7165,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7182,7 +7182,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7201,7 +7201,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7211,7 +7211,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7228,17 +7228,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7247,7 +7247,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7257,7 +7257,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7267,7 +7267,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7279,7 +7279,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7287,7 +7287,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7297,7 +7297,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7318,7 +7318,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7333,7 +7333,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7343,7 +7343,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7357,7 +7357,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7413,7 +7413,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7591,7 +7591,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7600,7 +7600,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7609,7 +7609,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7618,7 +7618,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7628,13 +7628,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7647,7 +7647,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7656,7 +7656,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7665,7 +7665,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7674,7 +7674,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7683,7 +7683,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7692,7 +7692,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7701,7 +7701,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7710,7 +7710,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7720,17 +7720,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7739,7 +7739,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8166,7 +8166,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8176,7 +8176,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8220,12 +8220,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8234,7 +8234,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8291,7 +8291,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8309,7 +8309,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8322,7 +8322,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "show"
 
@@ -8387,7 +8387,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8452,7 +8452,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8461,12 +8461,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8475,7 +8475,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8484,7 +8484,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8493,7 +8493,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8518,7 +8518,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8653,27 +8653,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8699,18 +8699,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8725,7 +8725,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8746,7 +8746,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8763,7 +8763,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8776,7 +8776,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8786,7 +8786,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8800,7 +8800,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8821,7 +8821,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8835,7 +8835,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9022,7 +9022,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9031,7 +9031,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9153,7 +9153,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9236,7 +9236,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9286,7 +9286,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9403,7 +9403,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9482,48 +9482,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9956,38 +9956,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9995,8 +9995,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10006,8 +10006,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10019,35 +10019,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10061,69 +10061,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10143,13 +10143,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10157,58 +10157,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10224,25 +10224,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10252,43 +10252,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10298,190 +10298,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10491,305 +10491,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr "chord"
+#~ msgid "chord1"
+#~ msgstr "chord"
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10799,97 +10799,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10899,144 +10899,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11046,15 +11046,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr "show"
+#~ msgid "show2"
+#~ msgstr "show"
 
 #: js/palette.js:1222
 
@@ -11064,23 +11064,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr "my blocks"
+#~ msgid "myblocks"
+#~ msgstr "my blocks"
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11090,8 +11090,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11099,224 +11099,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11332,37 +11332,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11370,28 +11370,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr "right"
+#~ msgid "right2"
+#~ msgstr "right"
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr "left"
+#~ msgid "left2"
+#~ msgstr "left"
 
 #: js/pitchtimematrix.js:323
 
@@ -11405,8 +11405,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11416,65 +11416,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11482,8 +11482,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11493,127 +11493,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11621,608 +11621,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12232,165 +12232,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12404,28 +12404,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12433,133 +12433,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12567,136 +12567,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12706,127 +12706,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12834,397 +12834,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13236,196 +13236,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13433,155 +13433,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr "This toolbar contains the palette buttons, Matrix, Notes, Tone, Turtle, and more."
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr "This toolbar contains the palette buttons, Matrix, Notes, Tone, Turtle, and more."
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13589,252 +13589,252 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13848,223 +13848,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14074,144 +14074,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14219,57 +14219,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14279,30 +14279,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14310,112 +14310,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14423,287 +14423,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14711,13 +14711,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14725,86 +14725,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -770,7 +770,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -837,7 +837,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -851,33 +851,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -977,7 +977,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -1206,8 +1206,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -1366,7 +1366,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -1376,14 +1376,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -1414,7 +1414,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -1439,7 +1439,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -1448,7 +1448,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -1487,8 +1487,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -1590,7 +1590,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -1724,14 +1724,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -1806,7 +1806,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -1851,7 +1851,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -2342,7 +2342,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -2354,8 +2354,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -2365,7 +2365,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -2377,8 +2377,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -2388,15 +2388,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -2405,14 +2405,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -2421,14 +2421,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -2469,7 +2469,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -2478,7 +2478,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -2495,7 +2495,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -2564,8 +2564,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -2587,7 +2587,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -2873,7 +2873,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -3204,21 +3204,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -3227,12 +3227,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -3245,62 +3245,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -3313,7 +3313,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -3322,7 +3322,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -3335,7 +3335,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -3344,17 +3344,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -3363,12 +3363,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -3381,7 +3381,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -3390,17 +3390,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -3417,56 +3417,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -3474,7 +3474,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -3482,7 +3482,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -3491,7 +3491,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -3499,7 +3499,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -3508,8 +3508,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -3517,7 +3517,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -3531,116 +3531,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -3659,19 +3659,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -3679,61 +3679,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -3743,149 +3743,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -3894,7 +3894,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3973,22 +3973,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -4145,7 +4145,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -4167,7 +4167,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -4178,7 +4178,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -4207,7 +4207,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -4216,7 +4216,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -4249,7 +4249,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -4259,7 +4259,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -4268,7 +4268,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -4277,7 +4277,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -4300,13 +4300,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -4315,7 +4315,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -4324,7 +4324,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -4344,7 +4344,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -4383,7 +4383,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -4393,7 +4393,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -4431,7 +4431,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -4440,7 +4440,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -4453,18 +4453,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -4585,7 +4585,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -4604,7 +4604,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -4613,7 +4613,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -4630,7 +4630,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -4643,7 +4643,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -4672,7 +4672,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -4695,7 +4695,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -4712,7 +4712,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -4721,7 +4721,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -4738,7 +4738,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -4747,7 +4747,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -4790,7 +4790,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -4807,7 +4807,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -4822,7 +4822,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -4856,12 +4856,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -4870,12 +4870,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -4884,13 +4884,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -4908,7 +4908,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -4940,8 +4940,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "rhythm"
 
@@ -4997,7 +4997,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -5154,12 +5154,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -5169,8 +5169,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "beats per minute"
 
@@ -5178,12 +5178,12 @@ msgstr "beats per minute"
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -5192,7 +5192,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -5209,7 +5209,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -5219,12 +5219,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -5234,7 +5234,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -5243,7 +5243,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -5293,7 +5293,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -5335,12 +5335,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -5349,7 +5349,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -5358,7 +5358,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -5367,7 +5367,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -5378,8 +5378,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -5389,7 +5389,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -5415,7 +5415,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -5453,12 +5453,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -5470,12 +5470,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "name"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -5484,7 +5484,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -5530,22 +5530,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -5554,7 +5554,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -5567,7 +5567,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -5576,47 +5576,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -5629,7 +5629,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -5638,7 +5638,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -5646,7 +5646,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -5660,8 +5660,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -5690,7 +5690,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -5715,14 +5715,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -5732,7 +5732,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -5751,7 +5751,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -5778,17 +5778,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -5797,7 +5797,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -5807,7 +5807,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -5817,7 +5817,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -5837,7 +5837,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -5847,7 +5847,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -5868,7 +5868,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -5883,7 +5883,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -5893,7 +5893,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -5907,7 +5907,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -5963,7 +5963,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -6150,7 +6150,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -6159,7 +6159,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -6168,7 +6168,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -6178,13 +6178,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -6197,7 +6197,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -6206,7 +6206,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -6215,7 +6215,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -6224,7 +6224,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -6233,7 +6233,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -6242,7 +6242,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -6251,7 +6251,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -6260,7 +6260,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -6270,17 +6270,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -6289,7 +6289,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -6716,7 +6716,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -6726,7 +6726,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -6770,12 +6770,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -6784,7 +6784,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -6841,7 +6841,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -6859,7 +6859,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -6872,7 +6872,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "show"
 
@@ -6937,7 +6937,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -7011,12 +7011,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -7025,7 +7025,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -7034,7 +7034,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -7043,7 +7043,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -7068,7 +7068,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -7203,27 +7203,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -7249,18 +7249,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -7296,7 +7296,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -7313,7 +7313,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -7326,7 +7326,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -7336,7 +7336,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -7350,7 +7350,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -7371,7 +7371,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -7385,7 +7385,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -7572,7 +7572,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -7581,7 +7581,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -7703,7 +7703,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -7786,7 +7786,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -7836,7 +7836,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -7953,7 +7953,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -8032,48 +8032,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -8506,38 +8506,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -8545,8 +8545,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -8556,8 +8556,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -8569,35 +8569,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -8611,69 +8611,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8693,13 +8693,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8707,58 +8707,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -8774,25 +8774,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -8802,43 +8802,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -8848,190 +8848,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -9041,305 +9041,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr "chord"
+#~ msgid "chord1"
+#~ msgstr "chord"
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -9349,97 +9349,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -9449,144 +9449,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -9596,15 +9596,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr "show"
+#~ msgid "show2"
+#~ msgstr "show"
 
 #: js/palette.js:1222
 
@@ -9614,23 +9614,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr "my blocks"
+#~ msgid "myblocks"
+#~ msgstr "my blocks"
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -9640,8 +9640,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -9649,224 +9649,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -9882,37 +9882,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -9920,28 +9920,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr "right"
+#~ msgid "right2"
+#~ msgstr "right"
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr "left"
+#~ msgid "left2"
+#~ msgstr "left"
 
 #: js/pitchtimematrix.js:323
 
@@ -9955,8 +9955,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -9966,65 +9966,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -10032,8 +10032,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -10043,127 +10043,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -10171,608 +10171,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -10782,165 +10782,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -10954,28 +10954,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10983,133 +10983,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11117,136 +11117,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -11256,127 +11256,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -11384,397 +11384,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -11786,196 +11786,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11983,155 +11983,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12139,257 +12139,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -12403,223 +12403,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -12629,144 +12629,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -12774,57 +12774,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -12834,30 +12834,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12865,112 +12865,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -12978,287 +12978,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13266,13 +13266,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -13280,86 +13280,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -11,10 +11,10 @@ msgstr ""
 "Language: es\n"
 "X-Generator: Poedit 1.7.4\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -109,7 +109,7 @@ msgstr "acción"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr "pato"
 
@@ -176,7 +176,7 @@ msgstr "Ocultar"
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "Mi proyecto"
 
@@ -190,33 +190,33 @@ msgid "Your recording is in progress."
 msgstr "Tu grabación está en curso."
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "Nombre del archivo"
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "Título del proyecto"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "Autor del Proyecto"
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "Incluye MIDI?"
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "Incluye tablatura de guitarra"
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "Guardar como lilypond"
 
@@ -238,7 +238,7 @@ msgstr "Guardar como lilypond"
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "Sr. Ratón"
 
@@ -316,7 +316,7 @@ msgstr "Mostrar Cartesiano"
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr "grado de escala"
 
@@ -545,8 +545,8 @@ msgstr "Guardar ayuda de bloque"
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "si la sol fa mi re do"
 
@@ -705,7 +705,7 @@ msgstr "regla"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "timbre"
 
@@ -715,14 +715,14 @@ msgstr "escalera"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "tempo"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "modo"
 
@@ -753,7 +753,7 @@ msgstr "tambor"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "hacer un ritmo"
 
@@ -778,7 +778,7 @@ msgstr "hacer un ritmo"
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "valor de la nota"
 
@@ -787,7 +787,7 @@ msgstr "valor de la nota"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "intervalo escalar"
 
@@ -808,7 +808,7 @@ msgid "silence"
 msgstr "silencio"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "abajo"
 
@@ -826,8 +826,8 @@ msgstr "arriba"
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "tono"
 
@@ -929,7 +929,7 @@ msgstr "tenor"
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "bass"
 
@@ -1063,14 +1063,14 @@ msgstr "No hay bloque seleccionado."
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "avatar"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "muestra de audio"
 
@@ -1145,7 +1145,7 @@ msgstr "iniciar tambor"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "ritmo"
 
@@ -1181,7 +1181,7 @@ msgstr "flujo"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr "sensores"
 
@@ -1190,7 +1190,7 @@ msgstr "sensores"
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr "medios"
 
@@ -1681,7 +1681,7 @@ msgstr "La reproducción está preparada."
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "doble agudas"
 
@@ -1693,8 +1693,8 @@ msgstr "doble agudas"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "agudas"
 
@@ -1704,7 +1704,7 @@ msgstr "agudas"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "normal"
 
@@ -1716,8 +1716,8 @@ msgstr "normal"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "planas"
 
@@ -1727,15 +1727,15 @@ msgstr "planas"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "doble planas"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr "unísono"
 
@@ -1744,14 +1744,14 @@ msgstr "unísono"
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "mayor"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr "ionian"
 
@@ -1760,14 +1760,14 @@ msgstr "ionian"
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "menor"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr "aeolian"
 
@@ -1808,7 +1808,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr "Ha elegido la tecla para la vista previa de su tono."
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "Debe tener al menos un bloque parcial dentro de un bloque parcial ponderado."
 
@@ -1817,7 +1817,7 @@ msgid "synth cannot play chords."
 msgstr "Synth no puede tocar acordes."
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr "https://github.com/sugarlabs/musicblocks/tree/master/guide-es/README.md"
 
@@ -1834,7 +1834,7 @@ msgstr "buscar"
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "metro"
 
@@ -1903,8 +1903,8 @@ msgstr "extras"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "programa"
 
@@ -1926,7 +1926,7 @@ msgstr "lógica"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr "música"
 
@@ -2212,7 +2212,7 @@ msgstr "Activar/desactivar pentagramas musicales."
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr "Borrar"
 
@@ -2543,21 +2543,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr "Séptimo disminuido, más una octava"
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "1ÃÂº 2ÃÂº 3ÃÂº 4ÃÂº 5ÃÂº 6ÃÂº 7ÃÂº 8ÃÂº 9ÃÂº 10ÃÂº 11ÃÂº 12ÃÂº"
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "aumentado"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "disminuido"
 
@@ -2566,12 +2566,12 @@ msgstr "disminuido"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "perfecto"
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "cromático"
 
@@ -2584,62 +2584,62 @@ msgid "spanish"
 msgstr "español"
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr "octatonic"
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "armónico mayor"
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "natural menor"
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "armónico menor"
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "melódico menor"
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr "dorio"
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr "frigio"
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr "lidio"
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "mixolidio"
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr "locrian"
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "jazz menor"
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr "bebop"
 
@@ -2652,7 +2652,7 @@ msgid "byzantine"
 msgstr "bizantino"
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "enigmático"
 
@@ -2661,7 +2661,7 @@ msgid "ethiopian"
 msgstr "etíope"
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "geez"
 
@@ -2674,7 +2674,7 @@ msgid "hungarian"
 msgstr "húngaro"
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "romano menor"
 
@@ -2683,17 +2683,17 @@ msgid "spanish gypsy"
 msgstr "gitana española"
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "maqam"
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "blues menor"
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr "blues mayor"
 
@@ -2702,12 +2702,12 @@ msgid "whole tone"
 msgstr "tono completo"
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "pentatonic minor"
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "pentatonic mayor"
 
@@ -2720,7 +2720,7 @@ msgid "egyptian"
 msgstr "egipcio"
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "hirajoshi"
 
@@ -2729,17 +2729,17 @@ msgid "Japan"
 msgstr "Japón"
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "in"
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "minyo"
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "fibonacci"
 
@@ -2756,56 +2756,56 @@ msgstr "fibonacci"
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr "personalizado"
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr "highpass"
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -2813,7 +2813,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "sine"
 
@@ -2821,7 +2821,7 @@ msgstr "sine"
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "cuadrado"
 
@@ -2830,7 +2830,7 @@ msgstr "cuadrado"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "triángulo"
 
@@ -2838,7 +2838,7 @@ msgstr "triángulo"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "diente de sierra"
 
@@ -2847,8 +2847,8 @@ msgstr "diente de sierra"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr "par"
 
@@ -2856,7 +2856,7 @@ msgstr "par"
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr "impar"
 
@@ -2870,116 +2870,116 @@ msgstr "escalar"
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr "piano"
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr "violín"
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr "viola"
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "xilófono"
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "vibráfono"
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr "violonchelo"
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr "contrabajo"
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr "guitarra"
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr "guitarra acustica"
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr "flauta"
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr "clarinete"
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr "saxofón"
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr "tuba"
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr "trompeta"
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr "oboe"
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr "trombón"
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr "sintetizador electronico"
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "simple-1"
 
@@ -2998,19 +2998,19 @@ msgstr "simple 4"
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr "ruido blanco"
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "ruido marrón"
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "ruido rosa"
 
@@ -3018,61 +3018,61 @@ msgstr "ruido rosa"
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr "tambor militar pequeño"
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr "tambor de patada"
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr "tom tom"
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr "piso tom"
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr "tambor de bajo"
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "taza de tambor"
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr "darbuka"
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr "campana de paseo"
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr "campana de vaca"
 
@@ -3082,149 +3082,149 @@ msgstr "tambor japonés"
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr "campana japonesa"
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr "campana triangular"
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr "castañuelas"
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "campaneo"
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr "gong"
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr "estruendo"
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr "choque"
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr "botella"
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr "palmada"
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr "bofetada"
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr "salpicadura"
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr "burbujas"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr "gota de agua"
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr "gato"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr "grillo"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr "perro"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr "banjo"
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr "koto"
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr "dulcimer"
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr "guitarra electrica"
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr "fagot"
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr "celeste"
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr "igual"
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "Pitagórico"
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr "solo entonación"
 
@@ -3233,7 +3233,7 @@ msgstr "solo entonación"
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3312,22 +3312,22 @@ msgid "previous"
 msgstr "anterior"
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "simple-2"
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "simple-3"
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "simple-4"
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr "taiko"
 
@@ -3484,7 +3484,7 @@ msgstr "El bloque obtener-valor devuelve un valor en el diccionario para una cla
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "obtener valor"
 
@@ -3506,7 +3506,7 @@ msgstr "clave"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "clave"
 
@@ -3517,7 +3517,7 @@ msgstr "El bloque valor-adjusto establece un valor en el diccionario para una cl
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr "valor ajustado"
 
@@ -3546,7 +3546,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr "Reemplace cada instancia de un tono con un sonido de tambor."
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "mapa de tono al tambor"
 
@@ -3555,7 +3555,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "En el ejemplo anterior, se reproducirá un sonido de bombo en lugar de sol."
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "fijar tambor"
 
@@ -3588,7 +3588,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "El bloque Pila-vacío? devuelve verdadero si la pila está vacío."
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "ÃÂ¿pila vacía?"
 
@@ -3598,7 +3598,7 @@ msgstr "El bloque Vacío pila vacía la pila."
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "vaciar pila"
 
@@ -3607,7 +3607,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr "El bloque Pila inversa invierte el orden de la pila."
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr "revertir la pila"
 
@@ -3616,7 +3616,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr "El bloque ÃÂndice de pila devuelve un valor en la pila en una ubicación especificada."
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "valor en la pila"
 
@@ -3639,13 +3639,13 @@ msgstr "El bloque Fijar entrada de pila establece un valor en la pila en la ubic
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "fijar pila"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "posición en la pila"
 
@@ -3654,7 +3654,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr "El bloque Pop elimina el valor en la parte superior del pila."
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "sacar"
 
@@ -3663,7 +3663,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr "El bloque Push agrega un valor a la parte superior del pila."
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "apilar"
 
@@ -3683,7 +3683,7 @@ msgstr "fijar temperamento"
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "octava"
 
@@ -3708,7 +3708,7 @@ msgid "current interval"
 msgstr "intervalo actua"
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr "medida de intervalo semitono"
 
@@ -3722,7 +3722,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr "El bloque Intervalo escalar mide la distancia entre dos notas en la clave y el modo actuales."
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr "medida de intervalo escalar"
 
@@ -3732,7 +3732,7 @@ msgstr "En la figura, agregamos sol# a sol."
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr "intervalo semitono"
 
@@ -3770,7 +3770,7 @@ msgid "In the figure, we add la to sol."
 msgstr "En la figura, sumamos la a sol."
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr "definir el modo"
 
@@ -3779,7 +3779,7 @@ msgid "movable Do"
 msgstr "movible Do"
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "longitud de modo"
 
@@ -3792,18 +3792,18 @@ msgid "Most Western scales have 7 notes."
 msgstr "La mayoría de las escalas occidentales tienen 7 notas."
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "modo actual"
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr "clave actual"
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "fijar clave"
 
@@ -3924,7 +3924,7 @@ msgstr "factor de legato"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr "vecino"
 
@@ -3943,7 +3943,7 @@ msgstr "legato"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "staccato"
 
@@ -3952,7 +3952,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr "El bloque Cargar-pila-en-app carga la pila en una página web."
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr "cargar pila desde aplicación"
 
@@ -3969,7 +3969,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr "El bloque Guardar-pila-en-app guarda la pila en una página web."
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr "guardar pila a aplicación"
 
@@ -3982,7 +3982,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr "El bloque Cargar pila carga la pila de un archivo."
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "cargar pila"
 
@@ -4011,7 +4011,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr "El bloque Carga-diccionario carga un diccionario desde un archivo."
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "carga diccionario"
 
@@ -4034,7 +4034,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr "El bloque fijar diccionario carga un diccionario."
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr "fijar diccionario"
 
@@ -4051,7 +4051,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr "El bloque Guardar pila guarda la pila en un archivo."
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "guardar pila"
 
@@ -4060,7 +4060,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr "El bloque Guardar diccionario guarda el diccionario en un archivo"
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr "guardar diccionario"
 
@@ -4077,7 +4077,7 @@ msgid "The Delete block block removes a block."
 msgstr "El bloque eliminar bloque elimina un bloque"
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr "eliminar bloque"
 
@@ -4086,7 +4086,7 @@ msgid "The Move block block moves a block."
 msgstr "El bloque mover bloque mueve un bloque."
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr "mover bloque"
 
@@ -4120,7 +4120,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr "ejecutar bloque"
 
@@ -4129,7 +4129,7 @@ msgid "The Dock block block connections two blocks."
 msgstr "El bloque connectar conecta dos bloques"
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr "connectar block"
 
@@ -4146,7 +4146,7 @@ msgid "The Make block block creates a new block."
 msgstr "El bloque crear bloque crea un bloque."
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr "crear bloque"
 
@@ -4161,7 +4161,7 @@ msgstr "crear bloque"
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "nota"
 
@@ -4195,12 +4195,12 @@ msgstr "Valor de la nota debe ser mayor que 0."
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "swing"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "valor de swing"
 
@@ -4209,12 +4209,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr "El bloque Omitir notas hará que las notas se omitan."
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "saltar notas"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "ritmo multiplican"
 
@@ -4223,13 +4223,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr "El bloque Atar funciona en pares de notas, combinándolas en una sola nota."
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "atar"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "punto"
 
@@ -4247,7 +4247,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr "Por ejemplo, una nota de un cuarto de puntos se reproducirá a 3/8 (1/4 + 1/8) de un tiempo."
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr "Valor de nota tambor"
 
@@ -4279,8 +4279,8 @@ msgstr "espacio de octava"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "ritmo"
 
@@ -4336,7 +4336,7 @@ msgstr "nota completa"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "tuplet"
 
@@ -4493,12 +4493,12 @@ msgid "duplicate factor"
 msgstr "duplicar factor"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr "meter actuale"
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "factor de ritmo"
 
@@ -4508,8 +4508,8 @@ msgstr "El bloque de latidos por minuto devuelve los latidos actuales por minuto
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "pulsaciones por minuto"
 
@@ -4517,12 +4517,12 @@ msgstr "pulsaciones por minuto"
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "pulsaciones por minuto"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr "cuenta de medidas"
 
@@ -4531,7 +4531,7 @@ msgid "The Measure count block returns the current measure."
 msgstr "El bloque de conteo de medidas devuelve la medida actual."
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr "cuenta de latidos"
 
@@ -4548,7 +4548,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr "por ejemplo, 1, 2, 3, o 4."
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr "cuenta las notas"
 
@@ -4558,12 +4558,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr "El bloque Contador de notas se puede usar para contar el número de notas contenidas."
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr "cuenta las notas"
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr "notas completa jugadas"
 
@@ -4573,7 +4573,7 @@ msgstr "El bloque Nota completa reproducidas devuelve el número total de notas 
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr "notas jugadas"
 
@@ -4582,7 +4582,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr "El bloque Sin reloj desacopla las notas del reloj maestro."
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "sin reloj"
 
@@ -4632,7 +4632,7 @@ msgstr "El bloque En-cada-nota-hacer le permite especificar acciones a realizar 
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr "latidos por minuto de dominar"
 
@@ -4665,7 +4665,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr "El bloque Pulsaciones por minuto establece el número de 1/4 notas por minuto."
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -4674,12 +4674,12 @@ msgid "number of beats"
 msgstr "número de latidos"
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "transposición"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr "escalar bajar"
 
@@ -4688,7 +4688,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr "El bloque Escalar bajar devuelve el número de semitonos a la nota anterior en la tecla y modo actuales."
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr "escalar aumentar"
 
@@ -4697,7 +4697,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr "El bloque Escalar aumentar devuelve el número de semitonos hasta la siguiente nota en la tecla y modo actuales."
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr "cambio en tono"
 
@@ -4706,7 +4706,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr "El cambio en el bloque de tono es la diferencia (en medio pasos) entre el tono actual que se está reproduciendo y el tono anterior."
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr "cambio en tono escalar"
 
@@ -4717,8 +4717,8 @@ msgstr "cambio en tono escalar"
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr "número de tono"
 
@@ -4728,7 +4728,7 @@ msgstr "El bloque Número de tono es el valor del tono de la nota que se está r
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr "tono en hertz"
 
@@ -4754,7 +4754,7 @@ msgid "alphabet"
 msgstr "alfabeto"
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr "clase de alfabeto"
 
@@ -4792,12 +4792,12 @@ msgstr "tono a color"
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr "MIDI"
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr "fijar offset del número de tono"
 
@@ -4809,12 +4809,12 @@ msgstr "El bloque Fijar del número de tono establecido se usa para establecer e
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "nombre"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "número a tono"
 
@@ -4823,7 +4823,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr "El bloque Número a tono convertirá un número de tono en un nombre pich."
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "número a octava"
 
@@ -4869,22 +4869,22 @@ msgstr "El bloque Invertir gira cualquier nota contenida alrededor de una nota d
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr "Invertir"
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "invertir (impar)"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "invertir (par)"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr "registro"
 
@@ -4893,7 +4893,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr "El bloque Registro proporciona una manera fácil de modificar el registro (octava) de las notas que lo siguen."
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr "50 centavos"
 
@@ -4906,7 +4906,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr "En el ejemplo que se muestra arriba, sol se desplaza hasta sol#."
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr "transposición semitono"
 
@@ -4915,47 +4915,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr "El bloque transponer por razón cambiará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) en una proporción"
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr "transponer por razón"
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr "sexto abajo"
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr "tercero abajo"
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr "séptimo"
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr "sexto"
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr "quinto"
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr "cuarto"
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr "tercio"
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr "segundo"
 
@@ -4968,7 +4968,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr "En el ejemplo que se muestra arriba, el sol se desplaza hacia arriba a la."
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr "transposición escalar"
 
@@ -4977,7 +4977,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr "El bloque Accidental se utiliza para crear objetos punzantes y pisos."
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr "anular accidental"
 
@@ -4985,7 +4985,7 @@ msgstr "anular accidental"
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr "hertz"
 
@@ -4999,8 +4999,8 @@ msgstr "El bloque de número de tono reproducirá un tono asociado por su númer
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr "nth tono modal"
 
@@ -5029,7 +5029,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr "El grado de la escala de 1 es siempre el primer tono de una escala determinada, independientemente de la octava."
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr "paso escalar"
 
@@ -5054,14 +5054,14 @@ msgstr "Oscilador"
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr "typo"
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr "parciales"
 
@@ -5071,7 +5071,7 @@ msgstr "Está agregando varios bloques de oscilador."
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr "duo sintetizador"
 
@@ -5090,7 +5090,7 @@ msgstr "intensidad de vibrato"
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr "AM sintetizador"
 
@@ -5100,7 +5100,7 @@ msgstr "El bloque Sintetizador AM es un modulador de amplitud usado para definir
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr "FM sintetizador"
 
@@ -5117,17 +5117,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr "El bloque Parcial se utiliza para especificar un peso para un armónico parcial específico."
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr "El peso parcial debe estar entre 0 y 1."
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr "El bloque Parcial debe usarse dentro de un bloque de parciales ponderados."
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr "parcial ponderada"
 
@@ -5136,7 +5136,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr "El bloque Armónicos agregará armónicos a las notas contenidas."
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr "armónico"
 
@@ -5146,7 +5146,7 @@ msgstr "El bloque Distorsión agrega distorsión al tono."
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr "distorsión"
 
@@ -5156,7 +5156,7 @@ msgstr "El bloque Tremolo añade un efecto de vacilación."
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr "tremolo"
 
@@ -5168,7 +5168,7 @@ msgstr "tremolo"
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr "velocidad"
 
@@ -5176,7 +5176,7 @@ msgstr "velocidad"
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr "intensidad"
 
@@ -5186,7 +5186,7 @@ msgstr "El bloque Phaser añade un sonido de barrido."
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr "phaser"
 
@@ -5207,7 +5207,7 @@ msgstr "El bloque Chorus añade un efecto chorus."
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr "coro"
 
@@ -5222,7 +5222,7 @@ msgstr "El bloque Vibrato agrega una variación rápida y leve en el tono."
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr "vibrato"
 
@@ -5232,7 +5232,7 @@ msgid "intensity"
 msgstr "intensidad"
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr "fijar synth"
 
@@ -5246,7 +5246,7 @@ msgstr "fijar instrumento predeterminado"
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr "fijar instrumento"
 
@@ -5302,7 +5302,7 @@ msgstr "calcular"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr "El bloque Hacer se utiliza para iniciar una acción."
 
@@ -5480,7 +5480,7 @@ msgid "Cannot find start block"
 msgstr "No se puede encontrar el bloque de inicar."
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "color de ratón"
 
@@ -5489,7 +5489,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr "El bloque de color del ratón devuelve el color del lápiz del ratón especificado."
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "color de tortuga"
 
@@ -5498,7 +5498,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr "El bloque de color de la tortuga devuelve el color del lápiz de la tortuga especificado."
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "rumbo de ratón"
 
@@ -5507,7 +5507,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr "El bloque de rumbo del ratón devuelve el rumbo del lápiz del ratón especificado."
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "rumbo de tortuga"
 
@@ -5517,13 +5517,13 @@ msgstr "El bloque de rumbo de la tortuga devuelve el rumbo del lápiz de la tort
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr "fijar ratón"
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr "fijar tortuga"
 
@@ -5536,7 +5536,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr "El bloque de tortuga establecer envía una pila de bloques para que los ejecute el tortuga especificado."
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "ratón y"
 
@@ -5545,7 +5545,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr "El bloque del ratón Y devuelve la posición Y del ratón especificado."
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "tortuga y"
 
@@ -5554,7 +5554,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr "El bloque de la tortuga Y devuelve la posición Y de la tortuga especificado."
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "ratón x"
 
@@ -5563,7 +5563,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr "El bloque del ratón X devuelve la posición X del ratón especificado."
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "tortuga x"
 
@@ -5572,7 +5572,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr "El bloque de la tortuga X devuelve la posición X de la tortuga especificado."
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "notas jugadas de ratón"
 
@@ -5581,7 +5581,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr "El bloque de notas jugadas del ratón devuelve el número de notas tocadas por el ratón especificado."
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "notas jugadas de tortuga"
 
@@ -5590,7 +5590,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr "El bloque de notas jugadas de la tortuga devuelve el número de notas tocadas por la tortuga especificado."
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "número de tono de ratón"
 
@@ -5599,7 +5599,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr "El bloque de tono del ratón devuelve el número de tono actual que está reproduciendo el ratón especificado."
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "número de tono de tortuga"
 
@@ -5609,17 +5609,17 @@ msgstr "El bloque de tono de la tortuga devuelve el número de tono actual que e
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr "valor de la nota del ratón"
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "valor de la nota de la tortuga"
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "sincronizar"
 
@@ -5628,7 +5628,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "El bloque sincronizar alinea el conteo de latidos entre ratones."
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "sincronizar"
 
@@ -6055,7 +6055,7 @@ msgid "wrap"
 msgstr "envolver"
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr "derecha"
 
@@ -6065,7 +6065,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr "El bloque Derecha devuelve la posición de la derecha del lienzo."
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "izquierdo"
 
@@ -6109,12 +6109,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr "El bloque altura devuelve la altura del lienzo."
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "detener"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr "borrar medios"
 
@@ -6123,7 +6123,7 @@ msgid "The Erase Media block erases text and images."
 msgstr "El bloque Erase Media borra texto e imágenes."
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "reproducir"
 
@@ -6180,7 +6180,7 @@ msgid "duration (MS)"
 msgstr "duración (MS)"
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "nota a frecuencia"
 
@@ -6198,7 +6198,7 @@ msgstr "El bloque Avatar se usa para cambiar la apariencia de la tortuga."
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "tamaño"
 
@@ -6211,7 +6211,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr "El bloque Mostrar se utiliza para mostrar texto o imágenes en el lienzo."
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "mostrar"
 
@@ -6276,7 +6276,7 @@ msgstr "Cargar proyecto desde archivo"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "rellenar pantalla"
 
@@ -6341,7 +6341,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr "El bloque de línea sin relleno crea una línea con un centro hueco."
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "linea sin relleno"
 
@@ -6350,12 +6350,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr "El bloque relleno rellena una forma con un color."
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "relleno"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "subir pluma"
 
@@ -6364,7 +6364,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "El bloque Subir pluma levanta la pluma para que no dibuje."
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "bajar pluma"
 
@@ -6373,7 +6373,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "El bloque de Haciar pluma abajo baja la pluma para que dibuje."
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "fijar pluma"
 
@@ -6382,7 +6382,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr "El bloque Fijar tamaño de la pluma de ajuste cambia el tamaño de la pluma."
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "fijar translucidez"
 
@@ -6407,7 +6407,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr "El bloque Fijar sombra cambia el color de la pluma de oscuro a claro."
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "fijar gris"
 
@@ -6542,27 +6542,27 @@ msgstr "El bloque teclado devuelve entrada de teclado."
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr "Envolvente"
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "atacar"
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "decaer"
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "sostener"
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "liberar"
 
@@ -6588,18 +6588,18 @@ msgstr "Está agregando varios bloques de envolvente."
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr "Filtrar"
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr "rodar"
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr "Roll off valor debe ser -12, -24, -48, o -96 decibelios."
 
@@ -6614,7 +6614,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr "Sube una muestra de audio y ajusta su centro de tono."
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "muestreador de audio"
 
@@ -6635,7 +6635,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr "El bloque Modo personalizado abre una herramienta para explorar el modo musical (el espaciado de las notas en una escala)."
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "modo personalizado"
 
@@ -6652,7 +6652,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr "La Matriz de percusión de tono se utiliza para asignar tonos a los sonidos de tambor."
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "matriz de tono en tambor"
 
@@ -6665,7 +6665,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr "La Herramienta de control deslizante tono se utiliza para generar tonos en las frecuencias seleccionadas."
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "deslizante de tono"
 
@@ -6675,7 +6675,7 @@ msgstr "teclado cromático"
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr "teclado musical"
 
@@ -6689,7 +6689,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr "La Herramienta escalera de tono se utiliza para generar tonos a partir de una relación dada."
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "escalera de tono"
 
@@ -6710,7 +6710,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr "El bloque Matriz de tono y tiempo abre una herramienta para crear frases musicales."
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "matriz de tono en tiempo"
 
@@ -6724,7 +6724,7 @@ msgstr "El bloque Estado abre una herramienta para inspeccionar el estado de Blo
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr "Música de IA"
 
@@ -6911,7 +6911,7 @@ msgstr "La velocidad del vibrato debe ser mayor que 0."
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr "El valor de profundidad está fuera de rango."
 
@@ -6920,7 +6920,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr "El valor de distorsión debe ser de 0 a 100."
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr "Parcial debe ser mayor o igual a 0."
 
@@ -7042,7 +7042,7 @@ msgid "Undo"
 msgstr "Deshacer"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr "Haga clic en el círculo para seleccionar notas para el modo."
 
@@ -7125,7 +7125,7 @@ msgid "Save drum machine"
 msgstr "Guardar la caja de ritmos"
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr "Toca un ritmo"
 
@@ -7175,7 +7175,7 @@ msgid "Playback"
 msgstr "Reproducir"
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr "tono de referencia"
 
@@ -7292,7 +7292,7 @@ msgstr "Sintetizador"
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr "Efectos"
 
@@ -7371,48 +7371,48 @@ msgid "Cannot connect to server"
 msgstr "No es posible conectar con el servidor."
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr "todos los proyectos"
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr "Mis proyectos"
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr "ejemplos"
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr "arte"
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr "mates"
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr "interactivo"
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr "diseño"
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr "juego"
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr "fragmento de código"
 
@@ -7845,765 +7845,765 @@ msgstr "mover"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr "Nada en la basura para restaurar."
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr "Nada en la basura para restaurar."
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr "Guarda audio de tu proyecto como WAV."
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr "Guarda audio de tu proyecto como WAV."
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr "Guarda tu proyecto como un archivo ABC."
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr "Guarda tu proyecto como un archivo ABC."
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "Guarde el proyecto como un archivo de LilyPond."
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "Guarde el proyecto como un archivo de LilyPond."
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr "Mostrar u ocultar las rejillas de coordenadas."
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr "Mostrar u ocultar las rejillas de coordenadas."
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr "Expandir/contraer los bloques"
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr "Expandir/contraer los bloques"
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "Mostrar estos mensajes."
+#~ msgid "Show these messages."
+#~ msgstr "Mostrar estos mensajes."
 
-#~msgid "sensors"
-#~msgstr "sensores"
+#~ msgid "sensors"
+#~ msgstr "sensores"
 
-#~msgid "media"
-#~msgstr "medios"
+#~ msgid "media"
+#~ msgstr "medios"
 
-#~msgid "Cartesian+polar"
-#~msgstr "Cartesiano+polar"
+#~ msgid "Cartesian+polar"
+#~ msgstr "Cartesiano+polar"
 
-#~msgid "show"
-#~msgstr "mostrar"
+#~ msgid "show"
+#~ msgstr "mostrar"
 
-#~msgid "Show/hide block"
-#~msgstr "Mostrar/ocultar bloques"
+#~ msgid "Show/hide block"
+#~ msgstr "Mostrar/ocultar bloques"
 
-#~msgid "grid"
-#~msgstr "cuadrícula"
+#~ msgid "grid"
+#~ msgstr "cuadrícula"
 
-#~msgid "You have chosen key "
-#~msgstr "Ha elegido la tecla "
+#~ msgid "You have chosen key "
+#~ msgstr "Ha elegido la tecla "
 
-#~msgid " for your pitch preview."
-#~msgstr " para la vista previa de su tono."
+#~ msgid " for your pitch preview."
+#~ msgstr " para la vista previa de su tono."
 
-#~msgid "Full Screen"
-#~msgstr "Pantalla completa"
+#~ msgid "Full Screen"
+#~ msgstr "Pantalla completa"
 
-#~msgid "New Project"
-#~msgstr "Nuevo Proyecto"
+#~ msgid "New Project"
+#~ msgstr "Nuevo Proyecto"
 
-#~msgid "music"
-#~msgstr "música"
+#~ msgid "music"
+#~ msgstr "música"
 
-#~msgid "save"
-#~msgstr "guardar"
+#~ msgid "save"
+#~ msgstr "guardar"
 
-#~msgid "Clean"
-#~msgstr "Limpiar"
+#~ msgid "Clean"
+#~ msgstr "Limpiar"
 
-#~msgid "Run slow"
-#~msgstr "Ejecutar lentamente"
+#~ msgid "Run slow"
+#~ msgstr "Ejecutar lentamente"
 
-#~msgid "Clear Workspace"
-#~msgstr "Borrar el espacio de trabajo"
+#~ msgid "Clear Workspace"
+#~ msgstr "Borrar el espacio de trabajo"
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr "Â¿Estás seguro de que quieres borrar el espacio de trabajo?"
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr "Â¿Estás seguro de que quieres borrar el espacio de trabajo?"
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
-#~msgid "Custom"
-#~msgstr "Personalizado"
+#~ msgid "Custom"
+#~ msgstr "Personalizado"
 
-#~msgid "hide blocks"
-#~msgstr "ocultar bloques"
+#~ msgid "hide blocks"
+#~ msgstr "ocultar bloques"
 
-#~msgid "duplicate"
-#~msgstr "duplicar"
+#~ msgid "duplicate"
+#~ msgstr "duplicar"
 
-#~msgid "stop"
-#~msgstr "detener"
+#~ msgid "stop"
+#~ msgstr "detener"
 
-#~msgid "duration (ms)"
-#~msgstr "duración (ms)"
+#~ msgid "duration (ms)"
+#~ msgstr "duración (ms)"
 
-#~msgid "clear"
-#~msgstr "limpiar"
+#~ msgid "clear"
+#~ msgstr "limpiar"
 
-#~msgid "invert"
-#~msgstr "invertir"
+#~ msgid "invert"
+#~ msgstr "invertir"
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr "Nth Modal Pitch toma el patrón de tonos en semitonos para un modo y hace que cada punto sea un grado del modo,"
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr "Nth Modal Pitch toma el patrón de tonos en semitonos para un modo y hace que cada punto sea un grado del modo,"
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr "Nth modal tono un número como entrada como el nth grado para el modo dado. 0 es la primera posición, 1 es la segunda, -1 es la nota anterior a la primera, etc."
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr "Nth modal tono un número como entrada como el nth grado para el modo dado. 0 es la primera posición, 1 es la segunda, -1 es la nota anterior a la primera, etc."
 
-#~msgid "oscillator"
-#~msgstr "oscilador"
+#~ msgid "oscillator"
+#~ msgstr "oscilador"
 
-#~msgid "delay"
-#~msgstr "retraso"
+#~ msgid "delay"
+#~ msgstr "retraso"
 
-#~msgid "envelope"
-#~msgstr "envolventes"
+#~ msgid "envelope"
+#~ msgstr "envolventes"
 
-#~msgid "filter"
-#~msgstr "filtrar"
+#~ msgid "filter"
+#~ msgstr "filtrar"
 
-#~msgid "aimusic"
-#~msgstr "música ia"
+#~ msgid "aimusic"
+#~ msgstr "música ia"
 
-#~msgid "a"
-#~msgstr "el"
+#~ msgid "a"
+#~ msgstr "el"
 
-#~msgid " below"
-#~msgstr " abajo"
+#~ msgid " below"
+#~ msgstr " abajo"
 
-#~msgid "New action block generated!"
-#~msgstr "Nuevo bloque de acción creado!"
+#~ msgid "New action block generated!"
+#~ msgstr "Nuevo bloque de acción creado!"
 
-#~msgid "Recording started..."
-#~msgstr "Grabación comenzó..."
+#~ msgid "Recording started..."
+#~ msgstr "Grabación comenzó..."
 
-#~msgid "Recording complete..."
-#~msgstr "Grabación completa..."
+#~ msgid "Recording complete..."
+#~ msgstr "Grabación completa..."
 
-#~msgid "duration"
-#~msgstr "duración"
+#~ msgid "duration"
+#~ msgstr "duración"
 
-#~msgid "close"
-#~msgstr "cerrar"
+#~ msgid "close"
+#~ msgstr "cerrar"
 
-#~msgid "Publish Project"
-#~msgstr "Publicar el proyecto"
+#~ msgid "Publish Project"
+#~ msgstr "Publicar el proyecto"
 
-#~msgid "play"
-#~msgstr "tocar"
+#~ msgid "play"
+#~ msgstr "tocar"
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr "Lilypond no puede procesar pickup de "
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr "Lilypond no puede procesar pickup de "
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr "Actualice su navegador para cambiar al modo avanzado."
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr "Actualice su navegador para cambiar al modo avanzado."
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr "Actualice su navegador para cambiar al modo principiante."
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr "Actualice su navegador para cambiar al modo principiante."
 
-#~msgid "New action blocks generated"
-#~msgstr "Nuevo bloques de acción creado"
+#~ msgid "New action blocks generated"
+#~ msgstr "Nuevo bloques de acción creado"
 
-#~msgid "New action block generated"
-#~msgstr "Nuevo bloque de acción creado"
+#~ msgid "New action block generated"
+#~ msgstr "Nuevo bloque de acción creado"
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr "Alternar editor de JavaScript"
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr "Alternar editor de JavaScript"
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr "El bloque Paso escalar debe utilizarse dentro de un bloque de nota."
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr "El bloque Paso escalar debe utilizarse dentro de un bloque de nota."
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr "El bloque Paso escalar debe ir precedida de un bloque de tono."
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr "El bloque Paso escalar debe ir precedida de un bloque de tono."
 
-#~msgid "FullScreen"
-#~msgstr "Pantalla completa"
+#~ msgid "FullScreen"
+#~ msgstr "Pantalla completa"
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr "El bloque Tuplet se usa para generar un grupo de notas tocadas en una cantidad de tiempo condensada."
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr "El bloque Tuplet se usa para generar un grupo de notas tocadas en una cantidad de tiempo condensada."
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr "Usar tuplets facilita la creación de grupos de notas que no se basan en una potencia de 2."
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr "Usar tuplets facilita la creación de grupos de notas que no se basan en una potencia de 2."
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr "El bloque Fijar temperamento se usa para elegir el sistema de afinación usado por los Bloques de Música."
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr "El bloque Fijar temperamento se usa para elegir el sistema de afinación usado por los Bloques de Música."
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr "El bloque de número de intervalo devuelve el número de pasos escalares en el intervalo actual."
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr "El bloque de número de intervalo devuelve el número de pasos escalares en el intervalo actual."
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr "El bloque de intervalo semitono mide la distancia entre dos notas en semitonos."
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr "El bloque de intervalo semitono mide la distancia entre dos notas en semitonos."
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr "El bloque Intervalo de semitono calcula un intervalo relativo basado en la mitad de los pasos."
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr "El bloque Intervalo de semitono calcula un intervalo relativo basado en la mitad de los pasos."
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr "El bloque Arpegio ejecutará cada bloque de notas varias veces, agregando una transposición basada en el acorde especificado."
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr "El bloque Arpegio ejecutará cada bloque de notas varias veces, agregando una transposición basada en el acorde especificado."
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr "El bloque Intervalo escalar calcula un intervalo relativo basado en el modo actual, omitiendo todas las notas fuera del modo."
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr "El bloque Intervalo escalar calcula un intervalo relativo basado en el modo actual, omitiendo todas las notas fuera del modo."
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr "El bloque Modo definir le permite definir un modo personalizado especificando números de tono."
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr "El bloque Modo definir le permite definir un modo personalizado especificando números de tono."
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr "Cuando Movible do es falso, los nombres de las notas de solfeo siempre están vinculados a tonos específicos,"
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr "Cuando Movible do es falso, los nombres de las notas de solfeo siempre están vinculados a tonos específicos,"
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr "Por ejemplo, \"do\" siempre es \"C-natural\" cuando Movible do es verdadero, los nombres de las notas del solfeo se asignan a grados de escala. \"do\" siempre es el primer grado de la escala mayor."
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr "Por ejemplo, \"do\" siempre es \"C-natural\" cuando Movible do es verdadero, los nombres de las notas del solfeo se asignan a grados de escala. \"do\" siempre es el primer grado de la escala mayor."
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr "El bloque Acción se utiliza para agrupar bloques de modo que puedan utilizarse más de una vez."
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr "El bloque Acción se utiliza para agrupar bloques de modo que puedan utilizarse más de una vez."
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr "El bloque Mayor que devuelve verdadero si el número superior es mayor que el número inferior."
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr "El bloque Mayor que devuelve verdadero si el número superior es mayor que el número inferior."
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr "El bloque Menor que devuelve Verdadero si el número superior es menor que el número inferior."
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr "El bloque Menor que devuelve Verdadero si el número superior es menor que el número inferior."
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "En este ejemplo, el ratón se mueve hacia la derecha hasta que alcanza el borde derecho del lienzo; luego reaparece a la izquierda del lienzo."
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "En este ejemplo, el ratón se mueve hacia la derecha hasta que alcanza el borde derecho del lienzo; luego reaparece a la izquierda del lienzo."
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "En este ejemplo, la tortuga se mueve hacia la derecha hasta que alcanza el borde derecho del lienzo; luego reaparece a la izquierda del lienzo."
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "En este ejemplo, la tortuga se mueve hacia la derecha hasta que alcanza el borde derecho del lienzo; luego reaparece a la izquierda del lienzo."
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "En este ejemplo, el ratón se mueve hacia arriba hasta que alcanza el borde superior del lienzo; luego reaparece en la parte inferior del lienzo."
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "En este ejemplo, el ratón se mueve hacia arriba hasta que alcanza el borde superior del lienzo; luego reaparece en la parte inferior del lienzo."
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "En este ejemplo, la tortuga se mueve hacia arriba hasta que alcanza el borde superior del lienzo; luego reaparece en la parte inferior del lienzo."
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "En este ejemplo, la tortuga se mueve hacia arriba hasta que alcanza el borde superior del lienzo; luego reaparece en la parte inferior del lienzo."
 
-#~msgid "video material"
-#~msgstr "material de video"
+#~ msgid "video material"
+#~ msgstr "material de video"
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr "El bloque Ejecutar bloque ejecuta un bloque. Acepta dos tipos de argumentos: número de bloque o nombre de bloque."
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr "El bloque Ejecutar bloque ejecuta un bloque. Acepta dos tipos de argumentos: número de bloque o nombre de bloque."
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr "El bloque Fijar tambor de ajuste seleccionará un sonido de tambor para reemplazar el tono de cualquier nota contenida."
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr "El bloque Fijar tambor de ajuste seleccionará un sonido de tambor para reemplazar el tono de cualquier nota contenida."
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr "El bloque Valor de la Nota es el valor de la duración de la nota que se está reproduciendo actualmente."
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr "El bloque Valor de la Nota es el valor de la duración de la nota que se está reproduciendo actualmente."
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr "El bloque Milisegundos es similar a un bloque de nota, excepto que usa el tiempo (en MS) para especificar la duración de la nota."
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr "El bloque Milisegundos es similar a un bloque de nota, excepto que usa el tiempo (en MS) para especificar la duración de la nota."
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr "El bloque Swing funciona en pares de notas (especificado por el valor de la nota), agregando cierta duración (especificada por el valor del swing) a la primera nota y tomando la misma cantidad de la segunda nota."
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr "El bloque Swing funciona en pares de notas (especificado por el valor de la nota), agregando cierta duración (especificada por el valor del swing) a la primera nota y tomando la misma cantidad de la segunda nota."
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr "El bloque Multiplicar de valor de nota cambia la duración de las notas al cambiar sus valores de nota."
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr "El bloque Multiplicar de valor de nota cambia la duración de las notas al cambiar sus valores de nota."
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr "Un resto de la duración del valor de nota especificado se puede construir utilizando un bloque de silencio."
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr "Un resto de la duración del valor de nota especificado se puede construir utilizando un bloque de silencio."
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr "El bloque Mostrar pila muestra el contenido de la pila en la parte superior de la pantalla."
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr "El bloque Mostrar pila muestra el contenido de la pila en la parte superior de la pantalla."
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr "La salida del ejemplo es: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr "La salida del ejemplo es: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr "Los condicionales le permiten a su programa tomar diferentes acciones dependiendo de la condición."
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr "Los condicionales le permiten a su programa tomar diferentes acciones dependiendo de la condición."
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr "En este ejemplo, si se presiona el botón del mouse, se reproducirá una caja. Si no, tocará un bombo."
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr "En este ejemplo, si se presiona el botón del mouse, se reproducirá una caja. Si no, tocará un bombo."
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr "En este ejemplo de una caja de ritmos simple, un bombo ejecutará 1/4 de notas para siempre."
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr "En este ejemplo de una caja de ritmos simple, un bombo ejecutará 1/4 de notas para siempre."
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr "El bloque Arco mueve el ratón en un arco."
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr "El bloque Arco mueve el ratón en un arco."
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr "El bloque Arco mueve la tortuga en un arco."
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr "El bloque Arco mueve la tortuga en un arco."
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr "El bloque fijar rumbo establece el rumbo del ratón."
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr "El bloque fijar rumbo establece el rumbo del ratón."
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr "El bloque Envolver habilita o deshabilita el ajuste de pantalla para las acciones gráficas dentro de él."
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr "El bloque Envolver habilita o deshabilita el ajuste de pantalla para las acciones gráficas dentro de él."
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr "El bloque Slur alarga el sostenimiento de las notas mientras mantiene el valor rítmico especificado de las notas."
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr "El bloque Slur alarga el sostenimiento de las notas mientras mantiene el valor rítmico especificado de las notas."
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr "El bloque Staccato acorta la longitud de la nota real mientras mantiene el valor rítmico especificado de las notas."
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr "El bloque Staccato acorta la longitud de la nota real mientras mantiene el valor rítmico especificado de las notas."
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr "El bloque Decrescendo disminuirá el volumen de las notas contenidas en una cantidad específica por cada nota tocada."
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "El bloque Decrescendo disminuirá el volumen de las notas contenidas en una cantidad específica por cada nota tocada."
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr "Por ejemplo, si tiene 7 notas en secuencia contenidas en un bloque de Decrescendo con un valor de 5, la nota final será un 35% menos que el volumen inicial."
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr "Por ejemplo, si tiene 7 notas en secuencia contenidas en un bloque de Decrescendo con un valor de 5, la nota final será un 35% menos que el volumen inicial."
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr "El bloque Crescendo aumentará el volumen de las notas contenidas en una cantidad específica por cada nota tocada."
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "El bloque Crescendo aumentará el volumen de las notas contenidas en una cantidad específica por cada nota tocada."
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr "Por ejemplo, si tiene 7 notas en secuencia contenidas en un bloque de Crescendo con un valor de 5, la nota final será un 35% más que el volumen inicial."
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr "Por ejemplo, si tiene 7 notas en secuencia contenidas en un bloque de Crescendo con un valor de 5, la nota final será un 35% más que el volumen inicial."
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr "El bloque Parcial se usa para especificar un peso para un armónico particular."
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr "El bloque Parcial se usa para especificar un peso para un armónico particular."
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr "El bloque Parciales ponderados se utiliza para especificar los parciales asociados con un timbre."
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr "El bloque Parciales ponderados se utiliza para especificar los parciales asociados con un timbre."
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr "El bloque fijar instrumentos predeterminado establecido cambia el instrumento predeterminado de sintetizador electrónico al instrumento de su elección."
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr "El bloque fijar instrumentos predeterminado establecido cambia el instrumento predeterminado de sintetizador electrónico al instrumento de su elección."
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr "El bloque Factor de Ritmo devuelve la relación entre el valor de la nota y el valor de la nota del medidor."
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr "El bloque Factor de Ritmo devuelve la relación entre el valor de la nota y el valor de la nota del medidor."
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr "En la figura, se utiliza para realizar una acción en el primer tiempo de cada compás."
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr "En la figura, se utiliza para realizar una acción en el primer tiempo de cada compás."
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr "(De forma predeterminada, cuenta las notas de un cuarto.)"
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr "(De forma predeterminada, cuenta las notas de un cuarto.)"
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr "El bloque Mostrar diccionario muestra el contenido del diccionario en la parte superior de la pantalla."
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr "El bloque Mostrar diccionario muestra el contenido del diccionario en la parte superior de la pantalla."
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr "El bloque Comentario imprime un comentario en la parte superior de la pantalla cuando el programa se está ejecutando en modo lento."
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr "El bloque Comentario imprime un comentario en la parte superior de la pantalla cuando el programa se está ejecutando en modo lento."
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr "El cursor sobre el bloque activa un evento cuando el cursor se mueve sobre un ratón."
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr "El cursor sobre el bloque activa un evento cuando el cursor se mueve sobre un ratón."
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr "El cursor sobre el bloque activa un evento cuando el cursor se mueve sobre una tortuga."
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr "El cursor sobre el bloque activa un evento cuando el cursor se mueve sobre una tortuga."
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr "El bloque de salida del cursor desencadena un evento cuando el cursor se mueve fuera de un ratón."
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr "El bloque de salida del cursor desencadena un evento cuando el cursor se mueve fuera de un ratón."
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr "El bloque de salida del cursor desencadena un evento cuando el cursor se mueve fuera de una tortuga."
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr "El bloque de salida del cursor desencadena un evento cuando el cursor se mueve fuera de una tortuga."
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr "El bloque hacia abajo del botón del cursor activa un evento cuando se presiona el botón del cursor en un ratón."
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr "El bloque hacia abajo del botón del cursor activa un evento cuando se presiona el botón del cursor en un ratón."
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr "El bloque hacia abajo del botón del cursor activa un evento cuando se presiona el botón del cursor en una tortuga."
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr "El bloque hacia abajo del botón del cursor activa un evento cuando se presiona el botón del cursor en una tortuga."
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr "El bloque del botón del cursor hacia arriba desencadena un evento cuando se suelta el botón del cursor sobre un ratón."
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr "El bloque del botón del cursor hacia arriba desencadena un evento cuando se suelta el botón del cursor sobre un ratón."
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr "El bloque del botón del cursor hacia arriba desencadena un evento cuando se suelta el botón del cursor sobre una tortuga."
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr "El bloque del botón del cursor hacia arriba desencadena un evento cuando se suelta el botón del cursor sobre una tortuga."
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr "El bloque Obtener azul devuelve el componente azul del píxel debajo del ratón."
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr "El bloque Obtener azul devuelve el componente azul del píxel debajo del ratón."
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr "El bloque Obtener azul devuelve el componente azul del píxel debajo de la tortuga."
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr "El bloque Obtener azul devuelve el componente azul del píxel debajo de la tortuga."
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr "El bloque Obtener verde devuelve el componente verde del píxel debajo del ratón."
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr "El bloque Obtener verde devuelve el componente verde del píxel debajo del ratón."
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr "El bloque Obtener verde devuelve el componente verde del píxel debajo de la tortuga."
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr "El bloque Obtener verde devuelve el componente verde del píxel debajo de la tortuga."
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr "El bloque de tiempo devuelve el número de segundos que el programa se ha estado ejecutando."
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr "El bloque de tiempo devuelve el número de segundos que el programa se ha estado ejecutando."
 
-#~msgid "More Details"
-#~msgstr "Más detalles"
+#~ msgid "More Details"
+#~ msgstr "Más detalles"
 
-#~msgid "Share project"
-#~msgstr "Compartir proyecto"
+#~ msgid "Share project"
+#~ msgstr "Compartir proyecto"
 
-#~msgid "Copy link to clipboard"
-#~msgstr "Copiar enlace al portapapeles"
+#~ msgid "Copy link to clipboard"
+#~ msgstr "Copiar enlace al portapapeles"
 
-#~msgid "Run project on startup."
-#~msgstr "Ejecutar código al inicio."
+#~ msgid "Run project on startup."
+#~ msgstr "Ejecutar código al inicio."
 
-#~msgid "Show code blocks on startup."
-#~msgstr "Mostrar código al inicio."
+#~ msgid "Show code blocks on startup."
+#~ msgstr "Mostrar código al inicio."
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr "Contraer bloques al inicio."
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr "Contraer bloques al inicio."
 
-#~msgid "Advanced Options"
-#~msgstr "Opciones avanzadas"
+#~ msgid "Advanced Options"
+#~ msgstr "Opciones avanzadas"
 
-#~msgid "Warning: Sound is only coming out from one side."
-#~msgstr "Advertencia: el sonido solo sale por un lado."
+#~ msgid "Warning: Sound is only coming out from one side."
+#~ msgstr "Advertencia: el sonido solo sale por un lado."
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr "Bloque de Hertz: Quizás quiso decir utilizar un bloque de nota?"
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr "Bloque de Hertz: Quizás quiso decir utilizar un bloque de nota?"
 
-#~msgid "chromatic semitone"
-#~msgstr "semitono cromático"
+#~ msgid "chromatic semitone"
+#~ msgstr "semitono cromático"
 
-#~msgid "diminished octave"
-#~msgstr "octava disminuida"
+#~ msgid "diminished octave"
+#~ msgstr "octava disminuida"
 
-#~msgid "triad (root position)"
-#~msgstr "tríada (posición raíz)"
+#~ msgid "triad (root position)"
+#~ msgstr "tríada (posición raíz)"
 
-#~msgid "triad (1st inversion)"
-#~msgstr "tríada (primera inversión)"
+#~ msgid "triad (1st inversion)"
+#~ msgstr "tríada (primera inversión)"
 
-#~msgid "triad (2nd inversion)"
-#~msgstr "tríada (segunda inversión)"
+#~ msgid "triad (2nd inversion)"
+#~ msgstr "tríada (segunda inversión)"
 
-#~msgid "seventh (root position)"
-#~msgstr "séptimo (posición raíz)"
+#~ msgid "seventh (root position)"
+#~ msgstr "séptimo (posición raíz)"
 
-#~msgid "seventh (1st inversion)"
-#~msgstr "séptima (primera inversión)"
+#~ msgid "seventh (1st inversion)"
+#~ msgstr "séptima (primera inversión)"
 
-#~msgid "seventh (2nd inversion)"
-#~msgstr "séptima (segunda inversión)"
+#~ msgid "seventh (2nd inversion)"
+#~ msgstr "séptima (segunda inversión)"
 
-#~msgid "seventh (3rd inversion)"
-#~msgstr "séptima (tercera inversión)"
+#~ msgid "seventh (3rd inversion)"
+#~ msgstr "séptima (tercera inversión)"
 
-#~msgid "ninth (root position)"
-#~msgstr "noveno (posición raíz)"
+#~ msgid "ninth (root position)"
+#~ msgstr "noveno (posición raíz)"
 
-#~msgid "thirteenth (root position)"
-#~msgstr "decimotercero (posición raíz)"
+#~ msgid "thirteenth (root position)"
+#~ msgstr "decimotercero (posición raíz)"
 
-#~msgid "Unlike project"
-#~msgstr "Proyecto \"No me gusta\""
+#~ msgid "Unlike project"
+#~ msgstr "Proyecto \"No me gusta\""
 
-#~msgid "Like project"
-#~msgstr "Proyecto \"Me gusta\""
+#~ msgid "Like project"
+#~ msgstr "Proyecto \"Me gusta\""
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr "Característica no disponible: no se puede conectar al servidor. Vuelve a cargar TortuBloques para intentarlo de nuevo."
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr "Característica no disponible: no se puede conectar al servidor. Vuelve a cargar TortuBloques para intentarlo de nuevo."
 
-#~msgid "Republish Project"
-#~msgstr "Volver a publicar el proyecto"
+#~ msgid "Republish Project"
+#~ msgstr "Volver a publicar el proyecto"
 
-#~msgid "audio file1"
-#~msgstr "archivo de audio 1"
+#~ msgid "audio file1"
+#~ msgstr "archivo de audio 1"
 
-#~msgid "audio file2"
-#~msgstr "archivo de audio 2"
+#~ msgid "audio file2"
+#~ msgstr "archivo de audio 2"
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr "Advertencia. El valor de la nota es mayor que 2"
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr "Advertencia. El valor de la nota es mayor que 2"
 
-#~msgid "chord5"
-#~msgstr "acorde V"
+#~ msgid "chord5"
+#~ msgstr "acorde V"
 
-#~msgid "chord4"
-#~msgstr "acorde 4"
+#~ msgid "chord4"
+#~ msgstr "acorde 4"
 
-#~msgid "chord1"
-#~msgstr "acorde 1"
+#~ msgid "chord1"
+#~ msgstr "acorde 1"
 
-#~msgid "Run fast"
-#~msgstr "Ejecutar rápidamente"
+#~ msgid "Run fast"
+#~ msgstr "Ejecutar rápidamente"
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "Expandir o colapsar los bloques colapsables"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "Expandir o colapsar los bloques colapsables"
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr "El bloque nombre de nth ratón devuelve el nombre de nth ratón"
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr "El bloque nombre de nth ratón devuelve el nombre de nth ratón"
 
-#~msgid "search for blocks"
-#~msgstr "buscar bloques"
+#~ msgid "search for blocks"
+#~ msgstr "buscar bloques"
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr "Por favor, configure el nivel de zoom del navegador al 100%"
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr "Por favor, configure el nivel de zoom del navegador al 100%"
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr "Para ejecutar este proyecto, abra Bloques de Música en un navegador web y arrastre y suelte este archivo en la ventana del navegador."
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr "Para ejecutar este proyecto, abra Bloques de Música en un navegador web y arrastre y suelte este archivo en la ventana del navegador."
 
-#~msgid "You must always have at least one start block."
-#~msgstr "Siempre debe tener al menos un bloque de inicio."
+#~ msgid "You must always have at least one start block."
+#~ msgstr "Siempre debe tener al menos un bloque de inicio."
 
-#~msgid "pitch up"
-#~msgstr "Aumentar el tono"
+#~ msgid "pitch up"
+#~ msgstr "Aumentar el tono"
 
-#~msgid "pitch down"
-#~msgstr "Disminuir el tono"
+#~ msgid "pitch down"
+#~ msgstr "Disminuir el tono"
 
-#~msgid "accidental up"
-#~msgstr "Aumentar el accidental"
+#~ msgid "accidental up"
+#~ msgstr "Aumentar el accidental"
 
-#~msgid "accidental down"
-#~msgstr "Disminuir el accidental"
+#~ msgid "accidental down"
+#~ msgstr "Disminuir el accidental"
 
-#~msgid "octave up"
-#~msgstr "Aumenter el octave"
+#~ msgid "octave up"
+#~ msgstr "Aumenter el octave"
 
-#~msgid "octave down"
-#~msgstr "Disminuir el octave"
+#~ msgid "octave down"
+#~ msgstr "Disminuir el octave"
 
-#~msgid "currency"
-#~msgstr "moneda"
+#~ msgid "currency"
+#~ msgstr "moneda"
 
-#~msgid "from"
-#~msgstr "desde"
+#~ msgid "from"
+#~ msgstr "desde"
 
-#~msgid "stock price"
-#~msgstr "valor de acción"
+#~ msgid "stock price"
+#~ msgstr "valor de acción"
 
-#~msgid "translate"
-#~msgstr "traducir"
+#~ msgid "translate"
+#~ msgstr "traducir"
 
-#~msgid "hello"
-#~msgstr "hola"
+#~ msgid "hello"
+#~ msgstr "hola"
 
-#~msgid "detect lang"
-#~msgstr "detectar idioma"
+#~ msgid "detect lang"
+#~ msgstr "detectar idioma"
 
-#~msgid "set lang"
-#~msgstr "cambiar idioma"
+#~ msgid "set lang"
+#~ msgstr "cambiar idioma"
 
-#~msgid "city latitude"
-#~msgstr "latitud de la ciudad"
+#~ msgid "city latitude"
+#~ msgstr "latitud de la ciudad"
 
-#~msgid "city longitude"
-#~msgstr "longitud de la ciudad"
+#~ msgid "city longitude"
+#~ msgstr "longitud de la ciudad"
 
-#~msgid "Coordinate data not available."
-#~msgstr "Coordinar datos no disponibles."
+#~ msgid "Coordinate data not available."
+#~ msgstr "Coordinar datos no disponibles."
 
-#~msgid "Google map"
-#~msgstr "Mapa de Google"
+#~ msgid "Google map"
+#~ msgstr "Mapa de Google"
 
-#~msgid "coordinates"
-#~msgstr "coordenadas"
+#~ msgid "coordinates"
+#~ msgstr "coordenadas"
 
-#~msgid "zoom factor"
-#~msgstr "factor de zoom"
+#~ msgid "zoom factor"
+#~ msgstr "factor de zoom"
 
-#~msgid "zoom"
-#~msgstr "zoom"
+#~ msgid "zoom"
+#~ msgstr "zoom"
 
-#~msgid "latitude"
-#~msgstr "latitud"
+#~ msgid "latitude"
+#~ msgstr "latitud"
 
-#~msgid "longitude"
-#~msgstr "longitud"
+#~ msgid "longitude"
+#~ msgstr "longitud"
 
-#~msgid "degrees"
-#~msgstr "grados"
+#~ msgid "degrees"
+#~ msgstr "grados"
 
-#~msgid "radians"
-#~msgstr "radianes"
+#~ msgid "radians"
+#~ msgstr "radianes"
 
-#~msgid "define"
-#~msgstr "definir"
+#~ msgid "define"
+#~ msgstr "definir"
 
-#~msgid "bitcoin"
-#~msgstr "bitcoin"
+#~ msgid "bitcoin"
+#~ msgstr "bitcoin"
 
-#~msgid "You need to select a file."
-#~msgstr "Debe seleccionar un archivo."
+#~ msgid "You need to select a file."
+#~ msgstr "Debe seleccionar un archivo."
 
-#~msgid "show treble"
-#~msgstr "Mostrar agudos"
+#~ msgid "show treble"
+#~ msgstr "Mostrar agudos"
 
-#~msgid "hide Polar"
-#~msgstr "Ocultar Polar"
+#~ msgid "hide Polar"
+#~ msgstr "Ocultar Polar"
 
-#~msgid "show bass"
-#~msgstr "Mostrar bass"
+#~ msgid "show bass"
+#~ msgstr "Mostrar bass"
 
-#~msgid "show mezzo-soprano"
-#~msgstr "Mostrar mezzo-soprano"
+#~ msgid "show mezzo-soprano"
+#~ msgstr "Mostrar mezzo-soprano"
 
-#~msgid "show alto"
-#~msgstr "Mostrar alto"
+#~ msgid "show alto"
+#~ msgstr "Mostrar alto"
 
-#~msgid "show tenor"
-#~msgstr "Mostrar tenor"
+#~ msgid "show tenor"
+#~ msgstr "Mostrar tenor"
 
-#~msgid "hide bass"
-#~msgstr "Ocultar bass"
+#~ msgid "hide bass"
+#~ msgstr "Ocultar bass"
 
-#~msgid "show Polar"
-#~msgstr "Mostrar Polar"
+#~ msgid "show Polar"
+#~ msgstr "Mostrar Polar"
 
-#~msgid "hide Cartesian"
-#~msgstr "Ocultar Cartesiano"
+#~ msgid "hide Cartesian"
+#~ msgstr "Ocultar Cartesiano"
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr "Lilypond no puede procesar tempo de "
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr "Lilypond no puede procesar tempo de "
 
-#~msgid "Save as PDF"
-#~msgstr "Guardar como PDF"
+#~ msgid "Save as PDF"
+#~ msgstr "Guardar como PDF"
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr "Lilypond ignorando el modo."
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr "Lilypond ignorando el modo."
 
-#~msgid "ZOOM IN"
-#~msgstr "ampliar"
+#~ msgid "ZOOM IN"
+#~ msgstr "ampliar"
 
-#~msgid "ZOOM OUT"
-#~msgstr "reducir"
+#~ msgid "ZOOM OUT"
+#~ msgstr "reducir"
 
-#~msgid "Click to select a block."
-#~msgstr "Haga clic para seleccionar un bloque."
+#~ msgid "Click to select a block."
+#~ msgstr "Haga clic para seleccionar un bloque."
 
-#~msgid "hide"
-#~msgstr "ocultar"
+#~ msgid "hide"
+#~ msgstr "ocultar"
 
-#~msgid "show2"
-#~msgstr "mostrar"
+#~ msgid "show2"
+#~ msgstr "mostrar"
 
-#~msgid "popout"
-#~msgstr "emerge"
+#~ msgid "popout"
+#~ msgstr "emerge"
 
-#~msgid "myblocks"
-#~msgstr "mi bloques"
+#~ msgid "myblocks"
+#~ msgstr "mi bloques"
 
-#~msgid "Do you want to save your project?"
-#~msgstr "ÃÂ¿Quieres guardar tu proyecto?"
+#~ msgid "Do you want to save your project?"
+#~ msgstr "ÃÂ¿Quieres guardar tu proyecto?"
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr "Bloque de tambor: Quizás quiso decir utilizar un bloque de nota?"
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr "Bloque de tambor: Quizás quiso decir utilizar un bloque de nota?"
 
-#~msgid "Start Recording"
-#~msgstr "Empezar a grabar"
+#~ msgid "Start Recording"
+#~ msgstr "Empezar a grabar"
 
-#~msgid "Stop Recording"
-#~msgstr "Para de grabar"
+#~ msgid "Stop Recording"
+#~ msgstr "Para de grabar"
 
-#~msgid "save rhythms"
-#~msgstr "guardar ritmos"
+#~ msgid "save rhythms"
+#~ msgstr "guardar ritmos"
 
-#~msgid "drag"
-#~msgstr "arrastrar"
+#~ msgid "drag"
+#~ msgstr "arrastrar"
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr "Bloque de tono: Quizás quiso decir utilizar un bloque de nota?"
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr "Bloque de tono: Quizás quiso decir utilizar un bloque de nota?"
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr "El bloque Clic devuelve Verdadero si se ha hecho clic en un ratón."
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr "El bloque Clic devuelve Verdadero si se ha hecho clic en un ratón."
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr "El bloque Caja 2 devuelve el valor almacenado en caja 2."
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr "El bloque Caja 2 devuelve el valor almacenado en caja 2."
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr "El bloque Caja 1 devuelve el valor almacenado en caja 1."
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr "El bloque Caja 1 devuelve el valor almacenado en caja 1."
 
-#~msgid "Cannot be further decreased"
-#~msgstr "No se puede disminuir más"
+#~ msgid "Cannot be further decreased"
+#~ msgstr "No se puede disminuir más"
 
-#~msgid "Cannot be further increased"
-#~msgstr "No se puede aumentar más"
+#~ msgid "Cannot be further increased"
+#~ msgstr "No se puede aumentar más"
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr "Las transposiciones escalares son iguales a las transposiciones de semitono para el temperamento personalizado."
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr "Las transposiciones escalares son iguales a las transposiciones de semitono para el temperamento personalizado."
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr "Solo puedes atar notas del mismo tono. ÃÂ¿Querías usar legato?"
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr "Solo puedes atar notas del mismo tono. ÃÂ¿Querías usar legato?"
 
-#~msgid "Note name must be one of A, AÃ¢ÂÂ¯, BÃ¢ÂÂ­, B, C, CÃ¢ÂÂ¯, DÃ¢ÂÂ­, D, DÃ¢ÂÂ¯, EÃ¢ÂÂ­, E, F, FÃ¢ÂÂ¯, GÃ¢ÂÂ­, G, GÃ¢ÂÂ¯ or AÃ¢ÂÂ­."
-#~msgstr "El nombre de la nota debe ser A, AÃ¢ÂÂ¯, BÃ¢ÂÂ­, B, C, CÃ¢ÂÂ¯, DÃ¢ÂÂ­, D, DÃ¢ÂÂ¯, EÃ¢ÂÂ­, E, F, FÃ¢ÂÂ¯, GÃ¢ÂÂ­, G, GÃ¢ÂÂ¯ o AÃ¢ÂÂ­."
+#~ msgid "Note name must be one of A, AÃ¢ÂÂ¯, BÃ¢ÂÂ­, B, C, CÃ¢ÂÂ¯, DÃ¢ÂÂ­, D, DÃ¢ÂÂ¯, EÃ¢ÂÂ­, E, F, FÃ¢ÂÂ¯, GÃ¢ÂÂ­, G, GÃ¢ÂÂ¯ or AÃ¢ÂÂ­."
+#~ msgstr "El nombre de la nota debe ser A, AÃ¢ÂÂ¯, BÃ¢ÂÂ­, B, C, CÃ¢ÂÂ¯, DÃ¢ÂÂ­, D, DÃ¢ÂÂ¯, EÃ¢ÂÂ­, E, F, FÃ¢ÂÂ¯, GÃ¢ÂÂ­, G, GÃ¢ÂÂ¯ o AÃ¢ÂÂ­."
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr "Este botón abre un visor para compartir proyectos y encontrar proyectos de ejemplo."
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr "Este botón abre un visor para compartir proyectos y encontrar proyectos de ejemplo."
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr "Haga clic en este botón para expandir o contraer la barra de herramientas auxiliar."
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr "Haga clic en este botón para expandir o contraer la barra de herramientas auxiliar."
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr "El ritmo de la música está determinado por el bloque Meter (de forma predeterminada, 4 1/4 notas por compás)."
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr "El ritmo de la música está determinado por el bloque Meter (de forma predeterminada, 4 1/4 notas por compás)."
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr "El bloque Maestro de pulsaciones por minuto establece el número de 1/4 notas por minuto para cada voz."
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr "El bloque Maestro de pulsaciones por minuto establece el número de 1/4 notas por minuto para cada voz."
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr "El bloque Cada nota le permite especificar acciones para tomar en cada nota."
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr "El bloque Cada nota le permite especificar acciones para tomar en cada nota."
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr "El bloque Notas ejecutadas es el número de notas que se han reproducido."
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr "El bloque Notas ejecutadas es el número de notas que se han reproducido."
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr "El bloque Número de tono reproducirá un tono asociado por su número, por ejemplo, 0 para C y 7 para G."
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr "El bloque Número de tono reproducirá un tono asociado por su número, por ejemplo, 0 para C y 7 para G."
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr "El bloque Fijar timbre selecciona una voz para el sintetizador,"
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr "El bloque Fijar timbre selecciona una voz para el sintetizador,"
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr "El bloque Deslizante de tono abre una herramienta para generar tonos arbitrarios."
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr "El bloque Deslizante de tono abre una herramienta para generar tonos arbitrarios."
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr "Todos los bloques de inicio se ejecutan al mismo tiempo cuando se presiona el botón Reproducir."
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr "Todos los bloques de inicio se ejecutan al mismo tiempo cuando se presiona el botón Reproducir."
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr "El bloque Guardar en caja 1 se utiliza para almacenar un valor en la caja 1."
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr "El bloque Guardar en caja 1 se utiliza para almacenar un valor en la caja 1."
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr "El bloque Guardar en caja 2 se utiliza para almacenar un valor en la caja 2."
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr "El bloque Guardar en caja 2 se utiliza para almacenar un valor en la caja 2."
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr "El bloque Avatar se usa para cambiar la apariencia del mouse."
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr "El bloque Avatar se usa para cambiar la apariencia del mouse."
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr "El bloque Pickup se utiliza para acomodar cualquier nota que venga antes del tiempo."
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr "El bloque Pickup se utiliza para acomodar cualquier nota que venga antes del tiempo."
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr "El bloque de Latidas por minuto cambia las pulsaciones por minuto de cualquier nota contenida."
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr "El bloque de Latidas por minuto cambia las pulsaciones por minuto de cualquier nota contenida."
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr "El bloque Latido fuerte hacer le permite especificar acciones para tomar en latidos específicos."
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr "El bloque Latido fuerte hacer le permite especificar acciones para tomar en latidos específicos."
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr "El bloque Latido débil hacer le permite especificar las acciones que se deben tomar en los tiempos débiles (fuera de ritmo)."
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr "El bloque Latido débil hacer le permite especificar las acciones que se deben tomar en los tiempos débiles (fuera de ritmo)."
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "por ejemplo, \ "do \" es siempre \ "C-natural \"); cuando Movible do es verdadero, los nombres de las notas de solfeo se asignan a grados de escala (\ "do \" es siempre el primer grado de la escala principal)."
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "por ejemplo, \"do\" es siempre \"C-natural\"; cuando Movible do es verdadero, los nombres de las notas de solfeo se asignan a grados de escala (\"do\" es siempre el primer grado de la escala principal)."
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr "El bloque Volumen de notas devuelve el volumen actual del sintetizador actual."
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr "El bloque Volumen de notas devuelve el volumen actual del sintetizador actual."
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr "El bloque Default se usa dentro de un interruptor para definir una acción predeterminada."
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr "El bloque Default se usa dentro de un interruptor para definir una acción predeterminada."
 
-#~msgid "set timbre"
-#~msgstr "fijar timbre"
+#~ msgid "set timbre"
+#~ msgstr "fijar timbre"
 
-#~msgid "down minor"
-#~msgstr "menor abajo"
+#~ msgid "down minor"
+#~ msgstr "menor abajo"
 
-#~msgid "down major"
-#~msgstr "mayor abajo"
+#~ msgid "down major"
+#~ msgstr "mayor abajo"
 
-#~msgid "eval"
-#~msgstr "evaluar"
+#~ msgid "eval"
+#~ msgstr "evaluar"
 
-#~msgid "right2"
-#~msgstr "dereche"
+#~ msgid "right2"
+#~ msgstr "dereche"
 
-#~msgid "left2"
-#~msgstr "izquierda"
+#~ msgid "left2"
+#~ msgstr "izquierda"
 
-#~msgid "Drag"
-#~msgstr "Arrastrar"
+#~ msgid "Drag"
+#~ msgstr "Arrastrar"
 
-#~msgid "playback music"
-#~msgstr "reproducir la música"
+#~ msgid "playback music"
+#~ msgstr "reproducir la música"
 
-#~msgid "pause playback"
-#~msgstr "pausar la reproducción"
+#~ msgid "pause playback"
+#~ msgstr "pausar la reproducción"
 
-#~msgid "restart playback"
-#~msgstr "reiniciar la reproducción"
+#~ msgid "restart playback"
+#~ msgstr "reiniciar la reproducción"
 
-#~msgid "prepare music for playback"
-#~msgstr "preparar música para la reproducción"
+#~ msgid "prepare music for playback"
+#~ msgstr "preparar música para la reproducción"
 
-#~msgid "expand"
-#~msgstr "expandir"
+#~ msgid "expand"
+#~ msgstr "expandir"
 
-#~msgid "collapse"
-#~msgstr "colapso"
+#~ msgid "collapse"
+#~ msgstr "colapso"
 
-#~msgid "Current Interval"
-#~msgstr "intervalo actual"
+#~ msgid "Current Interval"
+#~ msgstr "intervalo actual"
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -2214,7 +2214,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2281,7 +2281,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2295,33 +2295,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2343,7 +2343,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2650,8 +2650,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2820,14 +2820,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2858,7 +2858,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2883,7 +2883,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2892,7 +2892,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2913,7 +2913,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2931,8 +2931,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3034,7 +3034,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3168,14 +3168,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3250,7 +3250,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3286,7 +3286,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3295,7 +3295,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3786,7 +3786,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3798,8 +3798,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3809,7 +3809,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3821,8 +3821,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3832,15 +3832,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3849,14 +3849,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3865,14 +3865,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3922,7 +3922,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3939,7 +3939,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4008,8 +4008,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4031,7 +4031,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4317,7 +4317,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4648,21 +4648,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4671,12 +4671,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4689,62 +4689,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4757,7 +4757,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4766,7 +4766,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4779,7 +4779,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4788,17 +4788,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4807,12 +4807,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4825,7 +4825,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4834,17 +4834,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4861,56 +4861,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4926,7 +4926,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4935,7 +4935,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4943,7 +4943,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4952,8 +4952,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4961,7 +4961,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4975,116 +4975,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5103,19 +5103,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5123,61 +5123,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5187,149 +5187,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5338,7 +5338,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5417,22 +5417,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5589,7 +5589,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5611,7 +5611,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5622,7 +5622,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5651,7 +5651,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5660,7 +5660,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5693,7 +5693,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5703,7 +5703,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5712,7 +5712,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5721,7 +5721,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5744,13 +5744,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5759,7 +5759,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5768,7 +5768,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5788,7 +5788,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5813,7 +5813,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5827,7 +5827,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5837,7 +5837,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5875,7 +5875,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5884,7 +5884,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5897,18 +5897,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6029,7 +6029,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6048,7 +6048,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6057,7 +6057,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6074,7 +6074,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6087,7 +6087,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6116,7 +6116,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6139,7 +6139,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6156,7 +6156,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6165,7 +6165,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6182,7 +6182,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6191,7 +6191,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6225,7 +6225,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6251,7 +6251,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6266,7 +6266,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6300,12 +6300,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6314,12 +6314,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6328,13 +6328,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6352,7 +6352,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6384,8 +6384,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6441,7 +6441,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6598,12 +6598,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6613,8 +6613,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6622,12 +6622,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6636,7 +6636,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6653,7 +6653,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6663,12 +6663,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6678,7 +6678,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6687,7 +6687,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6737,7 +6737,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6770,7 +6770,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6779,12 +6779,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6793,7 +6793,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6802,7 +6802,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6811,7 +6811,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6822,8 +6822,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6833,7 +6833,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6859,7 +6859,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6897,12 +6897,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6914,12 +6914,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6928,7 +6928,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6974,22 +6974,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6998,7 +6998,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7011,7 +7011,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7020,47 +7020,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7073,7 +7073,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7082,7 +7082,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7090,7 +7090,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7104,8 +7104,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7134,7 +7134,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7159,14 +7159,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7176,7 +7176,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7195,7 +7195,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7205,7 +7205,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7222,17 +7222,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7241,7 +7241,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7251,7 +7251,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7261,7 +7261,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7273,7 +7273,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7281,7 +7281,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7291,7 +7291,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7312,7 +7312,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7327,7 +7327,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7337,7 +7337,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7351,7 +7351,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7407,7 +7407,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7585,7 +7585,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7594,7 +7594,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7603,7 +7603,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7612,7 +7612,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7622,13 +7622,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7641,7 +7641,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7650,7 +7650,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7659,7 +7659,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7668,7 +7668,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7677,7 +7677,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7686,7 +7686,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7695,7 +7695,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7704,7 +7704,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7714,17 +7714,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7733,7 +7733,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8160,7 +8160,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8170,7 +8170,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8214,12 +8214,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8228,7 +8228,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8285,7 +8285,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8303,7 +8303,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8316,7 +8316,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8381,7 +8381,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8446,7 +8446,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8455,12 +8455,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8469,7 +8469,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8478,7 +8478,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8487,7 +8487,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8512,7 +8512,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8647,27 +8647,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8693,18 +8693,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8719,7 +8719,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8740,7 +8740,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8757,7 +8757,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8770,7 +8770,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8780,7 +8780,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8794,7 +8794,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8815,7 +8815,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8829,7 +8829,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9016,7 +9016,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9025,7 +9025,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9147,7 +9147,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9230,7 +9230,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9280,7 +9280,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9397,7 +9397,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9476,48 +9476,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9950,38 +9950,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9989,8 +9989,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10000,8 +10000,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10013,35 +10013,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10055,69 +10055,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10137,13 +10137,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10151,58 +10151,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10218,25 +10218,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10246,43 +10246,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10292,190 +10292,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10485,305 +10485,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10793,97 +10793,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10893,144 +10893,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11040,15 +11040,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11058,23 +11058,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11084,8 +11084,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11093,224 +11093,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11326,37 +11326,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11364,28 +11364,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11399,8 +11399,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11410,65 +11410,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11476,8 +11476,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11487,127 +11487,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11615,608 +11615,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12226,165 +12226,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12398,28 +12398,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12427,133 +12427,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12561,136 +12561,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12700,127 +12700,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12828,397 +12828,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13230,196 +13230,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13427,155 +13427,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13583,257 +13583,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13847,223 +13847,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14073,144 +14073,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14218,57 +14218,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14278,30 +14278,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14309,112 +14309,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14422,287 +14422,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14710,13 +14710,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14724,86 +14724,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/ff.po
+++ b/po/ff.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "kynä ylös"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "kynä alas"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "aseta kynän koko"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Puhdas"
+#~ msgid "Clean"
+#~ msgstr "Puhdas"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "Kilpikonna"
+#~ msgid "turtle"
+#~ msgstr "Kilpikonna"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/fil.po
+++ b/po/fil.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -14,10 +14,10 @@ msgstr ""
 "X-Generator: Pootle 2.5.1.1\n"
 "X-POOTLE-MTIME: 1423841876.000000\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -112,7 +112,7 @@ msgstr "action"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr "cane"
 
@@ -179,7 +179,7 @@ msgstr "Cacher"
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "Mon projet"
 
@@ -193,33 +193,33 @@ msgid "Your recording is in progress."
 msgstr "Votre enregistrement est en cours."
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
-msgstr "om de fichier""
+msgstr "om de fichier"
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "Titre du projet"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "Auteur du projet"
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "Inclure une sortie MIDI ?"
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "Inclure la sortie de tablature de guitare ?"
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "Enregistrer sous Lilypond"
 
@@ -241,7 +241,7 @@ msgstr "Enregistrer sous Lilypond"
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "Monsieur Souris"
 
@@ -319,7 +319,7 @@ msgstr "montrer cartésien"
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr "degré d'échelle"
 
@@ -548,8 +548,8 @@ msgstr "Enregistrer l'aide au bloc"
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "ti la sol fa mi ré do"
 
@@ -707,7 +707,7 @@ msgstr "règle"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "timbre"
 
@@ -717,14 +717,14 @@ msgstr "escalier"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "tempo"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "mode"
 
@@ -755,7 +755,7 @@ msgstr "tambour"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "créateur de rythme"
 
@@ -780,7 +780,7 @@ msgstr "créateur de rythme"
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "valeur de la note"
 
@@ -789,7 +789,7 @@ msgstr "valeur de la note"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "intervalle scalaire"
 
@@ -810,7 +810,7 @@ msgid "silence"
 msgstr "silence"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "bas"
 
@@ -828,8 +828,8 @@ msgstr "haut"
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "hauteur"
 
@@ -931,7 +931,7 @@ msgstr "ténor"
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "basse"
 
@@ -1065,14 +1065,14 @@ msgstr "Aucun bloc n'est sélectionné."
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "avatar"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "échantillon"
 
@@ -1147,7 +1147,7 @@ msgstr "démarrer le tambour"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "rythme"
 
@@ -1183,7 +1183,7 @@ msgstr "flux"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr "Capteurs"
 
@@ -1192,7 +1192,7 @@ msgstr "Capteurs"
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr "Médias"
 
@@ -1683,7 +1683,7 @@ msgstr "La lecture est prête."
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "double dièse"
 
@@ -1695,8 +1695,8 @@ msgstr "double dièse"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "dièse"
 
@@ -1706,7 +1706,7 @@ msgstr "dièse"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "naturel"
 
@@ -1718,8 +1718,8 @@ msgstr "naturel"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "bémol"
 
@@ -1729,15 +1729,15 @@ msgstr "bémol"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "double bémol"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr "unisson"
 
@@ -1746,14 +1746,14 @@ msgstr "unisson"
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "majeur"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr "ionien"
 
@@ -1762,14 +1762,14 @@ msgstr "ionien"
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "mineur"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr "éolien"
 
@@ -1810,7 +1810,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr "Vous avez choisi la clé pour votre aperçu de hauteur."
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "Vous devez avoir au moins un bloc partiel à l'intérieur d'un bloc partiel pondéré"
 
@@ -1819,7 +1819,7 @@ msgid "synth cannot play chords."
 msgstr "le synthé ne peut pas jouer d'accords."
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr "URL du guide"
 
@@ -1836,7 +1836,7 @@ msgstr "recherche"
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "métrique"
 
@@ -1905,8 +1905,8 @@ msgstr "extras"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "programme"
 
@@ -1928,7 +1928,7 @@ msgstr "logique"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr "Musique"
 
@@ -2214,7 +2214,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr "Effacer"
 
@@ -2545,21 +2545,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr "Septième diminuée, plus une octave"
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "1er 2e 3e 4e 5e 6e 7e 8e 9e 10e 11e 12e"
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "augmenté"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "diminué"
 
@@ -2568,12 +2568,12 @@ msgstr "diminué"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "parfait"
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "chromatique"
 
@@ -2586,62 +2586,62 @@ msgid "spanish"
 msgstr "espagnol"
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr "octatonique"
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "majeur harmonique"
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "mineur naturel"
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "mineur harmonique"
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "mineur mélodique"
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr "dorien"
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr "phrygien"
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr "lydien"
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "mixolydien"
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr "locrien"
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "mineur jazz"
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr "bebop"
 
@@ -2654,7 +2654,7 @@ msgid "byzantine"
 msgstr "byzantin"
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "énigmatique"
 
@@ -2663,7 +2663,7 @@ msgid "ethiopian"
 msgstr "éthiopien"
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "geez"
 
@@ -2676,7 +2676,7 @@ msgid "hungarian"
 msgstr "hongrois"
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "mineur roumain"
 
@@ -2685,17 +2685,17 @@ msgid "spanish gypsy"
 msgstr "gitan espagnol"
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "maqam"
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "blues mineur"
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr "blues majeur"
 
@@ -2704,12 +2704,12 @@ msgid "whole tone"
 msgstr "ton entier"
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "pentatonique mineur"
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "pentatonique majeur"
 
@@ -2722,7 +2722,7 @@ msgid "egyptian"
 msgstr "égyptien"
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "hirajoshi"
 
@@ -2731,17 +2731,17 @@ msgid "Japan"
 msgstr "Japon"
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "in"
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "minyo"
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "fibonacci"
 
@@ -2758,56 +2758,56 @@ msgstr "fibonacci"
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr "personnalisé"
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr "passe-haut"
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr "passe-bas"
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr "passe-bande"
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr "étagère haute"
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr "étagère basse"
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr "notch"
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr "passe-tout"
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr "crête"
 
@@ -2815,7 +2815,7 @@ msgstr "crête"
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "sinusoïde"
 
@@ -2823,7 +2823,7 @@ msgstr "sinusoïde"
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "carré"
 
@@ -2832,7 +2832,7 @@ msgstr "carré"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "triangle"
 
@@ -2840,7 +2840,7 @@ msgstr "triangle"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "dent de scie"
 
@@ -2849,8 +2849,8 @@ msgstr "dent de scie"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr "pair"
 
@@ -2858,7 +2858,7 @@ msgstr "pair"
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr "impair"
 
@@ -2872,116 +2872,116 @@ msgstr "scalair"
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr "piano"
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr "violon"
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr "alto"
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "xylophone"
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "vibraphone"
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr "violoncelle"
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr "contrebasse"
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr "guitare"
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr "guitare acoustique"
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr "flûte"
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr "clarinette"
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr "saxophone"
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr "tuba"
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr "trompette"
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr "hautbois"
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr "trombone"
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr "synthétiseur électronique"
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "simple 1"
 
@@ -3000,19 +3000,19 @@ msgstr "simple 4"
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr "bruit blanc"
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "bruit brun"
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "bruit rose"
 
@@ -3020,61 +3020,61 @@ msgstr "bruit rose"
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr "caisse claire"
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr "grosse caisse"
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr "tom-tom"
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr "tom de sol"
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr "grosse caisse"
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "tambour en coupe"
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr "darbouka"
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr "charleston"
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr "cloche ride"
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr "cloche de vache"
 
@@ -3084,149 +3084,149 @@ msgstr "tambour japonais"
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr "cloche japonaise"
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr "triangle"
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr "cymbalettes"
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "carillon"
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr "gong"
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr "cliquetis"
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr "crash"
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr "bouteille"
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr "claquement"
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr "claque"
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr "éclaboussure"
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr "bulles"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr "goutte de pluie"
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr "chat"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr "grillon"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr "chien"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr "banjo"
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr "koto"
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr "dulcimer"
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr "guitare électrique"
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr "basson"
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr "célesta"
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr "égal"
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "Pythagoricien"
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr "intonation juste"
 
@@ -3235,7 +3235,7 @@ msgstr "intonation juste"
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr "Meantone"
 
@@ -3314,22 +3314,22 @@ msgid "previous"
 msgstr "précédent"
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "simple-2"
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "simple-3"
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "simple-4"
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr "taiko"
 
@@ -3486,7 +3486,7 @@ msgstr "Le bloc Get-dict renvoie une valeur dans le dictionnaire pour une clé s
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "obtenir la valeur"
 
@@ -3508,7 +3508,7 @@ msgstr "clé2"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "clé"
 
@@ -3519,7 +3519,7 @@ msgstr "Le bloc Set-dict définit une valeur dans le dictionnaire pour une clé 
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr "définir la valeur"
 
@@ -3548,7 +3548,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr "Remplacer chaque instance d'une hauteur par un son de tambour."
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "mapper la hauteur au tambour"
 
@@ -3557,7 +3557,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "Dans l'exemple ci-dessus, un son de grosse caisse sera joué à la place de sol."
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "définir le tambour"
 
@@ -3590,7 +3590,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "Le bloc Heap-empty? renvoie true si le tas est vide."
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "tas vide?"
 
@@ -3600,7 +3600,7 @@ msgstr "Le bloc Empty-heap vide le tas."
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "vider le tas"
 
@@ -3609,7 +3609,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr "Le bloc Reverse-heap inverse l'ordre du tas."
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr "inverser le tas"
 
@@ -3618,7 +3618,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr "Le bloc Index-heap renvoie une valeur dans le tas à un emplacement spécifié."
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "indexer le tas"
 
@@ -3641,13 +3641,13 @@ msgstr "Le bloc Set-heap entry définit une valeur dans le tas à l'emplacement 
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "définir le tas"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "index"
 
@@ -3656,7 +3656,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr "Le bloc Pop supprime la valeur en haut du tas."
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "dépiler"
 
@@ -3665,7 +3665,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr "Le bloc Push ajoute une valeur en haut du tas."
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "empiler"
 
@@ -3685,7 +3685,7 @@ msgstr "définir le tempérament"
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "octave"
 
@@ -3710,7 +3710,7 @@ msgid "current interval"
 msgstr "intervalle actuel"
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr "mesure de l'intervalle en demi-tons"
 
@@ -3724,7 +3724,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr "Le bloc d'intervalle scalaire mesure la distance entre deux notes dans la tonalité et le mode actuels."
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr "mesure d'intervalle scalaire"
 
@@ -3734,7 +3734,7 @@ msgstr "Dans la figure, nous ajoutons sol# à sol."
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr "intervalle de demi-ton"
 
@@ -3772,7 +3772,7 @@ msgid "In the figure, we add la to sol."
 msgstr "Dans la figure, nous ajoutons la à sol."
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr "définir un mode"
 
@@ -3781,7 +3781,7 @@ msgid "movable Do"
 msgstr "Do mobile"
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "longueur du mode"
 
@@ -3794,18 +3794,18 @@ msgid "Most Western scales have 7 notes."
 msgstr "La plupart des échelles occidentales ont 7 notes."
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "mode actuel"
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr "tonalité actuelle"
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "définir la tonalité"
 
@@ -3926,7 +3926,7 @@ msgstr "facteur de liaison"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr "voisin"
 
@@ -3945,7 +3945,7 @@ msgstr "liaison"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "staccato"
 
@@ -3954,7 +3954,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr "Le bloc Charger-heap-de-l'application charge le tas depuis une page web."
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr "charger le tas depuis l'application"
 
@@ -3971,7 +3971,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr "Le bloc Enregistrer-le-tas-dans-l'application enregistre le tas dans une page web."
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr "enregistrer le tas dans l'application"
 
@@ -3984,7 +3984,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr "Le bloc Charger-le-tas charge le tas depuis un fichier."
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "charger le tas"
 
@@ -4013,7 +4013,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr "Le bloc Charger le dictionnaire charge un dictionnaire à partir d'un fichier."
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "charger le dictionnaire"
 
@@ -4036,7 +4036,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr "Le bloc Définir le dictionnaire charge un dictionnaire."
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr "définir le dictionnaire"
 
@@ -4053,7 +4053,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr "Le bloc Sauvegarder le tas sauvegarde le tas dans un fichier."
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "sauvegarder le tas"
 
@@ -4062,7 +4062,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr "Le bloc Sauvegarder le dictionnaire sauvegarde un dictionnaire dans un fichier."
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr "sauvegarder le dictionnaire"
 
@@ -4079,7 +4079,7 @@ msgid "The Delete block block removes a block."
 msgstr "Le bloc Supprimer le bloc supprime un bloc."
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr "supprimer le bloc"
 
@@ -4088,7 +4088,7 @@ msgid "The Move block block moves a block."
 msgstr "Le bloc Déplacer le bloc déplace un bloc."
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr "déplacer le bloc"
 
@@ -4122,7 +4122,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr "exécuter le bloc"
 
@@ -4131,7 +4131,7 @@ msgid "The Dock block block connections two blocks."
 msgstr "Le bloc Dock connecte deux blocs."
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr "connecter les blocs"
 
@@ -4148,7 +4148,7 @@ msgid "The Make block block creates a new block."
 msgstr "Le bloc Créer un bloc crée un nouveau bloc."
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr "créer un bloc"
 
@@ -4163,7 +4163,7 @@ msgstr "créer un bloc"
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "note"
 
@@ -4197,12 +4197,12 @@ msgstr "La valeur de la note doit être supérieure à 0."
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "swing"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "valeur du swing"
 
@@ -4211,12 +4211,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr "Le bloc Sauter des notes fera que des notes seront sautées."
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "sauter des notes"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "multiplier la valeur de la note"
 
@@ -4225,13 +4225,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr "Le bloc Lier fonctionne sur des paires de notes, les combinant en une seule note."
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "lier"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "point"
 
@@ -4249,7 +4249,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr "Par exemple, une noire pointée jouera pendant 3/8 (1/4 + 1/8) d'un temps."
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr "valeur de note pour tambour"
 
@@ -4281,8 +4281,8 @@ msgstr "espace d'octave"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "rythme1"
 
@@ -4338,7 +4338,7 @@ msgstr "ronde"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "tuplet"
 
@@ -4495,12 +4495,12 @@ msgid "duplicate factor"
 msgstr "facteur de"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr "métrique actuelle"
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "facteur de battement"
 
@@ -4510,8 +4510,8 @@ msgstr "Le bloc Battements par minute renvoie le nombre actuel de battements par
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "battements par minute2"
 
@@ -4519,12 +4519,12 @@ msgstr "battements par minute2"
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "battements par minute"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr "compte des mesures"
 
@@ -4533,7 +4533,7 @@ msgid "The Measure count block returns the current measure."
 msgstr "Le bloc Compte des mesures renvoie la mesure actuelle."
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr "compte des battements"
 
@@ -4550,7 +4550,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr "par exemple 1, 2, 3 ou 4."
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr "somme des valeurs de notes"
 
@@ -4560,12 +4560,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr "Le bloc Compteur de notes peut être utilisé pour compter le nombre de notes contenues."
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr "compteur de notes"
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr "notes entières jouées"
 
@@ -4575,7 +4575,7 @@ msgstr "Le bloc Notes entières jouées renvoie le nombre total de notes entièr
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr "notes jouées"
 
@@ -4584,7 +4584,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr "Le bloc Pas d'horloge découple les notes de l'horloge principale."
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "pas d'horloge"
 
@@ -4634,7 +4634,7 @@ msgstr "Le bloc Sur chaque note vous permet de spécifier des actions à effectu
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr "battements par minute maître"
 
@@ -4667,7 +4667,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr "Le bloc Battements par minute définit le nombre de notes de 1/4 par minute."
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr "levée"
 
@@ -4676,12 +4676,12 @@ msgid "number of beats"
 msgstr "nombre de battements"
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "transposition"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr "descente scalaire"
 
@@ -4690,7 +4690,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr "Le bloc Descente scalaire renvoie le nombre de demi-tons vers la note précédente dans la tonalité et le mode actuels."
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr "montée scalaire"
 
@@ -4699,7 +4699,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr "Le bloc Montée scalaire renvoie le nombre de demi-tons vers la note suivante dans la tonalité et le mode actuels."
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr "changement de hauteur"
 
@@ -4708,7 +4708,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr "Le bloc Changement de hauteur est la différence (en demi-tons) entre la hauteur actuelle jouée et la hauteur précédente jouée."
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr "changement scalaire de hauteur"
 
@@ -4719,8 +4719,8 @@ msgstr "changement scalaire de hauteur"
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr "numéro de hauteur"
 
@@ -4730,7 +4730,7 @@ msgstr "Le bloc Numéro de hauteur est la valeur de la hauteur de la note actuel
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr "hauteur en hertz"
 
@@ -4756,7 +4756,7 @@ msgid "alphabet"
 msgstr "alphabet"
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr "classe de lettres"
 
@@ -4794,12 +4794,12 @@ msgstr "hauteur à couleur"
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr "MIDI"
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr "fixer le décalage du numéro de hauteur"
 
@@ -4811,12 +4811,12 @@ msgstr "Le bloc Fixer le décalage du numéro de hauteur est utilisé pour défi
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "nom2"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "numéro à hauteur"
 
@@ -4825,7 +4825,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "numéro à octave"
 
@@ -4871,22 +4871,22 @@ msgstr "Le bloc Inverser fait pivoter toutes les notes contenues autour d'une no
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr "Inverser"
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "inverser (impair)"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "inverser (pair)"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr "registre"
 
@@ -4895,7 +4895,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr "Le bloc Registre offre un moyen facile de modifier le registre (octave) des notes qui le suivent."
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr "50 cents"
 
@@ -4908,7 +4908,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr "Dans l'exemple montré ci-dessus, sol est déplacé vers sol#."
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr "transposer en demi-ton"
 
@@ -4917,47 +4917,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr "Le bloc Transposer par ratio déplacera les hauteurs contenues dans les blocs de note vers le haut (ou vers le bas) par un ratio"
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr "transposer par ratio"
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr "sixte descendante"
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr "tierce descendante"
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr "septième"
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr "sixte"
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr "quinte"
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr "quarte"
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr "tierce"
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr "seconde"
 
@@ -4970,7 +4970,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr "Dans l'exemple ci-dessus, sol est déplacé vers le haut à la."
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr "transposition scalaire"
 
@@ -4979,7 +4979,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr "Le bloc Accidentel est utilisé pour créer des dièses et des bémols"
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr "remplacement accidentel"
 
@@ -4987,7 +4987,7 @@ msgstr "remplacement accidentel"
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr "hertz"
 
@@ -5001,8 +5001,8 @@ msgstr "Le bloc Numéro de hauteur jouera une hauteur associée par son numéro,
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr "nième hauteur modale"
 
@@ -5031,7 +5031,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr "Le degré de l'échelle 1 est toujours la première hauteur dans une échelle donnée, quelle que soit l'octave."
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr "pas scalaire"
 
@@ -5056,14 +5056,14 @@ msgstr "Oscillateur"
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr "type"
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr "partiels"
 
@@ -5073,7 +5073,7 @@ msgstr "Vous ajoutez plusieurs blocs d'oscillateur."
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr "synthé duo"
 
@@ -5092,7 +5092,7 @@ msgstr "intensité du vibrato"
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr "synthé AM"
 
@@ -5102,7 +5102,7 @@ msgstr "Le bloc Synthé AM est un modulateur d'amplitude utilisé pour définir 
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr "synthé FM"
 
@@ -5119,17 +5119,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr "Le bloc Partiel est utilisé pour spécifier un poids pour un harmonique partiel spécifique."
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr "Le poids partiel doit être compris entre 0 et 1."
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr "Le bloc Partiel doit être utilisé à l'intérieur d'un bloc Partiels pondérés."
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr "partiels pondérés"
 
@@ -5138,7 +5138,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr "Le bloc Harmonique ajoutera des harmoniques aux notes contenues."
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr "harmonique"
 
@@ -5148,7 +5148,7 @@ msgstr "Le bloc Distorsion ajoute de la distorsion à la hauteur."
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr "distorsion"
 
@@ -5158,7 +5158,7 @@ msgstr "Le bloc Tremolo ajoute un effet de tremblement."
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr "tremolo"
 
@@ -5170,7 +5170,7 @@ msgstr "tremolo"
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr "taux"
 
@@ -5178,7 +5178,7 @@ msgstr "taux"
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr "profondeur"
 
@@ -5188,7 +5188,7 @@ msgstr "Le bloc Phaser ajoute un son de balayage."
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr "phaser"
 
@@ -5209,7 +5209,7 @@ msgstr "Le bloc Chorus ajoute un effet de chœur."
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr "chœur"
 
@@ -5224,7 +5224,7 @@ msgstr "Le bloc Vibrato ajoute une variation rapide et légère de la hauteur."
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr "vibrato"
 
@@ -5234,7 +5234,7 @@ msgid "intensity"
 msgstr "intensité"
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr "définir le synthé"
 
@@ -5248,7 +5248,7 @@ msgstr "définir l'instrument par défaut"
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr "définir l'instrument"
 
@@ -5304,7 +5304,7 @@ msgstr "calculer"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr "Le bloc Faire est utilisé pour initier une action."
 
@@ -5482,7 +5482,7 @@ msgid "Cannot find start block"
 msgstr "Impossible de trouver le bloc de démarrage"
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "couleur de la souris"
 
@@ -5491,7 +5491,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr "Le bloc Couleur de la souris renvoie la couleur du stylo de la souris spécifiée."
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "couleur de la tortue"
 
@@ -5500,7 +5500,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr "Le bloc Couleur de la tortue renvoie la couleur du stylo de la tortue spécifiée."
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "direction de la souris"
 
@@ -5509,7 +5509,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr "Le bloc Direction de la souris renvoie la direction de la souris spécifiée."
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "direction de la tortue"
 
@@ -5519,13 +5519,13 @@ msgstr "Le bloc Direction de la tortue renvoie la direction de la tortue spécif
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr "régler la souris"
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr "régler la tortue"
 
@@ -5538,7 +5538,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr "Le bloc Régler la tortue envoie une pile de blocs à exécuter par la tortue spécifiée."
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "souris y"
 
@@ -5547,7 +5547,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr "Le bloc Y souris renvoie la position Y de la souris spécifiée."
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "tortue y"
 
@@ -5556,7 +5556,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr "Le bloc Y tortue renvoie la position Y de la tortue spécifiée."
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "souris x"
 
@@ -5565,7 +5565,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr "Le bloc X souris renvoie la position X de la souris spécifiée."
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "tortue x"
 
@@ -5574,7 +5574,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr "Le bloc X tortue renvoie la position X de la tortue spécifiée."
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "notes jouées par la souris"
 
@@ -5583,7 +5583,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr "Le bloc Notes jouées par la souris renvoie le nombre de notes jouées par la souris spécifiée."
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "notes jouées par la tortue"
 
@@ -5592,7 +5592,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr "Le bloc Notes de la tortue renvoie le nombre de notes jouées par la tortue spécifiée."
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "numéro de hauteur de la souris"
 
@@ -5601,7 +5601,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr "Le bloc Hauteur de la souris renvoie le numéro de hauteur actuellement joué par la souris spécifiée."
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "numéro de hauteur de la tortue"
 
@@ -5611,17 +5611,17 @@ msgstr "Le bloc Hauteur de la tortue renvoie le numéro de hauteur actuellement 
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr "valeur de note de la souris"
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "valeur de note de la tortue"
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "synchronisation de la souris"
 
@@ -5630,7 +5630,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "Le bloc Synchronisation de la souris aligne le compte des battements entre les souris."
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "synchronisation de la tortue"
 
@@ -6057,7 +6057,7 @@ msgid "wrap"
 msgstr "envelopper"
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr "droite (écran)"
 
@@ -6067,7 +6067,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr "Le bloc Droite renvoie la position de la droite de la toile."
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "gauche (écran)"
 
@@ -6111,12 +6111,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr "Le bloc Hauteur renvoie la hauteur de la toile."
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "arrêter la lecture"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr "effacer les médias"
 
@@ -6125,7 +6125,7 @@ msgid "The Erase Media block erases text and images."
 msgstr "Le bloc Effacer les médias efface le texte et les images."
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "lecture"
 
@@ -6182,7 +6182,7 @@ msgid "duration (MS)"
 msgstr "durée (MS)"
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "note en fréquence"
 
@@ -6200,7 +6200,7 @@ msgstr "Le bloc Avatar est utilisé pour changer l'apparence de la tortue."
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "taille"
 
@@ -6213,7 +6213,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr "Le bloc Afficher est utilisé pour afficher du texte ou des images sur la toile."
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "afficher1"
 
@@ -6278,7 +6278,7 @@ msgstr "arrête le remplissage"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "le fond"
 
@@ -6343,7 +6343,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr "Le bloc Ligne creuse crée une ligne avec un centre creux."
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "ligne creuse"
 
@@ -6352,12 +6352,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr "Le bloc Remplissage remplit une forme avec une couleur."
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "remplir"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "crayon levé"
 
@@ -6366,7 +6366,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "Le bloc Crayon levé soulève le crayon pour qu'il ne dessine pas."
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "crayon abaissé"
 
@@ -6375,7 +6375,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "Le bloc Crayon abaissé abaisse le crayon pour qu'il dessine."
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "fixe l'épaisseur du crayon"
 
@@ -6384,7 +6384,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr "Le bloc Définir la taille du crayon change la taille du crayon."
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "définir la translucidité"
 
@@ -6409,7 +6409,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr "Le bloc Définir l'ombre change la couleur du crayon du foncé au clair."
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "fixer gris"
 
@@ -6544,27 +6544,27 @@ msgstr "Le bloc Clavier renvoie l'entrée du clavier de l'ordinateur."
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr "Enveloppe"
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "attaque"
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "décroissance"
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "soutien"
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "relâchement"
 
@@ -6590,18 +6590,18 @@ msgstr "Vous ajoutez plusieurs blocs d'enveloppe."
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr "Filtre"
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr "décroissance"
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr "La valeur de décroissance doit être de -12, -24, -48 ou -96 décibels/octave."
 
@@ -6616,7 +6616,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr "Téléchargez un échantillon et ajustez son centre de hauteur."
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "échantillonneur"
 
@@ -6637,7 +6637,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr "Le bloc Mode personnalisé ouvre un outil pour explorer le mode"
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "mode personnalisé"
 
@@ -6654,7 +6654,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr "La matrice de tambour de hauteur est utilisée pour mapper les hauteurs aux sons de tambour."
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "mappeur de tambour de hauteur"
 
@@ -6667,7 +6667,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr "L'outil de curseur de hauteur est utilisé pour générer des hauteurs à des fréquences sélectionnées."
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "curseur de hauteur"
 
@@ -6677,7 +6677,7 @@ msgstr "clavier chromatique"
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr "clavier de musique"
 
@@ -6691,7 +6691,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr "L'outil d'escalier de hauteur est utilisé pour générer des hauteurs à partir d'un rapport donné."
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "escalier de hauteur"
 
@@ -6712,7 +6712,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr "Le bloc Créateur de phrases ouvre un outil pour créer des phrases musicales."
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "créateur de phrases"
 
@@ -6726,7 +6726,7 @@ msgstr "Le bloc Statut ouvre un outil pour inspecter le statut de Music Blocks e
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr "Musique IA"
 
@@ -6913,7 +6913,7 @@ msgstr "La vitesse du vibrato doit être supérieure à 0."
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr "La profondeur est hors de portée."
 
@@ -6922,7 +6922,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr "La distorsion doit être comprise entre 0 et 100."
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr "La composante partielle doit être supérieure ou égale à 0."
 
@@ -7044,7 +7044,7 @@ msgid "Undo"
 msgstr "Annuler"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr "Cliquez dans le cercle pour sélectionner les notes pour le mode."
 
@@ -7127,7 +7127,7 @@ msgid "Save drum machine"
 msgstr "Enregistrer la boîte à rythmes"
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr "Tapoter un rythme"
 
@@ -7177,7 +7177,7 @@ msgid "Playback"
 msgstr "Lecture"
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr "ton de référence"
 
@@ -7294,7 +7294,7 @@ msgstr "Synthétiseur"
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr "Effets"
 
@@ -7373,48 +7373,48 @@ msgid "Cannot connect to server"
 msgstr "Impossible de se connecter au serveur"
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr "Tous les projets"
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr "Mes projets"
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr "Exemples"
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr "Art"
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr "Mathématiques"
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr "Interactif"
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr "Conception"
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr "Jeu"
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr "Extrait de code"
 
@@ -7847,43 +7847,43 @@ msgstr "mouvement"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr "Rien dans la corbeille à restaurer."
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr "Rien dans la corbeille à restaurer."
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr "Enregistrer l'audio de votre projet en tant que WAV."
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr "Enregistrer l'audio de votre projet en tant que WAV."
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr "Enregistrez votre projet en tant que fichier ABC."
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr "Enregistrez votre projet en tant que fichier ABC."
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "Enregistrez votre projet en tant que fichier Lilypond."
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "Enregistrez votre projet en tant que fichier Lilypond."
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr "Afficher ou masquer une grille de coordonnées."
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr "Afficher ou masquer une grille de coordonnées."
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr "Développer/réduire les blocs rétractables"
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr "Développer/réduire les blocs rétractables"
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "Afficher ces messages."
+#~ msgid "Show these messages."
+#~ msgstr "Afficher ces messages."
 
 #: js/blocks/PitchBlocks.js:682
 
-#~msgid "The Number to pitch block will convert a pitch number to a pitch name."
-#~msgstr "Le bloc Numéro à hauteur convertira un numéro de hauteur en un nom de hauteur."
+#~ msgid "The Number to pitch block will convert a pitch number to a pitch name."
+#~ msgstr "Le bloc Numéro à hauteur convertira un numéro de hauteur en un nom de hauteur."
 
 #: js/rubrics.js:531
 
@@ -7891,8 +7891,8 @@ msgstr "mouvement"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "capteurs"
+#~ msgid "sensors"
+#~ msgstr "capteurs"
 
 #: js/rubrics.js:532
 
@@ -7902,8 +7902,8 @@ msgstr "mouvement"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "média"
+#~ msgid "media"
+#~ msgstr "média"
 
 #: js/block-verbose.js:3837
 
@@ -7915,35 +7915,35 @@ msgstr "mouvement"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr "Cartésien+polaires"
+#~ msgid "Cartesian+polar"
+#~ msgstr "Cartésien+polaires"
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "montrer"
+#~ msgid "show"
+#~ msgstr "montrer"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr "Montrer/cacher le bloc"
+#~ msgid "Show/hide block"
+#~ msgstr "Montrer/cacher le bloc"
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "grille"
+#~ msgid "grid"
+#~ msgstr "grille"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr "Vous avez choisi la touche "
+#~ msgid "You have chosen key "
+#~ msgstr "Vous avez choisi la touche "
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr " pour votre aperçu de hauteur."
+#~ msgid " for your pitch preview."
+#~ msgstr " pour votre aperçu de hauteur."
 
 #: js/toolbar.js:113
 
@@ -7957,64 +7957,64 @@ msgstr "mouvement"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr "Plein écran"
+#~ msgid "Full Screen"
+#~ msgstr "Plein écran"
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr "Nouveau projet"
+#~ msgid "New Project"
+#~ msgstr "Nouveau projet"
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr "musique"
+#~ msgid "music"
+#~ msgstr "musique"
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr "enregistrer"
+#~ msgid "save"
+#~ msgstr "enregistrer"
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Nettoyer"
+#~ msgid "Clean"
+#~ msgstr "Nettoyer"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "Exécuter lentement"
+#~ msgid "Run slow"
+#~ msgstr "Exécuter lentement"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr "Effacer l'espace de travail"
+#~ msgid "Clear Workspace"
+#~ msgstr "Effacer l'espace de travail"
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr "ton moyen"
+#~ msgid "meantone"
+#~ msgstr "ton moyen"
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr "Personnalisé"
+#~ msgid "Custom"
+#~ msgstr "Personnalisé"
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "cacher les blocs"
+#~ msgid "hide blocks"
+#~ msgstr "cacher les blocs"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr "dupliquer"
+#~ msgid "duplicate"
+#~ msgstr "dupliquer"
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8034,13 +8034,13 @@ msgstr "mouvement"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "arrêter"
+#~ msgid "stop"
+#~ msgstr "arrêter"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "durée (ms)"
+#~ msgid "duration (ms)"
+#~ msgstr "durée (ms)"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8048,58 +8048,58 @@ msgstr "mouvement"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "effacer"
+#~ msgid "clear"
+#~ msgstr "effacer"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "inverser"
+#~ msgid "invert"
+#~ msgstr "inverser"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr "La hauteur modale n^ème prend le motif des hauteurs en demi-tons pour un mode et fait de chaque point un degré du mode,"
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr "La hauteur modale n^ème prend le motif des hauteurs en demi-tons pour un mode et fait de chaque point un degré du mode,"
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr "La hauteur modale n^ème prend un nombre en entrée comme le n^ème degré pour le mode donné. 0 est la première position, 1 est la deuxième, -1 est la note avant la première, etc."
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr "La hauteur modale n^ème prend un nombre en entrée comme le n^ème degré pour le mode donné. 0 est la première position, 1 est la deuxième, -1 est la note avant la première, etc."
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr "oscillateur"
+#~ msgid "oscillator"
+#~ msgstr "oscillateur"
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr "délai"
+#~ msgid "delay"
+#~ msgstr "délai"
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr "enveloppe"
+#~ msgid "envelope"
+#~ msgstr "enveloppe"
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr "filtre"
+#~ msgid "filter"
+#~ msgstr "filtre"
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr "musiqueIA"
+#~ msgid "aimusic"
+#~ msgstr "musiqueIA"
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr "un"
+#~ msgid "a"
+#~ msgstr "un"
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr " en dessous"
+#~ msgid " below"
+#~ msgstr " en dessous"
 
 #: js/widgets/modewidget.js:1017
 
@@ -8115,25 +8115,25 @@ msgstr "mouvement"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr "Nouveau bloc d'action généré !"
+#~ msgid "New action block generated!"
+#~ msgstr "Nouveau bloc d'action généré !"
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr "Enregistrement démarré..."
+#~ msgid "Recording started..."
+#~ msgstr "Enregistrement démarré..."
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr "Enregistrement terminé..."
+#~ msgid "Recording complete..."
+#~ msgstr "Enregistrement terminé..."
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "durée"
+#~ msgid "duration"
+#~ msgstr "durée"
 
 #: js/widgets/temperament.js:454
 
@@ -8143,43 +8143,43 @@ msgstr "mouvement"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr "fermer"
+#~ msgid "close"
+#~ msgstr "fermer"
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr "Publier le projet"
+#~ msgid "Publish Project"
+#~ msgstr "Publier le projet"
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr "jouer"
+#~ msgid "play"
+#~ msgstr "jouer"
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr "Lilypond ne peut pas traiter la pickup de "
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr "Lilypond ne peut pas traiter la pickup de "
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr "Rafraîchissez votre navigateur pour passer en mode avancé."
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr "Rafraîchissez votre navigateur pour passer en mode avancé."
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr "Rafraîchissez votre navigateur pour passer en mode débutant."
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr "Rafraîchissez votre navigateur pour passer en mode débutant."
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr "Nouveaux blocs d'action générés"
+#~ msgid "New action blocks generated"
+#~ msgstr "Nouveaux blocs d'action générés"
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr "Nouveau bloc d'action généré"
+#~ msgid "New action block generated"
+#~ msgstr "Nouveau bloc d'action généré"
 
 #: js/toolbar.js:70
 
@@ -8189,190 +8189,190 @@ msgstr "mouvement"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr "Basculer l'éditeur JavaScript"
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr "Basculer l'éditeur JavaScript"
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr "Le bloc Hauteur de la tortue renvoie le numéro de hauteur actuel joué par la tortue spécifiée."
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr "Le bloc Hauteur de la tortue renvoie le numéro de hauteur actuel joué par la tortue spécifiée."
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr "Le bloc de pas scalaire doit être utilisé à l'intérieur d'un bloc de notes."
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr "Le bloc de pas scalaire doit être utilisé à l'intérieur d'un bloc de notes."
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr "Le bloc de pas scalaire doit être précédé par un bloc de hauteur."
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr "Le bloc de pas scalaire doit être précédé par un bloc de hauteur."
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr "Nouveaux blocs d'action générés !"
+#~ msgid "New action blocks generated!"
+#~ msgstr "Nouveaux blocs d'action générés !"
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr "Plein écran"
+#~ msgid "FullScreen"
+#~ msgstr "Plein écran"
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr "Basculer en mode plein écran."
+#~ msgid "Toggle full screen mode."
+#~ msgstr "Basculer en mode plein écran."
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr "Le bloc Tuplet est utilisé pour générer un groupe de notes jouées en un temps condensé."
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr "Le bloc Tuplet est utilisé pour générer un groupe de notes jouées en un temps condensé."
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr "L'utilisation des tuplets facilite la création de groupes de notes qui ne sont pas basés sur une puissance de 2."
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr "L'utilisation des tuplets facilite la création de groupes de notes qui ne sont pas basés sur une puissance de 2."
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr "Le bloc Définir le tempérament est utilisé pour choisir le système d'accord utilisé par Music Blocks."
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr "Le bloc Définir le tempérament est utilisé pour choisir le système d'accord utilisé par Music Blocks."
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr "Le bloc Numéro d'intervalle renvoie le nombre de pas scalaires dans l'intervalle actuel."
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr "Le bloc Numéro d'intervalle renvoie le nombre de pas scalaires dans l'intervalle actuel."
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr "Le bloc Intervalle de demi-ton mesure la distance entre deux notes en demi-tons."
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr "Le bloc Intervalle de demi-ton mesure la distance entre deux notes en demi-tons."
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr "Le bloc Intervalle de demi-ton calcule un intervalle relatif basé sur des demi-tons."
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr "Le bloc Intervalle de demi-ton calcule un intervalle relatif basé sur des demi-tons."
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr "Le bloc Arpège exécutera chaque bloc de notes plusieurs fois, en ajoutant une transposition basée sur l'accord spécifié."
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr "Le bloc Arpège exécutera chaque bloc de notes plusieurs fois, en ajoutant une transposition basée sur l'accord spécifié."
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr "Le bloc Intervalle scalaire calcule un intervalle relatif basé sur le mode actuel, en sautant toutes les notes en dehors du mode."
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr "Le bloc Intervalle scalaire calcule un intervalle relatif basé sur le mode actuel, en sautant toutes les notes en dehors du mode."
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr "Le bloc Définir le mode vous permet de définir un mode personnalisé en spécifiant des numéros de hauteur."
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr "Le bloc Définir le mode vous permet de définir un mode personnalisé en spécifiant des numéros de hauteur."
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr "Lorsque le do mobile est faux, les noms des notes de solfège sont toujours liés à des hauteurs spécifiques,"
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr "Lorsque le do mobile est faux, les noms des notes de solfège sont toujours liés à des hauteurs spécifiques,"
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr "par exemple \"do\" est toujours \"C naturel\" lorsque le do mobile est vrai, les noms des notes de solfège sont attribués aux degrés de la gamme \"do\" est toujours le premier degré de la gamme majeure."
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr "par exemple \"do\" est toujours \"C naturel\" lorsque le do mobile est vrai, les noms des notes de solfège sont attribués aux degrés de la gamme \"do\" est toujours le premier degré de la gamme majeure."
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr "Le bloc Action est utilisé pour regrouper des blocs afin qu'ils puissent être utilisés plus d'une fois."
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr "Le bloc Action est utilisé pour regrouper des blocs afin qu'ils puissent être utilisés plus d'une fois."
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr "Le bloc Plus grand que renvoie Vrai si le nombre supérieur est plus grand que le nombre inférieur."
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr "Le bloc Plus grand que renvoie Vrai si le nombre supérieur est plus grand que le nombre inférieur."
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr "Le bloc Moins que renvoie Vrai si le nombre supérieur est plus petit que le nombre inférieur."
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr "Le bloc Moins que renvoie Vrai si le nombre supérieur est plus petit que le nombre inférieur."
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "Dans cet exemple, la souris se déplace vers la droite jusqu'à atteindre le bord droit de la toile ; puis elle réapparaît à gauche de la toile."
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "Dans cet exemple, la souris se déplace vers la droite jusqu'à atteindre le bord droit de la toile ; puis elle réapparaît à gauche de la toile."
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "Dans cet exemple, la tortue se déplace vers la droite jusqu'à atteindre le bord droit de la toile ; puis elle réapparaît à gauche de la toile."
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "Dans cet exemple, la tortue se déplace vers la droite jusqu'à atteindre le bord droit de la toile ; puis elle réapparaît à gauche de la toile."
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "Dans cet exemple, la souris se déplace vers le haut jusqu'à atteindre le bord supérieur de la toile ; puis elle réapparaît en bas de la toile."
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "Dans cet exemple, la souris se déplace vers le haut jusqu'à atteindre le bord supérieur de la toile ; puis elle réapparaît en bas de la toile."
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "Dans cet exemple, la tortue se déplace vers le haut jusqu'à atteindre le bord supérieur de la toile ; puis elle réapparaît en bas de la toile."
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "Dans cet exemple, la tortue se déplace vers le haut jusqu'à atteindre le bord supérieur de la toile ; puis elle réapparaît en bas de la toile."
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr "matériel vidéo"
+#~ msgid "video material"
+#~ msgstr "matériel vidéo"
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr "Le bloc Exécuter un bloc exécute un bloc. Il accepte deux types d'arguments : numéro de bloc ou nom de bloc."
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr "Le bloc Exécuter un bloc exécute un bloc. Il accepte deux types d'arguments : numéro de bloc ou nom de bloc."
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr "Le bloc Définir le tambour sélectionnera un son de tambour pour remplacer la hauteur de toutes les notes contenues."
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr "Le bloc Définir le tambour sélectionnera un son de tambour pour remplacer la hauteur de toutes les notes contenues."
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr "Le bloc Valeur de la note est la valeur de la durée de la note actuellement jouée."
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr "Le bloc Valeur de la note est la valeur de la durée de la note actuellement jouée."
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr "Le bloc Millisecondes est similaire à un bloc de notes, sauf qu'il utilise le temps (en MS) pour spécifier la durée de la note."
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr "Le bloc Millisecondes est similaire à un bloc de notes, sauf qu'il utilise le temps (en MS) pour spécifier la durée de la note."
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr "Le bloc Swing fonctionne sur des paires de notes (spécifiées par la valeur de la note), en ajoutant une certaine durée (spécifiée par la valeur de swing) à la première note et en prenant la même quantité à la deuxième note."
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr "Le bloc Swing fonctionne sur des paires de notes (spécifiées par la valeur de la note), en ajoutant une certaine durée (spécifiée par la valeur de swing) à la première note et en prenant la même quantité à la deuxième note."
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr "Le bloc Multiplier la valeur de la note modifie la durée des notes en changeant leurs valeurs de note."
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr "Le bloc Multiplier la valeur de la note modifie la durée des notes en changeant leurs valeurs de note."
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr "Un silence de la durée de la valeur de note spécifiée peut être construit à l'aide d'un bloc de silence."
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr "Un silence de la durée de la valeur de note spécifiée peut être construit à l'aide d'un bloc de silence."
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr "Le bloc Afficher le tas affiche le contenu du tas en haut de l'écran."
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr "Le bloc Afficher le tas affiche le contenu du tas en haut de l'écran."
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr "La sortie de l'exemple est : Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr "La sortie de l'exemple est : Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
 
 #: js/FlowBlocks.js:679
 
@@ -8382,305 +8382,305 @@ msgstr "mouvement"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr "Les conditionnels permettent à votre programme de prendre différentes actions en fonction de la condition."
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr "Les conditionnels permettent à votre programme de prendre différentes actions en fonction de la condition."
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr "Dans cet exemple, si le bouton de la souris est enfoncé, une caisse claire jouera, sinon une grosse caisse jouera."
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr "Dans cet exemple, si le bouton de la souris est enfoncé, une caisse claire jouera, sinon une grosse caisse jouera."
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr "Dans cet exemple d'une simple boîte à rythmes, une grosse caisse jouera des notes de 1/4 pour toujours."
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr "Dans cet exemple d'une simple boîte à rythmes, une grosse caisse jouera des notes de 1/4 pour toujours."
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr "Le bloc Arc déplace la souris en arc."
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr "Le bloc Arc déplace la souris en arc."
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr "Le bloc Arc déplace la tortue en arc."
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr "Le bloc Arc déplace la tortue en arc."
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr "Le bloc Définir le cap fixe le cap de la souris."
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr "Le bloc Définir le cap fixe le cap de la souris."
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr "Le bloc Enveloppe active ou désactive l'enveloppement de l'écran pour les actions graphiques à l'intérieur."
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr "Le bloc Enveloppe active ou désactive l'enveloppement de l'écran pour les actions graphiques à l'intérieur."
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr "Le bloc Liaison allonge la durée des notes tout en maintenant la valeur rythmique spécifiée des notes."
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr "Le bloc Liaison allonge la durée des notes tout en maintenant la valeur rythmique spécifiée des notes."
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr "Le bloc Staccato raccourcit la longueur de la note réelle tout en maintenant la valeur rythmique spécifiée des notes."
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr "Le bloc Staccato raccourcit la longueur de la note réelle tout en maintenant la valeur rythmique spécifiée des notes."
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr "Le bloc Decrescendo diminuera le volume des notes contenues d'un montant spécifié pour chaque note jouée."
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "Le bloc Decrescendo diminuera le volume des notes contenues d'un montant spécifié pour chaque note jouée."
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr "Par exemple, si vous avez 7 notes en séquence contenues dans un bloc Decrescendo avec une valeur de 5, la note finale sera à 35 % de moins que le volume de départ."
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr "Par exemple, si vous avez 7 notes en séquence contenues dans un bloc Decrescendo avec une valeur de 5, la note finale sera à 35 % de moins que le volume de départ."
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr "Le bloc Crescendo augmentera le volume des notes contenues d'un montant spécifié pour chaque note jouée."
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "Le bloc Crescendo augmentera le volume des notes contenues d'un montant spécifié pour chaque note jouée."
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr "Par exemple, si vous avez 7 notes en séquence contenues dans un bloc Crescendo avec une valeur de 5, la note finale sera à 35 % de plus que le volume de départ."
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr "Par exemple, si vous avez 7 notes en séquence contenues dans un bloc Crescendo avec une valeur de 5, la note finale sera à 35 % de plus que le volume de départ."
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr "Le bloc Partiel est utilisé pour spécifier un poids pour un harmonique partiel spécifique."
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr "Le bloc Partiel est utilisé pour spécifier un poids pour un harmonique partiel spécifique."
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr "Le bloc Partiels pondérés est utilisé pour spécifier les partiels associés à un timbre."
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr "Le bloc Partiels pondérés est utilisé pour spécifier les partiels associés à un timbre."
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr "Le bloc de définition de l'instrument par défaut modifie l'instrument par défaut de synthé électronique à l'instrument de votre choix."
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr "Le bloc de définition de l'instrument par défaut modifie l'instrument par défaut de synthé électronique à l'instrument de votre choix."
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr "Le bloc Facteur de battement renvoie le rapport de la valeur de la note à la valeur de la note du mètre."
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr "Le bloc Facteur de battement renvoie le rapport de la valeur de la note à la valeur de la note du mètre."
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr "Dans la figure, il est utilisé pour effectuer une action sur le premier temps de chaque mesure."
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr "Dans la figure, il est utilisé pour effectuer une action sur le premier temps de chaque mesure."
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr "(Par défaut, il compte les noires.)"
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr "(Par défaut, il compte les noires.)"
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr "Le bloc Afficher le dictionnaire affiche le contenu du dictionnaire en haut de l'écran."
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr "Le bloc Afficher le dictionnaire affiche le contenu du dictionnaire en haut de l'écran."
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr "Le bloc Commentaire imprime un commentaire en haut de l'écran lorsque le programme fonctionne en mode lent."
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr "Le bloc Commentaire imprime un commentaire en haut de l'écran lorsque le programme fonctionne en mode lent."
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr "Le bloc Curseur sur déclenche un événement lorsque le curseur est déplacé sur une souris."
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr "Le bloc Curseur sur déclenche un événement lorsque le curseur est déplacé sur une souris."
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr "Le bloc Curseur sur déclenche un événement lorsque le curseur est déplacé sur une tortue."
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr "Le bloc Curseur sur déclenche un événement lorsque le curseur est déplacé sur une tortue."
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr "Le bloc Curseur hors déclenche un événement lorsque le curseur est déplacé hors d'une souris."
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr "Le bloc Curseur hors déclenche un événement lorsque le curseur est déplacé hors d'une souris."
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr "Le bloc Curseur hors déclenche un événement lorsque le curseur est déplacé hors d'une tortue."
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr "Le bloc Curseur hors déclenche un événement lorsque le curseur est déplacé hors d'une tortue."
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr "Le bloc Bouton du curseur enfoncé déclenche un événement lorsque le bouton du curseur est enfoncé sur une souris."
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr "Le bloc Bouton du curseur enfoncé déclenche un événement lorsque le bouton du curseur est enfoncé sur une souris."
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr "Le bloc Bouton du curseur enfoncé déclenche un événement lorsque le bouton du curseur est enfoncé sur une tortue."
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr "Le bloc Bouton du curseur enfoncé déclenche un événement lorsque le bouton du curseur est enfoncé sur une tortue."
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr "Le bloc Bouton du curseur haut déclenche un événement lorsque le bouton du curseur est relâché au-dessus d'une tortue."
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr "Le bloc Bouton du curseur haut déclenche un événement lorsque le bouton du curseur est relâché au-dessus d'une tortue."
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr "Le bloc Obtenir bleu renvoie la composante bleue du pixel sous la souris."
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr "Le bloc Obtenir bleu renvoie la composante bleue du pixel sous la souris."
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr "Le bloc Obtenir bleu renvoie la composante bleue du pixel sous la tortue."
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr "Le bloc Obtenir bleu renvoie la composante bleue du pixel sous la tortue."
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr "Le bloc Obtenir vert renvoie la composante verte du pixel sous la souris."
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr "Le bloc Obtenir vert renvoie la composante verte du pixel sous la souris."
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr "Le bloc Obtenir vert renvoie la composante verte du pixel sous la tortue."
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr "Le bloc Obtenir vert renvoie la composante verte du pixel sous la tortue."
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr "Le bloc Temps renvoie le nombre de secondes pendant lesquelles le programme a été exécuté."
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr "Le bloc Temps renvoie le nombre de secondes pendant lesquelles le programme a été exécuté."
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr "Plus de détails"
+#~ msgid "More Details"
+#~ msgstr "Plus de détails"
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr "Partager le projet"
+#~ msgid "Share project"
+#~ msgstr "Partager le projet"
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr "Copier le lien dans le presse-papiers"
+#~ msgid "Copy link to clipboard"
+#~ msgstr "Copier le lien dans le presse-papiers"
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr "Exécuter le projet au démarrage."
+#~ msgid "Run project on startup."
+#~ msgstr "Exécuter le projet au démarrage."
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr "Afficher les blocs de code au démarrage."
+#~ msgid "Show code blocks on startup."
+#~ msgstr "Afficher les blocs de code au démarrage."
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr "Réduire les blocs de code au démarrage."
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr "Réduire les blocs de code au démarrage."
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr "Options avancées"
+#~ msgid "Advanced Options"
+#~ msgstr "Options avancées"
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr "Bloc Hertz : Vouliez-vous utiliser un bloc Note ?"
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr "Bloc Hertz : Vouliez-vous utiliser un bloc Note ?"
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr "Ne pas aimer le projet"
+#~ msgid "Unlike project"
+#~ msgstr "Ne pas aimer le projet"
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr "Aimer le projet"
+#~ msgid "Like project"
+#~ msgstr "Aimer le projet"
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr "Fonctionnalité indisponible - impossible de se connecter au serveur. Rechargez Turtle Blocks pour réessayer."
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr "Fonctionnalité indisponible - impossible de se connecter au serveur. Rechargez Turtle Blocks pour réessayer."
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr "Republier le projet"
+#~ msgid "Republish Project"
+#~ msgstr "Republier le projet"
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr "fichier audio1"
+#~ msgid "audio file1"
+#~ msgstr "fichier audio1"
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr "fichier audio2"
+#~ msgid "audio file2"
+#~ msgstr "fichier audio2"
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr "Avertissement : valeur de note supérieure à 2."
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr "Avertissement : valeur de note supérieure à 2."
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr "accord5"
+#~ msgid "chord5"
+#~ msgstr "accord5"
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr "accord4"
+#~ msgid "chord4"
+#~ msgstr "accord4"
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr "accord1"
+#~ msgid "chord1"
+#~ msgstr "accord1"
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr "Le bloc Curseur Y renvoie la position verticale de la tortue."
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr "Le bloc Curseur Y renvoie la position verticale de la tortue."
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr "Le bloc Curseur X renvoie la position horizontale de la tortue."
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr "Le bloc Curseur X renvoie la position horizontale de la tortue."
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr "Le bloc Nom de la Nème tortue renvoie le nom de la nème tortue."
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr "Le bloc Nom de la Nème tortue renvoie le nom de la nème tortue."
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "Exécuter vite"
+#~ msgid "Run fast"
+#~ msgstr "Exécuter vite"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "Développer/réduire les blocs rétractables"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "Développer/réduire les blocs rétractables"
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr "Le bloc Nom de la Nème souris renvoie le nom de la nème souris."
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr "Le bloc Nom de la Nème souris renvoie le nom de la nème souris."
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr "rechercher des blocs"
+#~ msgid "search for blocks"
+#~ msgstr "rechercher des blocs"
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr "Veuillez régler le niveau de zoom du navigateur à 100 %"
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr "Veuillez régler le niveau de zoom du navigateur à 100 %"
 
 #: js/toolbar.js:54
 
@@ -8690,97 +8690,97 @@ msgstr "mouvement"
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr "Menu auxiliaire"
+#~ msgid "Auxilary menu"
+#~ msgstr "Menu auxiliaire"
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr "Pour exécuter ce projet, ouvrez Music Blocks dans un navigateur Web et faites glisser ce fichier dans la fenêtre du navigateur."
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr "Pour exécuter ce projet, ouvrez Music Blocks dans un navigateur Web et faites glisser ce fichier dans la fenêtre du navigateur."
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr "Vous devez toujours avoir au moins un bloc de départ."
+#~ msgid "You must always have at least one start block."
+#~ msgstr "Vous devez toujours avoir au moins un bloc de départ."
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr "monter la hauteur"
+#~ msgid "pitch up"
+#~ msgstr "monter la hauteur"
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr "descendre la hauteur"
+#~ msgid "pitch down"
+#~ msgstr "descendre la hauteur"
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr "dièse"
+#~ msgid "accidental up"
+#~ msgstr "dièse"
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr "bémol"
+#~ msgid "accidental down"
+#~ msgstr "bémol"
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr "octave supérieure"
+#~ msgid "octave up"
+#~ msgstr "octave supérieure"
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr "octave inférieure"
+#~ msgid "octave down"
+#~ msgstr "octave inférieure"
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "devise"
+#~ msgid "currency"
+#~ msgstr "devise"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "de"
+#~ msgid "from"
+#~ msgstr "de"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "prix de l'action"
+#~ msgid "stock price"
+#~ msgstr "prix de l'action"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "traduire"
+#~ msgid "translate"
+#~ msgstr "traduire"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "bonjour"
+#~ msgid "hello"
+#~ msgstr "bonjour"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "détecter la langue"
+#~ msgid "detect lang"
+#~ msgstr "détecter la langue"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "définir la langue"
+#~ msgid "set lang"
+#~ msgstr "définir la langue"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "latitude de la ville"
+#~ msgid "city latitude"
+#~ msgstr "latitude de la ville"
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "longitude de la ville"
+#~ msgid "city longitude"
+#~ msgstr "longitude de la ville"
 
 #: plugins/gmap.rtp:71
 
@@ -8790,144 +8790,144 @@ msgstr "mouvement"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "Données de coordonnées non disponibles."
+#~ msgid "Coordinate data not available."
+#~ msgstr "Données de coordonnées non disponibles."
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "Google map"
+#~ msgid "Google map"
+#~ msgstr "Google map"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "coordonnées"
+#~ msgid "coordinates"
+#~ msgstr "coordonnées"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "facteur de zoom"
+#~ msgid "zoom factor"
+#~ msgstr "facteur de zoom"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "zoom"
+#~ msgid "zoom"
+#~ msgstr "zoom"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "latitude"
+#~ msgid "latitude"
+#~ msgstr "latitude"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "longitude"
+#~ msgid "longitude"
+#~ msgstr "longitude"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "degrés"
+#~ msgid "degrees"
+#~ msgstr "degrés"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "radians"
+#~ msgid "radians"
+#~ msgstr "radians"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "définir"
+#~ msgid "define"
+#~ msgstr "définir"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "bitcoin"
+#~ msgid "bitcoin"
+#~ msgstr "bitcoin"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr "Vous devez sélectionner un fichier."
+#~ msgid "You need to select a file."
+#~ msgstr "Vous devez sélectionner un fichier."
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr "montrer l'aigu"
+#~ msgid "show treble"
+#~ msgstr "montrer l'aigu"
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr "cacher Polar"
+#~ msgid "hide Polar"
+#~ msgstr "cacher Polar"
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr "montrer la basse"
+#~ msgid "show bass"
+#~ msgstr "montrer la basse"
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr "montrer le mezzo-soprano"
+#~ msgid "show mezzo-soprano"
+#~ msgstr "montrer le mezzo-soprano"
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr "montrer l'alto"
+#~ msgid "show alto"
+#~ msgstr "montrer l'alto"
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr "montrer le ténor"
+#~ msgid "show tenor"
+#~ msgstr "montrer le ténor"
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr "cacher la basse"
+#~ msgid "hide bass"
+#~ msgstr "cacher la basse"
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr "montrer Polar"
+#~ msgid "show Polar"
+#~ msgstr "montrer Polar"
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr "cacher Cartésien"
+#~ msgid "hide Cartesian"
+#~ msgstr "cacher Cartésien"
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr "Lilypond ne peut pas traiter le tempo de "
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr "Lilypond ne peut pas traiter le tempo de "
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr "Enregistrer en PDF"
+#~ msgid "Save as PDF"
+#~ msgstr "Enregistrer en PDF"
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr "Lilypond ignore le mode"
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr "Lilypond ignore le mode"
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr "ZOOM AVANT"
+#~ msgid "ZOOM IN"
+#~ msgstr "ZOOM AVANT"
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr "ZOOM ARRIÈRE"
+#~ msgid "ZOOM OUT"
+#~ msgstr "ZOOM ARRIÈRE"
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr "Cliquez pour sélectionner un bloc."
+#~ msgid "Click to select a block."
+#~ msgstr "Cliquez pour sélectionner un bloc."
 
 #: js/palette.js:1205
 
@@ -8937,15 +8937,15 @@ msgstr "mouvement"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr "cacher"
+#~ msgid "hide"
+#~ msgstr "cacher"
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr "montrer2"
+#~ msgid "show2"
+#~ msgstr "montrer2"
 
 #: js/palette.js:1222
 
@@ -8955,23 +8955,23 @@ msgstr "mouvement"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr "détacher"
+#~ msgid "popout"
+#~ msgstr "détacher"
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr "mesblocs"
+#~ msgid "myblocks"
+#~ msgstr "mesblocs"
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr "Voulez-vous enregistrer votre projet ?"
+#~ msgid "Do you want to save your project?"
+#~ msgstr "Voulez-vous enregistrer votre projet ?"
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr "Bloc Tambour : Vouliez-vous utiliser un bloc Note ?"
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr "Bloc Tambour : Vouliez-vous utiliser un bloc Note ?"
 
 #: js/pitchtracker.js:181
 
@@ -8981,8 +8981,8 @@ msgstr "mouvement"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr "Commencer l'enregistrement"
+#~ msgid "Start Recording"
+#~ msgstr "Commencer l'enregistrement"
 
 #: js/pitchtracker.js:188
 
@@ -8990,224 +8990,224 @@ msgstr "mouvement"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr "Arrêter l'enregistrement"
+#~ msgid "Stop Recording"
+#~ msgstr "Arrêter l'enregistrement"
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr "enregistrer les rythmes"
+#~ msgid "save rhythms"
+#~ msgstr "enregistrer les rythmes"
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr "glisser"
+#~ msgid "drag"
+#~ msgstr "glisser"
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr "Bloc Hauteur : Vouliez-vous utiliser un bloc Note ?"
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr "Bloc Hauteur : Vouliez-vous utiliser un bloc Note ?"
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr "M. Souris\", 0, 0)]"
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr "M. Souris\", 0, 0)]"
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr "Le bloc Clic renvoie Vrai si une souris a été cliquée."
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr "Le bloc Clic renvoie Vrai si une souris a été cliquée."
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr "Le bloc box2 renvoie la valeur stockée dans box2."
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr "Le bloc box2 renvoie la valeur stockée dans box2."
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr "Le bloc box1 renvoie la valeur stockée dans box1."
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr "Le bloc box1 renvoie la valeur stockée dans box1."
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr "Cacher les blocs."
+#~ msgid "Hide blocks."
+#~ msgstr "Cacher les blocs."
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr "Ne peut pas être diminué davantage"
+#~ msgid "Cannot be further decreased"
+#~ msgstr "Ne peut pas être diminué davantage"
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr "Ne peut pas être augmenté davantage"
+#~ msgid "Cannot be further increased"
+#~ msgstr "Ne peut pas être augmenté davantage"
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr "Erreur : Impossible d'enregistrer car vous avez épuisé l'espace de stockage local. Essayez de supprimer certains projets enregistrés."
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr "Erreur : Impossible d'enregistrer car vous avez épuisé l'espace de stockage local. Essayez de supprimer certains projets enregistrés."
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr "Désactivation du clignotement de la souris ; réglage des FPS à 10."
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr "Désactivation du clignotement de la souris ; réglage des FPS à 10."
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr "Activation du clignotement de la souris ; réglage des FPS à 30."
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr "Activation du clignotement de la souris ; réglage des FPS à 30."
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr "Les transpositions scalaires sont égales aux transpositions en demi-tons pour un tempérament personnalisé."
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr "Les transpositions scalaires sont égales aux transpositions en demi-tons pour un tempérament personnalisé."
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr "Vous ne pouvez lier que des notes de même hauteur. Vouliez-vous utiliser le legato?"
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr "Vous ne pouvez lier que des notes de même hauteur. Vouliez-vous utiliser le legato?"
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr "Avertissement : La valeur de la note est supérieure à 2."
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr "Avertissement : La valeur de la note est supérieure à 2."
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr "Le nom de la note doit être l'un des suivants : A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ ou A♭."
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr "Le nom de la note doit être l'un des suivants : A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ ou A♭."
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr "Voulez-vous supprimer toutes les piles de votre palette \"%s\" ?"
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr "Voulez-vous supprimer toutes les piles de votre palette \"%s\" ?"
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr "Ce bouton ouvre un visualiseur pour partager des projets et pour trouver des projets d'exemple."
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr "Ce bouton ouvre un visualiseur pour partager des projets et pour trouver des projets d'exemple."
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr "Cliquez sur ce bouton pour développer ou réduire la barre d'outils auxiliaire."
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr "Cliquez sur ce bouton pour développer ou réduire la barre d'outils auxiliaire."
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr "Le rythme de la musique est déterminé par le bloc Mètre (par défaut, 4 notes de 1/4 par mesure)."
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr "Le rythme de la musique est déterminé par le bloc Mètre (par défaut, 4 notes de 1/4 par mesure)."
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr "Le bloc Maître battements par minute définit le nombre de notes de 1/4 par minute pour chaque voix."
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr "Le bloc Maître battements par minute définit le nombre de notes de 1/4 par minute pour chaque voix."
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr "Le bloc Sur chaque note vous permet de spécifier des actions à effectuer sur chaque note."
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr "Le bloc Sur chaque note vous permet de spécifier des actions à effectuer sur chaque note."
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr "Le bloc Notes jouées est le nombre de notes qui ont été jouées."
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr "Le bloc Notes jouées est le nombre de notes qui ont été jouées."
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr "Le bloc Numéro de hauteur jouera une hauteur associée par son numéro, par exemple 0 pour C et 7 pour G."
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr "Le bloc Numéro de hauteur jouera une hauteur associée par son numéro, par exemple 0 pour C et 7 pour G."
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr "Le bloc Curseur de hauteur ouvre un outil pour générer des hauteurs arbitraires."
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr "Le bloc Curseur de hauteur ouvre un outil pour générer des hauteurs arbitraires."
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr "Tous les blocs Démarrer s'exécutent en même temps lorsque le bouton Lecture est pressé."
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr "Tous les blocs Démarrer s'exécutent en même temps lorsque le bouton Lecture est pressé."
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr "Le bloc Stocker dans box1 est utilisé pour stocker une valeur dans box1."
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr "Le bloc Stocker dans box1 est utilisé pour stocker une valeur dans box1."
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr "Le bloc Stocker dans box2 est utilisé pour stocker une valeur dans box2."
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr "Le bloc Stocker dans box2 est utilisé pour stocker une valeur dans box2."
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr "Le bloc Coquille est utilisé pour changer l'apparence de la souris."
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr "Le bloc Coquille est utilisé pour changer l'apparence de la souris."
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr "Le bloc Pickup est utilisé pour accueillir toutes les notes qui arrivent avant le temps fort."
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr "Le bloc Pickup est utilisé pour accueillir toutes les notes qui arrivent avant le temps fort."
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr "Le bloc Battements par minute change les battements par minute de toutes les notes contenues."
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr "Le bloc Battements par minute change les battements par minute de toutes les notes contenues."
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr "Le bloc Sur temps fort vous permet de spécifier des actions à effectuer sur des temps forts spécifiés."
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr "Le bloc Sur temps fort vous permet de spécifier des actions à effectuer sur des temps forts spécifiés."
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr "Le bloc Sur temps faible vous permet de spécifier des actions à effectuer sur des temps faibles (non accentués)."
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr "Le bloc Sur temps faible vous permet de spécifier des actions à effectuer sur des temps faibles (non accentués)."
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "par exemple, \"do\" est toujours \"C-naturel\"); lorsque le do mobile est vrai, les noms de notes solfège sont attribués aux degrés de l'échelle (\"do\" est toujours le premier degré de l'échelle majeure)."
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "par exemple, \"do\" est toujours \"C-naturel\"); lorsque le do mobile est vrai, les noms de notes solfège sont attribués aux degrés de l'échelle (\"do\" est toujours le premier degré de l'échelle majeure)."
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr "Le bloc Volume de la note renvoie le volume actuel du synthétiseur actuel."
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr "Le bloc Volume de la note renvoie le volume actuel du synthétiseur actuel."
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr "Le bloc Par défaut est utilisé à l'intérieur d'un Commutateur pour définir une action par défaut."
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr "Le bloc Par défaut est utilisé à l'intérieur d'un Commutateur pour définir une action par défaut."
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr "Le bloc Note de la souris renvoie la valeur de note actuelle jouée par la souris spécifiée."
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr "Le bloc Note de la souris renvoie la valeur de note actuelle jouée par la souris spécifiée."
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr "mineur descendant"
+#~ msgid "down minor"
+#~ msgstr "mineur descendant"
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr "majeur descendant"
+#~ msgid "down major"
+#~ msgstr "majeur descendant"
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr "évaluer"
+#~ msgid "eval"
+#~ msgstr "évaluer"
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr "100"
+#~ msgid "100"
+#~ msgstr "100"
 
 #: js/playback.js:87
 
@@ -9223,37 +9223,37 @@ msgstr "mouvement"
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr "Glisser"
+#~ msgid "Drag"
+#~ msgstr "Glisser"
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr "lecture de la musique"
+#~ msgid "playback music"
+#~ msgstr "lecture de la musique"
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr "pause lecture"
+#~ msgid "pause playback"
+#~ msgstr "pause lecture"
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr "redémarrer la lecture"
+#~ msgid "restart playback"
+#~ msgstr "redémarrer la lecture"
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr "préparer la musique pour la lecture"
+#~ msgid "prepare music for playback"
+#~ msgstr "préparer la musique pour la lecture"
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr "Charger les blocs"
+#~ msgid "Load blocks"
+#~ msgstr "Charger les blocs"
 
 #: js/turtledefs.js:304
 
@@ -9261,28 +9261,28 @@ msgstr "mouvement"
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr "Le bloc Définir timbre sélectionne une voix pour le synthétiseur,"
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr "Le bloc Définir timbre sélectionne une voix pour le synthétiseur,"
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr "Le bloc Exécuter exécute un bloc."
+#~ msgid "The Run block block runs a block."
+#~ msgstr "Le bloc Exécuter exécute un bloc."
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr "définir timbre"
+#~ msgid "set timbre"
+#~ msgstr "définir timbre"
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr "droite2"
+#~ msgid "right2"
+#~ msgstr "droite2"
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr "gauche2"
+#~ msgid "left2"
+#~ msgstr "gauche2"
 
 #: js/pitchtimematrix.js:323
 
@@ -9296,8 +9296,8 @@ msgstr "mouvement"
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr "développer"
+#~ msgid "expand"
+#~ msgstr "développer"
 
 #: js/pitchtimematrix.js:338
 
@@ -9307,65 +9307,65 @@ msgstr "mouvement"
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr "réduire"
+#~ msgid "collapse"
+#~ msgstr "réduire"
 
-#~msgid "crescendo factor"
-#~msgstr "facteur de crescendo"
+#~ msgid "crescendo factor"
+#~ msgstr "facteur de crescendo"
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr "Au cœur de Music Blocks se trouve le bloc <em>Note</em>. Le bloc <em>Note</em> est un conteneur pour un bloc <em>Hauteur</em> qui spécifie la durée (valeur de la note) de la hauteur."
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr "Au cœur de Music Blocks se trouve le bloc <em>Note</em>. Le bloc <em>Note</em> est un conteneur pour un bloc <em>Hauteur</em> qui spécifie la durée (valeur de la note) de la hauteur."
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr "Le bloc <em>Temps</em> renvoie le nombre de secondes pendant lesquelles le programme a été exécuté."
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr "Le bloc <em>Temps</em> renvoie le nombre de secondes pendant lesquelles le programme a été exécuté."
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr "Le bloc <em>Stocker dans box1</em> est utilisé pour stocker une valeur dans <em>box1</em>."
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr "Le bloc <em>Stocker dans box1</em> est utilisé pour stocker une valeur dans <em>box1</em>."
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr "Le bloc <em>Multiplier</em> est utilisé pour multiplier."
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr "Le bloc <em>Multiplier</em> est utilisé pour multiplier."
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr "Aucun bloc n'est sélectionné."
+#~ msgid "There is no block is selected."
+#~ msgstr "Aucun bloc n'est sélectionné."
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr "Le bloc <em>Transposition scalaire</em> déplacera les hauteurs contenues dans les blocs <em>Note</em> vers le haut (ou vers le bas) de l'échelle. Dans l'exemple montré ci-dessus, <em>sol</em> est déplacé vers <em>la</em>."
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr "Le bloc <em>Transposition scalaire</em> déplacera les hauteurs contenues dans les blocs <em>Note</em> vers le haut (ou vers le bas) de l'échelle. Dans l'exemple montré ci-dessus, <em>sol</em> est déplacé vers <em>la</em>."
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr "Initialiser un nouveau projet."
+#~ msgid "Initialise a new project."
+#~ msgstr "Initialiser un nouveau projet."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr "japonais"
+#~ msgid "japanese"
+#~ msgstr "japonais"
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr "7ème"
+#~ msgid "7th"
+#~ msgstr "7ème"
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr "accord' + ' ' + 'V"
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr "accord' + ' ' + 'V"
 
 #: js/musicutils.js:345
 
@@ -9373,8 +9373,8 @@ msgstr "mouvement"
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr "chine"
+#~ msgid "chine"
+#~ msgstr "chine"
 
 #: js/timbre.js:743
 
@@ -9384,127 +9384,127 @@ msgstr "mouvement"
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr "annuler"
+#~ msgid "undo"
+#~ msgstr "annuler"
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr "accord' + ' ' + 'I"
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr "accord' + ' ' + 'I"
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr "espace réservé"
+#~ msgid "placeholder"
+#~ msgstr "espace réservé"
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr "Le bloc <em>Déplacer bloc</em> déplace un bloc."
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr "Le bloc <em>Déplacer bloc</em> déplace un bloc."
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr "Le bloc <em>Altération</em> est utilisé pour créer des <em>dièses</em> et des <em>bémols</em>"
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr "Le bloc <em>Altération</em> est utilisé pour créer des <em>dièses</em> et des <em>bémols</em>"
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr "Le bloc <em>Cacher blocs</em> cache les blocs."
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr "Le bloc <em>Cacher blocs</em> cache les blocs."
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr "Le bloc <em>Attendre</em> attendra que la condition soit vraie."
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr "Le bloc <em>Attendre</em> attendra que la condition soit vraie."
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr "régler le volume"
+#~ msgid "set volume"
+#~ msgstr "régler le volume"
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr "Le bloc <em>Jouer du bruit</em> générera du bruit blanc, rose ou brun."
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr "Le bloc <em>Jouer du bruit</em> générera du bruit blanc, rose ou brun."
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr "Le bloc <em>Bezier</em> dessine une courbe de Bezier."
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr "Le bloc <em>Bezier</em> dessine une courbe de Bezier."
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr "heures avant"
+#~ msgid "hours ago"
+#~ msgstr "heures avant"
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr "Blues majeur"
+#~ msgid "Major Blues"
+#~ msgstr "Blues majeur"
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr "Le bloc <em>Arrière</em> déplace la souris en arrière."
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr "Le bloc <em>Arrière</em> déplace la souris en arrière."
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr "Le bloc <em>Définir nom</em> est utilisé pour nommer une souris."
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr "Le bloc <em>Définir nom</em> est utilisé pour nommer une souris."
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr "Le bloc <em>Statut</em> ouvre un outil pour inspecter le statut de Music Blocks pendant son exécution."
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr "Le bloc <em>Statut</em> ouvre un outil pour inspecter le statut de Music Blocks pendant son exécution."
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr "jouer la gamme"
+#~ msgid "play scale"
+#~ msgstr "jouer la gamme"
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr "Cette barre d'outils contient les boutons de palette Matrice, Note, Ton, Tortue, et plus encore. Cliquez pour afficher les palettes de blocs et faites glisser les blocs des palettes vers le canevas pour les utiliser."
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr "Cette barre d'outils contient les boutons de palette Matrice, Note, Ton, Tortue, et plus encore. Cliquez pour afficher les palettes de blocs et faites glisser les blocs des palettes vers le canevas pour les utiliser."
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr "Le bloc <em>Battements par minute</em> renvoie le nombre de battements par minute actuel."
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr "Le bloc <em>Battements par minute</em> renvoie le nombre de battements par minute actuel."
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr "Le bloc Pas de l'échelle (en combinaison avec un bloc Nombre) jouera la prochaine hauteur dans une échelle,"
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr "Le bloc Pas de l'échelle (en combinaison avec un bloc Nombre) jouera la prochaine hauteur dans une échelle,"
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr "La hauteur peut être spécifiée en termes de <em>ni dha pa ma ga re sa</em>."
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr "La hauteur peut être spécifiée en termes de <em>ni dha pa ma ga re sa</em>."
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr "Énigmatique"
+#~ msgid "Enigmatic"
+#~ msgstr "Énigmatique"
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr "quintes"
+#~ msgid "fifths"
+#~ msgstr "quintes"
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr "ml"
+#~ msgid "ml"
+#~ msgstr "ml"
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr "mi"
+#~ msgid "mi"
+#~ msgstr "mi"
 
 #: js/turtledefs.js:251
 
@@ -9512,608 +9512,608 @@ msgstr "mouvement"
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr "Le bloc <em>Do</em> est utilisé pour initier une action."
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr "Le bloc <em>Do</em> est utilisé pour initier une action."
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr "Le bloc Indexheap renvoie une valeur dans le tas à un emplacement spécifié."
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr "Le bloc Indexheap renvoie une valeur dans le tas à un emplacement spécifié."
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr "Le bloc <em>Pen-up</em> lève le stylo pour qu'il ne dessine pas."
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr "Le bloc <em>Pen-up</em> lève le stylo pour qu'il ne dessine pas."
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr "Le bloc <em>New mouse</em> créera une nouvelle souris."
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr "Le bloc <em>New mouse</em> créera une nouvelle souris."
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr "lecture"
+#~ msgid "playback"
+#~ msgstr "lecture"
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr "Fusionner le projet à partir du fichier"
+#~ msgid "Merge project from file"
+#~ msgstr "Fusionner le projet à partir du fichier"
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr "Le bloc <em>Left</em> renvoie la position de la gauche de la toile."
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr "Le bloc <em>Left</em> renvoie la position de la gauche de la toile."
 
-#~msgid "eatme"
-#~msgstr "manger"
+#~ msgid "eatme"
+#~ msgstr "manger"
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr "Le bloc <em>Whole notes played</em> renvoie le nombre total de notes entières jouées."
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr "Le bloc <em>Whole notes played</em> renvoie le nombre total de notes entières jouées."
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr "mobile"
+#~ msgid "movable"
+#~ msgstr "mobile"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr "bruit brun"
+#~ msgid "brown-noise"
+#~ msgstr "bruit brun"
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr "Japonais"
+#~ msgid "Japanese"
+#~ msgstr "Japonais"
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr "cloche triangulaire"
+#~ msgid "triangle-bell"
+#~ msgstr "cloche triangulaire"
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr "Cacher la grille"
+#~ msgid "Hide grid"
+#~ msgstr "Cacher la grille"
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr "Le bloc <em>FM synth</em> est un modulateur de fréquence utilisé pour définir un timbre."
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr "Le bloc <em>FM synth</em> est un modulateur de fréquence utilisé pour définir un timbre."
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr "Le bloc Show heap affiche le contenu du tas en haut de l'écran."
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr "Le bloc Show heap affiche le contenu du tas en haut de l'écran."
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr "Le bloc <em>Number</em> contient un nombre."
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr "Le bloc <em>Number</em> contient un nombre."
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr "Le bloc <em>Case</em> est utilisé à l'intérieur d'un <em>Switch</em> pour définir des correspondances."
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr "Le bloc <em>Case</em> est utilisé à l'intérieur d'un <em>Switch</em> pour définir des correspondances."
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr "Le bloc Background définit la couleur de fond."
+#~ msgid "The Background block sets the background color."
+#~ msgstr "Le bloc Background définit la couleur de fond."
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr "Page précédente"
+#~ msgid "Previous page"
+#~ msgstr "Page précédente"
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr "Le bloc <em>Open file</em> ouvre un fichier pour être utilisé avec le bloc <em>Show</em>."
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr "Le bloc <em>Open file</em> ouvre un fichier pour être utilisé avec le bloc <em>Show</em>."
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr "Le bloc <em>Set-color</em> change la couleur du stylo."
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr "Le bloc <em>Set-color</em> change la couleur du stylo."
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr "accord' + ' ' + 'IV"
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr "accord' + ' ' + 'IV"
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr "effets"
+#~ msgid "effects"
+#~ msgstr "effets"
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr "tom basse"
+#~ msgid "floor-tom"
+#~ msgstr "tom basse"
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr "Le bloc <em>Height</em> renvoie la hauteur de la toile."
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr "Le bloc <em>Height</em> renvoie la hauteur de la toile."
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr "Partager sur Facebook"
+#~ msgid "Share on Facebook"
+#~ msgstr "Partager sur Facebook"
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr "Le bloc <em>Shade</em> renvoie la valeur actuelle de la nuance du stylo."
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr "Le bloc <em>Shade</em> renvoie la valeur actuelle de la nuance du stylo."
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr "Le bloc On-every-beat vous permet de spécifier des actions à effectuer à chaque battement."
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr "Le bloc On-every-beat vous permet de spécifier des actions à effectuer à chaque battement."
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr "M. Mouse est notre chef d'orchestre de Music Blocks. M. Mouse vous encourage à explorer Music Blocks. Commençons notre visite!"
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr "M. Mouse est notre chef d'orchestre de Music Blocks. M. Mouse vous encourage à explorer Music Blocks. Commençons notre visite!"
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr "re"
+#~ msgid "re"
+#~ msgstr "re"
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr "Gitan espagnol"
+#~ msgid "Spanish Gypsy"
+#~ msgstr "Gitan espagnol"
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr "diviser la valeur de la note"
+#~ msgid "divide note value"
+#~ msgstr "diviser la valeur de la note"
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr "par ex., C Majeur"
+#~ msgid "e.g., C Major"
+#~ msgstr "par ex., C Majeur"
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr "appui long pour exécuter la musique lentement"
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr "appui long pour exécuter la musique lentement"
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr "enregistrer la boîte à rythmes"
+#~ msgid "save drum machine"
+#~ msgstr "enregistrer la boîte à rythmes"
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr "activer le défilement horizontal"
+#~ msgid "enable horizontal scrolling"
+#~ msgstr "activer le défilement horizontal"
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr "Le bloc <em>Pickup</em> est utilisé pour accueillir toutes les notes qui arrivent avant le battement."
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr "Le bloc <em>Pickup</em> est utilisé pour accueillir toutes les notes qui arrivent avant le battement."
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr "Le bloc <em>Hollow line</em> crée une ligne avec un centre creux."
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr "Le bloc <em>Hollow line</em> crée une ligne avec un centre creux."
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr "Pour copier une pile dans le presse-papiers, cliquez dessus avec le bouton droit."
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr "Pour copier une pile dans le presse-papiers, cliquez dessus avec le bouton droit."
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr "Le bloc <em>Stopplayback</em>"
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr "Le bloc <em>Stopplayback</em>"
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr "Enregistrer en abc"
+#~ msgid "Save as abc"
+#~ msgstr "Enregistrer en abc"
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr "Le bloc <em>To frequency</em> convertit un nom de hauteur et une octave en Hertz."
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr "Le bloc <em>To frequency</em> convertit un nom de hauteur et une octave en Hertz."
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr "haut"
+#~ msgid "top"
+#~ msgstr "haut"
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "Ouvrir un panneau pour configurer Music Blocks."
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "Ouvrir un panneau pour configurer Music Blocks."
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr "Le bloc <em>And</em> est l'opérateur logique et."
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr "Le bloc <em>And</em> est l'opérateur logique et."
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr "Enregistrer en .wav"
+#~ msgid "Save as .wav"
+#~ msgstr "Enregistrer en .wav"
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr "La Planète est indisponible."
+#~ msgid "The Planet is unavailable."
+#~ msgstr "La Planète est indisponible."
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr "Vous pouvez utiliser plusieurs blocs <em>Drum</em> dans un bloc <em>Note</em>."
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr "Vous pouvez utiliser plusieurs blocs <em>Drum</em> dans un bloc <em>Note</em>."
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr "Vous pouvez également utiliser Alt+V pour coller une pile de blocs. "
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr "Vous pouvez également utiliser Alt+V pour coller une pile de blocs. "
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr "Le bloc <em>Video</em> sélectionne la vidéo à utiliser avec le bloc <em>Show</em>."
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr "Le bloc <em>Video</em> sélectionne la vidéo à utiliser avec le bloc <em>Show</em>."
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "Lorsque <em>Movable do</em> est faux, les noms des notes de solfège sont toujours liés à des hauteurs spécifiques (par exemple, \"do\" est toujours \"C-naturel\"); lorsque <em>Movable do</em> est vrai, les noms des notes de solfège sont attribués à des degrés de gamme (\"do\" est toujours le premier degré de la gamme majeure)."
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "Lorsque <em>Movable do</em> est faux, les noms des notes de solfège sont toujours liés à des hauteurs spécifiques (par exemple, \"do\" est toujours \"C-naturel\"); lorsque <em>Movable do</em> est vrai, les noms des notes de solfège sont attribués à des degrés de gamme (\"do\" est toujours le premier degré de la gamme majeure)."
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr "Le bloc <em>Pop</em> supprime la valeur en haut du tas."
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr "Le bloc <em>Pop</em> supprime la valeur en haut du tas."
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr "Le bloc <em>Decrescendo</em> diminuera le volume des notes contenues d'un montant spécifié pour chaque note jouée. Par exemple, si vous avez 7 notes en séquence contenues dans un bloc <em>Decrescendo</em> avec une valeur de 5, la note finale sera à 35% de moins que le volume de départ."
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr "Le bloc <em>Decrescendo</em> diminuera le volume des notes contenues d'un montant spécifié pour chaque note jouée. Par exemple, si vous avez 7 notes en séquence contenues dans un bloc <em>Decrescendo</em> avec une valeur de 5, la note finale sera à 35% de moins que le volume de départ."
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr "Le bouton save-stack enregistre une pile sur une palette personnalisée."
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr "Le bouton save-stack enregistre une pile sur une palette personnalisée."
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr "Égyptien"
+#~ msgid "Egyptian"
+#~ msgstr "Égyptien"
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr "Le bouton coller est activé lorsqu'il y a des blocs copiés dans le presse-papiers."
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr "Le bouton coller est activé lorsqu'il y a des blocs copiés dans le presse-papiers."
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr "Algérien"
+#~ msgid "Algerian"
+#~ msgstr "Algérien"
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr "dénominateur"
+#~ msgid "denominator"
+#~ msgstr "dénominateur"
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr "Le bloc Emptyheap vide le tas."
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr "Le bloc Emptyheap vide le tas."
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr "Le bloc <em>Phaser</em> ajoute un son de balayage."
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr "Le bloc <em>Phaser</em> ajoute un son de balayage."
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr "Le bloc <em>Open project</em> est utilisé pour ouvrir un projet à partir d'une page Web."
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr "Le bloc <em>Open project</em> est utilisé pour ouvrir un projet à partir d'une page Web."
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr "Données d'impact non disponibles."
+#~ msgid "Impact data not available."
+#~ msgstr "Données d'impact non disponibles."
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr "Appuyez longuement sur le bouton d'exécution pour exécuter la musique en mode lent."
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr "Appuyez longuement sur le bouton d'exécution pour exécuter la musique en mode lent."
 
-#~msgid "mashape"
-#~msgstr "mashape"
+#~ msgid "mashape"
+#~ msgstr "mashape"
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr "tiers"
+#~ msgid "thirds"
+#~ msgstr "tiers"
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr "Le bloc <em>X</em> renvoie la position horizontale de la souris."
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr "Le bloc <em>X</em> renvoie la position horizontale de la souris."
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr "Le bloc <em>Delete block</em> supprime un bloc."
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr "Le bloc <em>Delete block</em> supprime un bloc."
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr "Le bloc <em>Scroll XY</em> déplace la toile."
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr "Le bloc <em>Scroll XY</em> déplace la toile."
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr "Le bloc <em>Return to URL</em> renverra une valeur à une page Web."
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr "Le bloc <em>Return to URL</em> renverra une valeur à une page Web."
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr "Le bloc <em>Left</em> tourne la souris vers la gauche."
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr "Le bloc <em>Left</em> tourne la souris vers la gauche."
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr "Exécuter"
+#~ msgid "Run"
+#~ msgstr "Exécuter"
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "Vous pouvez charger de nouveaux blocs à partir du système de fichiers."
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "Vous pouvez charger de nouveaux blocs à partir du système de fichiers."
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr "Paramètres"
+#~ msgid "Settings"
+#~ msgstr "Paramètres"
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr "Le bloc <em>Boolean</em> est utilisé pour spécifier vrai ou faux."
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr "Le bloc <em>Boolean</em> est utilisé pour spécifier vrai ou faux."
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr "Le bloc <em>On-strong-beat</em> vous permet de spécifier des actions à effectuer sur des battements spécifiés."
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr "Le bloc <em>On-strong-beat</em> vous permet de spécifier des actions à effectuer sur des battements spécifiés."
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr "Le bloc <em>Indexheap</em> renvoie une valeur dans le tas à un emplacement spécifié."
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr "Le bloc <em>Indexheap</em> renvoie une valeur dans le tas à un emplacement spécifié."
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr "Le bloc <em>Arg</em> contient la valeur d'un argument passé à une action."
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr "Le bloc <em>Arg</em> contient la valeur d'un argument passé à une action."
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr "descendre"
+#~ msgid "move down"
+#~ msgstr "descendre"
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr "étape consonante vers le haut"
+#~ msgid "consonant step up"
+#~ msgstr "étape consonante vers le haut"
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr "Le bloc <em>Emptyheap</em> vide le tas."
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr "Le bloc <em>Emptyheap</em> vide le tas."
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr "Le bloc <em>Default</em> est utilisé à l'intérieur d'un <em>Switch</em> pour définir une action par défaut."
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr "Le bloc <em>Default</em> est utilisé à l'intérieur d'un <em>Switch</em> pour définir une action par défaut."
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr "Le bloc <em>Scalar step up</em> renvoie le nombre de demi-tons jusqu'à la note suivante dans la tonalité et le mode actuels."
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr "Le bloc <em>Scalar step up</em> renvoie le nombre de demi-tons jusqu'à la note suivante dans la tonalité et le mode actuels."
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr "Le bloc <em>Rhythm Maker</em> ouvre un outil pour créer des boîtes à rythmes."
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr "Le bloc <em>Rhythm Maker</em> ouvre un outil pour créer des boîtes à rythmes."
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr "Le bloc <em>Cap de la souris</em> renvoie le cap de la souris spécifiée."
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr "Le bloc <em>Cap de la souris</em> renvoie le cap de la souris spécifiée."
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr "curseur de hauteur"
+#~ msgid "pitchslider"
+#~ msgstr "curseur de hauteur"
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr "Voir plus"
+#~ msgid "View More"
+#~ msgstr "Voir plus"
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr "réduire"
+#~ msgid "collpase"
+#~ msgstr "réduire"
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr "Le bloc Tas-vide? renvoie vrai si le tas est vide."
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr "Le bloc Tas-vide? renvoie vrai si le tas est vide."
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr "Fibonacci"
+#~ msgid "Fibonacci"
+#~ msgstr "Fibonacci"
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr "Exécuter la musique lentement"
+#~ msgid "Run music slowly"
+#~ msgstr "Exécuter la musique lentement"
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr "Le bloc <em>Définir la translucidité</em> modifie l'opacité du stylo."
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr "Le bloc <em>Définir la translucidité</em> modifie l'opacité du stylo."
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr "Le bloc <em>Hauteur</em> spécifie le nom et l'octave de la hauteur d'une note qui déterminent la fréquence de la note."
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr "Le bloc <em>Hauteur</em> spécifie le nom et l'octave de la hauteur d'une note qui déterminent la fréquence de la note."
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr "Le bloc <em>Staccato</em> raccourcit la durée de la note réelle—les rendant plus courtes—tout en maintenant la valeur rythmique spécifiée des notes."
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr "Le bloc <em>Staccato</em> raccourcit la durée de la note réelle—les rendant plus courtes—tout en maintenant la valeur rythmique spécifiée des notes."
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr "Utilisez le curseur pour changer la hauteur."
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr "Utilisez le curseur pour changer la hauteur."
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr "Le bloc <em>Droite</em> renvoie la position de la droite de la toile."
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr "Le bloc <em>Droite</em> renvoie la position de la droite de la toile."
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr "Le bloc <em>Définir le volume du synthé</em> changera le volume d'un synthé particulier, par exemple, guitare, violon, caisse claire, etc. Le volume par défaut est de 50; la plage est de 0 (silence) à 100 (volume maximum)."
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr "Le bloc <em>Définir le volume du synthé</em> changera le volume d'un synthé particulier, par exemple, guitare, violon, caisse claire, etc. Le volume par défaut est de 50; la plage est de 0 (silence) à 100 (volume maximum)."
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr "Le bloc <em>Crescendo</em> augmentera le volume des notes contenues d'un montant spécifié pour chaque note jouée. Par exemple, si vous avez 7 notes en séquence contenues dans un bloc <em>Crescendo</em> avec une valeur de 5, la note finale sera à 35% de plus que le volume de départ."
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr "Le bloc <em>Crescendo</em> augmentera le volume des notes contenues d'un montant spécifié pour chaque note jouée. Par exemple, si vous avez 7 notes en séquence contenues dans un bloc <em>Crescendo</em> avec une valeur de 5, la note finale sera à 35% de plus que le volume de départ."
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr "volume de la note"
+#~ msgid "note volume"
+#~ msgstr "volume de la note"
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr "cymbales à doigts"
+#~ msgid "finger-cymbals"
+#~ msgstr "cymbales à doigts"
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr "matrice hauteur-tambour"
+#~ msgid "pitch-drum matrix"
+#~ msgstr "matrice hauteur-tambour"
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr "Bloc Tuplet : Vouliez-vous utiliser un bloc Matrice ?"
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr "Bloc Tuplet : Vouliez-vous utiliser un bloc Matrice ?"
 
-#~msgid "set beats per minute"
-#~msgstr "définir les battements par minute"
+#~ msgid "set beats per minute"
+#~ msgstr "définir les battements par minute"
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr "Effacer tout"
+#~ msgid "Delete all"
+#~ msgstr "Effacer tout"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr "bruit rose"
+#~ msgid "pink-noise"
+#~ msgstr "bruit rose"
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr "UID"
+#~ msgid "UID"
+#~ msgstr "UID"
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr "Chromatique"
+#~ msgid "Chromatic"
+#~ msgstr "Chromatique"
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr "tourner dans le sens horaire"
+#~ msgid "rotate clockwise"
+#~ msgstr "tourner dans le sens horaire"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr "hirajoshi (Japon)"
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr "hirajoshi (Japon)"
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr "L'entrée du bloc Mineur doit être 2, 3, 6 ou 7"
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr "L'entrée du bloc Mineur doit être 2, 3, 6 ou 7"
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr "bas"
+#~ msgid "bottom"
+#~ msgstr "bas"
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr "Le bloc <em>Définir la tonalité</em> est utilisé pour définir la tonalité et le mode, par exemple, <em>Do Majeur</em>"
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr "Le bloc <em>Définir la tonalité</em> est utilisé pour définir la tonalité et le mode, par exemple, <em>Do Majeur</em>"
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr "Le bloc <em>Multiplier la valeur de la note</em> modifie la durée des notes en changeant leurs valeurs de note."
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr "Le bloc <em>Multiplier la valeur de la note</em> modifie la durée des notes en changeant leurs valeurs de note."
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr "Le bloc <em>Y</em> renvoie la position verticale de la souris."
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr "Le bloc <em>Y</em> renvoie la position verticale de la souris."
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr "numérateur"
+#~ msgid "numerator"
+#~ msgstr "numérateur"
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr "tambour de tasse"
+#~ msgid "cup-drum"
+#~ msgstr "tambour de tasse"
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr "charleston"
+#~ msgid "hi-hat"
+#~ msgstr "charleston"
 
 #: js/palette.js:1763
 
@@ -10123,165 +10123,165 @@ msgstr "mouvement"
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr "sol"
+#~ msgid "sol"
+#~ msgstr "sol"
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr "Le bloc <em>Arc</em> déplace la souris en arc."
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr "Le bloc <em>Arc</em> déplace la souris en arc."
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr "L'outil <em>Escalier de hauteur</em> est utilisé pour générer des hauteurs à partir d'un ratio donné."
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr "L'outil <em>Escalier de hauteur</em> est utilisé pour générer des hauteurs à partir d'un ratio donné."
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr "Le bloc <em>Volume de la note</em> renvoie le volume actuel du synthétiseur actuel."
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr "Le bloc <em>Volume de la note</em> renvoie le volume actuel du synthétiseur actuel."
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr "Le rythme de la musique est déterminé par le bloc <em>Mesure</em> (par défaut, 4 notes 1/4 par mesure)."
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr "Le rythme de la musique est déterminé par le bloc <em>Mesure</em> (par défaut, 4 notes 1/4 par mesure)."
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr "Le bloc <em>Sélecteur d'altérations</em> est utilisé pour choisir entre double-dièse, dièse, naturel, bémol et double-bémol."
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr "Le bloc <em>Sélecteur d'altérations</em> est utilisé pour choisir entre double-dièse, dièse, naturel, bémol et double-bémol."
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr "Phrygien"
+#~ msgid "Phrygian"
+#~ msgstr "Phrygien"
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr "Le bloc <em>Définir le mode</em> vous permet de définir un mode personnalisé en spécifiant des numéros de hauteur."
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr "Le bloc <em>Définir le mode</em> vous permet de définir un mode personnalisé en spécifiant des numéros de hauteur."
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr "Exécuter rapidement / appui long pour exécuter lentement / appui très long pour exécuter la musique lentement"
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr "Exécuter rapidement / appui long pour exécuter lentement / appui très long pour exécuter la musique lentement"
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr "Music Blocks est une collection d'outils de manipulation pour explorer les concepts musicaux fondamentaux de manière intégrative et amusante."
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr "Music Blocks est une collection d'outils de manipulation pour explorer les concepts musicaux fondamentaux de manière intégrative et amusante."
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr "la"
+#~ msgid "la"
+#~ msgstr "la"
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr "voir la distance"
+#~ msgid "see distance"
+#~ msgstr "voir la distance"
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr "Le bloc <em>Tuplet</em> est utilisé pour générer un groupe de notes jouées dans un laps de temps condensé."
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr "Le bloc <em>Tuplet</em> est utilisé pour générer un groupe de notes jouées dans un laps de temps condensé."
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr "Le bloc Interrupteur exécutera le code dans le Cas correspondant."
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr "Le bloc Interrupteur exécutera le code dans le Cas correspondant."
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr "intervalle relatif"
+#~ msgid "relative interval"
+#~ msgstr "intervalle relatif"
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr "Le bloc <em>Battements par minute</em> définit le nombre de notes 1/4 par minute."
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr "Le bloc <em>Battements par minute</em> définit le nombre de notes 1/4 par minute."
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr "Le bloc <em>Largeur</em> renvoie la largeur de la toile."
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr "Le bloc <em>Largeur</em> renvoie la largeur de la toile."
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr "Arrêtez la musique (et les tortues)."
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr "Arrêtez la musique (et les tortues)."
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr "tom basse"
+#~ msgid "floor-tom-tom"
+#~ msgstr "tom basse"
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr "Le bloc <em>Liaison</em> fonctionne sur des paires de notes, les combinant en une seule note."
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr "Le bloc <em>Liaison</em> fonctionne sur des paires de notes, les combinant en une seule note."
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr "La hauteur peut être spécifiée en termes de <em>do ré mi fa sol la si<em>."
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr "La hauteur peut être spécifiée en termes de <em>do ré mi fa sol la si<em>."
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr "Le bloc <em>Afficher</em> est utilisé pour afficher du texte ou des images sur la toile."
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr "Le bloc <em>Afficher</em> est utilisé pour afficher du texte ou des images sur la toile."
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr "Le bloc <em>Arrière-plan</em> définit la couleur de fond."
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr "Le bloc <em>Arrière-plan</em> définit la couleur de fond."
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr "note de tortue"
+#~ msgid "turtle note"
+#~ msgstr "note de tortue"
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr "Cette barre d'outils contient les boutons de la palette, y compris Rythme, Hauteur, Ton, Tortue et plus."
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr "Cette barre d'outils contient les boutons de la palette, y compris Rythme, Hauteur, Ton, Tortue et plus."
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr "Le bloc <em>Tant que</em> se répétera tant que la condition est vraie."
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr "Le bloc <em>Tant que</em> se répétera tant que la condition est vraie."
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr "Le bloc <em>Moins</em> est utilisé pour soustraire."
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr "Le bloc <em>Moins</em> est utilisé pour soustraire."
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr "bloc d'œuvres d'art"
+#~ msgid "block artwork"
+#~ msgstr "bloc d'œuvres d'art"
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr "Le bloc <em>Voisin</em> passe rapidement entre les hauteurs voisines."
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr "Le bloc <em>Voisin</em> passe rapidement entre les hauteurs voisines."
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr "Le bloc <em>Distorsion</em> ajoute de la distorsion à la hauteur."
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr "Le bloc <em>Distorsion</em> ajoute de la distorsion à la hauteur."
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr "br"
+#~ msgid "br"
+#~ msgstr "br"
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr "1er"
+#~ msgid "1st"
+#~ msgstr "1er"
 
 #: js/logo.js:2177
 
@@ -10295,28 +10295,28 @@ msgstr "mouvement"
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr "Impossible de trouver la tortue"
+#~ msgid "Could not find turtle"
+#~ msgstr "Impossible de trouver la tortue"
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr "Le bloc <em>Liaison</em> prolonge la tenue des notes tout en maintenant la valeur rythmique spécifiée des notes."
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr "Le bloc <em>Liaison</em> prolonge la tenue des notes tout en maintenant la valeur rythmique spécifiée des notes."
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr "Hongrois"
+#~ msgid "Hungarian"
+#~ msgstr "Hongrois"
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr "jouer l'accord"
+#~ msgid "play chord"
+#~ msgstr "jouer l'accord"
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr "Optimiser les retours"
+#~ msgid "Optimize feedback"
+#~ msgstr "Optimiser les retours"
 
 #: js/turtledefs.js:187
 
@@ -10324,133 +10324,133 @@ msgstr "mouvement"
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr "Enregistrer l'œuvre d'art du bloc"
+#~ msgid "Save block artwork"
+#~ msgstr "Enregistrer l'œuvre d'art du bloc"
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr "Le bloc <em>Curseur de hauteur<em> ouvre un outil pour générer des hauteurs arbitraires."
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr "Le bloc <em>Curseur de hauteur<em> ouvre un outil pour générer des hauteurs arbitraires."
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr "Le bloc de pas d'échelle doit être utilisé à l'intérieur d'un bloc Note."
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr "Le bloc de pas d'échelle doit être utilisé à l'intérieur d'un bloc Note."
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr "Music Blocks est une collection d'outils open source pour explorer les concepts musicaux. Une liste complète des contributeurs peut être trouvée dans le dépôt GitHub de Music Blocks. Music Blocks est sous licence AGPL. La version actuelle est :"
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr "Music Blocks est une collection d'outils open source pour explorer les concepts musicaux. Une liste complète des contributeurs peut être trouvée dans le dépôt GitHub de Music Blocks. Music Blocks est sous licence AGPL. La version actuelle est :"
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr "quatrièmes"
+#~ msgid "fourths"
+#~ msgstr "quatrièmes"
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr "Le bloc <em>Curseur Y</em> renvoie la position verticale de la souris."
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr "Le bloc <em>Curseur Y</em> renvoie la position verticale de la souris."
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr "Le bloc Crescendo augmentera (ou diminuera) le volume des notes contenues d'un montant spécifié pour chaque note jouée. Par exemple, si vous avez 7 notes en séquence contenues dans un bloc <em>Crescendo</em> avec une valeur de 5, la note finale sera à 35% de plus que le volume de départ."
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr "Le bloc Crescendo augmentera (ou diminuera) le volume des notes contenues d'un montant spécifié pour chaque note jouée. Par exemple, si vous avez 7 notes en séquence contenues dans un bloc <em>Crescendo</em> avec une valeur de 5, la note finale sera à 35% de plus que le volume de départ."
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr "Le bloc <em>Clavier</em> renvoie l'entrée du clavier de l'ordinateur."
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr "Le bloc <em>Clavier</em> renvoie l'entrée du clavier de l'ordinateur."
 
-#~msgid "Save your project to a server."
-#~msgstr "Enregistrez votre projet sur un serveur."
+#~ msgid "Save your project to a server."
+#~ msgstr "Enregistrez votre projet sur un serveur."
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr "multiplier la valeur du battement"
+#~ msgid "multiply beat value"
+#~ msgstr "multiplier la valeur du battement"
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr "Ton entier"
+#~ msgid "Whole Tone"
+#~ msgstr "Ton entier"
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr "Le bloc <em>Int</em> renvoie un entier."
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr "Le bloc <em>Int</em> renvoie un entier."
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr "Le bloc <em>boîte2</em> renvoie la valeur stockée dans <em>boîte2</em>."
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr "Le bloc <em>boîte2</em> renvoie la valeur stockée dans <em>boîte2</em>."
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr "Cliquez pour exécuter uniquement la musique en mode lent."
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr "Cliquez pour exécuter uniquement la musique en mode lent."
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr "Le bloc <em>Parler</em> sort vers le synthétiseur de texte à parole."
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr "Le bloc <em>Parler</em> sort vers le synthétiseur de texte à parole."
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr "Le bloc <em>Gris</em> renvoie la valeur grise actuelle du stylo."
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr "Le bloc <em>Gris</em> renvoie la valeur grise actuelle du stylo."
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr "6ème"
+#~ msgid "6th"
+#~ msgstr "6ème"
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "L'entrée du bloc Augmenté doit être 1, 2, 3, 4, 5, 6, 7 ou 8"
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "L'entrée du bloc Augmenté doit être 1, 2, 3, 4, 5, 6, 7 ou 8"
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr "Le bloc <em>Nom du tambour</em> est utilisé pour sélectionner un tambour."
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr "Le bloc <em>Nom du tambour</em> est utilisé pour sélectionner un tambour."
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr "Exécuter rapidement / appui long pour exécuter lentement / appui très long pour exécuter la musique lentement"
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr "Exécuter rapidement / appui long pour exécuter lentement / appui très long pour exécuter la musique lentement"
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr "enregistrer sous lilypond"
+#~ msgid "save as lilypond"
+#~ msgstr "enregistrer sous lilypond"
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr "Le bloc <em>Diviser</em> est utilisé pour diviser."
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr "Le bloc <em>Diviser</em> est utilisé pour diviser."
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr "Le bloc <em>Partiel</em> est utilisé pour spécifier un poids pour un harmonique partiel spécifique."
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr "Le bloc <em>Partiel</em> est utilisé pour spécifier un poids pour un harmonique partiel spécifique."
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr "Le bloc <em>Nom du tempérament</em> est utilisé pour sélectionner une méthode d'accordage."
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr "Le bloc <em>Nom du tempérament</em> est utilisé pour sélectionner une méthode d'accordage."
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr "Diminué"
+#~ msgid "Diminished"
+#~ msgstr "Diminué"
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr "Développer ou réduire la barre d'outils"
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr "Développer ou réduire la barre d'outils"
 
 #: js/turtledefs.js:187
 
@@ -10458,136 +10458,136 @@ msgstr "mouvement"
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr "Enregistrer en SVG"
+#~ msgid "Save as SVG"
+#~ msgstr "Enregistrer en SVG"
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr "Le bloc Charger le tas charge le tas à partir d'un fichier."
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr "Le bloc Charger le tas charge le tas à partir d'un fichier."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr "in (Japon)"
+#~ msgid "in (Japan)"
+#~ msgstr "in (Japon)"
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr "Alternativement, vous pouvez appuyer sur la touche ENTRER ou RETOUR."
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr "Alternativement, vous pouvez appuyer sur la touche ENTRER ou RETOUR."
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr "Le bloc <em>Définir le timbre</em> sélectionne une voix pour le synthétiseur, par exemple, guitare, piano, violon ou violoncelle."
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr "Le bloc <em>Définir le timbre</em> sélectionne une voix pour le synthétiseur, par exemple, guitare, piano, violon ou violoncelle."
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "tortue"
+#~ msgid "turtle"
+#~ msgstr "tortue"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr "Le bloc <em>Souris Y</em> renvoie la position Y de la souris spécifiée."
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr "Le bloc <em>Souris Y</em> renvoie la position Y de la souris spécifiée."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr "minyo (Japon)"
+#~ msgid "minyo (Japan)"
+#~ msgstr "minyo (Japon)"
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr "Temps d'impact non trouvé."
+#~ msgid "Impact Time not found."
+#~ msgstr "Temps d'impact non trouvé."
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr "Le bloc <em>Battements par minute</em> modifie les battements par minute de toutes les notes contenues."
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr "Le bloc <em>Battements par minute</em> modifie les battements par minute de toutes les notes contenues."
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr "Le bloc <em>Arrêter la souris</em> arrête la souris spécifiée."
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr "Le bloc <em>Arrêter la souris</em> arrête la souris spécifiée."
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr "3ème"
+#~ msgid "3rd"
+#~ msgstr "3ème"
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr "Le bloc <em>Dupliquer</em> exécutera chaque bloc plusieurs fois. La sortie de l'exemple est : Sol, Sol, Sol, Sol, Ré, Ré, Ré, Ré, Sol, Sol, Sol, Sol."
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr "Le bloc <em>Dupliquer</em> exécutera chaque bloc plusieurs fois. La sortie de l'exemple est : Sol, Sol, Sol, Sol, Ré, Ré, Ré, Ré, Sol, Sol, Sol, Sol."
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr "Le bloc <em>Doublement</em> doublera la taille d'un intervalle."
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr "Le bloc <em>Doublement</em> doublera la taille d'un intervalle."
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr "Le bloc <em>Exécuter le bloc</em> exécute un bloc."
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr "Le bloc <em>Exécuter le bloc</em> exécute un bloc."
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr "jouer en avant"
+#~ msgid "play forward"
+#~ msgstr "jouer en avant"
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr "basse"
+#~ msgid "basse"
+#~ msgstr "basse"
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr "Le bloc <em>Hertz</em> (en combinaison avec un bloc <em>Nombre</em>) jouera un son à la fréquence spécifiée."
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr "Le bloc <em>Hertz</em> (en combinaison avec un bloc <em>Nombre</em>) jouera un son à la fréquence spécifiée."
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr "Le bloc <em>Staccato</em> raccourcit la durée de la note tout en maintenant la valeur rythmique spécifiée des notes."
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr "Le bloc <em>Staccato</em> raccourcit la durée de la note tout en maintenant la valeur rythmique spécifiée des notes."
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr "Le bloc <em>Vers ASCII</em> convertit les nombres en lettres."
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr "Le bloc <em>Vers ASCII</em> convertit les nombres en lettres."
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr "Le bloc <em>Longueur du mode</em> est le nombre de notes dans l'échelle actuelle. La plupart des échelles <em>occidentales</em> ont 7 notes."
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr "Le bloc <em>Longueur du mode</em> est le nombre de notes dans l'échelle actuelle. La plupart des échelles <em>occidentales</em> ont 7 notes."
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr "Le bloc <em>Ajouter-1-à<em> ajoute un à la valeur stockée dans une boîte."
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr "Le bloc <em>Ajouter-1-à<em> ajoute un à la valeur stockée dans une boîte."
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr "440 hertz"
+#~ msgid "440 hertz"
+#~ msgstr "440 hertz"
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr "Le bloc <em>Définir XY</em> déplace la souris à une position spécifique sur l'écran."
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr "Le bloc <em>Définir XY</em> déplace la souris à une position spécifique sur l'écran."
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr "Optimiser la performance"
+#~ msgid "Optimize performance"
+#~ msgstr "Optimiser la performance"
 
 #: js/playback.js:31
 
@@ -10597,127 +10597,127 @@ msgstr "mouvement"
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr "tout jouer"
+#~ msgid "play all"
+#~ msgstr "tout jouer"
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr "Le bloc <em>Caméra</em> connecte une webcam au bloc <em>Afficher</em>."
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr "Le bloc <em>Caméra</em> connecte une webcam au bloc <em>Afficher</em>."
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr "cymbales à doigts"
+#~ msgid "finger cymbols"
+#~ msgstr "cymbales à doigts"
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr "simple-1"
+#~ msgid "simple-1"
+#~ msgstr "simple-1"
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr "descente consonante"
+#~ msgid "consonant step down"
+#~ msgstr "descente consonante"
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr "cloche de ride"
+#~ msgid "ride-bell"
+#~ msgstr "cloche de ride"
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr "Music Blocks est une collection d'outils pour explorer les concepts musicaux."
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr "Music Blocks est une collection d'outils pour explorer les concepts musicaux."
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr "Impossible de lire la couleur du pixel"
+#~ msgid "Cannot read pixel color"
+#~ msgstr "Impossible de lire la couleur du pixel"
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr "Le bloc <em>Règle de rythme</em> ouvre un outil pour créer des boîtes à rythmes."
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr "Le bloc <em>Règle de rythme</em> ouvre un outil pour créer des boîtes à rythmes."
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr "Le bloc <em>Racine carrée</em> renvoie la racine carrée."
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr "Le bloc <em>Racine carrée</em> renvoie la racine carrée."
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr "Le bloc <em>Compteur de notes</em> peut être utilisé pour compter le nombre de notes contenues."
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr "Le bloc <em>Compteur de notes</em> peut être utilisé pour compter le nombre de notes contenues."
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr "Le bloc <em>Tas vide?</em> renvoie vrai si le tas est vide."
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr "Le bloc <em>Tas vide?</em> renvoie vrai si le tas est vide."
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr "Lydien"
+#~ msgid "Lydian"
+#~ msgstr "Lydien"
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr "Le bloc <em>Nom du bruit</em> est utilisé pour sélectionner un synthétiseur de bruit."
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr "Le bloc <em>Nom du bruit</em> est utilisé pour sélectionner un synthétiseur de bruit."
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr "La <em>Matrice de tambour</em> est utilisée pour mapper les hauteurs aux sons de tambour."
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr "La <em>Matrice de tambour</em> est utilisée pour mapper les hauteurs aux sons de tambour."
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr "Le bloc <em>Point</em> prolonge la durée d'une note de 50%. Par exemple, une noire pointée jouera pendant 3/8 (1/4 + 1/8) d'un battement."
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr "Le bloc <em>Point</em> prolonge la durée d'une note de 50%. Par exemple, une noire pointée jouera pendant 3/8 (1/4 + 1/8) d'un battement."
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr "Le bloc <em>boîte2</em> renvoie la valeur stockée dans <em>boîte2</em>."
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr "Le bloc <em>boîte2</em> renvoie la valeur stockée dans <em>boîte2</em>."
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr "Le bloc Numéro de hauteur jouera une hauteur associée à son numéro, par exemple, 1 pour C, 7 pour G."
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr "Le bloc Numéro de hauteur jouera une hauteur associée à son numéro, par exemple, 1 pour C, 7 pour G."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr "majeur harmonique"
+#~ msgid "harmonic-major"
+#~ msgstr "majeur harmonique"
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr "Menu auxiliaire"
+#~ msgid "Auxillary menu"
+#~ msgstr "Menu auxiliaire"
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr "Publier"
+#~ msgid "Publish"
+#~ msgstr "Publier"
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr "Le bloc <em>Empiler</em> ajoute une valeur en haut du tas."
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr "Le bloc <em>Empiler</em> ajoute une valeur en haut du tas."
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr "Mineur roumain"
+#~ msgid "Romanian Minor"
+#~ msgstr "Mineur roumain"
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr "Dans l'exemple, il est utilisé avec le bloc <em>Un de</em> pour choisir une phase aléatoire."
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr "Dans l'exemple, il est utilisé avec le bloc <em>Un de</em> pour choisir une phase aléatoire."
 
 #: js/activity.js:2433
 
@@ -10725,397 +10725,397 @@ msgstr "mouvement"
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr "sans titre"
+#~ msgid "untitled"
+#~ msgstr "sans titre"
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr "Mondial"
+#~ msgid "Worldwide"
+#~ msgstr "Mondial"
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr "Par exemple, une noire pointée jouera pendant 3/8 (1/4 + 1/8) d'un battement."
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr "Par exemple, une noire pointée jouera pendant 3/8 (1/4 + 1/8) d'un battement."
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr "appui long pour exécuter lentement"
+#~ msgid "long press to run slowly"
+#~ msgstr "appui long pour exécuter lentement"
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr "Le bloc Enregistrer le tas dans l'application enregistre le tas dans une page Web."
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr "Le bloc Enregistrer le tas dans l'application enregistre le tas dans une page Web."
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr "pincer"
+#~ msgid "pluck"
+#~ msgstr "pincer"
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr "Le bloc <em>Note de la souris</em> renvoie la valeur de la note actuelle jouée par la souris spécifiée."
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr "Le bloc <em>Note de la souris</em> renvoie la valeur de la note actuelle jouée par la souris spécifiée."
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr "Le bloc <em>Liaison</em> prolonge la tenue des notes—durant plus longtemps que la durée notée et se fondant dans la note suivante—tou"
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr "Le bloc <em>Liaison</em> prolonge la tenue des notes—durant plus longtemps que la durée notée et se fondant dans la note suivante—tou"
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr "sur temps faible"
+#~ msgid "on weak beat"
+#~ msgstr "sur temps faible"
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr "Le bloc <em>Sans horloge</em> découple les notes de l'horloge principale."
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr "Le bloc <em>Sans horloge</em> découple les notes de l'horloge principale."
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr "Le bloc <em>Définir la taille du stylo</em> change la taille du stylo."
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr "Le bloc <em>Définir la taille du stylo</em> change la taille du stylo."
 
-#~msgid "end hollow line"
-#~msgstr "fin de ligne creuse"
+#~ msgid "end hollow line"
+#~ msgstr "fin de ligne creuse"
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr "Le bloc <em>Remplir</em> remplit une forme avec une couleur."
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr "Le bloc <em>Remplir</em> remplit une forme avec une couleur."
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr "facteur de saut"
+#~ msgid "skip factor"
+#~ msgstr "facteur de saut"
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr "Le bloc <em>Vibrato</em> ajoute une variation rapide et légère de la hauteur."
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr "Le bloc <em>Vibrato</em> ajoute une variation rapide et légère de la hauteur."
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr "Le bloc <em>Synchronisation de la souris</em> aligne le compte des battements entre les souris."
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr "Le bloc <em>Synchronisation de la souris</em> aligne le compte des battements entre les souris."
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Ouvrir"
+#~ msgid "Open"
+#~ msgstr "Ouvrir"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr "Le bloc <em>Pas d'échelle</em> (en combinaison avec un bloc <em>Numéro</em>) jouera la prochaine hauteur d'une échelle, par exemple, si la dernière note jouée était <em>sol</em>, <em>Pas d'échelle 1</em> jouera <em>la</em>."
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr "Le bloc <em>Pas d'échelle</em> (en combinaison avec un bloc <em>Numéro</em>) jouera la prochaine hauteur d'une échelle, par exemple, si la dernière note jouée était <em>sol</em>, <em>Pas d'échelle 1</em> jouera <em>la</em>."
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr "définir le tempéramentX"
+#~ msgid "define temperamentX"
+#~ msgstr "définir le tempéramentX"
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr "Le bloc <em>Swing</em> fonctionne par paires de notes (spécifiées par la valeur de la note), ajoutant une certaine durée (spécifiée par la valeur du swing) à la première note et prenant la même quantité de la deuxième note."
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr "Le bloc <em>Swing</em> fonctionne par paires de notes (spécifiées par la valeur de la note), ajoutant une certaine durée (spécifiée par la valeur du swing) à la première note et prenant la même quantité de la deuxième note."
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr "définir la voix"
+#~ msgid "set voice"
+#~ msgstr "définir la voix"
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr "Sinon, une grosse caisse jouera."
+#~ msgid "Else a kick drum will play."
+#~ msgstr "Sinon, une grosse caisse jouera."
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr "Enregistrer en wav"
+#~ msgid "Save as wav"
+#~ msgstr "Enregistrer en wav"
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr "Cliquez ici pour coller."
+#~ msgid "Click here to paste."
+#~ msgstr "Cliquez ici pour coller."
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr "Le bloc <em>Hauteur</em> spécifie le nom et l'octave d'une note qui déterminent ensemble la fréquence de la note."
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr "Le bloc <em>Hauteur</em> spécifie le nom et l'octave d'une note qui déterminent ensemble la fréquence de la note."
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr "tom-tom"
+#~ msgid "tom-tom"
+#~ msgstr "tom-tom"
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr "Ionien"
+#~ msgid "Ionian"
+#~ msgstr "Ionien"
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr "ch"
+#~ msgid "ch"
+#~ msgstr "ch"
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr "Le bloc <em>Liaison</em> prolonge la tenue des notes tout en maintenant la valeur rythmique spécifiée des notes."
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr "Le bloc <em>Liaison</em> prolonge la tenue des notes tout en maintenant la valeur rythmique spécifiée des notes."
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr "ajouter des hauteurs"
+#~ msgid "add pitches"
+#~ msgstr "ajouter des hauteurs"
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr "Le bloc <em>Souris X</em> renvoie la position X de la souris spécifiée."
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr "Le bloc <em>Souris X</em> renvoie la position X de la souris spécifiée."
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr "Music Blocks est une collection d'outils open source pour explorer les concepts musicaux. Une liste complète des contributeurs se trouve dans le dépôt GitHub de Music Blocks. Music Blocks est sous licence AGPL. La version actuelle est:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr "Music Blocks est une collection d'outils open source pour explorer les concepts musicaux. Une liste complète des contributeurs se trouve dans le dépôt GitHub de Music Blocks. Music Blocks est sous licence AGPL. La version actuelle est:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr "cb"
+#~ msgid "cb"
+#~ msgstr "cb"
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr "hauteur de référence"
+#~ msgid "reference pitch"
+#~ msgstr "hauteur de référence"
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr "Cliquez pour exécuter la musique note par note."
+#~ msgid "Click to run the music note by note."
+#~ msgstr "Cliquez pour exécuter la musique note par note."
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr "poly"
+#~ msgid "poly"
+#~ msgstr "poly"
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr "Rechercher un projet\","
+#~ msgid "Search for a project\","
+#~ msgstr "Rechercher un projet\","
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr "monter"
+#~ msgid "move up"
+#~ msgstr "monter"
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr "confirmer"
+#~ msgid "confirm"
+#~ msgstr "confirmer"
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr "Le bloc <em>Espace</em> est utilisé pour ajouter de l'espace entre les blocs."
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr "Le bloc <em>Espace</em> est utilisé pour ajouter de l'espace entre les blocs."
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr "Le bloc <em>Synchronisation de la souris</em> aligne le compte des battements entre les souris."
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr "Le bloc <em>Synchronisation de la souris</em> aligne le compte des battements entre les souris."
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr "Maqam"
+#~ msgid "Maqam"
+#~ msgstr "Maqam"
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr "Éolien"
+#~ msgid "Aeolian"
+#~ msgstr "Éolien"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr "mineur harmonique"
+#~ msgid "harmonic-minor"
+#~ msgstr "mineur harmonique"
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr "Par exemple, si vous avez 7 notes en séquence contenues dans un bloc Decrescendo avec une valeur de 5, la dernière note sera à 35 % de moins que le volume de départ."
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr "Par exemple, si vous avez 7 notes en séquence contenues dans un bloc Decrescendo avec une valeur de 5, la dernière note sera à 35 % de moins que le volume de départ."
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr "Le bloc <em>Plus grand que</em> renvoie <em>Vrai</em> si le nombre supérieur est plus grand que le nombre inférieur."
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr "Le bloc <em>Plus grand que</em> renvoie <em>Vrai</em> si le nombre supérieur est plus grand que le nombre inférieur."
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr "Le bloc <em>Ajouter à</em> est utilisé pour ajouter à la valeur stockée dans une boîte. Il peut également être utilisé avec d'autres blocs, tels que <em>Couleur</em>, <em>Taille du stylo</em>, etc."
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr "Le bloc <em>Ajouter à</em> est utilisé pour ajouter à la valeur stockée dans une boîte. Il peut également être utilisé avec d'autres blocs, tels que <em>Couleur</em>, <em>Taille du stylo</em>, etc."
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr "Le bloc Reverseheap inverse l'ordre du tas."
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr "Le bloc Reverseheap inverse l'ordre du tas."
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr "Le bloc <em>Un de</em> renvoie l'un des deux choix."
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr "Le bloc <em>Un de</em> renvoie l'un des deux choix."
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr "Locrien"
+#~ msgid "Locrian"
+#~ msgstr "Locrien"
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr "Le bloc <em>Définir la teinte</em> change la couleur du stylo."
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr "Le bloc <em>Définir la teinte</em> change la couleur du stylo."
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr "Le bloc <em>Stocker dans</em> stockera une valeur dans une boîte."
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr "Le bloc <em>Stocker dans</em> stockera une valeur dans une boîte."
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr "Enregistrer en .svg"
+#~ msgid "Save as .svg"
+#~ msgstr "Enregistrer en .svg"
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr "Blues"
+#~ msgid "Blues"
+#~ msgstr "Blues"
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr "Vous pouvez taper \"d\" pour créer un bloc \"do\", \"r\" pour créer un bloc \"re\", etc."
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr "Vous pouvez taper \"d\" pour créer un bloc \"do\", \"r\" pour créer un bloc \"re\", etc."
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr "Impossible d'analyser les données Impact."
+#~ msgid "Cannot parse Impact data."
+#~ msgstr "Impossible d'analyser les données Impact."
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr "par exemple, guitare, violon, caisse claire, etc."
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr "par exemple, guitare, violon, caisse claire, etc."
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr "Le bloc <em>Tempo</em> ouvre un métronome pour visualiser le rythme."
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr "Le bloc <em>Tempo</em> ouvre un métronome pour visualiser le rythme."
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr "Le bloc <em>Inverser</em> fait pivoter les notes contenues autour d'une note cible."
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr "Le bloc <em>Inverser</em> fait pivoter les notes contenues autour d'une note cible."
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr "champ"
+#~ msgid "field"
+#~ msgstr "champ"
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr "m"
+#~ msgid "m"
+#~ msgstr "m"
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr "Le bloc <em>Sur chaque battement</em> vous permet de spécifier les actions à effectuer sur chaque battement."
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr "Le bloc <em>Sur chaque battement</em> vous permet de spécifier les actions à effectuer sur chaque battement."
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr "Pour plus d'informations, veuillez consulter le <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">guide Music Blocks</a>."
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr "Pour plus d'informations, veuillez consulter le <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">guide Music Blocks</a>."
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr "rs"
+#~ msgid "rs"
+#~ msgstr "rs"
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr "Le bloc <em>Clic</em> renvoie <em>Vrai</em> si une souris a été cliquée."
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr "Le bloc <em>Clic</em> renvoie <em>Vrai</em> si une souris a été cliquée."
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr "Champ Impact non trouvé."
+#~ msgid "Impact field not found."
+#~ msgstr "Champ Impact non trouvé."
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr "gs"
+#~ msgid "gs"
+#~ msgstr "gs"
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr "Mineur"
+#~ msgid "Minor"
+#~ msgstr "Mineur"
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr " "
+#~ msgid " "
+#~ msgstr " "
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr "Byzantin"
+#~ msgid "Byzantine"
+#~ msgstr "Byzantin"
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr "Mineur Jazz"
+#~ msgid "Jazz Minor"
+#~ msgstr "Mineur Jazz"
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr "Le bloc <em>Do</em> est utilisé pour initier une action. Dans l'exemple, il est utilisé avec le bloc <em>Un de</em> pour choisir une phase aléatoire."
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr "Le bloc <em>Do</em> est utilisé pour initier une action. Dans l'exemple, il est utilisé avec le bloc <em>Un de</em> pour choisir une phase aléatoire."
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr "Enregistrer en HTML"
+#~ msgid "Save as HTML"
+#~ msgstr "Enregistrer en HTML"
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr "sur le temps"
+#~ msgid "on beat"
+#~ msgstr "sur le temps"
 
 #: js/activity.js:3857
 
@@ -11127,196 +11127,196 @@ msgstr "mouvement"
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr "Charger le projet à partir des fichiers"
+#~ msgid "Load project from files"
+#~ msgstr "Charger le projet à partir des fichiers"
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr "Le bloc <em>Définir le tempérament</em> est utilisé pour choisir le système d'accord utilisé par Music Blocks."
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr "Le bloc <em>Définir le tempérament</em> est utilisé pour choisir le système d'accord utilisé par Music Blocks."
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr "Le bloc <em>Dispatch</em> est utilisé pour déclencher un événement."
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr "Le bloc <em>Dispatch</em> est utilisé pour déclencher un événement."
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "Masquer ou afficher les palettes de blocs."
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "Masquer ou afficher les palettes de blocs."
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr "Exécuter rapidement / appui long pour exécuter lentement"
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr "Exécuter rapidement / appui long pour exécuter lentement"
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr "masquer la grille"
+#~ msgid "hide grid"
+#~ msgstr "masquer la grille"
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr "caisse claire"
+#~ msgid "snare-drum"
+#~ msgstr "caisse claire"
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr "Le bloc <em>Compte des mesures</em> renvoie la mesure actuelle."
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr "Le bloc <em>Compte des mesures</em> renvoie la mesure actuelle."
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr "Le bloc <em>Souris trouvée</em> renverra vrai si la souris spécifiée peut être trouvée."
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr "Le bloc <em>Souris trouvée</em> renverra vrai si la souris spécifiée peut être trouvée."
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr "Le bloc Dispatch est utilisé pour déclencher un événement."
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr "Le bloc Dispatch est utilisé pour déclencher un événement."
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr "Rechercher"
+#~ msgid "Search"
+#~ msgstr "Rechercher"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr "bruit blanc"
+#~ msgid "white-noise"
+#~ msgstr "bruit blanc"
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr "Octatonique"
+#~ msgid "Octatonic"
+#~ msgstr "Octatonique"
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr "Le bloc Matrice hauteur-temps ouvre un outil pour créer des phrases musicales."
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr "Le bloc Matrice hauteur-temps ouvre un outil pour créer des phrases musicales."
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr "Le bloc <em>Haut</em> renvoie la position du haut de la toile."
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr "Le bloc <em>Haut</em> renvoie la position du haut de la toile."
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr "Le bloc <em>Écouter</em> est utilisé pour écouter un événement tel qu'un clic de souris. Lorsque l'événement se produit, une <em>action</em> est effectuée."
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr "Le bloc <em>Écouter</em> est utilisé pour écouter un événement tel qu'un clic de souris. Lorsque l'événement se produit, une <em>action</em> est effectuée."
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr "sens gauche"
+#~ msgid "sense left"
+#~ msgstr "sens gauche"
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr "Le bloc <em>Clavier de musique</em> ouvre un clavier de piano qui peut être utilisé pour créer des notes."
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr "Le bloc <em>Clavier de musique</em> ouvre un clavier de piano qui peut être utilisé pour créer des notes."
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr "Le bloc <em>Setheapentry</em> définit une valeur dans le tas à l'emplacement spécifié."
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr "Le bloc <em>Setheapentry</em> définit une valeur dans le tas à l'emplacement spécifié."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr "jazz-mineur"
+#~ msgid "jazz-minor"
+#~ msgstr "jazz-mineur"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr "blues mineur"
+#~ msgid "minor-blues"
+#~ msgstr "blues mineur"
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr "page précédente"
+#~ msgid "previous page"
+#~ msgstr "page précédente"
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr "Le bloc <em>Stylo en bas</em> abaisse le stylo pour qu'il dessine."
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr "Le bloc <em>Stylo en bas</em> abaisse le stylo pour qu'il dessine."
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr "Le bloc <em>Transposition en demi-tons</em> déplace les hauteurs contenues dans les blocs <em>Note</em> vers le haut (ou vers le bas) par demi-tons. Dans l'exemple ci-dessus, <em>sol</em> est déplacé vers le haut à <em>sol#</em>."
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr "Le bloc <em>Transposition en demi-tons</em> déplace les hauteurs contenues dans les blocs <em>Note</em> vers le haut (ou vers le bas) par demi-tons. Dans l'exemple ci-dessus, <em>sol</em> est déplacé vers le haut à <em>sol#</em>."
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr "Vous pouvez rechercher des blocs par nom."
+#~ msgid "You can search for blocks by name."
+#~ msgstr "Vous pouvez rechercher des blocs par nom."
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr "cloche de vache"
+#~ msgid "cow-bell"
+#~ msgstr "cloche de vache"
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr "2ème"
+#~ msgid "2nd"
+#~ msgstr "2ème"
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr "Le bloc <em>Média</em> est utilisé pour importer une image."
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr "Le bloc <em>Média</em> est utilisé pour importer une image."
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr "Hors ligne. Le partage est indisponible."
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr "Hors ligne. Le partage est indisponible."
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr "Le bloc Stopplayback"
+#~ msgid "The Stopplayback block"
+#~ msgstr "Le bloc Stopplayback"
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr "Les conditionnels permettent à votre programme de prendre différentes actions en fonction de la <em>condition</em>. Dans cet exemple, <em>si</em> le bouton de la souris est pressé, un tambour de caisse claire jouera. Sinon (<em>else</em>), un tambour de grosse caisse jouera."
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr "Les conditionnels permettent à votre programme de prendre différentes actions en fonction de la <em>condition</em>. Dans cet exemple, <em>si</em> le bouton de la souris est pressé, un tambour de caisse claire jouera. Sinon (<em>else</em>), un tambour de grosse caisse jouera."
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr "Le bloc <em>Volume</em> renvoie le volume détecté par le microphone."
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr "Le bloc <em>Volume</em> renvoie le volume détecté par le microphone."
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr "Le bloc <em>Afficher les blocs</em> affiche les blocs."
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr "Le bloc <em>Afficher les blocs</em> affiche les blocs."
 
-#~msgid "food"
-#~msgstr "nourriture"
+#~ msgid "food"
+#~ msgstr "nourriture"
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr "diviser la valeur du rythme"
+#~ msgid "divide beat value"
+#~ msgstr "diviser la valeur du rythme"
 
 #: js/turtledefs.js:187
 
@@ -11324,155 +11324,155 @@ msgstr "mouvement"
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr "Enregistrer sous PNG"
+#~ msgid "Save as PNG"
+#~ msgstr "Enregistrer sous PNG"
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr "Le bloc <em>Commentaire</em> affiche un commentaire en haut de l'écran lorsque le programme fonctionne en mode lent."
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr "Le bloc <em>Commentaire</em> affiche un commentaire en haut de l'écran lorsque le programme fonctionne en mode lent."
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr "Le bloc <em>Arrêter le média</em> arrête la lecture audio ou vidéo."
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr "Le bloc <em>Arrêter le média</em> arrête la lecture audio ou vidéo."
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr "Le bloc <em>Bouton de souris</em> renvoie <em>Vrai</em> si le bouton de la souris est pressé."
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr "Le bloc <em>Bouton de souris</em> renvoie <em>Vrai</em> si le bouton de la souris est pressé."
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr "blues"
+#~ msgid "blues"
+#~ msgstr "blues"
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr "Plus"
+#~ msgid "More"
+#~ msgstr "Plus"
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr "Le bloc <em>Curseur Y</em> renvoie la position verticale de la souris."
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr "Le bloc <em>Curseur Y</em> renvoie la position verticale de la souris."
 
-#~msgid "maths"
-#~msgstr "math"
+#~ msgid "maths"
+#~ msgstr "math"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr "Sinon (else), un tambour de grosse caisse jouera."
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr "Sinon (else), un tambour de grosse caisse jouera."
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr "Ouvrir le projet depuis un fichier\","
+#~ msgid "Open project from file\","
+#~ msgstr "Ouvrir le projet depuis un fichier\","
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr "triton"
+#~ msgid "tritone"
+#~ msgstr "triton"
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr "Dorienne"
+#~ msgid "Dorian"
+#~ msgstr "Dorienne"
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr "Cette barre d'outils contient les boutons de la palette Matrix Notes Ton Turtle et plus."
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr "Cette barre d'outils contient les boutons de la palette Matrix Notes Ton Turtle et plus."
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr "grosse caisse"
+#~ msgid "kick-drum"
+#~ msgstr "grosse caisse"
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr "5ème"
+#~ msgid "5th"
+#~ msgstr "5ème"
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr "Le bloc <em>Notes écoulées de la souris</em> renvoie le nombre de notes jouées par la souris spécifiée."
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr "Le bloc <em>Notes écoulées de la souris</em> renvoie le nombre de notes jouées par la souris spécifiée."
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr "Le bloc <em>Hauteur de la souris</em> renvoie le numéro de hauteur actuel joué par la souris spécifiée."
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr "Le bloc <em>Hauteur de la souris</em> renvoie le numéro de hauteur actuel joué par la souris spécifiée."
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr "Cette barre d'outils contient les boutons de la palette, y compris Rhythm Pitch Tone Action et plus."
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr "Cette barre d'outils contient les boutons de la palette, y compris Rhythm Pitch Tone Action et plus."
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr "page suivante"
+#~ msgid "next page"
+#~ msgstr "page suivante"
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr "Le bloc <em>Répéter</em> répétera les blocs contenus. Dans cet exemple, la note sera jouée 4 fois."
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr "Le bloc <em>Répéter</em> répétera les blocs contenus. Dans cet exemple, la note sera jouée 4 fois."
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr "Le bouton de sauvegarde de la pile enregistre une pile sur une palette personnalisée. Il apparaît après un \"appui long\" sur une pile."
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr "Le bouton de sauvegarde de la pile enregistre une pile sur une palette personnalisée. Il apparaît après un \"appui long\" sur une pile."
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr "Rythme"
+#~ msgid "Rhythm"
+#~ msgstr "Rythme"
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr "Le bloc <em>Nombre en octave</em> convertira un numéro de hauteur en octave."
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr "Le bloc <em>Nombre en octave</em> convertira un numéro de hauteur en octave."
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr "Pour copier une pile dans le presse-papiers, faites un \"appui long\" sur la pile. Le bouton Coller sera surligné."
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr "Pour copier une pile dans le presse-papiers, faites un \"appui long\" sur la pile. Le bouton Coller sera surligné."
 
-#~msgid "hspace"
-#~msgstr "espace horizontal"
+#~ msgid "hspace"
+#~ msgstr "espace horizontal"
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr "Appui long sur le(s) bloc(s) pour copier. Cliquez ici pour coller."
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr "Appui long sur le(s) bloc(s) pour copier. Cliquez ici pour coller."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr "mineur mélodique"
+#~ msgid "melodic-minor"
+#~ msgstr "mineur mélodique"
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr "Le bloc Tas vide? renvoie vrai si le tas est vide."
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr "Le bloc Tas vide? renvoie vrai si le tas est vide."
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr "Le bloc Lecture"
+#~ msgid "The Playback block"
+#~ msgstr "Le bloc Lecture"
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr "Le bloc <em>Valeur de la note</em> est la valeur de la durée de la note actuellement jouée."
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr "Le bloc <em>Valeur de la note</em> est la valeur de la durée de la note actuellement jouée."
 
 #: js/turtledefs.js:187
 
@@ -11480,257 +11480,257 @@ msgstr "mouvement"
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr "Enregistrer sous WAV"
+#~ msgid "Save as WAV"
+#~ msgstr "Enregistrer sous WAV"
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr "Le bloc <em>Tremolo</em> ajoute un effet de tremblement."
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr "Le bloc <em>Tremolo</em> ajoute un effet de tremblement."
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr "Le bloc <em>Définir le gris</em> change la vivacité de la couleur du stylo."
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr "Le bloc <em>Définir le gris</em> change la vivacité de la couleur du stylo."
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr "Le bloc <em>Texte</em> contient une chaîne de texte."
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr "Le bloc <em>Texte</em> contient une chaîne de texte."
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr "actions"
+#~ msgid "actions"
+#~ msgstr "actions"
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr "Le bloc <em>Registre</em> fournit un moyen facile de modifier le registre (octave) des notes qui le suivent."
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr "Le bloc <em>Registre</em> fournit un moyen facile de modifier le registre (octave) des notes qui le suivent."
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr "La valeur de la note doit être supérieure à 0"
+#~ msgid "Note value must be greater than 0"
+#~ msgstr "La valeur de la note doit être supérieure à 0"
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr "<em>Les tuplets</em> sont une collection de notes qui sont mises à l'échelle pour une durée spécifique. Utiliser des tuplets facilite la création de groupes de notes qui ne sont pas basés sur une puissance de 2."
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr "<em>Les tuplets</em> sont une collection de notes qui sont mises à l'échelle pour une durée spécifique. Utiliser des tuplets facilite la création de groupes de notes qui ne sont pas basés sur une puissance de 2."
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr "matrice hauteur-temps"
+#~ msgid "pitch-time matrix"
+#~ msgstr "matrice hauteur-temps"
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr "par exemple guitare, violon, caisse claire, etc."
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr "par exemple guitare, violon, caisse claire, etc."
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr "Le bloc <em>Intervalle scalaire</em> mesure la distance entre deux notes en demi-tons."
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr "Le bloc <em>Intervalle scalaire</em> mesure la distance entre deux notes en demi-tons."
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr "Appuyez longuement sur le bouton d'exécution pour exécuter le projet en mode lent."
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr "Appuyez longuement sur le bouton d'exécution pour exécuter le projet en mode lent."
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr "Le bloc <em>Définir le décalage du numéro de hauteur</em> est utilisé pour définir le décalage pour mapper les numéros de hauteur à la hauteur et à l'octave."
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr "Le bloc <em>Définir le décalage du numéro de hauteur</em> est utilisé pour définir le décalage pour mapper les numéros de hauteur à la hauteur et à l'octave."
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "Afficher ou masquer une grille de coordonnées polaires."
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "Afficher ou masquer une grille de coordonnées polaires."
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr "Il peut également être utilisé avec d'autres blocs, tels que Couleur, Taille du stylo."
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr "Il peut également être utilisé avec d'autres blocs, tels que Couleur, Taille du stylo."
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr "Copiez ce lien pour partager votre projet."
+#~ msgid "Copy this link to share your project."
+#~ msgstr "Copiez ce lien pour partager votre projet."
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "Effacer l'écran et retourner les tortues à leurs positions initiales."
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "Effacer l'écran et retourner les tortues à leurs positions initiales."
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr "Le <em>bloc1</em> renvoie la valeur stockée sur <em>bloc1</em>."
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr "Le <em>bloc1</em> renvoie la valeur stockée sur <em>bloc1</em>."
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr "Le bloc de hauteur de pas doit être utilisé à l'intérieur d'un bloc de note."
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr "Le bloc de hauteur de pas doit être utilisé à l'intérieur d'un bloc de note."
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr "clignoter (ms)"
+#~ msgid "blink (ms)"
+#~ msgstr "clignoter (ms)"
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr "Le bloc <em>Duo synth</em> est un modulateur de duo-fréquence utilisé pour définir un timbre."
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr "Le bloc <em>Duo synth</em> est un modulateur de duo-fréquence utilisé pour définir un timbre."
 
-#~msgid "begin hollow line"
-#~msgstr "début de ligne creuse"
+#~ msgid "begin hollow line"
+#~ msgstr "début de ligne creuse"
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr "Guèze"
+#~ msgid "Geez"
+#~ msgstr "Guèze"
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr "Bloc de rythme : Vouliez-vous utiliser un bloc de note ?"
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr "Bloc de rythme : Vouliez-vous utiliser un bloc de note ?"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr "Dans cet exemple, si le bouton de la souris est pressé, une caisse claire jouera."
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr "Dans cet exemple, si le bouton de la souris est pressé, une caisse claire jouera."
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr "Cette barre d'outils contient les boutons de la palette Matrix, Notes, Ton, Turtle, et plus encore. Cliquez pour afficher les palettes de blocs et faites glisser les blocs des palettes sur la toile pour les utiliser."
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr "Cette barre d'outils contient les boutons de la palette Matrix, Notes, Ton, Turtle, et plus encore. Cliquez pour afficher les palettes de blocs et faites glisser les blocs des palettes sur la toile pour les utiliser."
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr "Le bloc <em>Dock block</em> connecte deux blocs."
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr "Le bloc <em>Dock block</em> connecte deux blocs."
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr "Le bloc <em>Hauteur de pas</em> (en combinaison avec un bloc <em>Nombre</em>) jouera la prochaine hauteur dans une échelle, par ex., si la dernière note jouée était <em>sol</em>, <em>Hauteur de pas 1</em> jouera <em>la</em>."
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr "Le bloc <em>Hauteur de pas</em> (en combinaison avec un bloc <em>Nombre</em>) jouera la prochaine hauteur dans une échelle, par ex., si la dernière note jouée était <em>sol</em>, <em>Hauteur de pas 1</em> jouera <em>la</em>."
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr "Le bloc <em>Arrière</em> exécute le code dans l'ordre inverse (rétrograde musical)."
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr "Le bloc <em>Arrière</em> exécute le code dans l'ordre inverse (rétrograde musical)."
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr "valeur de note obsolète"
+#~ msgid "deprecated note value"
+#~ msgstr "valeur de note obsolète"
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr "Arabe"
+#~ msgid "Arabic"
+#~ msgstr "Arabe"
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr "Dans cet exemple, une boîte à rythmes simple, une grosse caisse jouera des notes 1/4 indéfiniment."
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr "Dans cet exemple, une boîte à rythmes simple, une grosse caisse jouera des notes 1/4 indéfiniment."
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr "Bloc de Hertz : Vouliez-vous utiliser un bloc de Note3?"
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr "Bloc de Hertz : Vouliez-vous utiliser un bloc de Note3?"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr "blues majeur"
+#~ msgid "major-blues"
+#~ msgstr "blues majeur"
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr "Le bloc <em>Mod</em> renvoie le reste d'une division."
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr "Le bloc <em>Mod</em> renvoie le reste d'une division."
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr "La hauteur peut être spécifiée en termes de <em>C D E F G A B</em>."
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr "La hauteur peut être spécifiée en termes de <em>C D E F G A B</em>."
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr "Hindou"
+#~ msgid "Hindu"
+#~ msgstr "Hindou"
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr "Le bloc <em>Millisecondes</em> est similaire à un bloc <em>Note</em> sauf qu'il utilise le temps (en MS) pour spécifier la durée de la note."
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr "Le bloc <em>Millisecondes</em> est similaire à un bloc <em>Note</em> sauf qu'il utilise le temps (en MS) pour spécifier la durée de la note."
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr "Le bloc <em>Non</em> est l'opérateur logique de négation."
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr "Le bloc <em>Non</em> est l'opérateur logique de négation."
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr "Nouveau projet\","
+#~ msgid "New project\","
+#~ msgstr "Nouveau projet\","
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr "hauteur par étape"
+#~ msgid "step pitch"
+#~ msgstr "hauteur par étape"
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr "Le bloc <em>Stocker dans la boîte2</em> est utilisé pour stocker une valeur dans <em>boîte2</em>."
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr "Le bloc <em>Stocker dans la boîte2</em> est utilisé pour stocker une valeur dans <em>boîte2</em>."
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr "Enregistrer en tant que png"
+#~ msgid "Save as png"
+#~ msgstr "Enregistrer en tant que png"
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr "Le bloc <em>Notes sautées</em> fera en sorte que des notes soient sautées."
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr "Le bloc <em>Notes sautées</em> fera en sorte que des notes soient sautées."
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr "Le bloc <em>Intervalle scalaire</em> calcule un intervalle relatif basé sur le mode actuel, en sautant toutes les notes en dehors du mode. Dans la figure, nous ajoutons <em>la</em> à <em>sol</em>."
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr "Le bloc <em>Intervalle scalaire</em> calcule un intervalle relatif basé sur le mode actuel, en sautant toutes les notes en dehors du mode. Dans la figure, nous ajoutons <em>la</em> à <em>sol</em>."
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr "jouer en arrière"
+#~ msgid "play backward"
+#~ msgstr "jouer en arrière"
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr "Le bloc <em>Changement de hauteur</em> est la différence (en demi-tons) entre la hauteur actuelle jouée et la hauteur précédente."
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr "Le bloc <em>Changement de hauteur</em> est la différence (en demi-tons) entre la hauteur actuelle jouée et la hauteur précédente."
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr "Le bloc <em>Point de contrôle 1</em> définit le premier point de contrôle pour la courbe de Bézier."
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr "Le bloc <em>Point de contrôle 1</em> définit le premier point de contrôle pour la courbe de Bézier."
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr "bk"
+#~ msgid "bk"
+#~ msgstr "bk"
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr "bt"
+#~ msgid "bt"
+#~ msgstr "bt"
 
 #: js/logo.js:2175
 
@@ -11744,223 +11744,223 @@ msgstr "mouvement"
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr "Impossible de trouver la souris"
+#~ msgid "Could not find mouse"
+#~ msgstr "Impossible de trouver la souris"
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr "Le bloc <em>Obtenir le vert</em> renvoie la composante verte du pixel sous la souris."
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr "Le bloc <em>Obtenir le vert</em> renvoie la composante verte du pixel sous la souris."
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr "Le bloc <em>Rythme</em> est utilisé pour générer des motifs rythmiques."
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr "Le bloc <em>Rythme</em> est utilisé pour générer des motifs rythmiques."
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr "???"
+#~ msgid "???"
+#~ msgstr "???"
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr "Le bloc <em>Curseur X</em> renvoie la position horizontale de la souris."
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr "Le bloc <em>Curseur X</em> renvoie la position horizontale de la souris."
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr "Enregistrer le projet"
+#~ msgid "Save Project"
+#~ msgstr "Enregistrer le projet"
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr "Le bloc <em>Définir la police</em> définit la police utilisée par le bloc <em>Afficher</em>."
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr "Le bloc <em>Définir la police</em> définit la police utilisée par le bloc <em>Afficher</em>."
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr "do ré mi fa sol la si"
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr "do ré mi fa sol la si"
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr "Le bloc <em>Jusqu'à</em> se répétera jusqu'à ce que la condition soit vraie."
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr "Le bloc <em>Jusqu'à</em> se répétera jusqu'à ce que la condition soit vraie."
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr "Le bloc <em>Ou</em> est l'opérateur logique de ou."
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr "Le bloc <em>Ou</em> est l'opérateur logique de ou."
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr "tourner dans le sens antihoraire"
+#~ msgid "rotate counter clockwise"
+#~ msgstr "tourner dans le sens antihoraire"
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr "etc."
+#~ msgid "etc."
+#~ msgstr "etc."
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr "trier"
+#~ msgid "sort"
+#~ msgstr "trier"
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr "Bloc de hauteur : Vouliez-vous utiliser un bloc de note2 ?"
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr "Bloc de hauteur : Vouliez-vous utiliser un bloc de note2 ?"
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr "Distorsion hors de portée"
+#~ msgid "Distortion not in range"
+#~ msgstr "Distorsion hors de portée"
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr "Le bloc <em>Taille du stylo</em> renvoie la valeur actuelle de la taille du stylo."
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr "Le bloc <em>Taille du stylo</em> renvoie la valeur actuelle de la taille du stylo."
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr "Le bloc <em>Enregistrer le tas dans l'application</em> enregistre le tas sur une page Web."
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr "Le bloc <em>Enregistrer le tas dans l'application</em> enregistre le tas sur une page Web."
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr "Le bloc <em>Aléatoire</em> renvoie un nombre aléatoire."
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr "Le bloc <em>Aléatoire</em> renvoie un nombre aléatoire."
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr "Coordonnées polaires"
+#~ msgid "Polar"
+#~ msgstr "Coordonnées polaires"
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr "nom de la hauteur actuelle"
+#~ msgid "current pitch name"
+#~ msgstr "nom de la hauteur actuelle"
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "Afficher ou masquer une grille coordonnée cartésienne."
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "Afficher ou masquer une grille coordonnée cartésienne."
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr "Le bloc <em>Afficher le tas</em> affiche le contenu du tas en haut de l'écran."
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr "Le bloc <em>Afficher le tas</em> affiche le contenu du tas en haut de l'écran."
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr "gp"
+#~ msgid "gp"
+#~ msgstr "gp"
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr "Le bloc <em>Nom de la souris</em> renvoie le nom d'une souris."
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr "Le bloc <em>Nom de la souris</em> renvoie le nom d'une souris."
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr "Enregistrer en tant que .png"
+#~ msgid "Save as .png"
+#~ msgstr "Enregistrer en tant que .png"
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr "Mixolydien"
+#~ msgid "Mixolydian"
+#~ msgstr "Mixolydien"
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr "mClavier"
+#~ msgid "mKeyboard"
+#~ msgstr "mClavier"
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr "Le bloc <em>Arrêter</em> arrêtera une boucle (par exemple, Toujours, Répéter, Tant que, ou Jusqu'à)."
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr "Le bloc <em>Arrêter</em> arrêtera une boucle (par exemple, Toujours, Répéter, Tant que, ou Jusqu'à)."
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr "Le bloc <em>Numéro de hauteur</em> est la valeur de la hauteur de la note actuellement jouée."
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr "Le bloc <em>Numéro de hauteur</em> est la valeur de la hauteur de la note actuellement jouée."
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr "Le bloc <em>Coquille</em> est utilisé pour changer l'apparence de la souris."
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr "Le bloc <em>Coquille</em> est utilisé pour changer l'apparence de la souris."
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr "Le bloc <em>Égal</em> renvoie <em>Vrai</em> si les deux nombres sont égaux."
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr "Le bloc <em>Égal</em> renvoie <em>Vrai</em> si les deux nombres sont égaux."
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr "Télécharger sur Planet"
+#~ msgid "Upload to Planet"
+#~ msgstr "Télécharger sur Planet"
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr "Le bloc <em>Descente scalaire</em> renvoie le nombre de demi-tons jusqu'à la note précédente dans la tonalité et le mode actuels."
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr "Le bloc <em>Descente scalaire</em> renvoie le nombre de demi-tons jusqu'à la note précédente dans la tonalité et le mode actuels."
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr "Le bloc <em>Obtenir le pixel</em> renvoie la couleur du pixel sous la souris."
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr "Le bloc <em>Obtenir le pixel</em> renvoie la couleur du pixel sous la souris."
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr "Charger le plugin à partir du fichier"
+#~ msgid "Load plugin from file"
+#~ msgstr "Charger le plugin à partir du fichier"
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr "Le bloc <em>Lecture</em>"
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr "Le bloc <em>Lecture</em>"
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr "Enregistrer en tant que .abc"
+#~ msgid "Save as .abc"
+#~ msgstr "Enregistrer en tant que .abc"
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr "Lilypond ne peut pas traiter la part de "
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr "Lilypond ne peut pas traiter la part de "
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr "Le bloc <em>Hauteur en Hertz</em> est la valeur en Hertz de la hauteur de la note actuellement jouée."
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr "Le bloc <em>Hauteur en Hertz</em> est la valeur en Hertz de la hauteur de la note actuellement jouée."
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr "degré"
+#~ msgid "degree"
+#~ msgstr "degré"
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr "chanter"
+#~ msgid "sing"
+#~ msgstr "chanter"
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr "Le bloc <em>Point de contrôle 2</em> définit le deuxième point de contrôle pour la courbe de Bézier."
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr "Le bloc <em>Point de contrôle 2</em> définit le deuxième point de contrôle pour la courbe de Bézier."
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr "Chinois"
+#~ msgid "Chinese"
+#~ msgstr "Chinois"
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr "Jouer de la musique" 
+#~ msgid "Play music"
+#~ msgstr "Jouer de la musique" 
 
 
 
@@ -11972,144 +11972,144 @@ msgstr "mouvement"
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr "Télécharger"
+#~ msgid "Download"
+#~ msgstr "Télécharger"
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr "tambour darbuka"
+#~ msgid "darbuka-drum"
+#~ msgstr "tambour darbuka"
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr "Le bloc <em>Intervalle de demi-ton</em> calcule un intervalle relatif basé sur des demi-tons. Dans la figure, nous ajoutons <em>sol#</em> à <em>sol</em>."
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr "Le bloc <em>Intervalle de demi-ton</em> calcule un intervalle relatif basé sur des demi-tons. Dans la figure, nous ajoutons <em>sol#</em> à <em>sol</em>."
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr "Le bloc <em>Plus</em> est utilisé pour ajouter."
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr "Le bloc <em>Plus</em> est utilisé pour ajouter."
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr "par exemple, 1, 2, 3 ou 4."
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr "par exemple, 1, 2, 3 ou 4."
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr "Le bloc <em>Charger le tas</em> charge le tas à partir d'un fichier."
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr "Le bloc <em>Charger le tas</em> charge le tas à partir d'un fichier."
 
-#~msgid "cloud"
-#~msgstr "nuage"
+#~ msgid "cloud"
+#~ msgstr "nuage"
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr "Le bloc <em>Bas</em> renvoie la position du bas de la toile."
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr "Le bloc <em>Bas</em> renvoie la position du bas de la toile."
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr "Enregistrer en tant que svg"
+#~ msgid "Save as svg"
+#~ msgstr "Enregistrer en tant que svg"
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr "UID d'impact non trouvé."
+#~ msgid "Impact UID not found."
+#~ msgstr "UID d'impact non trouvé."
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr "Solfa"
+#~ msgid "Solfa"
+#~ msgstr "Solfa"
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr "ajouter un filtre"
+#~ msgid "add filter"
+#~ msgstr "ajouter un filtre"
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr "turtleHeaps ne contient pas un tas valide pour"
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr "turtleHeaps ne contient pas un tas valide pour"
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr "Vous pouvez également utiliser Alt+C pour copier une pile de blocs. "
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr "Vous pouvez également utiliser Alt+C pour copier une pile de blocs. "
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr "Afficher/masquer les palettes"
+#~ msgid "Show/hide palettes"
+#~ msgstr "Afficher/masquer les palettes"
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr "Accueil' + ' [ACCUEIL]"
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr "Accueil' + ' [ACCUEIL]"
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr "Le bloc <em>Démarrer la souris</em> démarre la souris spécifiée."
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr "Le bloc <em>Démarrer la souris</em> démarre la souris spécifiée."
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr "récupérer"
+#~ msgid "fetch"
+#~ msgstr "récupérer"
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr "Le bloc <em>Boîte</em> renvoie la valeur stockée dans une boîte."
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr "Le bloc <em>Boîte</em> renvoie la valeur stockée dans une boîte."
 
-#~msgid "rodi"
-#~msgstr "RoDi"
+#~ msgid "rodi"
+#~ msgstr "RoDi"
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr "Le bloc <em>Définir la souris</em> envoie une pile de blocs à exécuter par la souris spécifiée."
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr "Le bloc <em>Définir la souris</em> envoie une pile de blocs à exécuter par la souris spécifiée."
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr "Le bloc <em>boîte1</em> renvoie la valeur stockée dans <em>boîte1</em>."
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr "Le bloc <em>boîte1</em> renvoie la valeur stockée dans <em>boîte1</em>."
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr "Vous pouvez également utiliser Alt+P pour coller une pile de blocs. "
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr "Vous pouvez également utiliser Alt+P pour coller une pile de blocs. "
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr "pentatonique"
+#~ msgid "pentatonic"
+#~ msgstr "pentatonique"
 
-#~msgid "blocks"
-#~msgstr "blocs"
+#~ msgid "blocks"
+#~ msgstr "blocs"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr "Le bloc <em>Matrice temps-hauteur</em> ouvre un outil pour créer des phrases musicales."
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr "Le bloc <em>Matrice temps-hauteur</em> ouvre un outil pour créer des phrases musicales."
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr "Le bloc <em>Orientation</em> renvoie l'orientation de la souris."
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr "Le bloc <em>Orientation</em> renvoie l'orientation de la souris."
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr "Le bloc <em>Abs</em> renvoie la valeur absolue."
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr "Le bloc <em>Abs</em> renvoie la valeur absolue."
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr "Par exemple, si vous avez 7 notes en séquence contenues dans un bloc Crescendo avec une valeur de 5, la note finale sera à 35% de plus que le volume de départ."
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr "Par exemple, si vous avez 7 notes en séquence contenues dans un bloc Crescendo avec une valeur de 5, la note finale sera à 35% de plus que le volume de départ."
 
 #: js/block.js:962
 
@@ -12117,57 +12117,57 @@ msgstr "mouvement"
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr "règle de rythme"
+#~ msgid "rhythm ruler"
+#~ msgstr "règle de rythme"
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr "La profondeur entrée est hors de portée"
+#~ msgid "Depth entered is out of range"
+#~ msgstr "La profondeur entrée est hors de portée"
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr "Le bloc <em>Intervalle scalaire</em> mesure la distance entre deux notes dans la tonalité et le mode actuels."
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr "Le bloc <em>Intervalle scalaire</em> mesure la distance entre deux notes dans la tonalité et le mode actuels."
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr "Le bloc <em>Avancer</em> déplace la souris vers l'avant."
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr "Le bloc <em>Avancer</em> déplace la souris vers l'avant."
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr "Pentatonique"
+#~ msgid "Pentatonic"
+#~ msgstr "Pentatonique"
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr "L'outil <em>Tempérament</em> est utilisé pour définir un accord personnalisé."
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr "L'outil <em>Tempérament</em> est utilisé pour définir un accord personnalisé."
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr "L'entrée du bloc Majeur doit être 2, 3, 6 ou 7"
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr "L'entrée du bloc Majeur doit être 2, 3, 6 ou 7"
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr "Le bloc <em>Imprimer</em> affiche du texte en haut de l'écran."
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr "Le bloc <em>Imprimer</em> affiche du texte en haut de l'écran."
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr "Le bloc <em>Partiels pondérés</em> est utilisé pour spécifier les partiels associés à un timbre."
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr "Le bloc <em>Partiels pondérés</em> est utilisé pour spécifier les partiels associés à un timbre."
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr "articulation"
+#~ msgid "articulation"
+#~ msgstr "articulation"
 
 #: js/turtledefs.js:387
 
@@ -12177,30 +12177,30 @@ msgstr "mouvement"
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr "Le bloc <em>Calculer</em> renvoie une valeur calculée par une action."
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr "Le bloc <em>Calculer</em> renvoie une valeur calculée par une action."
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr "Options avancées"
+#~ msgid "Advanced options"
+#~ msgstr "Options avancées"
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr "Le bloc <em>Retourner</em> renverra une valeur d'une action."
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr "Le bloc <em>Retourner</em> renverra une valeur d'une action."
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr "Le bloc <em>Action</em> est utilisé pour regrouper des blocs afin qu'ils puissent être utilisés plus d'une fois. Il est souvent utilisé pour stocker une phrase musicale qui se répète."
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr "Le bloc <em>Action</em> est utilisé pour regrouper des blocs afin qu'ils puissent être utilisés plus d'une fois. Il est souvent utilisé pour stocker une phrase musicale qui se répète."
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr "Le bloc <em>Obtenir bleu</em> renvoie la composante bleue du pixel sous la souris."
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr "Le bloc <em>Obtenir bleu</em> renvoie la composante bleue du pixel sous la souris."
 
 #: js/turtledefs.js:187
 
@@ -12208,112 +12208,112 @@ msgstr "mouvement"
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr "Enregistrer la partition"
+#~ msgid "Save sheet music"
+#~ msgstr "Enregistrer la partition"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr "mineur roumain"
+#~ msgid "romanian-minor"
+#~ msgstr "mineur roumain"
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr "4ème"
+#~ msgid "4th"
+#~ msgstr "4ème"
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr "Le bloc <em>Définir le volume relatif</em> modifie le volume des notes contenues."
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr "Le bloc <em>Définir le volume relatif</em> modifie le volume des notes contenues."
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr "Le bloc <em>Interrupteur</em> exécutera le code dans le <em>Cas</em> correspondant."
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr "Le bloc <em>Interrupteur</em> exécutera le code dans le <em>Cas</em> correspondant."
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr "ajuster la transposition"
+#~ msgid "adjust transposition"
+#~ msgstr "ajuster la transposition"
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "Cliquer pour exécuter vite."
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "Cliquer pour exécuter vite."
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr "Exécuter note par note"
+#~ msgid "Run note by note"
+#~ msgstr "Exécuter note par note"
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr "Le bloc partiel doit ^etre utilise` a l' interieur d'un bloc de ponderations partielles."
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr "Le bloc partiel doit ^etre utilise` a l' interieur d'un bloc de ponderations partielles."
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr "Le bloc Longueur du tas renvoie la longueur du tas."
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr "Le bloc Longueur du tas renvoie la longueur du tas."
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr "carapace"
+#~ msgid "shell"
+#~ msgstr "carapace"
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr "Fermer Planète\","
+#~ msgid "Close Planet\","
+#~ msgstr "Fermer Planète\","
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr "Page suivante"
+#~ msgid "Next page"
+#~ msgstr "Page suivante"
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr "Appui long sur les blocs pour copier."
+#~ msgid "Long press on blocks to copy."
+#~ msgstr "Appui long sur les blocs pour copier."
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr "Le bloc <em>Chœur</em> ajoute un effet de chœur."
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr "Le bloc <em>Chœur</em> ajoute un effet de chœur."
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr "Le bloc <em>Mode personnalisé</em> ouvre un outil pour explorer le mode musical (l'espacement des notes dans une gamme)."
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr "Le bloc <em>Mode personnalisé</em> ouvre un outil pour explorer le mode musical (l'espacement des notes dans une gamme)."
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr "Veuillez fermer la matrice actuelle avant d'en ouvrir une nouvelle."
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr "Veuillez fermer la matrice actuelle avant d'en ouvrir une nouvelle."
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr "Le bloc <em>Attendre</em> met le programme en pause pendant un nombre de secondes spécifié."
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr "Le bloc <em>Attendre</em> met le programme en pause pendant un nombre de secondes spécifié."
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr "Le bloc <em>Définir la batterie</em> sélectionnera un son de batterie pour remplacer la hauteur de toutes les notes contenues. Dans l'exemple ci-dessus, un son de <em>grosse caisse</em> sera joué à la place de <em>sol</em>."
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr "Le bloc <em>Définir la batterie</em> sélectionnera un son de batterie pour remplacer la hauteur de toutes les notes contenues. Dans l'exemple ci-dessus, un son de <em>grosse caisse</em> sera joué à la place de <em>sol</em>."
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr "Le bloc <em>Longueur du tas</em> renvoie la longueur du tas."
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr "Le bloc <em>Longueur du tas</em> renvoie la longueur du tas."
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr "sur le contretemps do"
+#~ msgid "on offbeat do"
+#~ msgstr "sur le contretemps do"
 
 #: js/StringHelper.js:17
 
@@ -12321,282 +12321,282 @@ msgstr "mouvement"
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr "infobulle"
+#~ msgid "data-tooltip"
+#~ msgstr "infobulle"
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr "pause"
+#~ msgid "pause"
+#~ msgstr "pause"
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr "Un silence de la durée de valeur de note spécifiée peut être construit en utilisant un bloc <em>Silence</em>."
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr "Un silence de la durée de valeur de note spécifiée peut être construit en utilisant un bloc <em>Silence</em>."
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr "par exemple, guitare, piano, violon ou violoncelle."
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr "par exemple, guitare, piano, violon ou violoncelle."
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr "Arrêt brutal"
+#~ msgid "Hard stop"
+#~ msgstr "Arrêt brutal"
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr "Le bloc <em>Obtenir rouge</em> renvoie la composante rouge du pixel sous la souris."
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr "Le bloc <em>Obtenir rouge</em> renvoie la composante rouge du pixel sous la souris."
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr "temps libre"
+#~ msgid "free time"
+#~ msgstr "temps libre"
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr "par exemple, si la dernière note jouée était sol, Pas Scalaire 1 jouera la."
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr "par exemple, si la dernière note jouée était sol, Pas Scalaire 1 jouera la."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr "ton entier"
+#~ msgid "whole-tone"
+#~ msgstr "ton entier"
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr "Vous pouvez également utiliser Alt+C pour copier une pile de blocs."
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr "Vous pouvez également utiliser Alt+C pour copier une pile de blocs."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr "mineur naturel"
+#~ msgid "natural-minor"
+#~ msgstr "mineur naturel"
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr "Cliquez ici pour coller"
+#~ msgid "Click here to paste"
+#~ msgstr "Cliquez ici pour coller"
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr "Ce bouton ouvre et ferme la barre d'outils principale."
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr "Ce bouton ouvre et ferme la barre d'outils principale."
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr "Exécuter la musique étape par étape"
+#~ msgid "Run music step by step"
+#~ msgstr "Exécuter la musique étape par étape"
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr "Le bloc <em>Sauvegarder le tas</em> enregistre le tas dans un fichier."
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr "Le bloc <em>Sauvegarder le tas</em> enregistre le tas dans un fichier."
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr "Éthiopien"
+#~ msgid "Ethiopian"
+#~ msgstr "Éthiopien"
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr "Il apparaît après une longue pression sur une pile."
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr "Il apparaît après une longue pression sur une pile."
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr "L'entrée du bloc Parfait doit être 1, 4, 5 ou 8"
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr "L'entrée du bloc Parfait doit être 1, 4, 5 ou 8"
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr "table"
+#~ msgid "table"
+#~ msgstr "table"
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr "Enregistrer sous .tb"
+#~ msgid "Save as .tb"
+#~ msgstr "Enregistrer sous .tb"
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr "Le bloc <em>Sur temps faible</em> vous permet de spécifier des actions à effectuer sur les temps faibles (hors temps)."
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr "Le bloc <em>Sur temps faible</em> vous permet de spécifier des actions à effectuer sur les temps faibles (hors temps)."
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr "sens droit"
+#~ msgid "sense right"
+#~ msgstr "sens droit"
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr "Le bloc <em>Charger le tas depuis l'application</em> charge le tas depuis une page web."
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr "Le bloc <em>Charger le tas depuis l'application</em> charge le tas depuis une page web."
 
-#~msgid "vspace"
-#~msgstr "espace vertical"
+#~ msgid "vspace"
+#~ msgstr "espace vertical"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr "gitan espagnol"
+#~ msgid "spanish-gypsy"
+#~ msgstr "gitan espagnol"
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr "Le bloc <em>Couleur</em> renvoie la couleur actuelle du stylo."
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr "Le bloc <em>Couleur</em> renvoie la couleur actuelle du stylo."
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr "Bebop"
+#~ msgid "Bebop"
+#~ msgstr "Bebop"
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr "Le bouton Coller sera mis en surbrillance."
+#~ msgid "The Paste Button will highlight."
+#~ msgstr "Le bouton Coller sera mis en surbrillance."
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr "Le bloc Charger le tas depuis l'application charge le tas depuis une page web."
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr "Le bloc Charger le tas depuis l'application charge le tas depuis une page web."
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr "Le bloc Pas de hauteur doit être utilisé à l'intérieur d'un bloc Note."
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr "Le bloc Pas de hauteur doit être utilisé à l'intérieur d'un bloc Note."
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "Supprimer tout le contenu de la toile, y compris les blocs."
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "Supprimer tout le contenu de la toile, y compris les blocs."
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr "enregistrer svg"
+#~ msgid "save svg"
+#~ msgstr "enregistrer svg"
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr "Sur mon appareil"
+#~ msgid "On my device"
+#~ msgstr "Sur mon appareil"
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr "Le bloc <em>Pas de fond</em> élimine le fond de la sortie SVG enregistrée."
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr "Le bloc <em>Pas de fond</em> élimine le fond de la sortie SVG enregistrée."
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr "Ma création Music Blocks"
+#~ msgid "My Music Blocks Creation"
+#~ msgstr "Ma création Music Blocks"
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr "Le bloc <em>Ouvrir la palette</em> ouvre une palette."
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr "Le bloc <em>Ouvrir la palette</em> ouvre une palette."
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr "Le bloc <em>Pour toujours</em> répétera les blocs contenus pour toujours. Dans cet exemple, une simple boîte à rythmes, une grosse caisse jouera des croches pour toujours."
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr "Le bloc <em>Pour toujours</em> répétera les blocs contenus pour toujours. Dans cet exemple, une simple boîte à rythmes, une grosse caisse jouera des croches pour toujours."
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "L'entrée du bloc Diminué doit être 1, 2, 3, 4, 5, 6, 7 ou 8"
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "L'entrée du bloc Diminué doit être 1, 2, 3, 4, 5, 6, 7 ou 8"
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr "Exécuter la musique lentement"
+#~ msgid "Run music slow"
+#~ msgstr "Exécuter la musique lentement"
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr "Pour copier une pile dans le presse-papiers, faites un appui long sur la pile."
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr "Pour copier une pile dans le presse-papiers, faites un appui long sur la pile."
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr "par exemple, guitare, piano, violon ou violoncelle."
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr "par exemple, guitare, piano, violon ou violoncelle."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr "pentatonique mineur"
+#~ msgid "minor-pentatonic"
+#~ msgstr "pentatonique mineur"
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr "Le bloc <em>Synthé AM</em> est un modulateur d'amplitude utilisé pour définir un timbre."
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr "Le bloc <em>Synthé AM</em> est un modulateur d'amplitude utilisé pour définir un timbre."
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr "Le bloc <em>Droite</em> tourne la souris vers la droite."
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr "Le bloc <em>Droite</em> tourne la souris vers la droite."
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr "Le bloc <em>Harmonique</em> ajoutera des harmoniques aux notes contenues."
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr "Le bloc <em>Harmonique</em> ajoutera des harmoniques aux notes contenues."
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr "exporter"
+#~ msgid "export"
+#~ msgstr "exporter"
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr "Le bloc <em>Puissance</em> calcule une fonction puissance."
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr "Le bloc <em>Puissance</em> calcule une fonction puissance."
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr "Le bloc <em>Définir l'orientation</em> définit l'orientation de la souris."
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr "Le bloc <em>Définir l'orientation</em> définit l'orientation de la souris."
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr "Le bloc <em>Note</em> est un conteneur pour un ou plusieurs blocs <em>Hauteur</em>. Le bloc <em>Note</em> spécifie la durée (valeur de la note) de son contenu."
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr "Le bloc <em>Note</em> est un conteneur pour un ou plusieurs blocs <em>Hauteur</em>. Le bloc <em>Note</em> spécifie la durée (valeur de la note) de son contenu."
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr "Le bloc <em>Inférieur à</em> renvoie <em>Vrai</em> si le nombre supérieur est inférieur au nombre inférieur."
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr "Le bloc <em>Inférieur à</em> renvoie <em>Vrai</em> si le nombre supérieur est inférieur au nombre inférieur."
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4. In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr "Le bloc <em>Compte de battement</em> est le numéro du battement actuel, par exemple, 1, 2, 3 ou 4. Dans la figure, il est utilisé pour effectuer une action sur le premier battement de chaque mesure."
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4. In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr "Le bloc <em>Compte de battement</em> est le numéro du battement actuel, par exemple, 1, 2, 3 ou 4. Dans la figure, il est utilisé pour effectuer une action sur le premier battement de chaque mesure."
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr "Le bloc <em>Couleur de la souris</em> renvoie la couleur du stylo de la souris spécifiée."
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr "Le bloc <em>Couleur de la souris</em> renvoie la couleur du stylo de la souris spécifiée."
 
 #: js/turtledefs.js:187
 
@@ -12604,13 +12604,13 @@ msgstr "mouvement"
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr "Enregistrer en tant que ABC"
+#~ msgid "Save as ABC"
+#~ msgstr "Enregistrer en tant que ABC"
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr "synthétiseur"
+#~ msgid "synthesizer"
+#~ msgstr "synthétiseur"
 
 #: js/logo.js:630
 
@@ -12618,86 +12618,86 @@ msgstr "mouvement"
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr "Majeur"
+#~ msgid "Major"
+#~ msgstr "Majeur"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr "Le bloc Saveheap enregistre le tas dans un fichier."
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr "Le bloc Saveheap enregistre le tas dans un fichier."
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr "Le bloc <em>Définir le volume principal</em> définit le volume de tous les synthétiseurs."
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr "Le bloc <em>Définir le volume principal</em> définit le volume de tous les synthétiseurs."
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr "dupliquer les notes"
+#~ msgid "duplicate notes"
+#~ msgstr "dupliquer les notes"
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr "Le bloc Setheapentry définit une valeur dans le tas à l'emplacement spécifié."
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr "Le bloc Setheapentry définit une valeur dans le tas à l'emplacement spécifié."
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr "Désactiver le défilement"
+#~ msgid "Disable scrolling"
+#~ msgstr "Désactiver le défilement"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr "Le bloc Intervalle scalaire mesure la distance entre deux notes en demi-tons."
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr "Le bloc Intervalle scalaire mesure la distance entre deux notes en demi-tons."
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr "Bloc Rythme : Vouliez-vous utiliser un bloc Matrice ?"
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr "Bloc Rythme : Vouliez-vous utiliser un bloc Matrice ?"
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr "Le bloc <em>Notes jouées</em> est le nombre de notes qui ont été jouées. (Par défaut, il compte les noires.)"
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr "Le bloc <em>Notes jouées</em> est le nombre de notes qui ont été jouées. (Par défaut, il compte les noires.)"
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr "Le volume par défaut est de 50 ; la plage est de 0 (silence) à 100 (volume maximum)."
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr "Le volume par défaut est de 50 ; la plage est de 0 (silence) à 100 (volume maximum)."
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr "Chaque bloc <em>Début</em> est une voix distincte. Tous les blocs <em>Début</em> s'exécutent en même temps lorsque le bouton <em>Lecture</em> est enfoncé."
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr "Chaque bloc <em>Début</em> est une voix distincte. Tous les blocs <em>Début</em> s'exécutent en même temps lorsque le bouton <em>Lecture</em> est enfoncé."
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "par exemple, « do » est toujours « C naturel » ; lorsque le do mobile est vrai, les noms des notes de solfège sont attribués aux degrés de la gamme (le « do » est toujours le premier degré de la gamme majeure)."
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "par exemple, « do » est toujours « C naturel » ; lorsque le do mobile est vrai, les noms des notes de solfège sont attribués aux degrés de la gamme (le « do » est toujours le premier degré de la gamme majeure)."
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr "octave de hauteur actuelle"
+#~ msgid "current pitch octave"
+#~ msgstr "octave de hauteur actuelle"
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr "Le bloc <em>Reverseheap</em> inverse l'ordre du tas."
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr "Le bloc <em>Reverseheap</em> inverse l'ordre du tas."
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr "Hirajoshi"
+#~ msgid "Hirajoshi"
+#~ msgstr "Hirajoshi"
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr "Le bloc <em>Créer un bloc</em> crée un nouveau bloc."
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr "Le bloc <em>Créer un bloc</em> crée un nouveau bloc."
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr "Espagno"
+#~ msgid "Spanish"
+#~ msgstr "Espagno"
 

--- a/po/gn.po
+++ b/po/gn.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/gug.po
+++ b/po/gug.po
@@ -18,10 +18,10 @@ msgstr ""
 "X-Generator: Pootle 2.5.1.1\n"
 "X-POOTLE-MTIME: 1480121257.000000\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -41,7 +41,7 @@ msgstr ""
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
 #: js/languagebox.js:208
-#.TRANS: Actualice su navegador para cambiar su preferencia de idioma.
+#. TRANS: Actualice su navegador para cambiar su preferencia de idioma.
 msgid "Refresh your browser to change your language preference."
 msgstr ""
 
@@ -50,7 +50,7 @@ msgid "Music Blocks is already set to this language."
 msgstr "Music Blocks ya está configurado en este idioma."
 
 #: js/planetInterface.js:131
-#.TRANS: El proyecto no está definido.
+#. TRANS: El proyecto no está definido.
 msgid "project undefined"
 msgstr ""
 
@@ -103,15 +103,15 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2501
 #: js/widgets/rhythmruler.js:2508
 #: js/widgets/phrasemaker.js:4996
-#.TRANS: acción
+#. TRANS: acción
 msgid "action"
 msgstr "apopy"
 
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
-#.TRANS: pato
+#. TRANS: animal sound effect
+#. TRANS: pato
 msgid "duck"
 msgstr "ype"
 
@@ -122,60 +122,60 @@ msgstr ""
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
-#.TRANS: Proyecto de Bloques de Música
+#. TRANS: Proyecto de Bloques de Música
 msgid "Music Blocks Project"
 msgstr ""
 
 #: js/SaveInterface.js:63
-#.TRANS: Este proyecto fue creado en Bloques de Música
+#. TRANS: Este proyecto fue creado en Bloques de Música
 msgid "This project was created in Music Blocks"
 msgstr ""
 
 #: js/SaveInterface.js:67
-#.TRANS: Bloques de Música es una aplicación de Software Libre
+#. TRANS: Bloques de Música es una aplicación de Software Libre
 msgid "Music Blocks is a Free/Libre Software application."
 msgstr ""
 
 #: js/SaveInterface.js:69
-#.TRANS: Se puede acceder al código fuente en
+#. TRANS: Se puede acceder al código fuente en
 msgid "The source code can be accessed at"
 msgstr ""
 
 #: js/SaveInterface.js:72
-#.TRANS: Para más información, consulte el
+#. TRANS: Para más información, consulte el
 msgid "For more information, please consult the"
 msgstr ""
 
 #: js/SaveInterface.js:76
 #: js/turtledefs.js:489
-#.TRANS: Guía de Bloques de Música
+#. TRANS: Guía de Bloques de Música
 msgid "Music Blocks Guide"
 msgstr ""
 
 #: js/SaveInterface.js:83
-#.TRANS: Alternativamente, abra el archivo en Bloques de Música usando el botón Cargar proyecto.
+#. TRANS: Alternativamente, abra el archivo en Bloques de Música usando el botón Cargar proyecto.
 msgid "Alternatively, open the file in Music Blocks using the Load project button."
 msgstr ""
 
 #: js/SaveInterface.js:85
-#.TRANS: Código de proyecto
+#. TRANS: Código de proyecto
 msgid "Project Code"
 msgstr ""
 
 #: js/SaveInterface.js:87
-#.TRANS: Este código almacena datos sobre los bloques en un proyecto.
+#. TRANS: Este código almacena datos sobre los bloques en un proyecto.
 msgid "This code stores data about the blocks in a project."
 msgstr ""
 
 #: js/SaveInterface.js:89
 #: js/blocks.js:5091
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: Mostrar
+#. TRANS: Mostrar
 msgid "Show"
 msgstr ""
 
 #: js/SaveInterface.js:91
-#.TRANS: Ocultar
+#. TRANS: Ocultar
 msgid "Hide"
 msgstr ""
 
@@ -189,56 +189,56 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
-#.TRANS: Mi proyecto
+#. TRANS: default project title when saving as Lilypond
+#. TRANS: Mi proyecto
 msgid "My Project"
 msgstr "Che ajaposéva"
 
 #: js/SaveInterface.js:197
 #: planet/js/SaveInterface.js:58
-#.TRANS: Ninguna descripción provista
+#. TRANS: Ninguna descripción provista
 msgid "No description provided"
 msgstr ""
 
 #: js/SaveInterface.js:346
-#.TRANS: Tu grabación está en curso.
+#. TRANS: Tu grabación está en curso.
 msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
-#.TRANS: Nombre del archivo
+#. TRANS: File name prompt for save as Lilypond
+#. TRANS: Nombre del archivo
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
-#.TRANS: Título del proyecto
+#. TRANS: Project title prompt for save as Lilypond
+#. TRANS: Título del proyecto
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
-#.TRANS: Autor del Proyecto
+#. TRANS: Project title prompt for save as Lilypond
+#. TRANS: Autor del Proyecto
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
-#.TRANS: Incluye MIDI?
+#. TRANS: MIDI prompt for save as Lilypond
+#. TRANS: Incluye MIDI?
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
-#.TRANS: Incluye tablatura de guitarra
+#. TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Incluye tablatura de guitarra
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
-#.TRANS: Guardar como lilypond
+#. TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Guardar como lilypond
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -260,19 +260,19 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
-#.TRANS: Sr. Ratón
+#. TRANS: default project author when saving as Lilypond
+#. TRANS: Sr. Ratón
 msgid "Mr. Mouse"
 msgstr ""
 
 #: js/SaveInterface.js:589
-#.TRANS: El código de Lilypond se copia al portapapeles. Puedes pegarlo aquí:
+#. TRANS: El código de Lilypond se copia al portapapeles. Puedes pegarlo aquí:
 msgid "The Lilypond code is copied to clipboard. You can paste it here: "
 msgstr ""
 
 #: js/activity.js:411
 #: js/activity.js:416
-#.TRANS: Buscar bloques
+#. TRANS: Buscar bloques
 msgid "Search for blocks"
 msgstr ""
 
@@ -293,57 +293,57 @@ msgid "Click on stop saving"
 msgstr ""
 
 #: js/activity.js:1882
-#.TRANS: atrapar ratones
+#. TRANS: atrapar ratones
 msgid "Catching mice"
 msgstr ""
 
 #: js/activity.js:1883
-#.TRANS: limpiar los instrumentos
+#. TRANS: limpiar los instrumentos
 msgid "Cleaning the instruments"
 msgstr ""
 
 #: js/activity.js:1884
-#.TRANS: probando piezas clave
+#. TRANS: probando piezas clave
 msgid "Testing key pieces"
 msgstr ""
 
 #: js/activity.js:1885
-#.TRANS: lectura a primera vista
+#. TRANS: lectura a primera vista
 msgid "Sight-reading"
 msgstr ""
 
 #: js/activity.js:1886
-#.TRANS: combinando matemáticas y música
+#. TRANS: combinando matemáticas y música
 msgid "Combining math and music"
 msgstr ""
 
 #: js/activity.js:1887
-#.TRANS: generando más bloques
+#. TRANS: generando más bloques
 msgid "Generating more blocks"
 msgstr ""
 
 #: js/activity.js:1888
-#.TRANS: Do Re Mi Fa Sol La Si Do
+#. TRANS: Do Re Mi Fa Sol La Si Do
 msgid "Do Re Mi Fa Sol La Ti Do"
 msgstr ""
 
 #: js/activity.js:1889
-#.TRANS: afinar instrumentos de cuerda
+#. TRANS: afinar instrumentos de cuerda
 msgid "Tuning string instruments"
 msgstr ""
 
 #: js/activity.js:1890
-#.TRANS: presionando teclas aleatorias
+#. TRANS: presionando teclas aleatorias
 msgid "Pressing random keys"
 msgstr ""
 
 #: js/activity.js:2072
-#.TRANS: los plugins se eliminarán al reiniciar.
+#. TRANS: los plugins se eliminarán al reiniciar.
 msgid "plugins will be removed upon restart."
 msgstr ""
 
 #: js/activity.js:2081
-#.TRANS: Mostrar Cartesiano
+#. TRANS: Mostrar Cartesiano
 msgid "show Cartesian"
 msgstr ""
 
@@ -352,144 +352,144 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: grado de escala
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: grado de escala
 msgid "scale degree"
 msgstr "ojupijupi"
 
 #: js/activity.js:2606
 #: js/palette.js:681
-#.TRANS: nombre de voz
+#. TRANS: nombre de voz
 msgid "voice name"
 msgstr ""
 
 #: js/activity.js:2609
 #: js/palette.js:678
-#.TRANS: modo invertido
+#. TRANS: modo invertido
 msgid "invert mode"
 msgstr ""
 
 #: js/activity.js:2612
-#.TRANS: herramientas de producción
+#. TRANS: herramientas de producción
 msgid "output tools"
 msgstr ""
 
 #: js/activity.js:2615
-#.TRANS: nota personalizada
+#. TRANS: nota personalizada
 msgid "custom note"
 msgstr ""
 
 #: js/activity.js:2618
-#.TRANS: nombre accidental
+#. TRANS: nombre accidental
 msgid "accidental name"
 msgstr ""
 
 #: js/activity.js:2621
 #: js/blocks/PitchBlocks.js:855
-#.TRANS: 
+#. TRANS: 
 msgid "east indian solfege"
 msgstr ""
 
 #: js/activity.js:2624
 #: js/blocks/PitchBlocks.js:869
-#.TRANS: nombre de la nota
+#. TRANS: nombre de la nota
 msgid "note name"
 msgstr ""
 
 #: js/activity.js:2627
 #: js/blocks/IntervalsBlocks.js:94
-#.TRANS: nombre de temperamento
+#. TRANS: nombre de temperamento
 msgid "temperament name"
 msgstr ""
 
 #: js/activity.js:2630
 #: js/palette.js:675
-#.TRANS: nombre de modo
+#. TRANS: nombre de modo
 msgid "mode name"
 msgstr ""
 
 #: js/activity.js:2633
-#.TRANS: nombre de achorde
+#. TRANS: nombre de achorde
 msgid "chord name"
 msgstr ""
 
 #: js/activity.js:2636
 #: js/palette.js:698
-#.TRANS: nombre de intervalo
+#. TRANS: nombre de intervalo
 msgid "interval name"
 msgstr ""
 
 #: js/activity.js:2639
-#.TRANS: tipo de filtro
+#. TRANS: tipo de filtro
 msgid "filter type"
 msgstr ""
 
 #: js/activity.js:2642
-#.TRANS: tipo de oscilador
+#. TRANS: tipo de oscilador
 msgid "oscillator type"
 msgstr ""
 
 #: js/activity.js:2645
 #: js/blocks.js:2479
 #: js/blocks.js:2487
-#.TRANS: archivo de audio
+#. TRANS: archivo de audio
 msgid "audio file"
 msgstr ""
 
 #: js/activity.js:2648
 #: js/blocks/DrumBlocks.js:32
-#.TRANS: nombre de ruido
+#. TRANS: nombre de ruido
 msgid "noise name"
 msgstr ""
 
 #: js/activity.js:2651
 #: js/blocks/DrumBlocks.js:75
-#.TRANS: nombre del tambor
+#. TRANS: nombre del tambor
 msgid "drum name"
 msgstr ""
 
 #: js/activity.js:2654
 #: js/blocks/DrumBlocks.js:119
-#.TRANS: nombre de efectos
+#. TRANS: nombre de efectos
 msgid "effects name"
 msgstr ""
 
 #: js/activity.js:2657
-#.TRANS: modo de envoltura
+#. TRANS: modo de envoltura
 msgid "wrap mode"
 msgstr ""
 
 #: js/activity.js:2660
-#.TRANS: cargar archivo
+#. TRANS: cargar archivo
 msgid "load file"
 msgstr ""
 
 #: js/activity.js:2830
 #: js/activity.js:6368
-#.TRANS: Este bloque está en desuso.
+#. TRANS: Este bloque está en desuso.
 msgid "This block is deprecated."
 msgstr ""
 
 #: js/activity.js:2832
 #: js/activity.js:6370
-#.TRANS: Este bloque no se puede encontrar.
+#. TRANS: Este bloque no se puede encontrar.
 msgid "Block cannot be found."
 msgstr ""
 
 #: js/activity.js:3041
-#.TRANS: Guardar ilustraciones de bloques
+#. TRANS: Guardar ilustraciones de bloques
 msgid "Saving block artwork"
 msgstr ""
 
 #: js/activity.js:3045
 #: js/turtledefs.js:708
 #: planet/js/LocalCard.js:31
-#.TRANS: Copiar
+#. TRANS: Copiar
 msgid "Copy"
 msgstr "Mbohesegua"
 
 #: js/activity.js:3052
-#.TRANS: Borrar
+#. TRANS: Borrar
 msgid "Erase"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:4608
 #: js/widgets/phrasemaker.js:4722
 #: plugins/rodi.rtp:191
-#.TRANS: Tocar
+#. TRANS: Tocar
 msgid "Play"
 msgstr ""
 
@@ -588,18 +588,18 @@ msgstr ""
 #: plugins/rodi.rtp:29
 #: plugins/rodi.rtp:73
 #: plugins/rodi.rtp:413
-#.TRANS: Detener
+#. TRANS: Detener
 msgid "Stop"
 msgstr "Joko"
 
 #: js/activity.js:3084
 #: js/activity.js:3106
-#.TRANS: Pegar
+#. TRANS: Pegar
 msgid "Paste"
 msgstr "Mboja"
 
 #: js/activity.js:3088
-#.TRANS: Guardar ayuda de bloque
+#. TRANS: Guardar ayuda de bloque
 msgid "Save block help"
 msgstr ""
 
@@ -610,60 +610,60 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: si la sol fa mi re do
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: si la sol fa mi re do
 msgid "ti la sol fa mi re do"
 msgstr "si la sol fa mi re do"
 
 #: js/activity.js:3173
-#.TRANS: Saltando al final de la página
+#. TRANS: Saltando al final de la página
 msgid "Jumping to the bottom of the page."
 msgstr ""
 
 #: js/activity.js:3179
-#.TRANS: Desplazarse hacia arriba
+#. TRANS: Desplazarse hacia arriba
 msgid "Scrolling up."
 msgstr ""
 
 #: js/activity.js:3184
-#.TRANS: Desplazarse hacia abajo
+#. TRANS: Desplazarse hacia abajo
 msgid "Scrolling down."
 msgstr ""
 
 #: js/activity.js:3189
-#.TRANS: Bloque de extracción
+#. TRANS: Bloque de extracción
 msgid "Extracting block"
 msgstr ""
 
 #: js/activity.js:3197
-#.TRANS: Mover bloque hacia arriba
+#. TRANS: Mover bloque hacia arriba
 msgid "Moving block up."
 msgstr ""
 
 #: js/activity.js:3218
-#.TRANS: Mover bloque hacia abajo
+#. TRANS: Mover bloque hacia abajo
 msgid "Moving block down."
 msgstr ""
 
 #: js/activity.js:3239
-#.TRANS: Mover bloque a la izquierda
+#. TRANS: Mover bloque a la izquierda
 msgid "Moving block left."
 msgstr ""
 
 #: js/activity.js:3256
-#.TRANS: Mover bloque a la derecha
+#. TRANS: Mover bloque a la derecha
 msgid "Moving block right."
 msgstr ""
 
 #: js/activity.js:3271
-#.TRANS: Saltar a la posición inicial
+#. TRANS: Saltar a la posición inicial
 msgid "Jump to home position."
 msgstr ""
 
 #: js/activity.js:3298
 #: js/blocks/ExtrasBlocks.js:274
-#.TRANS: Ocultar bloques
+#. TRANS: Ocultar bloques
 msgid "Hide blocks"
 msgstr ""
 
@@ -674,7 +674,7 @@ msgstr ""
 
 #: js/activity.js:3679
 #: js/activity.js:3760
-#.TRANS: Objeto recuperado de la basura.
+#. TRANS: Objeto recuperado de la basura.
 msgid "Item restored from the trash."
 msgstr ""
 
@@ -687,69 +687,69 @@ msgid "Restore all items"
 msgstr ""
 
 #: js/activity.js:5016
-#.TRANS: Haga clic en el botón ejecutar para ejecutar el proyecto.
+#. TRANS: Haga clic en el botón ejecutar para ejecutar el proyecto.
 msgid "Click the run button to run the project."
 msgstr ""
 
 #: js/activity.js:6201
 #: js/turtledefs.js:756
-#.TRANS: Casa
+#. TRANS: Casa
 msgid "Home"
 msgstr "Óga"
 
 #: js/activity.js:6209
 #: js/turtledefs.js:762
-#.TRANS: Mostrar u ocultar los bloques.
+#. TRANS: Mostrar u ocultar los bloques.
 msgid "Show/hide blocks"
 msgstr "Ehechauka tér ã emokañy vorekuéra"
 
 #: js/activity.js:6215
 #: js/turtledefs.js:768
-#.TRANS: Expandir / Contraer bloques
+#. TRANS: Expandir / Contraer bloques
 msgid "Expand/collapse blocks"
 msgstr ""
 
 #: js/activity.js:6221
 #: js/turtledefs.js:776
-#.TRANS: Disminuir el tamaño de los bloques
+#. TRANS: Disminuir el tamaño de los bloques
 msgid "Decrease block size"
 msgstr "Emomichĩ jakatuha vorekuéra"
 
 #: js/activity.js:6227
 #: js/turtledefs.js:782
-#.TRANS: Incrementar tamaño de bloques
+#. TRANS: Incrementar tamaño de bloques
 msgid "Increase block size"
 msgstr "Embotuicha jakatuha vorekuéra"
 
 #: js/activity.js:6493
-#.TRANS: No se pudo analizar la entrada de JSON.
+#. TRANS: No se pudo analizar la entrada de JSON.
 msgid "Could not parse JSON input."
 msgstr ""
 
 #: js/activity.js:6624
-#.TRANS: Seleccionar está habilitado.
+#. TRANS: Seleccionar está habilitado.
 msgid "Select is enabled."
 msgstr ""
 
 #: js/activity.js:6624
-#.TRANS: Seleccionar está deshabilitado.
+#. TRANS: Seleccionar está deshabilitado.
 msgid "Select is disabled."
 msgstr ""
 
 #: js/activity.js:7005
 #: js/activity.js:7111
 #: js/activity.js:7162
-#.TRANS: No se puede cargar el proyecto desde el archivo. Compruebe el tipo de archivo.
+#. TRANS: No se puede cargar el proyecto desde el archivo. Compruebe el tipo de archivo.
 msgid "Cannot load project from the file. Please check the file type."
 msgstr ""
 
 #: js/activity.js:7448
-#.TRANS: El parametro es invalido.
+#. TRANS: El parametro es invalido.
 msgid "Invalid parameters"
 msgstr ""
 
 #: js/activity.js:7599
-#.TRANS: Error al regenerar las paletas. Actualice la página.
+#. TRANS: Error al regenerar las paletas. Actualice la página.
 msgid "Error regenerating palettes. Please refresh the page."
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 #: js/palette.js:688
 #: js/blocks/IntervalsBlocks.js:63
 #: js/blocks/WidgetBlocks.js:259
-#.TRANS: temperamento
+#. TRANS: temperamento
 msgid "temperament"
 msgstr ""
 
@@ -772,67 +772,67 @@ msgstr ""
 #: js/turtles.js:119
 #: js/blocks/ProgramBlocks.js:1267
 #: js/blocks/ActionBlocks.js:1223
-#.TRANS: iniciar
+#. TRANS: iniciar
 msgid "start"
 msgstr "ñepyrũ"
 
 #: js/block.js:1590
-#.TRANS: matriz
+#. TRANS: matriz
 msgid "matrix"
 msgstr "moñepyrũmbygua"
 
 #: js/block.js:1597
 #: js/blocks/WidgetBlocks.js:1510
 #: plugins/rodi.rtp:324
-#.TRANS: estatus
+#. TRANS: estatus
 msgid "status"
 msgstr "henda"
 
 #: js/block.js:1604
-#.TRANS: mapa del tambor
+#. TRANS: mapa del tambor
 msgid "drum mapper"
 msgstr ""
 
 #: js/block.js:1611
-#.TRANS: regla
+#. TRANS: regla
 msgid "ruler"
 msgstr "mbojojaha"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
-#.TRANS: timbre
+#. TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre
 msgid "timbre"
 msgstr ""
 
 #: js/block.js:1625
-#.TRANS: escalera
+#. TRANS: escalera
 msgid "stair"
 msgstr "jupiha"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
-#.TRANS: tempo
+#. TRANS: the speed at music is should be played.
+#. TRANS: tempo
 msgid "tempo"
 msgstr "tempo"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
-#.TRANS: modo
+#. TRANS: mode, e.g., Major in C Major
+#. TRANS: modo
 msgid "mode"
 msgstr "kokatu"
 
 #: js/block.js:1646
-#.TRANS: deslizador
+#. TRANS: deslizador
 msgid "slider"
 msgstr "embosyrỹi"
 
 #: js/block.js:1653
 #: js/blocks/SensorsBlocks.js:1002
-#.TRANS: teclado
+#. TRANS: teclado
 msgid "keyboard"
 msgstr "votõkuéra renda"
 
@@ -848,15 +848,15 @@ msgstr "votõkuéra renda"
 #: js/blocks/RhythmBlocks.js:766
 #: js/blocks/VolumeBlocks.js:502
 #: js/widgets/phrasemaker.js:1124
-#.TRANS: tambor
+#. TRANS: tambor
 msgid "drum"
 msgstr "angu’atarara"
 
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
-#.TRANS: hacer un ritmo
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: hacer un ritmo
 msgid "rhythm maker"
 msgstr ""
 
@@ -881,8 +881,8 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
-#.TRANS: valor de la nota
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: valor de la nota
 msgid "note value"
 msgstr "kuatia’ihai repy"
 
@@ -891,14 +891,14 @@ msgstr "kuatia’ihai repy"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
-#.TRANS: intervalo escalar
+#. TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: intervalo escalar
 msgid "scalar interval"
 msgstr ""
 
 #: js/block.js:1688
 #: js/blocks/RhythmBlocks.js:148
-#.TRANS: milisegundos
+#. TRANS: milisegundos
 msgid "milliseconds"
 msgstr ""
 
@@ -910,18 +910,18 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:712
 #: js/widgets/rhythmruler.js:1177
 #: js/widgets/rhythmruler.js:1323
-#.TRANS: silencio
+#. TRANS: silencio
 msgid "silence"
 msgstr "kirirĩ"
 
 #: js/block.js:2542
-#.TRANS: scalar step
-#.TRANS: abajo
+#. TRANS: scalar step
+#. TRANS: abajo
 msgid "down"
 msgstr ""
 
 #: js/block.js:2543
-#.TRANS: arriba
+#. TRANS: arriba
 msgid "up"
 msgstr ""
 
@@ -935,20 +935,20 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
-#.TRANS: tono
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: tono
 msgid "pitch"
 msgstr "pu"
 
 #: js/block.js:2963
-#.TRANS: El bloqueo de silencio no se puede eliminar.
+#. TRANS: El bloqueo de silencio no se puede eliminar.
 msgid "Silence block cannot be removed."
 msgstr ""
 
 #: js/block.js:3135
 #: js/piemenus.js:3457
-#.TRANS: Puedes restaurar bloques eliminados de la papelera con el botón Restaurar desde la papelera.
+#. TRANS: Puedes restaurar bloques eliminados de la papelera con el botón Restaurar desde la papelera.
 msgid "You can restore deleted blocks from the trash with the Restore From Trash button."
 msgstr ""
 
@@ -968,7 +968,7 @@ msgstr ""
 #: js/blocks/BooleanBlocks.js:948
 #: js/blocks/BooleanBlocks.js:1033
 #: js/blocks/SensorsBlocks.js:911
-#.TRANS: verdadero
+#. TRANS: verdadero
 msgid "true"
 msgstr "añetete"
 
@@ -986,65 +986,65 @@ msgstr "añetete"
 #: js/blocks/BooleanBlocks.js:849
 #: js/blocks/BooleanBlocks.js:950
 #: js/blocks/SensorsBlocks.js:913
-#.TRANS: falso
+#. TRANS: falso
 msgid "false"
 msgstr "japu"
 
 #: js/block.js:3776
 #: js/block.js:3789
 #: js/blocks/ExtrasBlocks.js:618
-#.TRANS: Cartesiano
+#. TRANS: Cartesiano
 msgid "Cartesian"
 msgstr "Cartesiano"
 
 #: js/block.js:3777
 #: js/block.js:3790
 #: js/blocks/ExtrasBlocks.js:622
-#.TRANS: polar
+#. TRANS: polar
 msgid "polar"
 msgstr ""
 
 #: js/block.js:3778
 #: js/block.js:3791
 #: js/blocks/ExtrasBlocks.js:626
-#.TRANS: Cartesiano/Polar
+#. TRANS: Cartesiano/Polar
 msgid "Cartesian/Polar"
 msgstr ""
 
 #: js/block.js:3779
 #: js/block.js:3798
 #: js/blocks/ExtrasBlocks.js:655
-#.TRANS: ninguno
+#. TRANS: ninguno
 msgid "none"
 msgstr ""
 
 #: js/block.js:3792
 #: js/blocks/ExtrasBlocks.js:631
-#.TRANS: agudos
+#. TRANS: agudos
 msgid "treble"
 msgstr ""
 
 #: js/block.js:3793
 #: js/blocks/ExtrasBlocks.js:635
-#.TRANS: staff grande
+#. TRANS: staff grande
 msgid "grand staff"
 msgstr ""
 
 #: js/block.js:3794
 #: js/blocks/ExtrasBlocks.js:639
-#.TRANS: mezzo-soprano
+#. TRANS: mezzo-soprano
 msgid "mezzo-soprano"
 msgstr ""
 
 #: js/block.js:3795
 #: js/blocks/ExtrasBlocks.js:643
-#.TRANS: alto
+#. TRANS: alto
 msgid "alto"
 msgstr ""
 
 #: js/block.js:3796
 #: js/blocks/ExtrasBlocks.js:647
-#.TRANS: tenor
+#. TRANS: tenor
 msgid "tenor"
 msgstr ""
 
@@ -1052,37 +1052,37 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
-#.TRANS: bass
+#. TRANS: musical instrument
+#. TRANS: bass
 msgid "bass"
 msgstr ""
 
 #: js/block.js:3842
 #: js/blocks.js:2600
 #: js/blocks.js:3211
-#.TRANS: encendido
+#. TRANS: encendido
 msgid "on2"
 msgstr ""
 
 #: js/block.js:3844
 #: js/blocks.js:2602
 #: js/blocks.js:3213
-#.TRANS: apagado
+#. TRANS: apagado
 msgid "off"
 msgstr ""
 
 #: js/block.js:4411
-#.TRANS: no es un número
+#. TRANS: no es un número
 msgid "Not a number"
 msgstr ""
 
 #: js/block.js:4418
-#.TRANS: El valor de octava debe estar entre 1 y 8.
+#. TRANS: El valor de octava debe estar entre 1 y 8.
 msgid "Octave value must be between 1 and 8."
 msgstr ""
 
 #: js/block.js:4426
-#.TRANS: El bloqueo de silencio no se puede eliminar.
+#. TRANS: El bloqueo de silencio no se puede eliminar.
 msgid "Numbers can have at most 10 digits."
 msgstr ""
 
@@ -1100,19 +1100,19 @@ msgstr ""
 #: js/blocks/BoxesBlocks.js:285
 #: js/blocks/BoxesBlocks.js:405
 #: js/blocks/BoxesBlocks.js:594
-#.TRANS: caja
+#. TRANS: caja
 msgid "box"
 msgstr "mba’eryru"
 
 #: js/blocks.js:1713
-#.TRANS: Considera dividir esta pila en partes.
+#. TRANS: Considera dividir esta pila en partes.
 msgid "Consider breaking this stack into parts."
 msgstr ""
 
 #: js/blocks.js:2472
 #: js/palette.js:736
 #: js/blocks/MediaBlocks.js:602
-#.TRANS: abrir archivo
+#. TRANS: abrir archivo
 msgid "open file"
 msgstr "eipe’a ñongatuha"
 
@@ -1120,7 +1120,7 @@ msgstr "eipe’a ñongatuha"
 #: js/palette.js:657
 #: js/blocks/MediaBlocks.js:892
 #: js/blocks/MediaBlocks.js:963
-#.TRANS: texto
+#. TRANS: texto
 msgid "text"
 msgstr "haipyre"
 
@@ -1128,7 +1128,7 @@ msgstr "haipyre"
 #: js/palette.js:724
 #: js/palette.js:725
 #: js/blocks/BoxesBlocks.js:514
-#.TRANS: guardar en caja
+#. TRANS: guardar en caja
 msgid "store in box"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 #: js/blocks.js:5862
 #: js/blocks.js:5883
 #: js/blocks/BoxesBlocks.js:772
-#.TRANS: caja1
+#. TRANS: caja1
 msgid "box1"
 msgstr ""
 
@@ -1150,7 +1150,7 @@ msgstr ""
 #: js/blocks.js:5864
 #: js/blocks.js:5885
 #: js/blocks/BoxesBlocks.js:663
-#.TRANS: caja2
+#. TRANS: caja2
 msgid "box2"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 #: js/palette.js:727
 #: js/palette.js:1127
 #: js/blocks/BoxesBlocks.js:591
-#.TRANS: guardar en
+#. TRANS: guardar en
 msgid "store in"
 msgstr "eñongatu... pe"
 
@@ -1177,7 +1177,7 @@ msgstr "eñongatu... pe"
 #: js/blocks/EnsembleBlocks.js:393
 #: js/blocks/EnsembleBlocks.js:404
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: nombre
+#. TRANS: nombre
 msgid "name"
 msgstr "Téra"
 
@@ -1188,32 +1188,32 @@ msgstr "Téra"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/RhythmBlocks.js:1130
-#.TRANS: valor
+#. TRANS: valor
 msgid "value"
 msgstr "tepy"
 
 #: js/blocks.js:4465
-#.TRANS: Se detectó un bucle indefinido dentro de un bloque de valor de nota. Pueden ocurrir cosas inesperadas.
+#. TRANS: Se detectó un bucle indefinido dentro de un bloque de valor de nota. Pueden ocurrir cosas inesperadas.
 msgid "Forever loop detected inside a note value block. Unexpected things may happen."
 msgstr ""
 
 #: js/blocks.js:4988
-#.TRANS: No hay bloque seleccionado.
+#. TRANS: No hay bloque seleccionado.
 msgid "There is no block selected."
 msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
-#.TRANS: avatar
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: avatar
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
-#.TRANS: muestra de audio
+#. TRANS: The sound sample that the user uploads.
+#. TRANS: muestra de audio
 msgid "sample"
 msgstr ""
 
@@ -1222,62 +1222,62 @@ msgstr ""
 #: js/lilypond.js:910
 #: js/lilypond.js:948
 #: js/rubrics.js:526
-#.TRANS: ratón
+#. TRANS: ratón
 msgid "mouse"
 msgstr "anguja"
 
 #: js/lilypond.js:606
-#.TRANS: rata marrón
+#. TRANS: rata marrón
 msgid "brown rat"
 msgstr "anguja marrón"
 
 #: js/lilypond.js:607
-#.TRANS: topo
+#. TRANS: topo
 msgid "mole"
 msgstr "topo"
 
 #: js/lilypond.js:608
-#.TRANS: ardilla
+#. TRANS: ardilla
 msgid "chipmunk"
 msgstr "ardilla"
 
 #: js/lilypond.js:609
-#.TRANS: ardilla roja
+#. TRANS: ardilla roja
 msgid "red squirrel"
 msgstr "ardilla roja"
 
 #: js/lilypond.js:610
-#.TRANS: conejillo de indias
+#. TRANS: conejillo de indias
 msgid "guinea pig"
 msgstr "tapiti india gua"
 
 #: js/lilypond.js:611
-#.TRANS: capybara
+#. TRANS: capybara
 msgid "capybara"
 msgstr "carpincho"
 
 #: js/lilypond.js:612
-#.TRANS: coypu
+#. TRANS: coypu
 msgid "coypu"
 msgstr "coipu"
 
 #: js/lilypond.js:613
-#.TRANS: rata negra
+#. TRANS: rata negra
 msgid "black rat"
 msgstr "anguja hũ"
 
 #: js/lilypond.js:614
-#.TRANS: ardilla gris
+#. TRANS: ardilla gris
 msgid "grey squirrel"
 msgstr "ardilla gris"
 
 #: js/lilypond.js:615
-#.TRANS: ardilla voladora
+#. TRANS: ardilla voladora
 msgid "flying squirrel"
 msgstr "ardilla voladora"
 
 #: js/lilypond.js:616
-#.TRANS: murciélago
+#. TRANS: murciélago
 msgid "bat"
 msgstr "mbopi"
 
@@ -1286,7 +1286,7 @@ msgstr "mbopi"
 #: js/lilypond.js:951
 #: js/blocks/ActionBlocks.js:1256
 #: js/blocks/ExtrasBlocks.js:559
-#.TRANS: iniciar tambor
+#. TRANS: iniciar tambor
 msgid "start drum"
 msgstr "ñepỹru angu’atarara"
 
@@ -1301,15 +1301,15 @@ msgstr "ñepỹru angu’atarara"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
-#.TRANS: ritmo
+#. TRANS: an arrangement of notes based on duration
+#. TRANS: ritmo
 msgid "rhythm"
 msgstr "rítmo"
 
 #: js/rubrics.js:525
 #: js/turtledefs.js:126
 #: js/turtledefs.js:227
-#.TRANS: tono
+#. TRANS: tono
 msgid "tone"
 msgstr "pu"
 
@@ -1317,7 +1317,7 @@ msgstr "pu"
 #: js/turtledefs.js:135
 #: js/turtledefs.js:236
 #: js/widgets/phrasemaker.js:1126
-#.TRANS: pluma
+#. TRANS: pluma
 msgid "pen"
 msgstr "guyra rague"
 
@@ -1327,14 +1327,14 @@ msgstr "guyra rague"
 #: js/blocks/NumberBlocks.js:981
 #: js/blocks/PitchBlocks.js:1717
 #: js/blocks/PitchBlocks.js:1758
-#.TRANS: número
+#. TRANS: número
 msgid "number"
 msgstr "papaha"
 
 #: js/rubrics.js:529
 #: js/turtledefs.js:130
 #: js/turtledefs.js:231
-#.TRANS: flujo
+#. TRANS: flujo
 msgid "flow"
 msgstr "syry"
 
@@ -1342,8 +1342,8 @@ msgstr "syry"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: sensores
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: sensores
 msgid "Sensors"
 msgstr ""
 
@@ -1352,19 +1352,19 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: medios
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: medios
 msgid "Media"
 msgstr ""
 
 #: js/rubrics.js:533
-#.TRANS: ratón
+#. TRANS: ratón
 msgid "mice"
 msgstr ""
 
 #: js/toolbar.js:48
 #: js/toolbar.js:114
-#.TRANS: Acerca de los Bloques de Música
+#. TRANS: Acerca de los Bloques de Música
 msgid "About Music Blocks"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 #: js/toolbar.js:188
 #: js/toolbar.js:249
 #: js/turtledefs.js:509
-#.TRANS: Grabar
+#. TRANS: Grabar
 msgid "Record"
 msgstr ""
 
@@ -1385,7 +1385,7 @@ msgstr ""
 #: js/toolbar.js:190
 #: js/toolbar.js:250
 #: js/toolbar.js:251
-#.TRANS: Pantalla completa
+#. TRANS: Pantalla completa
 msgid "Full screen"
 msgstr ""
 
@@ -1394,7 +1394,7 @@ msgstr ""
 #: js/toolbar.js:191
 #: js/toolbar.js:252
 #: js/turtledefs.js:516
-#.TRANS: Alternar pantalla completa
+#. TRANS: Alternar pantalla completa
 msgid "Toggle Fullscreen"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 #: js/toolbar.js:1118
 #: js/turtledefs.js:522
 #: planet/js/StringHelper.js:33
-#.TRANS: Nuevo proyecto
+#. TRANS: Nuevo proyecto
 msgid "New project"
 msgstr ""
 
@@ -1414,7 +1414,7 @@ msgstr ""
 #: js/toolbar.js:193
 #: js/toolbar.js:254
 #: js/turtledefs.js:528
-#.TRANS: Cargar proyecto de archivo
+#. TRANS: Cargar proyecto de archivo
 msgid "Load project from file"
 msgstr "Ehupi jejaposéva ñongatuhape"
 
@@ -1426,7 +1426,7 @@ msgstr "Ehupi jejaposéva ñongatuhape"
 #: js/turtledefs.js:535
 #: js/turtledefs.js:546
 #: js/turtledefs.js:566
-#.TRANS: Guardar proyecto
+#. TRANS: Guardar proyecto
 msgid "Save project"
 msgstr "Eñongatu jejaposéva"
 
@@ -1444,7 +1444,7 @@ msgstr "Eñongatu jejaposéva"
 #: js/toolbar.js:279
 #: js/turtledefs.js:536
 #: js/turtledefs.js:567
-#.TRANS: Guardar como HTML
+#. TRANS: Guardar como HTML
 msgid "Save project as HTML"
 msgstr ""
 
@@ -1452,7 +1452,7 @@ msgstr ""
 #: js/toolbar.js:125
 #: js/toolbar.js:196
 #: js/toolbar.js:257
-#.TRANS: Encuentra y comparte proyectos
+#. TRANS: Encuentra y comparte proyectos
 msgid "Find and share projects"
 msgstr ""
 
@@ -1460,7 +1460,7 @@ msgstr ""
 #: js/toolbar.js:126
 #: js/toolbar.js:197
 #: js/toolbar.js:258
-#.TRANS: Desconectado. Compartir no está disponible.
+#. TRANS: Desconectado. Compartir no está disponible.
 msgid "Offline. Sharing is unavailable"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgstr ""
 #: js/toolbar.js:127
 #: js/toolbar.js:198
 #: js/toolbar.js:259
-#.TRANS: Menú auxiliar
+#. TRANS: Menú auxiliar
 msgid "Auxiliary menu"
 msgstr ""
 
@@ -1478,7 +1478,7 @@ msgstr ""
 #: js/toolbar.js:260
 #: js/piemenus.js:3386
 #: js/turtledefs.js:592
-#.TRANS: Ayuda
+#. TRANS: Ayuda
 msgid "Help"
 msgstr " Ñepytyvõ"
 
@@ -1487,7 +1487,7 @@ msgstr " Ñepytyvõ"
 #: js/toolbar.js:200
 #: js/toolbar.js:261
 #: js/turtledefs.js:598
-#.TRANS: Tocar lentamente
+#. TRANS: Tocar lentamente
 msgid "Run slowly"
 msgstr ""
 
@@ -1496,7 +1496,7 @@ msgstr ""
 #: js/toolbar.js:201
 #: js/toolbar.js:262
 #: js/turtledefs.js:604
-#.TRANS: Ejecutar paso a paso
+#. TRANS: Ejecutar paso a paso
 msgid "Run step by step"
 msgstr "Embopu guatahápe"
 
@@ -1505,7 +1505,7 @@ msgstr "Embopu guatahápe"
 #: js/toolbar.js:202
 #: js/toolbar.js:263
 #: js/turtledefs.js:611
-#.TRANS: Analizar
+#. TRANS: Analizar
 msgid "Display statistics"
 msgstr "Ma’e pypuku"
 
@@ -1514,7 +1514,7 @@ msgstr "Ma’e pypuku"
 #: js/toolbar.js:203
 #: js/toolbar.js:264
 #: js/turtledefs.js:617
-#.TRANS: Cargar plugin
+#. TRANS: Cargar plugin
 msgid "Load plugin"
 msgstr ""
 
@@ -1523,7 +1523,7 @@ msgstr ""
 #: js/toolbar.js:204
 #: js/toolbar.js:265
 #: js/turtledefs.js:625
-#.TRANS: Eliminar plugin
+#. TRANS: Eliminar plugin
 msgid "Delete plugin"
 msgstr ""
 
@@ -1531,7 +1531,7 @@ msgstr ""
 #: js/toolbar.js:134
 #: js/toolbar.js:205
 #: js/toolbar.js:266
-#.TRANS: Habilitar desplazamiento horizontal
+#. TRANS: Habilitar desplazamiento horizontal
 msgid "Enable horizontal scrolling"
 msgstr ""
 
@@ -1539,7 +1539,7 @@ msgstr ""
 #: js/toolbar.js:135
 #: js/toolbar.js:206
 #: js/toolbar.js:267
-#.TRANS: Deshabilitar desplazamiento horizontal
+#. TRANS: Deshabilitar desplazamiento horizontal
 msgid "Disable horizontal scrolling"
 msgstr ""
 
@@ -1572,14 +1572,14 @@ msgstr ""
 #: js/turtledefs.js:648
 #: planet/js/LocalCard.js:54
 #: planet/js/StringHelper.js:71
-#.TRANS: Unir con el proyecto actual
+#. TRANS: Unir con el proyecto actual
 msgid "Merge with current project"
 msgstr ""
 
 #: js/toolbar.js:74
 #: js/toolbar.js:140
 #: js/turtledefs.js:662
-#.TRANS: Establecer vista previa de tono
+#. TRANS: Establecer vista previa de tono
 msgid "Set Pitch Preview"
 msgstr ""
 
@@ -1588,7 +1588,7 @@ msgstr ""
 #: js/toolbar.js:211
 #: js/toolbar.js:272
 #: js/turtledefs.js:669
-#.TRANS: Editor de Javascript
+#. TRANS: Editor de Javascript
 msgid "JavaScript Editor"
 msgstr ""
 
@@ -1597,7 +1597,7 @@ msgstr ""
 #: js/toolbar.js:212
 #: js/toolbar.js:273
 #: js/turtledefs.js:676
-#.TRANS: Restaurar
+#. TRANS: Restaurar
 msgid "Restore"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 #: js/toolbar.js:143
 #: js/toolbar.js:213
 #: js/toolbar.js:274
-#.TRANS: Cambiar al modo principiante
+#. TRANS: Cambiar al modo principiante
 msgid "Switch to beginner mode"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 #: js/toolbar.js:144
 #: js/toolbar.js:214
 #: js/toolbar.js:275
-#.TRANS: Cambiar a modo avanzado
+#. TRANS: Cambiar a modo avanzado
 msgid "Switch to advanced mode"
 msgstr ""
 
@@ -1623,7 +1623,7 @@ msgstr ""
 #: js/toolbar.js:215
 #: js/toolbar.js:276
 #: js/turtledefs.js:690
-#.TRANS: Seleccione el idioma
+#. TRANS: Seleccione el idioma
 msgid "Select language"
 msgstr ""
 
@@ -1631,37 +1631,37 @@ msgstr ""
 #: js/toolbar.js:84
 #: js/toolbar.js:148
 #: js/turtledefs.js:538
-#.TRANS: Guardar ilustraciones del ratón como PNG
+#. TRANS: Guardar ilustraciones del ratón como PNG
 msgid "Save mouse artwork as PNG"
 msgstr ""
 
 #: js/toolbar.js:83
 #: js/toolbar.js:147
-#.TRANS: Guardar ilustraciones del ratón como SVG
+#. TRANS: Guardar ilustraciones del ratón como SVG
 msgid "Save mouse artwork as SVG"
 msgstr ""
 
 #: js/toolbar.js:85
 #: js/toolbar.js:149
 #: js/turtledefs.js:569
-#.TRANS: Guarda música como WAV
+#. TRANS: Guarda música como WAV
 msgid "Save music as WAV"
 msgstr ""
 
 #: js/toolbar.js:86
 #: js/toolbar.js:150
-#.TRANS: Guardar partituras como ABC
+#. TRANS: Guardar partituras como ABC
 msgid "Save sheet music as ABC"
 msgstr ""
 
 #: js/toolbar.js:87
 #: js/toolbar.js:151
-#.TRANS: Guardar partituras como Lilypond.
+#. TRANS: Guardar partituras como Lilypond.
 msgid "Save sheet music as Lilypond"
 msgstr ""
 
 #: js/toolbar.js:88
-#.TRANS: Guardar partituras como MusicXML
+#. TRANS: Guardar partituras como MusicXML
 msgid "Save sheet music as MusicXML"
 msgstr ""
 
@@ -1671,7 +1671,7 @@ msgstr ""
 #: js/toolbar.js:221
 #: js/toolbar.js:282
 #: js/turtledefs.js:558
-#.TRANS: Guardar bloque de ilustraciones como SVG
+#. TRANS: Guardar bloque de ilustraciones como SVG
 msgid "Save block artwork as SVG"
 msgstr ""
 
@@ -1689,7 +1689,7 @@ msgstr ""
 #: js/toolbar.js:223
 #: js/toolbar.js:284
 #: js/toolbar.js:1134
-#.TRANS: Confirmar
+#. TRANS: Confirmar
 msgid "Confirm"
 msgstr ""
 
@@ -1697,7 +1697,7 @@ msgstr ""
 #: js/toolbar.js:164
 #: js/toolbar.js:224
 #: js/toolbar.js:285
-#.TRANS: 
+#. TRANS: 
 msgid "English (United States)"
 msgstr ""
 
@@ -1705,7 +1705,7 @@ msgstr ""
 #: js/toolbar.js:165
 #: js/toolbar.js:225
 #: js/toolbar.js:286
-#.TRANS: 
+#. TRANS: 
 msgid "English (United Kingdom)"
 msgstr ""
 
@@ -1713,12 +1713,12 @@ msgstr ""
 #: js/toolbar.js:166
 #: js/toolbar.js:226
 #: js/toolbar.js:287
-#.TRANS: 
+#. TRANS: 
 msgid "日本語"
 msgstr ""
 
 #: js/toolbar.js:95
-#.TRANS: 
+#. TRANS: 
 msgid "한국어"
 msgstr ""
 
@@ -1726,7 +1726,7 @@ msgstr ""
 #: js/toolbar.js:168
 #: js/toolbar.js:228
 #: js/toolbar.js:289
-#.TRANS: 
+#. TRANS: 
 msgid "español"
 msgstr ""
 
@@ -1734,7 +1734,7 @@ msgstr ""
 #: js/toolbar.js:169
 #: js/toolbar.js:229
 #: js/toolbar.js:290
-#.TRANS: 
+#. TRANS: 
 msgid "português"
 msgstr ""
 
@@ -1742,7 +1742,7 @@ msgstr ""
 #: js/toolbar.js:170
 #: js/toolbar.js:230
 #: js/toolbar.js:291
-#.TRANS: 
+#. TRANS: 
 msgid "にほんご"
 msgstr ""
 
@@ -1750,7 +1750,7 @@ msgstr ""
 #: js/toolbar.js:171
 #: js/toolbar.js:231
 #: js/toolbar.js:292
-#.TRANS: 
+#. TRANS: 
 msgid "中文"
 msgstr ""
 
@@ -1758,7 +1758,7 @@ msgstr ""
 #: js/toolbar.js:172
 #: js/toolbar.js:232
 #: js/toolbar.js:293
-#.TRANS: 
+#. TRANS: 
 msgid "ภาษาไทย"
 msgstr ""
 
@@ -1766,7 +1766,7 @@ msgstr ""
 #: js/toolbar.js:173
 #: js/toolbar.js:233
 #: js/toolbar.js:294
-#.TRANS: 
+#. TRANS: 
 msgid "aymara"
 msgstr ""
 
@@ -1774,7 +1774,7 @@ msgstr ""
 #: js/toolbar.js:174
 #: js/toolbar.js:234
 #: js/toolbar.js:295
-#.TRANS: 
+#. TRANS: 
 msgid "quechua"
 msgstr ""
 
@@ -1782,7 +1782,7 @@ msgstr ""
 #: js/toolbar.js:175
 #: js/toolbar.js:235
 #: js/toolbar.js:296
-#.TRANS: 
+#. TRANS: 
 msgid "guarani"
 msgstr ""
 
@@ -1790,7 +1790,7 @@ msgstr ""
 #: js/toolbar.js:176
 #: js/toolbar.js:236
 #: js/toolbar.js:297
-#.TRANS: 
+#. TRANS: 
 msgid "हिंदी"
 msgstr ""
 
@@ -1798,7 +1798,7 @@ msgstr ""
 #: js/toolbar.js:178
 #: js/toolbar.js:237
 #: js/toolbar.js:299
-#.TRANS: 
+#. TRANS: 
 msgid "igbo"
 msgstr ""
 
@@ -1806,7 +1806,7 @@ msgstr ""
 #: js/toolbar.js:179
 #: js/toolbar.js:238
 #: js/toolbar.js:300
-#.TRANS: 
+#. TRANS: 
 msgid "عربى"
 msgstr ""
 
@@ -1814,7 +1814,7 @@ msgstr ""
 #: js/toolbar.js:177
 #: js/toolbar.js:239
 #: js/toolbar.js:298
-#.TRANS: 
+#. TRANS: 
 msgid "తెలుగు"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 #: js/toolbar.js:180
 #: js/toolbar.js:240
 #: js/toolbar.js:301
-#.TRANS: 
+#. TRANS: 
 msgid "עִברִית"
 msgstr ""
 
@@ -1840,7 +1840,7 @@ msgstr ""
 #: js/toolbar.js:278
 #: js/toolbar.js:281
 #: js/turtledefs.js:554
-#.TRANS: Guardar la ilustración de la tortuga como PNG
+#. TRANS: Guardar la ilustración de la tortuga como PNG
 msgid "Save turtle artwork as PNG"
 msgstr ""
 
@@ -1848,55 +1848,55 @@ msgstr ""
 #: js/toolbar.js:219
 #: js/toolbar.js:280
 #: js/turtledefs.js:550
-#.TRANS: Guardar la ilustración de la tortuga como SVG
+#. TRANS: Guardar la ilustración de la tortuga como SVG
 msgid "Save turtle artwork as SVG"
 msgstr ""
 
 #: js/toolbar.js:167
 #: js/toolbar.js:227
 #: js/toolbar.js:288
-#.TRANS: 
+#. TRANS: 
 msgid "한국인"
 msgstr ""
 
 #: js/toolbar.js:185
 #: js/toolbar.js:246
-#.TRANS: Sobre TortuBloques
+#. TRANS: Sobre TortuBloques
 msgid "About Turtle Blocks"
 msgstr ""
 
 #: js/toolbar.js:494
 #: js/toolbar.js:505
 #: js/toolbar.js:545
-#.TRANS: No Envolver
+#. TRANS: No Envolver
 msgid "Turtle Wrap Off"
 msgstr ""
 
 #: js/toolbar.js:514
 #: js/toolbar.js:554
-#.TRANS: Envolver
+#. TRANS: Envolver
 msgid "Turtle Wrap On"
 msgstr ""
 
 #: js/toolbar.js:1121
-#.TRANS: Â¿Estás seguro de que deseas crear un nuevo proyecto?
+#. TRANS: Â¿Estás seguro de que deseas crear un nuevo proyecto?
 msgid "Are you sure you want to create a new project?"
 msgstr ""
 
 #: js/logo.js:61
-#.TRANS: No es un nombre de tono válido.
+#. TRANS: No es un nombre de tono válido.
 msgid "Not a valid pitch name"
 msgstr ""
 
 #: js/logo.js:507
 #: js/blocks/ProgramBlocks.js:258
 #: js/blocks/ProgramBlocks.js:427
-#.TRANS: Debe seleccionar un archivo.
+#. TRANS: Debe seleccionar un archivo.
 msgid "You must select a file."
 msgstr "Eiporavo vaera peteĩ ñongatupyre"
 
 #: js/logo.js:1688
-#.TRANS: La reproducción está preparada.
+#. TRANS: La reproducción está preparada.
 msgid "Playback is ready."
 msgstr ""
 
@@ -1906,8 +1906,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
-#.TRANS: doble agudas
+#. TRANS: double sharp is a music term related to pitch
+#. TRANS: doble agudas
 msgid "double sharp"
 msgstr ""
 
@@ -1919,9 +1919,9 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
-#.TRANS: agudas
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
+#. TRANS: agudas
 msgid "sharp"
 msgstr "Agudas"
 
@@ -1931,8 +1931,8 @@ msgstr "Agudas"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
-#.TRANS: normal
+#. TRANS: natural is a music term related to pitch
+#. TRANS: normal
 msgid "natural"
 msgstr ""
 
@@ -1944,9 +1944,9 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
-#.TRANS: planas
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
+#. TRANS: planas
 msgid "flat"
 msgstr "Pe"
 
@@ -1956,17 +1956,17 @@ msgstr "Pe"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
-#.TRANS: doble planas
+#. TRANS: double flat is a music term related to pitch
+#. TRANS: doble planas
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
-#.TRANS: unísono
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
+#. TRANS: unísono
 msgid "unison"
 msgstr ""
 
@@ -1975,16 +1975,16 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
-#.TRANS: mayor
+#. TRANS: major is a music term related to intervals and mode
+#. TRANS: mayor
 msgid "major"
 msgstr "guasuve"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
-#.TRANS: ionian
+#. TRANS: modal scale for music
+#. TRANS: ionian
 msgid "ionian"
 msgstr "jónico"
 
@@ -1993,33 +1993,33 @@ msgstr "jónico"
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
-#.TRANS: menor
+#. TRANS: minor is a music term related to intervals and mode
+#. TRANS: menor
 msgid "minor"
 msgstr "michĩve"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
-#.TRANS: aeolian
+#. TRANS: modal scale for music
+#. TRANS: aeolian
 msgid "aeolian"
 msgstr "eólico"
 
 #: js/piemenus.js:3373
 #: js/blocks/FlowBlocks.js:136
-#.TRANS: Duplicar
+#. TRANS: Duplicar
 msgid "Duplicate"
 msgstr ""
 
 #: js/piemenus.js:3374
 #: js/turtledefs.js:714
-#.TRANS: Extraer
+#. TRANS: Extraer
 msgid "Extract"
 msgstr ""
 
 #: js/piemenus.js:3375
-#.TRANS: Mover para recargar
+#. TRANS: Mover para recargar
 msgid "Move to trash"
 msgstr ""
 
@@ -2030,50 +2030,50 @@ msgstr ""
 #: js/widgets/temperament.js:1441
 #: js/widgets/timbre.js:962
 #: planet/js/StringHelper.js:69
-#.TRANS: Cerrar
+#. TRANS: Cerrar
 msgid "Close"
 msgstr "Mboty"
 
 #: js/piemenus.js:3382
-#.TRANS: Guardar pila
+#. TRANS: Guardar pila
 msgid "Save stack"
 msgstr "Eñongatu aty"
 
 #: js/piemenus.js:3412
-#.TRANS: Se detectó un bucle indefinido dentro de un bloque de valor de nota. Pueden ocurrir cosas inesperadas.
+#. TRANS: Se detectó un bucle indefinido dentro de un bloque de valor de nota. Pueden ocurrir cosas inesperadas.
 msgid "In order to copy a sample, you must reload the widget, import the sample again, and export it."
 msgstr ""
 
 #: js/piemenus.js:3801
-#.TRANS: Ha elegido la tecla para la vista previa de su tono.
+#. TRANS: Ha elegido la tecla para la vista previa de su tono.
 msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
-#.TRANS: Debe tener al menos un bloque parcial dentro de un bloque parcial ponderado.
+#. TRANS: partials are weighted components in a harmonic series
+#. TRANS: Debe tener al menos un bloque parcial dentro de un bloque parcial ponderado.
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
 #: js/turtle-singer.js:2078
-#.TRANS: Synth no puede tocar acordes.
+#. TRANS: Synth no puede tocar acordes.
 msgid "synth cannot play chords."
 msgstr " Synth ndaikatui ambopu"
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
-#.TRANS: https://github.com/sugarlabs/musicblocks/tree/master/guide-es/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: https://github.com/sugarlabs/musicblocks/tree/master/guide-es/README.md
 msgid "guide url"
 msgstr ""
 
 #: js/turtledefs.js:88
-#.TRANS: TortuBloques
+#. TRANS: TortuBloques
 msgid "Turtle Blocks"
 msgstr ""
 
 #: js/turtledefs.js:121
 #: js/turtledefs.js:222
-#.TRANS: buscar
+#. TRANS: buscar
 msgid "search"
 msgstr ""
 
@@ -2081,20 +2081,20 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
-#.TRANS: metro
+#. TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: metro
 msgid "meter"
 msgstr "ta’ãha"
 
 #: js/turtledefs.js:125
 #: js/turtledefs.js:226
-#.TRANS: intervalos
+#. TRANS: intervalos
 msgid "intervals"
 msgstr "intervalos"
 
 #: js/turtledefs.js:127
 #: js/turtledefs.js:228
-#.TRANS: ornamento
+#. TRANS: ornamento
 msgid "ornament"
 msgstr ""
 
@@ -2103,32 +2103,32 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:362
 #: js/blocks/VolumeBlocks.js:502
 #: js/blocks/VolumeBlocks.js:545
-#.TRANS: volumen
+#. TRANS: volumen
 msgid "volume"
 msgstr ""
 
 #: js/turtledefs.js:132
 #: js/turtledefs.js:233
-#.TRANS: cajas
+#. TRANS: cajas
 msgid "boxes"
 msgstr "mba’eryru"
 
 #: js/turtledefs.js:133
 #: js/turtledefs.js:234
-#.TRANS: aparatos
+#. TRANS: aparatos
 msgid "widgets"
 msgstr "mba’e"
 
 #: js/turtledefs.js:134
 #: js/turtledefs.js:235
 #: js/widgets/phrasemaker.js:1125
-#.TRANS: gráficos
+#. TRANS: gráficos
 msgid "graphics"
 msgstr ""
 
 #: js/turtledefs.js:137
 #: js/turtledefs.js:238
-#.TRANS: booleano
+#. TRANS: booleano
 msgid "boolean"
 msgstr "boleano"
 
@@ -2136,7 +2136,7 @@ msgstr "boleano"
 #: js/turtledefs.js:241
 #: js/blocks/HeapBlocks.js:59
 #: js/widgets/status.js:143
-#.TRANS: pila
+#. TRANS: pila
 msgid "heap"
 msgstr "chovi"
 
@@ -2144,68 +2144,68 @@ msgstr "chovi"
 #: js/turtledefs.js:242
 #: js/blocks/DictBlocks.js:142
 #: js/blocks/ProgramBlocks.js:495
-#.TRANS: diccionario
+#. TRANS: diccionario
 msgid "dictionary"
 msgstr ""
 
 #: js/turtledefs.js:142
 #: js/turtledefs.js:243
-#.TRANS: conjunto
+#. TRANS: conjunto
 msgid "ensemble"
 msgstr ""
 
 #: js/turtledefs.js:143
 #: js/turtledefs.js:244
-#.TRANS: extras
+#. TRANS: extras
 msgid "extras"
 msgstr "ijykepegua"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
-#.TRANS: programa
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: programa
 msgid "program"
 msgstr ""
 
 #: js/turtledefs.js:146
 #: js/turtledefs.js:247
-#.TRANS: mis bloques
+#. TRANS: mis bloques
 msgid "my blocks"
 msgstr ""
 
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
-#.TRANS: arte
+#. TRANS: arte
 msgid "artwork"
 msgstr ""
 
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
-#.TRANS: lógica
+#. TRANS: lógica
 msgid "logic"
 msgstr ""
 
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: música
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: música
 msgid "Music"
 msgstr ""
 
 #: js/turtledefs.js:190
-#.TRANS: Bloques de Música
+#. TRANS: Bloques de Música
 msgid "Music Blocks"
 msgstr ""
 
 #: js/turtledefs.js:438
-#.TRANS: Bienvenidos a TortuBloques
+#. TRANS: Bienvenidos a TortuBloques
 msgid "Welcome to Turtle Blocks"
 msgstr ""
 
 #: js/turtledefs.js:439
-#.TRANS: TortuBloques es una tortuga basada en Logo que dibuja imÃÂÃÂ¡genes coloridas programable de una forma visual con bloques encastrables.
+#. TRANS: TortuBloques es una tortuga basada en Logo que dibuja imÃÂÃÂ¡genes coloridas programable de una forma visual con bloques encastrables.
 msgid "Turtle Blocks is a Logo-inspired turtle that draws colorful pictures with snap-together visual-programming blocks."
 msgstr ""
 
@@ -2213,93 +2213,93 @@ msgstr ""
 #: js/turtledefs.js:467
 #: js/turtledefs.js:822
 #: js/turtledefs.js:845
-#.TRANS: La versión actual es
+#. TRANS: La versión actual es
 msgid "The current version is"
 msgstr ""
 
 #: js/turtledefs.js:448
 #: js/turtledefs.js:493
-#.TRANS: Haga clic para ejecutar el proyecto en modo rápido.
+#. TRANS: Haga clic para ejecutar el proyecto en modo rápido.
 msgid "Click the run button to run the project in fast mode."
 msgstr ""
 
 #: js/turtledefs.js:454
-#.TRANS: Detener la tortuga.
+#. TRANS: Detener la tortuga.
 msgid "Stop the turtle."
 msgstr ""
 
 #: js/turtledefs.js:456
 #: js/turtledefs.js:501
-#.TRANS: También puede escribir Alt-S para detenerse.
+#. TRANS: También puede escribir Alt-S para detenerse.
 msgid "You can also type Alt-S to stop."
 msgstr ""
 
 #: js/turtledefs.js:464
 #: js/widgets/help.js:335
-#.TRANS: Bienvenido a Bloques de Música
+#. TRANS: Bienvenido a Bloques de Música
 msgid "Welcome to Music Blocks"
 msgstr "Tereg̃uaheporãite Vore puporãpe"
 
 #: js/turtledefs.js:465
-#.TRANS: Bloques de Música es una colección de herramientas de manipulación para explorar conceptos musicales fundamentales de una manera integradora y divertido.
+#. TRANS: Bloques de Música es una colección de herramientas de manipulación para explorar conceptos musicales fundamentales de una manera integradora y divertido.
 msgid "Music Blocks is a collection of tools for exploring fundamental musical concepts in a fun way."
 msgstr " Bloques de Música es una colección de herramientas de manipulación para explorar conceptos musicales fundamentales de una manera integradora y divertido."
 
 #: js/turtledefs.js:474
 #: js/widgets/help.js:336
-#.TRANS: Conoce Sr. Ratón
+#. TRANS: Conoce Sr. Ratón
 msgid "Meet Mr. Mouse!"
 msgstr "Eikuaa karai angujape"
 
 #: js/turtledefs.js:475
-#.TRANS: Sr. Ratón es nuestro conductor de Bloques de Música.
+#. TRANS: Sr. Ratón es nuestro conductor de Bloques de Música.
 msgid "Mr Mouse is our Music Blocks conductor."
 msgstr "Karai anguja ha’e ñande sambyhyha Vore puporãpe"
 
 #: js/turtledefs.js:477
-#.TRANS: Sr. Ratón le anima a explorar los Bloques de Música.
+#. TRANS: Sr. Ratón le anima a explorar los Bloques de Música.
 msgid "Mr Mouse encourages you to explore Music Blocks."
 msgstr " Karai anguja omoingove jepovyvy Vore puporã"
 
 #: js/turtledefs.js:479
-#.TRANS: Vamos a empezar nuestro recorrido!
+#. TRANS: Vamos a empezar nuestro recorrido!
 msgid "Let us start our tour!"
 msgstr "Ñañepyrũ ñande rape"
 
 #: js/turtledefs.js:484
 #: js/turtledefs.js:807
 #: js/widgets/help.js:337
-#.TRANS: Guía
+#. TRANS: Guía
 msgid "Guide"
 msgstr ""
 
 #: js/turtledefs.js:485
-#.TRANS: Una guía detallada de Bloques de Música está disponible.
+#. TRANS: Una guía detallada de Bloques de Música está disponible.
 msgid "A detailed guide to Music Blocks is available."
 msgstr ""
 
 #: js/turtledefs.js:499
-#.TRANS: Detener la música (y los ratones)
+#. TRANS: Detener la música (y los ratones)
 msgid "Stop the music (and the mice)."
 msgstr ""
 
 #: js/turtledefs.js:510
-#.TRANS: Grabe su proyecto como video.
+#. TRANS: Grabe su proyecto como video.
 msgid "Record your project as video."
 msgstr ""
 
 #: js/turtledefs.js:517
-#.TRANS: Alternar el modo de pantalla completa
+#. TRANS: Alternar el modo de pantalla completa
 msgid "Toggle Fullscreen mode."
 msgstr ""
 
 #: js/turtledefs.js:523
-#.TRANS: Inicializar un nuevo proyecto.
+#. TRANS: Inicializar un nuevo proyecto.
 msgid "Initialize a new project."
 msgstr ""
 
 #: js/turtledefs.js:529
-#.TRANS: También puede cargar proyectos desde el sistema de archivos.
+#. TRANS: También puede cargar proyectos desde el sistema de archivos.
 msgid "You can also load projects from the file system."
 msgstr "Ikatu avei ehupi jejaposéva ñongatuha rire"
 
@@ -2314,27 +2314,27 @@ msgstr "Ikatu avei ehupi jejaposéva ñongatuha rire"
 #: js/widgets/temperament.js:2173
 #: js/widgets/timbre.js:750
 #: js/widgets/phrasemaker.js:561
-#.TRANS: Guardar
+#. TRANS: Guardar
 msgid "Save"
 msgstr ""
 
 #: js/turtledefs.js:548
-#.TRANS: Guarde proyecto en archivo
+#. TRANS: Guarde proyecto en archivo
 msgid "Save your project to a file."
 msgstr "Eñongatu jejaposéva ñongatuhápe"
 
 #: js/turtledefs.js:552
-#.TRANS: Guardar gráficos de su proyecto como SVG
+#. TRANS: Guardar gráficos de su proyecto como SVG
 msgid "Save graphics from your project to as SVG."
 msgstr ""
 
 #: js/turtledefs.js:556
-#.TRANS: Guardar gráficos de su proyecto como PNG
+#. TRANS: Guardar gráficos de su proyecto como PNG
 msgid "Save graphics from your project as PNG."
 msgstr ""
 
 #: js/turtledefs.js:560
-#.TRANS: Guardar bloque de ilustraciones como un archivo de SVG
+#. TRANS: Guardar bloque de ilustraciones como un archivo de SVG
 msgid "Save block artwork as an SVG file."
 msgstr ""
 
@@ -2347,22 +2347,22 @@ msgid "Save block artwork as SVG or PNG"
 msgstr ""
 
 #: js/turtledefs.js:580
-#.TRANS: Cargar ejemplos desde el servidor
+#. TRANS: Cargar ejemplos desde el servidor
 msgid "Load samples from server"
 msgstr "Ehupi techapyrãkuéra"
 
 #: js/turtledefs.js:581
-#.TRANS: Este botón abre la pantalla de carga de proyectos de ejemplo.
+#. TRANS: Este botón abre la pantalla de carga de proyectos de ejemplo.
 msgid "This button opens a viewer for loading example projects."
 msgstr "Ko votõ oipe’a tendahesaperã jejaposéva techapyrã"
 
 #: js/turtledefs.js:586
-#.TRANS: Expandir/colapsar la barra de opciones.
+#. TRANS: Expandir/colapsar la barra de opciones.
 msgid "Expand/collapse option toolbar"
 msgstr " Eipyso/emboty yvyra pe poravokuaaha"
 
 #: js/turtledefs.js:587
-#.TRANS: Haga clic en este botón para expandir o contraer la barra de herramientas auxiliar.
+#. TRANS: Haga clic en este botón para expandir o contraer la barra de herramientas auxiliar.
 msgid "Click this button to expand or collapse the auxillary toolbar."
 msgstr "Ejopy clic votõ Eipyso/emboty haguã yvyra pe tembipuru ryru"
 
@@ -2371,17 +2371,17 @@ msgid "Displays help messages for the main and auxiliary toolbar, right-click co
 msgstr ""
 
 #: js/turtledefs.js:599
-#.TRANS: Haz click para ejecutar el proyecto en modo lento.
+#. TRANS: Haz click para ejecutar el proyecto en modo lento.
 msgid "Click to run the project in slow mode."
 msgstr "Eyopy clic ejapo haguã jejaposéva mbegueve "
 
 #: js/turtledefs.js:605
-#.TRANS: Haz click para ejecutar el proyecto en modo paso a paso.
+#. TRANS: Haz click para ejecutar el proyecto en modo paso a paso.
 msgid "Click to run the project step by step."
 msgstr "Eyopy clic ejapo haguã jejaposéva michĩmimi"
 
 #: js/turtledefs.js:612
-#.TRANS: Analizar los tipos de bloques usados.
+#. TRANS: Analizar los tipos de bloques usados.
 msgid "Display statistics about your Music project."
 msgstr "Ma’e pypuku vorekuéra ojeipurúva"
 
@@ -2390,17 +2390,17 @@ msgid "Load a selected plugin."
 msgstr ""
 
 #: js/turtledefs.js:626
-#.TRANS: Eliminar un plugin seleccionado.
+#. TRANS: Eliminar un plugin seleccionado.
 msgid "Delete a selected plugin."
 msgstr ""
 
 #: js/turtledefs.js:633
-#.TRANS: Activar scroll
+#. TRANS: Activar scroll
 msgid "Enable scrolling"
 msgstr "Emoingo scroll"
 
 #: js/turtledefs.js:634
-#.TRANS: Puedes mover los bloques por el área de trabajo
+#. TRANS: Puedes mover los bloques por el área de trabajo
 msgid "You can scroll the blocks on the canvas."
 msgstr "Ikatu emomyi vorekuéra mba’apoha rupi"
 
@@ -2413,12 +2413,12 @@ msgid "Click to add another project into the current one."
 msgstr ""
 
 #: js/turtledefs.js:654
-#.TRANS: Envolver tortuga
+#. TRANS: Envolver tortuga
 msgid "Wrap Turtle"
 msgstr ""
 
 #: js/turtledefs.js:655
-#.TRANS: Encender / apagar la envoltura de tortugas
+#. TRANS: Encender / apagar la envoltura de tortugas
 msgid "Turn Turtle wrapping On or Off."
 msgstr ""
 
@@ -2431,22 +2431,22 @@ msgid "Converts Music Block programs to JavaScript."
 msgstr ""
 
 #: js/turtledefs.js:677
-#.TRANS: Restaurar bloques de la papelera.
+#. TRANS: Restaurar bloques de la papelera.
 msgid "Restore blocks from the trash."
 msgstr "Eru jey vorekuéra kuatiaryrugi"
 
 #: js/turtledefs.js:684
-#.TRANS: Cambiar el modo
+#. TRANS: Cambiar el modo
 msgid "Switch mode"
 msgstr ""
 
 #: js/turtledefs.js:685
-#.TRANS: Cambia entre los modos principiante y avanzado.
+#. TRANS: Cambia entre los modos principiante y avanzado.
 msgid "Switch between beginner and advance modes."
 msgstr ""
 
 #: js/turtledefs.js:691
-#.TRANS: Seleccione su preferencia de idioma.
+#. TRANS: Seleccione su preferencia de idioma.
 msgid "Select your language preference."
 msgstr ""
 
@@ -2460,32 +2460,32 @@ msgstr ""
 
 #: js/turtledefs.js:702
 #: planet/js/StringHelper.js:46
-#.TRANS: Borrar
+#. TRANS: Borrar
 msgid "Delete"
 msgstr "mbogue"
 
 #: js/turtledefs.js:703
-#.TRANS: Para eliminar un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de eliminar.
+#. TRANS: Para eliminar un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de eliminar.
 msgid "To delete a block, right-click on it. You will see the delete option."
 msgstr ""
 
 #: js/turtledefs.js:709
-#.TRANS: Para copiar un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de copiar.
+#. TRANS: Para copiar un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de copiar.
 msgid "To copy a block, right-click on it. You will see the copy option."
 msgstr ""
 
 #: js/turtledefs.js:715
-#.TRANS: Para extraer un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de extracción.
+#. TRANS: Para extraer un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de extracción.
 msgid "To extract a block, right-click on it. You will see the extract option."
 msgstr ""
 
 #: js/turtledefs.js:721
-#.TRANS: Atajos de teclado
+#. TRANS: Atajos de teclado
 msgid "Keyboard shortcuts"
 msgstr ""
 
 #: js/turtledefs.js:722
-#.TRANS: Puede escribir \"d\" para crear un bloque \"do\", \"r\" para crear un bloque \"re\", etc.
+#. TRANS: Puede escribir \"d\" para crear un bloque \"do\", \"r\" para crear un bloque \"re\", etc.
 msgid "You can type d to create a do block and r to create a re block etc."
 msgstr ""
 
@@ -2500,7 +2500,7 @@ msgstr ""
 #: js/turtledefs.js:736
 #: js/turtles.js:940
 #: js/palette.js:654
-#.TRANS: Cuadrícula
+#. TRANS: Cuadrícula
 msgid "Grid"
 msgstr ""
 
@@ -2524,49 +2524,49 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
-#.TRANS: Borrar
+#. TRANS: clear all subdivisions from the ruler.
+#. TRANS: Borrar
 msgid "Clear"
 msgstr ""
 
 #: js/turtledefs.js:745
-#.TRANS: Borre la pantalla y devuelva los ratones a sus posiciones iniciales.
+#. TRANS: Borre la pantalla y devuelva los ratones a sus posiciones iniciales.
 msgid "Clear the screen and return the mice to their initial positions."
 msgstr ""
 
 #: js/turtledefs.js:750
 #: js/turtles.js:980
-#.TRANS: Contraer
+#. TRANS: Contraer
 msgid "Collapse"
 msgstr ""
 
 #: js/turtledefs.js:751
-#.TRANS: Contraer la ventana de gráficos.
+#. TRANS: Contraer la ventana de gráficos.
 msgid "Collapse the graphics window."
 msgstr ""
 
 #: js/turtledefs.js:757
-#.TRANS: Devolver todos los bloques para el centro de la pantalla.
+#. TRANS: Devolver todos los bloques para el centro de la pantalla.
 msgid "Return all blocks to the center of the screen."
 msgstr "Emyengovia vorekuéra tendahesaperã mbytépe"
 
 #: js/turtledefs.js:763
-#.TRANS: Ocultar o mostrar los bloques y las paletas.
+#. TRANS: Ocultar o mostrar los bloques y las paletas.
 msgid "Hide or show the blocks and the palettes."
 msgstr "Emongañy tera eichuka Yvyra pe ha vorekuera"
 
 #: js/turtledefs.js:769
-#.TRANS: Expandir o colapsar los bloques colapsables, cómo por ejemplo los bloques de empezar y los de acción.
+#. TRANS: Expandir o colapsar los bloques colapsables, cómo por ejemplo los bloques de empezar y los de acción.
 msgid "Expand or collapse start and action stacks."
 msgstr "Eipyso terã emboty vorekuéra oñembotykuaava"
 
 #: js/turtledefs.js:777
-#.TRANS: Disminuye el tamaño de los bloques
+#. TRANS: Disminuye el tamaño de los bloques
 msgid "Decrease the size of the blocks."
 msgstr "Omomichĩ jakatuha vorekuéra"
 
 #: js/turtledefs.js:783
-#.TRANS: Incrementa el tamaño de los bloques.
+#. TRANS: Incrementa el tamaño de los bloques.
 msgid "Increase the size of the blocks."
 msgstr "Ombotuicha jakatuha vorekuéra"
 
@@ -2579,86 +2579,86 @@ msgid "Left-click and drag on workspace to select multiple blocks."
 msgstr ""
 
 #: js/turtledefs.js:797
-#.TRANS: Botones de paleta
+#. TRANS: Botones de paleta
 msgid "Palette buttons"
 msgstr "Yvyra pe votõkuera"
 
 #: js/turtledefs.js:798
-#.TRANS: Esta barra de herramientas contiene los botones de la paleta de Ritmo, Tono, Tortuga, y más.
+#. TRANS: Esta barra de herramientas contiene los botones de la paleta de Ritmo, Tono, Tortuga, y más.
 msgid "This toolbar contains the palette buttons including Rhythm Pitch Tone Action and more."
 msgstr ""
 
 #: js/turtledefs.js:800
-#.TRANS: Haga clic para mostrar las paletas de bloques y bloques de arrastre de las gamas de colores en el lienzo para usarlos.
+#. TRANS: Haga clic para mostrar las paletas de bloques y bloques de arrastre de las gamas de colores en el lienzo para usarlos.
 msgid "Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
 msgstr "Eyopy clic oichuka haguã Yvyra pe vorekuera ha avei mbotyryryha vorekuera aorã sa’y eipuruhaguã"
 
 #: js/turtledefs.js:808
-#.TRANS: Se encuentra disponible una guía detallada de TortuBloques.
+#. TRANS: Se encuentra disponible una guía detallada de TortuBloques.
 msgid "A detailed guide to Turtle Blocks is available."
 msgstr ""
 
 #: js/turtledefs.js:812
-#.TRANS: Guía de TortuBloques
+#. TRANS: Guía de TortuBloques
 msgid "Turtle Blocks Guide"
 msgstr ""
 
 #: js/turtledefs.js:815
 #: js/turtledefs.js:838
 #: js/widgets/help.js:338
-#.TRANS: Acerca
+#. TRANS: Acerca
 msgid "About"
 msgstr ""
 
 #: js/turtledefs.js:816
-#.TRANS: TortuBloques es una colección de herramientas de Software Libre para explorar conceptos musicales. 
+#. TRANS: TortuBloques es una colección de herramientas de Software Libre para explorar conceptos musicales. 
 msgid "Turtle Blocks is an open source collection of tools for exploring musical concepts."
 msgstr ""
 
 #: js/turtledefs.js:818
-#.TRANS: Se puede encontrar una lista completa de colaboradores en el repositorio GitHub de TortuBloques.
+#. TRANS: Se puede encontrar una lista completa de colaboradores en el repositorio GitHub de TortuBloques.
 msgid "A full list of contributors can be found in the Turtle Blocks GitHub repository."
 msgstr ""
 
 #: js/turtledefs.js:820
-#.TRANS: TortuBloques está licenciado bajo el AGPL.
+#. TRANS: TortuBloques está licenciado bajo el AGPL.
 msgid "Turtle Blocks is licensed under the AGPL."
 msgstr ""
 
 #: js/turtledefs.js:828
-#.TRANS: El repositorio de GitHub de TortuBloques
+#. TRANS: El repositorio de GitHub de TortuBloques
 msgid "Turtle Blocks GitHub repository"
 msgstr ""
 
 #: js/turtledefs.js:831
 #: js/widgets/help.js:339
 #: js/widgets/help.js:361
-#.TRANS: Felicitaciones.
+#. TRANS: Felicitaciones.
 msgid "Congratulations."
 msgstr "Vy’apave"
 
 #: js/turtledefs.js:832
-#.TRANS: Ha terminado la gira. Por favor, disfrutar de TortuBloques
+#. TRANS: Ha terminado la gira. Por favor, disfrutar de TortuBloques
 msgid "You have finished the tour. Please enjoy Turtle Blocks!"
 msgstr ""
 
 #: js/turtledefs.js:839
-#.TRANS: Bloques de Música es una colección de herramientas de Software Libre para explorar conceptos musicales.
+#. TRANS: Bloques de Música es una colección de herramientas de Software Libre para explorar conceptos musicales.
 msgid "Music Blocks is an open source collection of tools for exploring musical concepts."
 msgstr ""
 
 #: js/turtledefs.js:841
-#.TRANS: Se puede encontrar una lista completa de colaboradores en el repositorio GitHub de Bloques de Música.
+#. TRANS: Se puede encontrar una lista completa de colaboradores en el repositorio GitHub de Bloques de Música.
 msgid "A full list of contributors can be found in the Music Blocks GitHub repository."
 msgstr ""
 
 #: js/turtledefs.js:843
-#.TRANS: Bloques de Música está licenciado bajo el AGPL.
+#. TRANS: Bloques de Música está licenciado bajo el AGPL.
 msgid "Music Blocks is licensed under the AGPL."
 msgstr ""
 
 #: js/turtledefs.js:851
-#.TRANS: El repositorio de GitHub de Bloques de Música
+#. TRANS: El repositorio de GitHub de Bloques de Música
 msgid "Music Blocks GitHub repository"
 msgstr ""
 
@@ -2667,39 +2667,39 @@ msgid "Congratulations!"
 msgstr ""
 
 #: js/turtledefs.js:855
-#.TRANS: Ha terminado la gira. Por favor, disfrutar de Bloques de Música!
+#. TRANS: Ha terminado la gira. Por favor, disfrutar de Bloques de Música!
 msgid "You have finished the tour. Please enjoy Music Blocks!"
 msgstr "Opa ojereva, ikatu eipuruvy’a vorekuéra pupoty"
 
 #: js/turtles.js:1052
-#.TRANS: Expandir
+#. TRANS: Expandir
 msgid "Expand"
 msgstr ""
 
 #: js/palette.js:663
-#.TRANS: efecto
+#. TRANS: efecto
 msgid "effect"
 msgstr ""
 
 #: js/palette.js:669
-#.TRANS: 
+#. TRANS: 
 msgid "sargam"
 msgstr ""
 
 #: js/palette.js:684
 #: js/blocks/PitchBlocks.js:1209
-#.TRANS: personalizado tono
+#. TRANS: personalizado tono
 msgid "custom pitch"
 msgstr ""
 
 #: js/palette.js:692
-#.TRANS: accidental
+#. TRANS: accidental
 msgid "accidental"
 msgstr ""
 
 #: js/palette.js:716
 #: js/blocks/PitchBlocks.js:405
-#.TRANS: convertidor de tono
+#. TRANS: convertidor de tono
 msgid "pitch converter"
 msgstr ""
 
@@ -2707,249 +2707,249 @@ msgstr ""
 #: js/utils/musicutils.js:644
 #: js/widgets/musickeyboard.js:2906
 #: js/widgets/pitchdrummatrix.js:228
-#.TRANS: descanso
+#. TRANS: descanso
 msgid "rest"
 msgstr "pytu’u"
 
 #: js/utils/musicutils.js:687
-#.TRANS: Unísono perfecto
+#. TRANS: Unísono perfecto
 msgid "Perfect unison"
 msgstr ""
 
 #: js/utils/musicutils.js:687
-#.TRANS: Segundo disminuido
+#. TRANS: Segundo disminuido
 msgid "Diminished second"
 msgstr ""
 
 #: js/utils/musicutils.js:688
-#.TRANS: Segundo menor
+#. TRANS: Segundo menor
 msgid "Minor second"
 msgstr ""
 
 #: js/utils/musicutils.js:688
-#.TRANS: Unísono aumentado
+#. TRANS: Unísono aumentado
 msgid "Augmented unison"
 msgstr ""
 
 #: js/utils/musicutils.js:689
-#.TRANS: Segundo mayor
+#. TRANS: Segundo mayor
 msgid "Major second"
 msgstr ""
 
 #: js/utils/musicutils.js:689
-#.TRANS: Tercio disminuido
+#. TRANS: Tercio disminuido
 msgid "Diminished third"
 msgstr ""
 
 #: js/utils/musicutils.js:690
-#.TRANS: Tercio menor
+#. TRANS: Tercio menor
 msgid "Minor third"
 msgstr ""
 
 #: js/utils/musicutils.js:690
-#.TRANS: Segundo aumentado
+#. TRANS: Segundo aumentado
 msgid "Augmented second"
 msgstr ""
 
 #: js/utils/musicutils.js:691
-#.TRANS: Tercio mayor
+#. TRANS: Tercio mayor
 msgid "Major third"
 msgstr ""
 
 #: js/utils/musicutils.js:691
-#.TRANS: Cuarta disminuida
+#. TRANS: Cuarta disminuida
 msgid "Diminished fourth"
 msgstr ""
 
 #: js/utils/musicutils.js:692
-#.TRANS: Cuarta perfecta
+#. TRANS: Cuarta perfecta
 msgid "Perfect fourth"
 msgstr ""
 
 #: js/utils/musicutils.js:692
-#.TRANS: Tercio aumentado
+#. TRANS: Tercio aumentado
 msgid "Augmented third"
 msgstr ""
 
 #: js/utils/musicutils.js:693
-#.TRANS: Quinta disminuida
+#. TRANS: Quinta disminuida
 msgid "Diminished fifth"
 msgstr ""
 
 #: js/utils/musicutils.js:693
-#.TRANS: Cuarta aumentada
+#. TRANS: Cuarta aumentada
 msgid "Augmented fourth"
 msgstr ""
 
 #: js/utils/musicutils.js:694
-#.TRANS: Quinta perfecta
+#. TRANS: Quinta perfecta
 msgid "Perfect fifth"
 msgstr ""
 
 #: js/utils/musicutils.js:694
-#.TRANS: Sexto disminuido
+#. TRANS: Sexto disminuido
 msgid "Diminished sixth"
 msgstr ""
 
 #: js/utils/musicutils.js:695
-#.TRANS: Sexto menor
+#. TRANS: Sexto menor
 msgid "Minor sixth"
 msgstr ""
 
 #: js/utils/musicutils.js:695
-#.TRANS: Quinta aumentada
+#. TRANS: Quinta aumentada
 msgid "Augmented fifth"
 msgstr ""
 
 #: js/utils/musicutils.js:696
-#.TRANS: Sexto mayor
+#. TRANS: Sexto mayor
 msgid "Major sixth"
 msgstr ""
 
 #: js/utils/musicutils.js:696
-#.TRANS: Séptimo disminuido
+#. TRANS: Séptimo disminuido
 msgid "Diminished seventh"
 msgstr ""
 
 #: js/utils/musicutils.js:697
-#.TRANS: Séptimo menor
+#. TRANS: Séptimo menor
 msgid "Minor seventh"
 msgstr ""
 
 #: js/utils/musicutils.js:697
-#.TRANS: Sexto aumentado
+#. TRANS: Sexto aumentado
 msgid "Augmented sixth"
 msgstr ""
 
 #: js/utils/musicutils.js:698
-#.TRANS: Séptimo mayor
+#. TRANS: Séptimo mayor
 msgid "Major seventh"
 msgstr ""
 
 #: js/utils/musicutils.js:698
-#.TRANS: Octavo disminuido
+#. TRANS: Octavo disminuido
 msgid "Diminished octave"
 msgstr ""
 
 #: js/utils/musicutils.js:699
-#.TRANS: Octavo perfecto
+#. TRANS: Octavo perfecto
 msgid "Perfect octave"
 msgstr ""
 
 #: js/utils/musicutils.js:699
-#.TRANS: Séptimo aumentado
+#. TRANS: Séptimo aumentado
 msgid "Augmented seventh"
 msgstr ""
 
 #: js/utils/musicutils.js:700
-#.TRANS: Novena menor
+#. TRANS: Novena menor
 msgid "Minor ninth"
 msgstr ""
 
 #: js/utils/musicutils.js:700
-#.TRANS: Octavo aumentado
+#. TRANS: Octavo aumentado
 msgid "Augmented octave"
 msgstr ""
 
 #: js/utils/musicutils.js:701
-#.TRANS: Novena mayor
+#. TRANS: Novena mayor
 msgid "Major ninth"
 msgstr ""
 
 #: js/utils/musicutils.js:701
-#.TRANS: Décima disminuida
+#. TRANS: Décima disminuida
 msgid "Diminished tenth"
 msgstr ""
 
 #: js/utils/musicutils.js:702
-#.TRANS: Décima menor
+#. TRANS: Décima menor
 msgid "Minor tenth"
 msgstr ""
 
 #: js/utils/musicutils.js:702
-#.TRANS: Novena aumentada
+#. TRANS: Novena aumentada
 msgid "Augmented ninth"
 msgstr ""
 
 #: js/utils/musicutils.js:703
-#.TRANS: Décima mayor
+#. TRANS: Décima mayor
 msgid "Major tenth"
 msgstr ""
 
 #: js/utils/musicutils.js:703
-#.TRANS: Undécimo disminuido
+#. TRANS: Undécimo disminuido
 msgid "Diminished eleventh"
 msgstr ""
 
 #: js/utils/musicutils.js:704
-#.TRANS: Undécimo perfecto
+#. TRANS: Undécimo perfecto
 msgid "Perfect eleventh"
 msgstr ""
 
 #: js/utils/musicutils.js:704
-#.TRANS: Décima aumentada
+#. TRANS: Décima aumentada
 msgid "Augmented tenth"
 msgstr ""
 
 #: js/utils/musicutils.js:705
-#.TRANS: Doce disminuido
+#. TRANS: Doce disminuido
 msgid "Diminished twelfth"
 msgstr ""
 
 #: js/utils/musicutils.js:705
-#.TRANS: Undécimo aumentado
+#. TRANS: Undécimo aumentado
 msgid "Augmented eleventh"
 msgstr ""
 
 #: js/utils/musicutils.js:706
-#.TRANS: Doce perfecto
+#. TRANS: Doce perfecto
 msgid "Perfect twelfth"
 msgstr ""
 
 #: js/utils/musicutils.js:706
-#.TRANS: Decimotercero disminuido
+#. TRANS: Decimotercero disminuido
 msgid "Diminished thirteenth"
 msgstr ""
 
 #: js/utils/musicutils.js:707
-#.TRANS: Doce menor
+#. TRANS: Doce menor
 msgid "Minor thirteenth"
 msgstr ""
 
 #: js/utils/musicutils.js:707
-#.TRANS: Quinta aumentada, más una octava
+#. TRANS: Quinta aumentada, más una octava
 msgid "Augmented fifth, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:708
-#.TRANS: Decimotercero mayor
+#. TRANS: Decimotercero mayor
 msgid "Major thirteenth"
 msgstr ""
 
 #: js/utils/musicutils.js:708
-#.TRANS: Séptimo disminuido, más una octava
+#. TRANS: Séptimo disminuido, más una octava
 msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
-#.TRANS: 1ÃÂº 2ÃÂº 3ÃÂº 4ÃÂº 5ÃÂº 6ÃÂº 7ÃÂº 8ÃÂº 9ÃÂº 10ÃÂº 11ÃÂº 12ÃÂº
+#. TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: 1ÃÂº 2ÃÂº 3ÃÂº 4ÃÂº 5ÃÂº 6ÃÂº 7ÃÂº 8ÃÂº 9ÃÂº 10ÃÂº 11ÃÂº 12ÃÂº
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
-#.TRANS: aumentado
+#. TRANS: augmented is a music term related to intervals
+#. TRANS: aumentado
 msgid "augmented"
 msgstr "mbohetapyre"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
-#.TRANS: disminuido
+#. TRANS: diminished is a music term related to intervals and mode
+#. TRANS: disminuido
 msgid "diminished"
 msgstr "momichĩ"
 
@@ -2958,218 +2958,218 @@ msgstr "momichĩ"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
-#.TRANS: perfecto
+#. TRANS: perfect is a music term related to intervals
+#. TRANS: perfecto
 msgid "perfect"
 msgstr "porã jepéva"
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
-#.TRANS: cromático
+#. TRANS: twelve semi-tone scale for music
+#. TRANS: cromático
 msgid "chromatic"
 msgstr "cromatico"
 
 #: js/utils/musicutils.js:1013
-#.TRANS: argelino
+#. TRANS: argelino
 msgid "algerian"
 msgstr "argelino"
 
 #: js/utils/musicutils.js:1014
-#.TRANS: español
+#. TRANS: español
 msgid "spanish"
 msgstr "españaygua"
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
-#.TRANS: octatonic
+#. TRANS: modal scale in music
+#. TRANS: octatonic
 msgid "octatonic"
 msgstr "octatónico"
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
-#.TRANS: armónico mayor
+#. TRANS: harmonic major scale in music
+#. TRANS: armónico mayor
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
-#.TRANS: natural menor
+#. TRANS: natural minor scales in music
+#. TRANS: natural menor
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
-#.TRANS: armónico menor
+#. TRANS: harmonic minor scale in music
+#. TRANS: armónico menor
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
-#.TRANS: melódico menor
+#. TRANS: melodic minor scale in music
+#. TRANS: melódico menor
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
-#.TRANS: dorio
+#. TRANS: modal scale for music
+#. TRANS: dorio
 msgid "dorian"
 msgstr "dorio"
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
-#.TRANS: frigio
+#. TRANS: modal scale for music
+#. TRANS: frigio
 msgid "phrygian"
 msgstr "frigio"
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
-#.TRANS: lidio
+#. TRANS: modal scale for music
+#. TRANS: lidio
 msgid "lydian"
 msgstr "lidio"
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
-#.TRANS: mixolidio
+#. TRANS: modal scale for music
+#. TRANS: mixolidio
 msgid "mixolydian"
 msgstr "mixolidio"
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
-#.TRANS: locrian
+#. TRANS: modal scale for music
+#. TRANS: locrian
 msgid "locrian"
 msgstr "locrio"
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
-#.TRANS: jazz menor
+#. TRANS: minor jazz scale for music
+#. TRANS: jazz menor
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
-#.TRANS: bebop
+#. TRANS: bebop scale for music
+#. TRANS: bebop
 msgid "bebop"
 msgstr "bebop"
 
 #: js/utils/musicutils.js:1043
-#.TRANS: arábica
+#. TRANS: arábica
 msgid "arabic"
 msgstr "arabica"
 
 #: js/utils/musicutils.js:1044
-#.TRANS: bizantino
+#. TRANS: bizantino
 msgid "byzantine"
 msgstr "bizantino"
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
-#.TRANS: enigmático
+#. TRANS: musical scale for music by Verdi
+#. TRANS: enigmático
 msgid "enigmatic"
 msgstr "enigmatico"
 
 #: js/utils/musicutils.js:1047
-#.TRANS: etíope
+#. TRANS: etíope
 msgid "ethiopian"
 msgstr "etiope"
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
-#.TRANS: geez
+#. TRANS: Ethiopic scale for music
+#. TRANS: geez
 msgid "geez"
 msgstr "geez"
 
 #: js/utils/musicutils.js:1050
-#.TRANS: hindú
+#. TRANS: hindú
 msgid "hindu"
 msgstr "hindu"
 
 #: js/utils/musicutils.js:1051
-#.TRANS: húngaro
+#. TRANS: húngaro
 msgid "hungarian"
 msgstr "hungaro"
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
-#.TRANS: romano menor
+#. TRANS: minor Romanian scale for music
+#. TRANS: romano menor
 msgid "romanian minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1054
-#.TRANS: gitana española
+#. TRANS: gitana española
 msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
-#.TRANS: maqam
+#. TRANS: musical scale for Mid-Eastern music
+#. TRANS: maqam
 msgid "maqam"
 msgstr "maqam"
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
-#.TRANS: blues menor
+#. TRANS: minor blues scale for music
+#. TRANS: blues menor
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
-#.TRANS: blues mayor
+#. TRANS: major blues scale for music
+#. TRANS: blues mayor
 msgid "major blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1061
-#.TRANS: tono completo
+#. TRANS: tono completo
 msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
-#.TRANS: pentatonic minor
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic minor
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
-#.TRANS: pentatonic mayor
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic mayor
 msgid "major pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1066
-#.TRANS: chino
+#. TRANS: chino
 msgid "chinese"
 msgstr "chino"
 
 #: js/utils/musicutils.js:1067
-#.TRANS: egipcio
+#. TRANS: egipcio
 msgid "egyptian"
 msgstr "egipcio"
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
-#.TRANS: hirajoshi
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: hirajoshi
 msgid "hirajoshi"
 msgstr "hirajoshi"
 
 #: js/utils/musicutils.js:1070
-#.TRANS: Japón
+#. TRANS: Japón
 msgid "Japan"
 msgstr "japonés"
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
-#.TRANS: in
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: in
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
-#.TRANS: minyo
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: minyo
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
-#.TRANS: fibonacci
+#. TRANS: Italian mathematician
+#. TRANS: fibonacci
 msgid "fibonacci"
 msgstr "fibonacci"
 
@@ -3186,65 +3186,65 @@ msgstr "fibonacci"
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
-#.TRANS: personalizado
+#. TRANS: customize voice
+#. TRANS: personalizado
 msgid "custom"
 msgstr "mboavarekoha"
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
-#.TRANS: highpass
+#. TRANS: highpass filter
+#. TRANS: highpass
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
-#.TRANS: 
+#. TRANS: lowpass filter
+#. TRANS: 
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
-#.TRANS: 
+#. TRANS: bandpass filter
+#. TRANS: 
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
-#.TRANS: 
+#. TRANS: high-shelf filter
+#. TRANS: 
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
-#.TRANS: 
+#. TRANS: low-shelf filter
+#. TRANS: 
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
-#.TRANS: 
+#. TRANS: notch-shelf filter
+#. TRANS: 
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
-#.TRANS: 
+#. TRANS: all-pass filter
+#. TRANS: 
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
-#.TRANS: 
+#. TRANS: peaking filter
+#. TRANS: 
 msgid "peaking"
 msgstr ""
 
@@ -3252,8 +3252,8 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
-#.TRANS: sine
+#. TRANS: sine wave
+#. TRANS: sine
 msgid "sine"
 msgstr "pyti’a"
 
@@ -3261,8 +3261,8 @@ msgstr "pyti’a"
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
-#.TRANS: cuadrado
+#. TRANS: square wave
+#. TRANS: cuadrado
 msgid "square"
 msgstr "irundy yke"
 
@@ -3271,8 +3271,8 @@ msgstr "irundy yke"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
-#.TRANS: triángulo
+#. TRANS: triangle wave
+#. TRANS: triángulo
 msgid "triangle"
 msgstr " mbohapy takamby"
 
@@ -3280,8 +3280,8 @@ msgstr " mbohapy takamby"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
-#.TRANS: diente de sierra
+#. TRANS: sawtooth wave
+#. TRANS: diente de sierra
 msgid "sawtooth"
 msgstr "tãi akua"
 
@@ -3290,9 +3290,9 @@ msgstr "tãi akua"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
-#.TRANS: par
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
+#. TRANS: par
 msgid "even"
 msgstr "mokõi"
 
@@ -3300,8 +3300,8 @@ msgstr "mokõi"
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
-#.TRANS: impar
+#. TRANS: odd numbers
+#. TRANS: impar
 msgid "odd"
 msgstr "jojaha’ỹ"
 
@@ -3309,178 +3309,178 @@ msgstr "jojaha’ỹ"
 #: js/utils/musicutils.js:1357
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:473
-#.TRANS: escalar
+#. TRANS: escalar
 msgid "scalar"
 msgstr ""
 
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
-#.TRANS: piano
+#. TRANS: musical instrument
+#. TRANS: piano
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
-#.TRANS: violín
+#. TRANS: musical instrument
+#. TRANS: violín
 msgid "violin"
 msgstr "mbaraka’i hasẽngy"
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
-#.TRANS: viola
+#. TRANS: viola musical instrument
+#. TRANS: viola
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
-#.TRANS: xilófono
+#. TRANS: xylophone musical instrument
+#. TRANS: xilófono
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
-#.TRANS: vibráfono
+#. TRANS: vibraphone musical instrument
+#. TRANS: vibráfono
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
-#.TRANS: violonchelo
+#. TRANS: musical instrument
+#. TRANS: violonchelo
 msgid "cello"
 msgstr "violonchelo"
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
-#.TRANS: contrabajo
+#. TRANS: viola musical instrument
+#. TRANS: contrabajo
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
-#.TRANS: guitarra
+#. TRANS: musical instrument
+#. TRANS: guitarra
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
-#.TRANS: guitarra acustica
+#. TRANS: musical instrument
+#. TRANS: guitarra acustica
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
-#.TRANS: flauta
+#. TRANS: musical instrument
+#. TRANS: flauta
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
-#.TRANS: clarinete
+#. TRANS: musical instrument
+#. TRANS: clarinete
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
-#.TRANS: saxofón
+#. TRANS: musical instrument
+#. TRANS: saxofón
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
-#.TRANS: tuba
+#. TRANS: musical instrument
+#. TRANS: tuba
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
-#.TRANS: trompeta
+#. TRANS: musical instrument
+#. TRANS: trompeta
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
-#.TRANS: oboe
+#. TRANS: musical instrument
+#. TRANS: oboe
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
-#.TRANS: trombón
+#. TRANS: musical instrument
+#. TRANS: trombón
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
-#.TRANS: sintetizador electronico
+#. TRANS: polytone synthesizer
+#. TRANS: sintetizador electronico
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
-#.TRANS: simple-1
+#. TRANS: simple monotone synthesizer
+#. TRANS: simple-1
 msgid "simple 1"
 msgstr ""
 
 #: js/utils/musicutils.js:1123
-#.TRANS: simple 2
+#. TRANS: simple 2
 msgid "simple 2"
 msgstr ""
 
 #: js/utils/musicutils.js:1124
-#.TRANS: simple 3
+#. TRANS: simple 3
 msgid "simple 3"
 msgstr ""
 
 #: js/utils/musicutils.js:1125
-#.TRANS: simple 4
+#. TRANS: simple 4
 msgid "simple 4"
 msgstr ""
 
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
-#.TRANS: ruido blanco
+#. TRANS: white noise synthesizer
+#. TRANS: ruido blanco
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
-#.TRANS: ruido marrón
+#. TRANS: brown noise synthesizer
+#. TRANS: ruido marrón
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
-#.TRANS: ruido rosa
+#. TRANS: pink noise synthesizer
+#. TRANS: ruido rosa
 msgid "pink noise"
 msgstr ""
 
@@ -3488,249 +3488,249 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
-#.TRANS: tambor militar pequeño
+#. TRANS: musical instrument
+#. TRANS: tambor militar pequeño
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
-#.TRANS: tambor de patada
+#. TRANS: musical instrument
+#. TRANS: tambor de patada
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
-#.TRANS: tom tom
+#. TRANS: musical instrument
+#. TRANS: tom tom
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
-#.TRANS: piso tom
+#. TRANS: musical instrument
+#. TRANS: piso tom
 msgid "floor tom"
 msgstr " tom tom yvy atã pegua"
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
-#.TRANS: tambor de bajo
+#. TRANS: musical instrument
+#. TRANS: tambor de bajo
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
-#.TRANS: taza de tambor
+#. TRANS: a drum made from an inverted cup
+#. TRANS: taza de tambor
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
-#.TRANS: darbuka
+#. TRANS: musical instrument
+#. TRANS: darbuka
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
-#.TRANS: 
+#. TRANS: musical instrument
+#. TRANS: 
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
-#.TRANS: campana de paseo
+#. TRANS: a small metal bell
+#. TRANS: campana de paseo
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
-#.TRANS: campana de vaca
+#. TRANS: musical instrument
+#. TRANS: campana de vaca
 msgid "cow bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1140
-#.TRANS: tambor japonés
+#. TRANS: tambor japonés
 msgid "japanese drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
-#.TRANS: campana japonesa
+#. TRANS: musical instrument
+#. TRANS: campana japonesa
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
-#.TRANS: campana triangular
+#. TRANS: musical instrument
+#. TRANS: campana triangular
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
-#.TRANS: castañuelas
+#. TRANS: musical instrument
+#. TRANS: castañuelas
 msgid "finger cymbals"
 msgstr "castañuelas"
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
-#.TRANS: campaneo
+#. TRANS: a musically tuned set of bells
+#. TRANS: campaneo
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
-#.TRANS: gong
+#. TRANS: a musical instrument
+#. TRANS: gong
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
-#.TRANS: estruendo
+#. TRANS: sound effect
+#. TRANS: estruendo
 msgid "clang"
 msgstr "sunu"
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
-#.TRANS: choque
+#. TRANS: sound effect
+#. TRANS: choque
 msgid "crash"
 msgstr "ombeti"
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
-#.TRANS: botella
+#. TRANS: sound effect
+#. TRANS: botella
 msgid "bottle"
 msgstr "liméta"
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
-#.TRANS: palmada
+#. TRANS: sound effect
+#. TRANS: palmada
 msgid "clap"
 msgstr "popete"
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
-#.TRANS: bofetada
+#. TRANS: sound effect
+#. TRANS: bofetada
 msgid "slap"
 msgstr "tovapete"
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
-#.TRANS: salpicadura
+#. TRANS: sound effect
+#. TRANS: salpicadura
 msgid "splash"
 msgstr "hypyi"
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
-#.TRANS: burbujas
+#. TRANS: sound effect
+#. TRANS: burbujas
 msgid "bubbles"
 msgstr "tyjúi"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
-#.TRANS: gota de agua
+#. TRANS: sound effect
+#. TRANS: gota de agua
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
-#.TRANS: gato
+#. TRANS: animal sound effect
+#. TRANS: gato
 msgid "cat"
 msgstr "mbarakaja"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
-#.TRANS: grillo
+#. TRANS: animal sound effect
+#. TRANS: grillo
 msgid "cricket"
 msgstr "kyju"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
-#.TRANS: perro
+#. TRANS: animal sound effect
+#. TRANS: perro
 msgid "dog"
 msgstr "jagua"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
-#.TRANS: banjo
+#. TRANS: musical instrument
+#. TRANS: banjo
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
-#.TRANS: koto
+#. TRANS: musical instrument
+#. TRANS: koto
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
-#.TRANS: dulcimer
+#. TRANS: musical instrument
+#. TRANS: dulcimer
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
-#.TRANS: guitarra electrica
+#. TRANS: musical instrument
+#. TRANS: guitarra electrica
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
-#.TRANS: fagot
+#. TRANS: musical instrument
+#. TRANS: fagot
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
-#.TRANS: celeste
+#. TRANS: musical instrument
+#. TRANS: celeste
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
-#.TRANS: igual
+#. TRANS: musical temperament
+#. TRANS: igual
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
-#.TRANS: Pitagórico
+#. TRANS: musical temperament
+#. TRANS: Pitagórico
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
-#.TRANS: solo entonación
+#. TRANS: musical temperament
+#. TRANS: solo entonación
 msgid "just intonation"
 msgstr ""
 
@@ -3739,285 +3739,285 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
-#.TRANS: 
+#. TRANS: musical temperament
+#. TRANS: 
 msgid "Meantone"
 msgstr ""
 
 #: js/utils/musicutils.js:1188
-#.TRANS: 7mo mayor
+#. TRANS: 7mo mayor
 msgid "major 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1189
-#.TRANS: 7mo menor
+#. TRANS: 7mo menor
 msgid "minor 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1190
-#.TRANS: 7ma dominante
+#. TRANS: 7ma dominante
 msgid "dominant 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1191
-#.TRANS: 7mo menor-mayor
+#. TRANS: 7mo menor-mayor
 msgid "minor-major 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1192
-#.TRANS: 7ÃÂº completamente disminuido
+#. TRANS: 7ÃÂº completamente disminuido
 msgid "fully-diminished 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1193
-#.TRANS: 7ÃÂº medio disminuido
+#. TRANS: 7ÃÂº medio disminuido
 msgid "half-diminished 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1600
 #: js/utils/musicutils.js:1616
-#.TRANS: Igual (12EDO)
+#. TRANS: Igual (12EDO)
 msgid "Equal (12EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1601
 #: js/utils/musicutils.js:1617
-#.TRANS: Igual (5EDO)
+#. TRANS: Igual (5EDO)
 msgid "Equal (5EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1602
 #: js/utils/musicutils.js:1618
-#.TRANS: Igual (7EDO)
+#. TRANS: Igual (7EDO)
 msgid "Equal (7EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1603
 #: js/utils/musicutils.js:1619
-#.TRANS: Igual (19EDO)
+#. TRANS: Igual (19EDO)
 msgid "Equal (19EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1604
 #: js/utils/musicutils.js:1620
-#.TRANS: Igual (31EDO)
+#. TRANS: Igual (31EDO)
 msgid "Equal (31EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1605
 #: js/utils/musicutils.js:1621
-#.TRANS: 5-Límite de entonación justa
+#. TRANS: 5-Límite de entonación justa
 msgid "5-limit Just Intonation"
 msgstr ""
 
 #: js/utils/musicutils.js:1606
 #: js/utils/musicutils.js:1622
-#.TRANS: Pythagorean (3-limite EJ)
+#. TRANS: Pythagorean (3-limite EJ)
 msgid "Pythagorean (3-limit JI)"
 msgstr ""
 
 #: js/utils/musicutils.js:5631
 #: js/utils/musicutils.js:5674
-#.TRANS: actuales
+#. TRANS: actuales
 msgid "current"
 msgstr "ko’ãga"
 
 #: js/utils/musicutils.js:5634
 #: js/utils/musicutils.js:5665
-#.TRANS: próximo
+#. TRANS: próximo
 msgid "next"
 msgstr "tenondegua"
 
 #: js/utils/musicutils.js:5637
 #: js/utils/musicutils.js:5670
-#.TRANS: anterior
+#. TRANS: anterior
 msgid "previous"
 msgstr "mboyvegua"
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
-#.TRANS: simple-2
+#. TRANS: simple monotone synthesizer
+#. TRANS: simple-2
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
-#.TRANS: simple-3
+#. TRANS: simple monotone synthesizer
+#. TRANS: simple-3
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
-#.TRANS: simple-4
+#. TRANS: simple monotone synthesizer
+#. TRANS: simple-4
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
-#.TRANS: taiko
+#. TRANS: musical instrument
+#. TRANS: taiko
 msgid "taiko"
 msgstr ""
 
 #: js/blocks/BooleanBlocks.js:44
-#.TRANS: El bloque No es el operador lógico no.
+#. TRANS: El bloque No es el operador lógico no.
 msgid "The Not block is the logical not operator."
 msgstr ""
 
 #: js/blocks/BooleanBlocks.js:62
-#.TRANS: no
+#. TRANS: no
 msgid "not"
 msgstr "nahániri"
 
 #: js/blocks/BooleanBlocks.js:134
-#.TRANS: El bloque Y es el lógico y el operador.
+#. TRANS: El bloque Y es el lógico y el operador.
 msgid "The And block is the logical and operator."
 msgstr ""
 
 #: js/blocks/BooleanBlocks.js:152
-#.TRANS: y
+#. TRANS: y
 msgid "and"
 msgstr "ha"
 
 #: js/blocks/BooleanBlocks.js:218
-#.TRANS: El bloque O es el lógico o el operador.
+#. TRANS: El bloque O es el lógico o el operador.
 msgid "The Or block is the logical or operator."
 msgstr ""
 
 #: js/blocks/BooleanBlocks.js:236
-#.TRANS: o
+#. TRANS: o
 msgid "or"
 msgstr "o"
 
 #: js/blocks/BooleanBlocks.js:302
-#.TRANS: El bloque XOR es el lógico XOR el operador.
+#. TRANS: El bloque XOR es el lógico XOR el operador.
 msgid "The XOR block is the logical XOR operator."
 msgstr ""
 
 #: js/blocks/BooleanBlocks.js:320
-#.TRANS: xor
+#. TRANS: xor
 msgid "xor"
 msgstr ""
 
 #: js/blocks/BooleanBlocks.js:808
-#.TRANS: El bloque Igual devuelve verdadero si los dos números son iguales.
+#. TRANS: El bloque Igual devuelve verdadero si los dos números son iguales.
 msgid "The Equal block returns True if the two numbers are equal."
 msgstr ""
 
 #: js/blocks/BooleanBlocks.js:909
-#.TRANS: El bloque No igual a devuelve Verdadero si los dos números no son iguales entre sí.
+#. TRANS: El bloque No igual a devuelve Verdadero si los dos números no son iguales entre sí.
 msgid "The Not-equal-to block returns True if the two numbers are not equal to each other."
 msgstr ""
 
 #: js/blocks/BooleanBlocks.js:1008
-#.TRANS: El bloque Booleano se utiliza para especificar verdadero o falso.
+#. TRANS: El bloque Booleano se utiliza para especificar verdadero o falso.
 msgid "The Boolean block is used to specify true or false."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:53
 #: js/blocks/BoxesBlocks.js:59
-#.TRANS: El bloque Agregar a se usa para agregar al valor almacenado en un cuadro.
+#. TRANS: El bloque Agregar a se usa para agregar al valor almacenado en un cuadro.
 msgid "The Add-to block is used to add to the value stored in a box."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:61
-#.TRANS: También se puede utilizar con otros bloques, como el color, el tamaño de la pluma.
+#. TRANS: También se puede utilizar con otros bloques, como el color, el tamaño de la pluma.
 msgid "It can also be used with other blocks such as Color and Pen size."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:73
-#.TRANS: sumar
+#. TRANS: sumar
 msgid "add"
 msgstr "embojo’a"
 
 #: js/blocks/BoxesBlocks.js:75
 #: js/widgets/temperament.js:825
-#.TRANS: para
+#. TRANS: para
 msgid "to"
 msgstr "guarã"
 
 #: js/blocks/BoxesBlocks.js:75
 #: js/blocks/BoxesBlocks.js:595
 #: js/blocks/HeapBlocks.js:544
-#.TRANS: valor
+#. TRANS: valor
 msgid "value1"
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:118
-#.TRANS: Bloque no soporta incremento.
+#. TRANS: Bloque no soporta incremento.
 msgid "Block does not support incrementing."
 msgstr "Vore ndikatui tuicha"
 
 #: js/blocks/BoxesBlocks.js:152
-#.TRANS: El bloque Sumar-1-a agrega uno al valor almacenado en un cuadro.
+#. TRANS: El bloque Sumar-1-a agrega uno al valor almacenado en un cuadro.
 msgid "The Add-1-to block adds one to the value stored in a box."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:163
-#.TRANS: sumar 1 a
+#. TRANS: sumar 1 a
 msgid "add 1 to"
 msgstr "embojo’a peteĩ "
 
 #: js/blocks/BoxesBlocks.js:211
-#.TRANS: El bloque restar-1-de resta uno al valor almacenado en un cuadro.
+#. TRANS: El bloque restar-1-de resta uno al valor almacenado en un cuadro.
 msgid "The Subtract-1-from block subtracts one from the value stored in a box."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:222
-#.TRANS: restar 1 de
+#. TRANS: restar 1 de
 msgid "subtract 1 from"
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:270
 #: js/blocks/BoxesBlocks.js:387
-#.TRANS: El bloque Caja devuelve el valor almacenado en una caja .
+#. TRANS: El bloque Caja devuelve el valor almacenado en una caja .
 msgid "The Box block returns the value stored in a box."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:500
 #: js/blocks/BoxesBlocks.js:576
-#.TRANS: El bloque Guardar en caja se utiliza para almacenar un valor en una caja.
+#. TRANS: El bloque Guardar en caja se utiliza para almacenar un valor en una caja.
 msgid "The Store in block will store a value in a box."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:595
 #: js/blocks/EnsembleBlocks.js:393
 #: js/blocks/EnsembleBlocks.js:404
-#.TRANS: nombre
+#. TRANS: nombre
 msgid "name1"
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:652
-#.TRANS: El bloque Caja 2 devuelve el valor almacenado en caja 2.
+#. TRANS: El bloque Caja 2 devuelve el valor almacenado en caja 2.
 msgid "The Box2 block returns the value stored in Box2."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:703
-#.TRANS: El bloque Guardar en caja2 se utiliza para almacenar un valor en caja2.
+#. TRANS: El bloque Guardar en caja2 se utiliza para almacenar un valor en caja2.
 msgid "The Store in Box2 block is used to store a value in Box2."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:715
-#.TRANS: guardar en caja 2
+#. TRANS: guardar en caja 2
 msgid "store in box2"
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:761
-#.TRANS: El bloque Caja 1 devuelve el valor almacenado en caja 1.
+#. TRANS: El bloque Caja 1 devuelve el valor almacenado en caja 1.
 msgid "The Box1 block returns the value stored in Box1."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:812
-#.TRANS: El bloque Guardar en caja1 se utiliza para almacenar un valor en caja1.
+#. TRANS: El bloque Guardar en caja1 se utiliza para almacenar un valor en caja1.
 msgid "The Store in Box1 block is used to store a value in Box1."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:826
-#.TRANS: guardar en caja 1
+#. TRANS: guardar en caja 1
 msgid "store in box1"
 msgstr ""
 
 #: js/blocks/DictBlocks.js:77
-#.TRANS: mostrar diccionario
+#. TRANS: mostrar diccionario
 msgid "show dictionary"
 msgstr ""
 
@@ -4028,25 +4028,25 @@ msgstr ""
 #: js/blocks/ProgramBlocks.js:396
 #: js/blocks/ProgramBlocks.js:501
 #: js/blocks/ProgramBlocks.js:664
-#.TRANS: mi diccionario
+#. TRANS: mi diccionario
 msgid "My Dictionary"
 msgstr ""
 
 #: js/blocks/DictBlocks.js:129
-#.TRANS: El bloque Diccionario devuelve un diccionario.
+#. TRANS: El bloque Diccionario devuelve un diccionario.
 msgid "The Dictionary block returns a dictionary."
 msgstr ""
 
 #: js/blocks/DictBlocks.js:197
 #: js/blocks/DictBlocks.js:339
-#.TRANS: El bloque obtener-valor devuelve un valor en el diccionario para una clave especificada.
+#. TRANS: El bloque obtener-valor devuelve un valor en el diccionario para una clave especificada.
 msgid "The Get-dict block returns a value in the dictionary for a specified key."
 msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
-#.TRANS: obtener valor
+#. TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: obtener valor
 msgid "get value"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:357
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
-#.TRANS: clave
+#. TRANS: clave
 msgid "key2"
 msgstr ""
 
@@ -4069,143 +4069,143 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
-#.TRANS: clave
+#. TRANS: key, e.g., C in C Major
+#. TRANS: clave
 msgid "key"
 msgstr "clave"
 
 #: js/blocks/DictBlocks.js:271
 #: js/blocks/DictBlocks.js:411
-#.TRANS: El bloque valor-adjusto establece un valor en el diccionario para una clave específica.
+#. TRANS: El bloque valor-adjusto establece un valor en el diccionario para una clave específica.
 msgid "The Set-dict block sets a value in the dictionary for a specified key."
 msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
-#.TRANS: valor ajustado
+#. TRANS: set a value in the dictionary for a given key
+#. TRANS: valor ajustado
 msgid "set value"
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:59
-#.TRANS: El bloque Nombre de ruido se utiliza para seleccionar un sintetizador de ruido.
+#. TRANS: El bloque Nombre de ruido se utiliza para seleccionar un sintetizador de ruido.
 msgid "The Noise name block is used to select a noise synthesizer."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:102
-#.TRANS: El bloque nombre del tambor se utiliza para seleccionar un tambor.
+#. TRANS: El bloque nombre del tambor se utiliza para seleccionar un tambor.
 msgid "The Drum name block is used to select a drum."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:146
-#.TRANS: El bloque nombre de efectos se utiliza para seleccionar un efecto de sonido.
+#. TRANS: El bloque nombre de efectos se utiliza para seleccionar un efecto de sonido.
 msgid "The Effects name block is used to select a sound effect."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:163
-#.TRANS: ruido
+#. TRANS: ruido
 msgid "noise"
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:177
-#.TRANS: El bloque Ruido de reproducción generará ruido blanco, rosa o marrón.
+#. TRANS: El bloque Ruido de reproducción generará ruido blanco, rosa o marrón.
 msgid "The Play noise block will generate white, pink, or brown noise."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:317
-#.TRANS: Reemplace cada instancia de un tono con un sonido de tambor.
+#. TRANS: Reemplace cada instancia de un tono con un sonido de tambor.
 msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
-#.TRANS: mapa de tono al tambor
+#. TRANS: map a pitch to a drum sound
+#. TRANS: mapa de tono al tambor
 msgid "map pitch to drum"
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:395
-#.TRANS: En el ejemplo anterior, se reproducirá un sonido de bombo en lugar de sol.
+#. TRANS: En el ejemplo anterior, se reproducirá un sonido de bombo en lugar de sol.
 msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
-#.TRANS: fijar tambor
+#. TRANS: set the current drum sound for playback
+#. TRANS: fijar tambor
 msgid "set drum"
 msgstr "emoĩ angu’atarara"
 
 #: js/blocks/DrumBlocks.js:451
-#.TRANS: efecto de sonido
+#. TRANS: efecto de sonido
 msgid "sound effect"
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:489
-#.TRANS: Puede utilizar varios bloques de percusión dentro de un bloque de notas.
+#. TRANS: Puede utilizar varios bloques de percusión dentro de un bloque de notas.
 msgid "You can use multiple Drum blocks within a Note block."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:49
-#.TRANS: El bloque Pila devuelve la pila.
+#. TRANS: El bloque Pila devuelve la pila.
 msgid "The Heap block returns the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:133
-#.TRANS: mostrar pila
+#. TRANS: mostrar pila
 msgid "show heap"
 msgstr "oichuka aty"
 
 #: js/blocks/HeapBlocks.js:181
-#.TRANS: El bloque Longitud de la pila devuelve la longitud de la pila.
+#. TRANS: El bloque Longitud de la pila devuelve la longitud de la pila.
 msgid "The Heap-length block returns the length of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:195
-#.TRANS: tamaño de la pila
+#. TRANS: tamaño de la pila
 msgid "heap length"
 msgstr "aty jakatuha"
 
 #: js/blocks/HeapBlocks.js:254
-#.TRANS: El bloque Pila-vacío? devuelve verdadero si la pila está vacío.
+#. TRANS: El bloque Pila-vacío? devuelve verdadero si la pila está vacío.
 msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
-#.TRANS: ÃÂ¿pila vacía?
+#. TRANS: Is the heap empty?
+#. TRANS: ÃÂ¿pila vacía?
 msgid "heap empty?"
 msgstr "aty nandi"
 
 #: js/blocks/HeapBlocks.js:317
-#.TRANS: El bloque Vacío pila vacía la pila.
+#. TRANS: El bloque Vacío pila vacía la pila.
 msgid "The Empty-heap block empties the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
-#.TRANS: vaciar pila
+#. TRANS: empty the heap
+#. TRANS: vaciar pila
 msgid "empty heap"
 msgstr "emonandi pe chovi"
 
 #: js/blocks/HeapBlocks.js:371
-#.TRANS: El bloque Pila inversa invierte el orden de la pila.
+#. TRANS: El bloque Pila inversa invierte el orden de la pila.
 msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
-#.TRANS: revertir la pila
+#. TRANS: reverse the order of the heap
+#. TRANS: revertir la pila
 msgid "reverse heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:428
-#.TRANS: El bloque ÃÂndice de pila devuelve un valor en la pila en una ubicación especificada.
+#. TRANS: El bloque ÃÂndice de pila devuelve un valor en la pila en una ubicación especificada.
 msgid "The Index-heap block returns a value in the heap at a specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
-#.TRANS: valor en la pila
+#. TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: valor en la pila
 msgid "index heap"
 msgstr "tepy aty pe"
 
@@ -4213,60 +4213,60 @@ msgstr "tepy aty pe"
 #: js/blocks/HeapBlocks.js:572
 #: js/blocks/EnsembleBlocks.js:124
 #: js/blocks/EnsembleBlocks.js:1200
-#.TRANS: El índice debe ser > 0.
+#. TRANS: El índice debe ser > 0.
 msgid "Index must be > 0."
 msgstr "Rysýi tuichave vaerã mba’evegui"
 
 #: js/blocks/HeapBlocks.js:479
 #: js/blocks/HeapBlocks.js:577
 #: js/blocks/EnsembleBlocks.js:129
-#.TRANS: El tamaño máximo de pilas es 1000.
+#. TRANS: El tamaño máximo de pilas es 1000.
 msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-#.TRANS: El bloque Fijar entrada de pila establece un valor en la pila en la ubicación especificada.
+#. TRANS: El bloque Fijar entrada de pila establece un valor en la pila en la ubicación especificada.
 msgid "The Set-heap entry block sets a value in he heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
-#.TRANS: fijar pila
+#. TRANS: load the heap from a JSON encoding
+#. TRANS: fijar pila
 msgid "set heap"
 msgstr "omoambue aty repy"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
-#.TRANS: posición en la pila
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: posición en la pila
 msgid "index"
 msgstr "henda aty pe"
 
 #: js/blocks/HeapBlocks.js:619
-#.TRANS: El bloque Pop elimina el valor en la parte superior del pila.
+#. TRANS: El bloque Pop elimina el valor en la parte superior del pila.
 msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
-#.TRANS: sacar
+#. TRANS: pop a value off the top of the heap
+#. TRANS: sacar
 msgid "pop"
 msgstr "pe’a"
 
 #: js/blocks/HeapBlocks.js:680
-#.TRANS: El bloque Push agrega un valor a la parte superior del pila.
+#. TRANS: El bloque Push agrega un valor a la parte superior del pila.
 msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
-#.TRANS: apilar
+#. TRANS: push a value onto the top of the heap
+#. TRANS: apilar
 msgid "push"
 msgstr "atyha"
 
 #: js/blocks/IntervalsBlocks.js:45
-#.TRANS: fijar temperamento
+#. TRANS: fijar temperamento
 msgid "set temperament"
 msgstr ""
 
@@ -4282,510 +4282,510 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
-#.TRANS: octava
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: octava
 msgid "octave"
 msgstr "Octava"
 
 #: js/blocks/IntervalsBlocks.js:99
-#.TRANS: El bloque Nombre Temperamento se utiliza para seleccionar un método de ajuste.
+#. TRANS: El bloque Nombre Temperamento se utiliza para seleccionar un método de ajuste.
 msgid "The Temperament name block is used to select a tuning method."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:161
-#.TRANS: doble
+#. TRANS: doble
 msgid "doubly"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:166
-#.TRANS: El bloque doble duplicará el tamaño de un intervalo.
+#. TRANS: El bloque doble duplicará el tamaño de un intervalo.
 msgid "The Doubly block will double the size of an interval."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:262
-#.TRANS: número de intervalo
+#. TRANS: número de intervalo
 msgid "interval number"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:317
-#.TRANS: intervalo actua
+#. TRANS: intervalo actua
 msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
-#.TRANS: medida de intervalo semitono
+#. TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: medida de intervalo semitono
 msgid "semi-tone interval measure"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:454
 #: js/blocks/IntervalsBlocks.js:570
-#.TRANS: Debe usar dos bloques de tono cuando mida un intervalo.
+#. TRANS: Debe usar dos bloques de tono cuando mida un intervalo.
 msgid "You must use two pitch blocks when measuring an interval."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:496
-#.TRANS: El bloque Intervalo escalar mide la distancia entre dos notas en la clave y el modo actuales.
+#. TRANS: El bloque Intervalo escalar mide la distancia entre dos notas en la clave y el modo actuales.
 msgid "The Scalar interval block measures the distance between two notes in the current key and mode."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
-#.TRANS: medida de intervalo escalar
+#. TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: medida de intervalo escalar
 msgid "scalar interval measure"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:678
-#.TRANS: En la figura, agregamos sol# a sol.
+#. TRANS: En la figura, agregamos sol# a sol.
 msgid "In the figure, we add sol# to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
-#.TRANS: intervalo semitono
+#. TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: intervalo semitono
 msgid "semi-tone interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:733
-#.TRANS: La salida del ejemplo es: do, mi, sol, sol, ti, mi
+#. TRANS: La salida del ejemplo es: do, mi, sol, sol, ti, mi
 msgid "The output of the example is: do, mi, sol, sol, ti, mi"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:740
 #: js/blocks/WidgetBlocks.js:768
-#.TRANS: arpegio
+#. TRANS: arpegio
 msgid "arpeggio"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:931
-#.TRANS: El bloque Acordes calcula acordes comunes.
+#. TRANS: El bloque Acordes calcula acordes comunes.
 msgid "The Chord block calculates common chords."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:933
-#.TRANS: En la figura generamos un acorde de C-mayor.
+#. TRANS: En la figura generamos un acorde de C-mayor.
 msgid "In the figure, we generate a C-major chord."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:938
-#.TRANS: acorde
+#. TRANS: acorde
 msgid "chord"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:990
-#.TRANS: El bloque intervalo de razón calcula un intervalo basado en una razón
+#. TRANS: El bloque intervalo de razón calcula un intervalo basado en una razón
 msgid "The Ratio Interval block calculates an interval based on a ratio."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:995
-#.TRANS: intervalo de razón
+#. TRANS: intervalo de razón
 msgid "ratio interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1064
-#.TRANS: En la figura, sumamos la a sol.
+#. TRANS: En la figura, sumamos la a sol.
 msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
-#.TRANS: definir el modo
+#. TRANS: define a custom mode
+#. TRANS: definir el modo
 msgid "define mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1173
-#.TRANS: movible Do
+#. TRANS: movible Do
 msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
-#.TRANS: longitud de modo
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: longitud de modo
 msgid "mode length"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1233
-#.TRANS: El bloque Longitud de modo es el número de notas en la escala actual.
+#. TRANS: El bloque Longitud de modo es el número de notas en la escala actual.
 msgid "The Mode length block is the number of notes in the current scale."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1235
-#.TRANS: La mayoría de las escalas occidentales tienen 7 notas.
+#. TRANS: La mayoría de las escalas occidentales tienen 7 notas.
 msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
-#.TRANS: modo actual
+#. TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: modo actual
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
-#.TRANS: clave actual
+#. TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: clave actual
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
-#.TRANS: fijar clave
+#. TRANS: set the key and mode, e.g. C Major
+#. TRANS: fijar clave
 msgid "set key"
 msgstr "emoĩ clave"
 
 #: js/blocks/IntervalsBlocks.js:1443
 #: js/blocks/IntervalsBlocks.js:1449
-#.TRANS: El bloque Fijar tecla se usa para configurar la tecla y el modo,
+#. TRANS: El bloque Fijar tecla se usa para configurar la tecla y el modo,
 msgid "The Set key block is used to set the key and mode,"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1449
-#.TRANS: por ejemplo, C Mayor
+#. TRANS: por ejemplo, C Mayor
 msgid "eg C Major"
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:28
-#.TRANS: El bloque Int devuelve un entero.
+#. TRANS: El bloque Int devuelve un entero.
 msgid "The Int block returns an integer."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:34
-#.TRANS: int
+#. TRANS: int
 msgid "int"
 msgstr "convertir un número real a un entero"
 
 #: js/blocks/NumberBlocks.js:73
-#.TRANS: El bloque Mod devuelve el resto de una división.
+#. TRANS: El bloque Mod devuelve el resto de una división.
 msgid "The Mod block returns the remainder from a division."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:79
-#.TRANS: módulo
+#. TRANS: módulo
 msgid "mod"
 msgstr "módulo"
 
 #: js/blocks/NumberBlocks.js:141
-#.TRANS: El bloque de potencia calcula una función de potencia.
+#. TRANS: El bloque de potencia calcula una función de potencia.
 msgid "The Power block calculates a power function."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:196
-#.TRANS: El bloque Sqrt devuelve la raíz cuadrada.
+#. TRANS: El bloque Sqrt devuelve la raíz cuadrada.
 msgid "The Sqrt block returns the square root."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:202
-#.TRANS: raíz
+#. TRANS: raíz
 msgid "sqrt"
 msgstr "hapó"
 
 #: js/blocks/NumberBlocks.js:248
-#.TRANS: El bloque Abs devuelve el valor absoluto.
+#. TRANS: El bloque Abs devuelve el valor absoluto.
 msgid "The Abs block returns the absolute value."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:254
-#.TRANS: abs
+#. TRANS: abs
 msgid "abs"
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:295
-#.TRANS: El bloque Distancia devuelve la distancia entre dos puntos. Por ejemplo, entre el ratón y el centro de la pantalla.
+#. TRANS: El bloque Distancia devuelve la distancia entre dos puntos. Por ejemplo, entre el ratón y el centro de la pantalla.
 msgid "The Distance block returns the distance between two points. For example, between the mouse and the center of the screen."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:301
 #: plugins/rodi.rtp:310
-#.TRANS: distancia
+#. TRANS: distancia
 msgid "distance"
 msgstr "mbyryguĩ"
 
 #: js/blocks/NumberBlocks.js:361
-#.TRANS: El bloque División se usa para dividir.
+#. TRANS: El bloque División se usa para dividir.
 msgid "The Divide block is used to divide."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:441
-#.TRANS: El bloque Multiplicar se usa para multiplicar.
+#. TRANS: El bloque Multiplicar se usa para multiplicar.
 msgid "The Multiply block is used to multiply."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:612
-#.TRANS: El bloque Minus se usa para restar.
+#. TRANS: El bloque Minus se usa para restar.
 msgid "The Minus block is used to subtract."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:723
-#.TRANS: El bloque Plus se utiliza para agregar.
+#. TRANS: El bloque Plus se utiliza para agregar.
 msgid "The Plus block is used to add."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:849
-#.TRANS: El bloque Uno de estos devuelve una de dos opciones.
+#. TRANS: El bloque Uno de estos devuelve una de dos opciones.
 msgid "The One-of block returns one of two choices."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:856
 #: js/blocks/PitchBlocks.js:616
-#.TRANS: uno de estos
+#. TRANS: uno de estos
 msgid "one of"
 msgstr "peteĩ áarehegua"
 
 #: js/blocks/NumberBlocks.js:858
-#.TRANS: éste
+#. TRANS: éste
 msgid "this"
 msgstr "kóa"
 
 #: js/blocks/NumberBlocks.js:858
-#.TRANS: ése
+#. TRANS: ése
 msgid "that"
 msgstr "péa"
 
 #: js/blocks/NumberBlocks.js:913
-#.TRANS: El bloque Aleatorio devuelve un número aleatorio.
+#. TRANS: El bloque Aleatorio devuelve un número aleatorio.
 msgid "The Random block returns a random number."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:920
-#.TRANS: aleatorio
+#. TRANS: aleatorio
 msgid "random"
 msgstr "oimerãea"
 
 #: js/blocks/NumberBlocks.js:922
-#.TRANS: min
+#. TRANS: min
 msgid "min"
 msgstr "sa’ivéva"
 
 #: js/blocks/NumberBlocks.js:922
-#.TRANS: max
+#. TRANS: max
 msgid "max"
 msgstr "tuichavéva"
 
 #: js/blocks/NumberBlocks.js:986
-#.TRANS: El bloque Numérico contiene un número.
+#. TRANS: El bloque Numérico contiene un número.
 msgid "The Number block holds a number."
 msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:32
-#.TRANS: factor de staccato
+#. TRANS: factor de staccato
 msgid "staccato factor"
 msgstr "staccato ypy"
 
 #: js/blocks/OrnamentBlocks.js:108
-#.TRANS: factor de legato
+#. TRANS: factor de legato
 msgid "slur factor"
 msgstr "legato ypy"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
-#.TRANS: vecino
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: vecino
 msgid "neighbor"
 msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:293
-#.TRANS: El bloque Vecino cambia rápidamente entre los tonos vecinos.
+#. TRANS: El bloque Vecino cambia rápidamente entre los tonos vecinos.
 msgid "The Neighbor block rapidly switches between neighboring pitches."
 msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:364
-#.TRANS: deslizarse
+#. TRANS: deslizarse
 msgid "glide"
 msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:479
 #: js/blocks/OrnamentBlocks.js:643
-#.TRANS: legato
+#. TRANS: legato
 msgid "slur"
 msgstr "legato"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
-#.TRANS: staccato
+#. TRANS: play each note sharply detached from the others
+#. TRANS: staccato
 msgid "staccato"
 msgstr "staccato"
 
 #: js/blocks/ProgramBlocks.js:33
-#.TRANS: El bloque Cargar-pila-en-app carga la pila en una página web.
+#. TRANS: El bloque Cargar-pila-en-app carga la pila en una página web.
 msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
-#.TRANS: cargar pila desde aplicación
+#. TRANS: load the heap contents from a URL
+#. TRANS: cargar pila desde aplicación
 msgid "load heap from App"
 msgstr "ehupi aty aplicación rire"
 
 #: js/blocks/ProgramBlocks.js:95
-#.TRANS: Error de análisis de datos JSON.
+#. TRANS: Error de análisis de datos JSON.
 msgid "Error parsing JSON data:"
 msgstr "Jejavy hesa’ỹijo mba’ekuaa JSON"
 
 #: js/blocks/ProgramBlocks.js:100
-#.TRANS: 404: Página no encontrada.
+#. TRANS: 404: Página no encontrada.
 msgid "404: Page not found"
 msgstr "404: Kuatia rogue ndotopái"
 
 #: js/blocks/ProgramBlocks.js:133
-#.TRANS: El bloque Guardar-pila-en-app guarda la pila en una página web.
+#. TRANS: El bloque Guardar-pila-en-app guarda la pila en una página web.
 msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
-#.TRANS: guardar pila a aplicación
+#. TRANS: save the heap contents to a URL
+#. TRANS: guardar pila a aplicación
 msgid "save heap to App"
 msgstr "eñongatu aty aplicación rire"
 
 #: js/blocks/ProgramBlocks.js:189
-#.TRANS: Pilas tortuga no contiene un montón válida para
+#. TRANS: Pilas tortuga no contiene un montón válida para
 msgid "Cannot find a valid heap for"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:206
-#.TRANS: El bloque Cargar pila carga la pila de un archivo.
+#. TRANS: El bloque Cargar pila carga la pila de un archivo.
 msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
-#.TRANS: cargar pila
+#. TRANS: load the heap from a file
+#. TRANS: cargar pila
 msgid "load heap"
 msgstr "e hupi aty"
 
 #: js/blocks/ProgramBlocks.js:270
-#.TRANS: El archivo seleccionado no contiene un pila válida.
+#. TRANS: El archivo seleccionado no contiene un pila válida.
 msgid "The file you selected does not contain a valid heap."
 msgstr "Pe mba’e ñongatupyre ndo rekói chovi oikóva"
 
 #: js/blocks/ProgramBlocks.js:275
-#.TRANS: El bloque Pila de carga necesita un bloque de archivo de carga.
+#. TRANS: El bloque Pila de carga necesita un bloque de archivo de carga.
 msgid "The loadHeap block needs a loadFile block."
 msgstr "Pe vore chovi hupiha oikoteve peteĩ vore ñongatuha hupiha"
 
 #: js/blocks/ProgramBlocks.js:291
-#.TRANS: El bloque fijar pila carga la pila.
+#. TRANS: El bloque fijar pila carga la pila.
 msgid "The Set-heap block loads the heap."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:340
-#.TRANS: El bloque que seleccionó no contiene una pila válido.
+#. TRANS: El bloque que seleccionó no contiene una pila válido.
 msgid "The block you selected does not contain a valid heap."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:343
-#.TRANS: El bloque fija pila necesita una pila.
+#. TRANS: El bloque fija pila necesita una pila.
 msgid "The Set heap block needs a heap."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:360
-#.TRANS: El bloque Carga-diccionario carga un diccionario desde un archivo.
+#. TRANS: El bloque Carga-diccionario carga un diccionario desde un archivo.
 msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
-#.TRANS: carga diccionario
+#. TRANS: load a dictionary from a file
+#. TRANS: carga diccionario
 msgid "load dictionary"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:390
 #: js/blocks/ProgramBlocks.js:658
 #: js/blocks/ToneBlocks.js:1025
-#.TRANS: archivo
+#. TRANS: archivo
 msgid "file"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:444
-#.TRANS: El archivo que seleccionó no contiene un diccionario válido.
+#. TRANS: El archivo que seleccionó no contiene un diccionario válido.
 msgid "The file you selected does not contain a valid dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:449
-#.TRANS: El bloque de diccionario de carga necesita un bloque de archivo
+#. TRANS: El bloque de diccionario de carga necesita un bloque de archivo
 msgid "The load dictionary block needs a load file block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:466
-#.TRANS: El bloque fijar diccionario carga un diccionario.
+#. TRANS: El bloque fijar diccionario carga un diccionario.
 msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
-#.TRANS: fijar diccionario
+#. TRANS: load a dictionary from a JSON
+#. TRANS: fijar diccionario
 msgid "set dictionary"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:546
-#.TRANS: El bloque que seleccionó no contiene un diccionario válido.
+#. TRANS: El bloque que seleccionó no contiene un diccionario válido.
 msgid "The block you selected does not contain a valid dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:550
-#.TRANS: El bloque Fijar dictionario necesita un diccionario.
+#. TRANS: El bloque Fijar dictionario necesita un diccionario.
 msgid "The set dictionary block needs a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:567
-#.TRANS: El bloque Guardar pila guarda la pila en un archivo.
+#. TRANS: El bloque Guardar pila guarda la pila en un archivo.
 msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
-#.TRANS: guardar pila
+#. TRANS: save the heap to a file
+#. TRANS: guardar pila
 msgid "save heap"
 msgstr "eñongatu aty"
 
 #: js/blocks/ProgramBlocks.js:629
-#.TRANS: El bloque Guardar diccionario guarda el diccionario en un archivo
+#. TRANS: El bloque Guardar diccionario guarda el diccionario en un archivo
 msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
-#.TRANS: guardar diccionario
+#. TRANS: save a dictionary to a file
+#. TRANS: guardar diccionario
 msgid "save dictionary"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:720
-#.TRANS: El bloque abrir la paleta abre una paleta
+#. TRANS: El bloque abrir la paleta abre una paleta
 msgid "The Open palette block opens a palette."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:727
-#.TRANS: abrir la paleta
+#. TRANS: abrir la paleta
 msgid "open palette"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:785
-#.TRANS: El bloque eliminar bloque elimina un bloque
+#. TRANS: El bloque eliminar bloque elimina un bloque
 msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
-#.TRANS: eliminar bloque
+#. TRANS: Move this block to the trash.
+#. TRANS: eliminar bloque
 msgid "delete block"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:861
-#.TRANS: El bloque mover bloque mueve un bloque.
+#. TRANS: El bloque mover bloque mueve un bloque.
 msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
-#.TRANS: mover bloque
+#. TRANS: Move the position of a block on the screen.
+#. TRANS: mover bloque
 msgid "move block"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:881
 #: js/blocks/ProgramBlocks.js:1048
-#.TRANS: número de bloque
+#. TRANS: número de bloque
 msgid "block number"
 msgstr ""
 
@@ -4798,7 +4798,7 @@ msgstr ""
 #: js/blocks/GraphicsBlocks.js:478
 #: js/blocks/GraphicsBlocks.js:525
 #: js/blocks/GraphicsBlocks.js:741
-#.TRANS: x
+#. TRANS: x
 msgid "x"
 msgstr "x"
 
@@ -4811,45 +4811,45 @@ msgstr "x"
 #: js/blocks/GraphicsBlocks.js:478
 #: js/blocks/GraphicsBlocks.js:525
 #: js/blocks/GraphicsBlocks.js:741
-#.TRANS: y
+#. TRANS: y
 msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
-#.TRANS: ejecutar bloque
+#. TRANS: Run program beginning at this block.
+#. TRANS: ejecutar bloque
 msgid "run block"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1025
-#.TRANS: El bloque connectar conecta dos bloques
+#. TRANS: El bloque connectar conecta dos bloques
 msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
-#.TRANS: connectar block
+#. TRANS: We can connect a block to another block.
+#. TRANS: connectar block
 msgid "connect blocks"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1048
-#.TRANS: bloque de destino
+#. TRANS: bloque de destino
 msgid "target block"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1048
-#.TRANS: número de conexion
+#. TRANS: número de conexion
 msgid "connection number"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1140
-#.TRANS: El bloque crear bloque crea un bloque.
+#. TRANS: El bloque crear bloque crea un bloque.
 msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
-#.TRANS: crear bloque
+#. TRANS: Create a new block
+#. TRANS: crear bloque
 msgid "make block"
 msgstr ""
 
@@ -4864,152 +4864,152 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
-#.TRANS: nota
+#. TRANS: a musical note consisting of pitch and duration
+#. TRANS: nota
 msgid "note"
 msgstr "ohesaho"
 
 #: js/blocks/ProgramBlocks.js:1285
-#.TRANS: No se puede encontrar el bloque.
+#. TRANS: No se puede encontrar el bloque.
 msgid "Cannot find block"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1304
 #: js/blocks/ProgramBlocks.js:1313
-#.TRANS: Advertencia: el tipo de argumento de bloque no coincide
+#. TRANS: Advertencia: el tipo de argumento de bloque no coincide
 msgid "Warning: block argument type mismatch"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1347
-#.TRANS: El bloque Abrir proyecto se utiliza para abrir un proyecto desde una página web.
+#. TRANS: El bloque Abrir proyecto se utiliza para abrir un proyecto desde una página web.
 msgid "The Open project block is used to open a project from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1357
-#.TRANS: abierto proyecto
+#. TRANS: abierto proyecto
 msgid "open project"
 msgstr "eipe’a jejaposéva"
 
 #: js/blocks/ProgramBlocks.js:1410
-#.TRANS: Por favor introduzca un URL válido.
+#. TRANS: Por favor introduzca un URL válido.
 msgid "Please enter a valid URL."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:182
 #: js/blocks/RhythmBlocks.js:1086
 #: js/blocks/RhythmBlocks.js:1162
-#.TRANS: Valor de la nota debe ser mayor que 0.
+#. TRANS: Valor de la nota debe ser mayor que 0.
 msgid "Note value must be greater than 0."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
-#.TRANS: swing
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing
 msgid "swing"
 msgstr "swing"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
-#.TRANS: valor de swing
+#. TRANS: the amount to shift to the offbeat note
+#. TRANS: valor de swing
 msgid "swing value"
 msgstr "swing tepy"
 
 #: js/blocks/RhythmBlocks.js:419
-#.TRANS: El bloque Omitir notas hará que las notas se omitan.
+#. TRANS: El bloque Omitir notas hará que las notas se omitan.
 msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
-#.TRANS: saltar notas
+#. TRANS: substitute rests on notes being skipped
+#. TRANS: saltar notas
 msgid "skip notes"
 msgstr "epo notas ári"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
-#.TRANS: ritmo multiplican
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: ritmo multiplican
 msgid "multiply note value"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:542
-#.TRANS: El bloque Atar funciona en pares de notas, combinándolas en una sola nota.
+#. TRANS: El bloque Atar funciona en pares de notas, combinándolas en una sola nota.
 msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
-#.TRANS: atar
+#. TRANS: tie notes together into one longer note
+#. TRANS: atar
 msgid "tie"
 msgstr "tie"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
-#.TRANS: punto
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: punto
 msgid "dot"
 msgstr "kyta"
 
 #: js/blocks/RhythmBlocks.js:619
 #: js/turtleactions/RhythmActions.js:221
-#.TRANS: Un argumento de -1 da como resultado un valor de nota de 0.
+#. TRANS: Un argumento de -1 da como resultado un valor de nota de 0.
 msgid "An argument of -1 results in a note value of 0."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:661
-#.TRANS: El bloque Punto extiende la duración de una nota en un 50%.
+#. TRANS: El bloque Punto extiende la duración de una nota en un 50%.
 msgid "The Dot block extends the duration of a note by 50%."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:663
-#.TRANS: Por ejemplo, una nota de un cuarto de puntos se reproducirá a 3/8 (1/4 + 1/8) de un tiempo.
+#. TRANS: Por ejemplo, una nota de un cuarto de puntos se reproducirá a 3/8 (1/4 + 1/8) de un tiempo.
 msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
-#.TRANS: Valor de nota tambor
+#. TRANS: Japanese only: note value block for drum
+#. TRANS: Valor de nota tambor
 msgid "note value drum"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:829
-#.TRANS: 392 hertz
+#. TRANS: 392 hertz
 msgid "392 hertz"
 msgstr "392 hertz"
 
 #: js/blocks/RhythmBlocks.js:1119
-#.TRANS: El bloque Nota es un contenedor para uno o más bloques de tono.
+#. TRANS: El bloque Nota es un contenedor para uno o más bloques de tono.
 msgid "The Note block is a container for one or more Pitch blocks."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:1121
-#.TRANS: El bloque Notas especifica la duración (valor de la nota) de su contenido.
+#. TRANS: El bloque Notas especifica la duración (valor de la nota) de su contenido.
 msgid "The Note block specifies the duration (note value) of its contents."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:1130
-#.TRANS: valor
+#. TRANS: valor
 msgid "value2"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:1200
-#.TRANS: definir frecuencia
+#. TRANS: definir frecuencia
 msgid "define frequency"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:1218
 #: js/widgets/temperament.js:757
 #: js/widgets/temperament.js:1522
-#.TRANS: espacio de octava
+#. TRANS: espacio de octava
 msgid "octave space"
 msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
-#.TRANS: ritmo
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
+#. TRANS: ritmo
 msgid "rhythm1"
 msgstr ""
 
@@ -5018,177 +5018,177 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:517
 #: js/blocks/RhythmBlockPaletteBlocks.js:586
 #: js/blocks/RhythmBlockPaletteBlocks.js:907
-#.TRANS: número de notas
+#. TRANS: número de notas
 msgid "number of notes"
 msgstr "notas papaha"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:126
-#.TRANS: ritmo polifónico
+#. TRANS: ritmo polifónico
 msgid "polyphonic rhythm"
 msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:219
-#.TRANS: El bloque Ritmo se utiliza para generar patrones de ritmo.
+#. TRANS: El bloque Ritmo se utiliza para generar patrones de ritmo.
 msgid "The Rhythm block is used to generate rhythm patterns."
 msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:281
 #: js/blocks/RhythmBlockPaletteBlocks.js:286
-#.TRANS: 1/64 nota
+#. TRANS: 1/64 nota
 msgid "1/64 note"
 msgstr "1/64 nota"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:312
 #: js/blocks/RhythmBlockPaletteBlocks.js:317
-#.TRANS: 1/32 nota
+#. TRANS: 1/32 nota
 msgid "1/32 note"
 msgstr "1/32 nota"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:346
 #: js/blocks/RhythmBlockPaletteBlocks.js:351
-#.TRANS: 1/16 nota
+#. TRANS: 1/16 nota
 msgid "1/16 note"
 msgstr "1/16 nota"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:380
-#.TRANS: 1/8 nota
+#. TRANS: 1/8 nota
 msgid "eighth note"
 msgstr "1/8 nota"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:408
-#.TRANS: 1/4 nota
+#. TRANS: 1/4 nota
 msgid "quarter note"
 msgstr "1/4 nota"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:436
 #: js/blocks/RhythmBlockPaletteBlocks.js:441
-#.TRANS: 1/2 nota
+#. TRANS: 1/2 nota
 msgid "half note"
 msgstr "1/2 nota"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:470
 #: js/blocks/RhythmBlockPaletteBlocks.js:475
-#.TRANS: nota completa
+#. TRANS: nota completa
 msgid "whole note"
 msgstr "nota oimbáva"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
-#.TRANS: tuplet
+#. TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: tuplet
 msgid "tuplet"
 msgstr "tuplet"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:800
-#.TRANS: septeto
+#. TRANS: septeto
 msgid "septuplet"
 msgstr " septuplet"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:828
-#.TRANS: quinteto
+#. TRANS: quinteto
 msgid "quintuplet"
 msgstr "quintuplet"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:856
-#.TRANS: trillizo
+#. TRANS: trillizo
 msgid "triplet"
 msgstr "triplet"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:883
-#.TRANS: tuplet simple
+#. TRANS: tuplet simple
 msgid "simple tuplet"
 msgstr "simple tuplet"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:893
-#.TRANS: Tuplets son una colección de notas que se escalan a una duración específica.
+#. TRANS: Tuplets son una colección de notas que se escalan a una duración específica.
 msgid "Tuplets are a collection of notes that get scaled to a specific duration."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:41
-#.TRANS: El bloque Atrás ejecuta el código en orden inverso (retrógrado en la música).
+#. TRANS: El bloque Atrás ejecuta el código en orden inverso (retrógrado en la música).
 msgid "The Backward block runs code in reverse order (Musical retrograde)."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:48
-#.TRANS: hacia atrás
+#. TRANS: hacia atrás
 msgid "backward"
 msgstr "tapykuéotyo"
 
 #: js/blocks/FlowBlocks.js:124
-#.TRANS: El bloque Duplicado ejecutará cada bloque varias veces.
+#. TRANS: El bloque Duplicado ejecutará cada bloque varias veces.
 msgid "The Duplicate block will run each block multiple times."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:334
-#.TRANS: El bloque predeterminado se usa dentro de un bloque de switch para definir la acción predeterminada.
+#. TRANS: El bloque predeterminado se usa dentro de un bloque de switch para definir la acción predeterminada.
 msgid "The Default block is used inside of a Switch to define the default action."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:342
-#.TRANS: el caso de forma predeterminada
+#. TRANS: el caso de forma predeterminada
 msgid "default"
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:361
 #: js/blocks/FlowBlocks.js:418
-#.TRANS: El bloque Caso debe utilizarse dentro de un bloque de switch.
+#. TRANS: El bloque Caso debe utilizarse dentro de un bloque de switch.
 msgid "The Case Block must be used inside of a Switch Block."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:389
-#.TRANS: El bloque Caso se utiliza dentro de un interruptor para definir coincidencias.
+#. TRANS: El bloque Caso se utiliza dentro de un interruptor para definir coincidencias.
 msgid "The Case block is used inside of a Switch to define matches."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:397
-#.TRANS: caso
+#. TRANS: caso
 msgid "case"
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:446
-#.TRANS: El bloque Switch ejecutará el código en el caso correspondiente.
+#. TRANS: El bloque Switch ejecutará el código en el caso correspondiente.
 msgid "The Switch block will run the code in the matching Case."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:454
-#.TRANS: switch
+#. TRANS: switch
 msgid "switch"
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:595
-#.TRANS: El bloque Parar detendrá un bucle.
+#. TRANS: El bloque Parar detendrá un bucle.
 msgid "The Stop block will stop a loop"
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:597
-#.TRANS: Por siempre, Repetir, Mientras o Hasta.
+#. TRANS: Por siempre, Repetir, Mientras o Hasta.
 msgid "Forever, Repeat, While, or Until."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:653
-#.TRANS: El bloque Esperar esperará hasta que la condición sea verdadera.
+#. TRANS: El bloque Esperar esperará hasta que la condición sea verdadera.
 msgid "The Waitfor block will wait until the condition is true."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:661
-#.TRANS: esperar hasta
+#. TRANS: esperar hasta
 msgid "wait for"
 msgstr "hã’arõ peẽ"
 
 #: js/blocks/FlowBlocks.js:732
-#.TRANS: El bloque Hasta se repetirá hasta que la condición sea verdadera.
+#. TRANS: El bloque Hasta se repetirá hasta que la condición sea verdadera.
 msgid "The Until block will repeat until the condition is true."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:740
-#.TRANS: hasta
+#. TRANS: hasta
 msgid "until"
 msgstr "peẽ"
 
 #: js/blocks/FlowBlocks.js:742
 #: js/blocks/FlowBlocks.js:822
-#.TRANS: hacer
+#. TRANS: hacer
 msgid "do2"
 msgstr ""
 
@@ -5199,96 +5199,96 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:610
 #: js/blocks/ActionBlocks.js:959
 #: js/blocks/ActionBlocks.js:1048
-#.TRANS: hacer
+#. TRANS: hacer
 msgid "do"
 msgstr "japo"
 
 #: js/blocks/FlowBlocks.js:812
-#.TRANS: El bloque Mientras se repetirá mientras la condición sea verdadera.
+#. TRANS: El bloque Mientras se repetirá mientras la condición sea verdadera.
 msgid "The While block will repeat while the condition is true."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:820
-#.TRANS: mientras
+#. TRANS: mientras
 msgid "while"
 msgstr "jave"
 
 #: js/blocks/FlowBlocks.js:903
 #: js/blocks/FlowBlocks.js:968
 #: js/blocks/FlowBlocks.js:979
-#.TRANS: En este ejemplo, si se presiona el botón del mouse, se reproducirá una caja.
+#. TRANS: En este ejemplo, si se presiona el botón del mouse, se reproducirá una caja.
 msgid "In this example if the mouse button is pressed a snare drum will play."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:925
 #: js/blocks/FlowBlocks.js:988
-#.TRANS: si
+#. TRANS: si
 msgid "if"
 msgstr "hẽe"
 
 #: js/blocks/FlowBlocks.js:927
 #: js/blocks/FlowBlocks.js:990
-#.TRANS: entonces
+#. TRANS: entonces
 msgid "then"
 msgstr "upéicharõ"
 
 #: js/blocks/FlowBlocks.js:927
-#.TRANS: sino
+#. TRANS: sino
 msgid "else"
 msgstr "osino"
 
 #: js/blocks/FlowBlocks.js:1025
-#.TRANS: El bloque Por siempre repetirá los bloques contenidos para siempre.
+#. TRANS: El bloque Por siempre repetirá los bloques contenidos para siempre.
 msgid "The Forever block will repeat the contained blocks forever."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:1037
-#.TRANS: por siempre
+#. TRANS: por siempre
 msgid "forever"
 msgstr "tapiã guarã"
 
 #: js/blocks/FlowBlocks.js:1073
-#.TRANS: El bloque Repetir repetirá los bloques contenidos.
+#. TRANS: El bloque Repetir repetirá los bloques contenidos.
 msgid "The Repeat block will repeat the contained blocks."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:1075
-#.TRANS: En este ejemplo la nota se tocará 4 veces.
+#. TRANS: En este ejemplo la nota se tocará 4 veces.
 msgid "In this example the note will be played 4 times."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:1083
-#.TRANS: repetir
+#. TRANS: repetir
 msgid "repeat"
 msgstr "jevy"
 
 #: js/blocks/FlowBlocks.js:1123
-#.TRANS: duplicar factor
+#. TRANS: duplicar factor
 msgid "duplicate factor"
 msgstr "momokoĩ ypy"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
-#.TRANS: meter actuale
+#. TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: meter actuale
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
-#.TRANS: factor de ritmo
+#. TRANS: number of beats per minute
+#. TRANS: factor de ritmo
 msgid "beat factor"
 msgstr "ypy de ritmo"
 
 #: js/blocks/MeterBlocks.js:161
-#.TRANS: El bloque de latidos por minuto devuelve los latidos actuales por minuto.
+#. TRANS: El bloque de latidos por minuto devuelve los latidos actuales por minuto.
 msgid "The Beats per minute block returns the current beats per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
-#.TRANS: pulsaciones por minuto
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: pulsaciones por minuto
 msgid "beats per minute2"
 msgstr ""
 
@@ -5296,25 +5296,25 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
-#.TRANS: pulsaciones por minuto
+#. TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: pulsaciones por minuto
 msgid "beats per minute"
 msgstr "mbopypyre aravo’igui"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
-#.TRANS: cuenta de medidas
+#. TRANS: count of current musical measure in meter
+#. TRANS: cuenta de medidas
 msgid "measure count"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:242
-#.TRANS: El bloque de conteo de medidas devuelve la medida actual.
+#. TRANS: El bloque de conteo de medidas devuelve la medida actual.
 msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
-#.TRANS: cuenta de latidos
+#. TRANS: count of current beat in the meter
+#. TRANS: cuenta de latidos
 msgid "beat count"
 msgstr ""
 
@@ -5322,85 +5322,85 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:312
 #: js/blocks/MeterBlocks.js:566
 #: js/blocks/MeterBlocks.js:577
-#.TRANS: El bloque Conteo de tiempos es el número del tiempo actual,
+#. TRANS: El bloque Conteo de tiempos es el número del tiempo actual,
 msgid "The Beat count block is the number of the current beat,"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:314
 #: js/blocks/MeterBlocks.js:579
-#.TRANS: por ejemplo, 1, 2, 3, o 4.
+#. TRANS: por ejemplo, 1, 2, 3, o 4.
 msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
-#.TRANS: cuenta las notas
+#. TRANS: count the number of notes
+#. TRANS: cuenta las notas
 msgid "sum note values"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:377
 #: js/blocks/MeterBlocks.js:441
-#.TRANS: El bloque Contador de notas se puede usar para contar el número de notas contenidas.
+#. TRANS: El bloque Contador de notas se puede usar para contar el número de notas contenidas.
 msgid "The Note counter block can be used to count the number of contained notes."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
-#.TRANS: cuenta las notas
+#. TRANS: count the number of notes
+#. TRANS: cuenta las notas
 msgid "note counter"
 msgstr "nota papaha"
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
-#.TRANS: notas completa jugadas
+#. TRANS: number of whole notes that have been played
+#. TRANS: notas completa jugadas
 msgid "whole notes played"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:506
-#.TRANS: El bloque Nota completa reproducidas devuelve el número total de notas completas reproducidas.
+#. TRANS: El bloque Nota completa reproducidas devuelve el número total de notas completas reproducidas.
 msgid "The Whole notes played block returns the total number of whole notes played."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
-#.TRANS: notas jugadas
+#. TRANS: number of notes that have been played
+#. TRANS: notas jugadas
 msgid "notes played"
 msgstr "notas ñembosaráipyre"
 
 #: js/blocks/MeterBlocks.js:654
-#.TRANS: El bloque Sin reloj desacopla las notas del reloj maestro.
+#. TRANS: El bloque Sin reloj desacopla las notas del reloj maestro.
 msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
-#.TRANS: sin reloj
+#. TRANS: don't lock notes to master clock
+#. TRANS: sin reloj
 msgid "no clock"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:701
-#.TRANS: en latido débil hacer
+#. TRANS: en latido débil hacer
 msgid "on weak beat do"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:706
-#.TRANS: El bloque En-latido-débil-hacer te permite especificar acciones a realizar en latido débiles.
+#. TRANS: El bloque En-latido-débil-hacer te permite especificar acciones a realizar en latido débiles.
 msgid "The On-weak-beat block lets you specify actions to take on weak (off) beats."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:751
-#.TRANS: en latido fuerte hacer
+#. TRANS: en latido fuerte hacer
 msgid "on strong beat"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:759
-#.TRANS: El bloque En-latido-fuerte-hacer le permite especificar acciones a realizar en latido específicos.
+#. TRANS: El bloque En-latido-fuerte-hacer le permite especificar acciones a realizar en latido específicos.
 msgid "The On-strong-beat block lets you specify actions to take on specified beats."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:770
-#.TRANS: latidos
+#. TRANS: latidos
 msgid "beat"
 msgstr ""
 
@@ -5409,123 +5409,123 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:610
 #: js/blocks/ActionBlocks.js:959
 #: js/blocks/ActionBlocks.js:1048
-#.TRANS: do
+#. TRANS: do
 msgid "do1"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:814
-#.TRANS: en cado latodo hacer
+#. TRANS: en cado latodo hacer
 msgid "on every beat do"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:822
-#.TRANS: El bloque En-cado-latido-hacer le permite especificar acciones a realizar en cado latado.
+#. TRANS: El bloque En-cado-latido-hacer le permite especificar acciones a realizar en cado latado.
 msgid "The On-every-beat block lets you specify actions to take on every beat."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:875
-#.TRANS: en cada nota hacer
+#. TRANS: en cada nota hacer
 msgid "on every note do"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:883
-#.TRANS: El bloque En-cada-nota-hacer le permite especificar acciones a realizar en cada nota.
+#. TRANS: El bloque En-cada-nota-hacer le permite especificar acciones a realizar en cada nota.
 msgid "The On-every-note block lets you specify actions to take on every note."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
-#.TRANS: latidos por minuto de dominar
+#. TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: latidos por minuto de dominar
 msgid "master beats per minute"
 msgstr "latidos por minuto de dominar"
 
 #: js/blocks/MeterBlocks.js:953
 #: js/blocks/MeterBlocks.js:1079
 #: js/blocks/MeterBlocks.js:1136
-#.TRANS: lpm
+#. TRANS: lpm
 msgid "bpm"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:953
 #: js/blocks/MeterBlocks.js:1079
 #: js/blocks/MeterBlocks.js:1136
-#.TRANS: valor de latidos
+#. TRANS: valor de latidos
 msgid "beat value"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1025
 #: js/blocks/MeterBlocks.js:1168
 #: js/blocks/MeterBlocks.js:1242
-#.TRANS: Latidos por minuto debe ser > 30.
+#. TRANS: Latidos por minuto debe ser > 30.
 msgid "Beats per minute must be > 30."
 msgstr "Tytýi peteĩ aravo’ipe tuichave vaerã mbohapypagui"
 
 #: js/blocks/MeterBlocks.js:1028
 #: js/blocks/MeterBlocks.js:1171
 #: js/blocks/MeterBlocks.js:1245
-#.TRANS: Los latidos por minuto como máximo es de 1000.
+#. TRANS: Los latidos por minuto como máximo es de 1000.
 msgid "Maximum beats per minute is 1000."
 msgstr "Tytýi peteĩ aravo’ipe su pee"
 
 #: js/blocks/MeterBlocks.js:1069
-#.TRANS: El bloque Pulsaciones por minuto establece el número de 1/4 notas por minuto.
+#. TRANS: El bloque Pulsaciones por minuto establece el número de 1/4 notas por minuto.
 msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
-#.TRANS: 
+#. TRANS: anacrusis
+#. TRANS: 
 msgid "pickup"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1368
-#.TRANS: número de latidos
+#. TRANS: número de latidos
 msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
-#.TRANS: transposición
+#. TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: transposición
 msgid "transposition"
 msgstr "O’hasa hi’ari"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
-#.TRANS: escalar bajar
+#. TRANS: step down one note in current musical scale
+#. TRANS: escalar bajar
 msgid "scalar step down"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:172
-#.TRANS: El bloque Escalar bajar devuelve el número de semitonos a la nota anterior en la tecla y modo actuales.
+#. TRANS: El bloque Escalar bajar devuelve el número de semitonos a la nota anterior en la tecla y modo actuales.
 msgid "The Scalar step down block returns the number of semi-tones down to the previous note in the current key and mode."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
-#.TRANS: escalar aumentar
+#. TRANS: step up one note in current musical scale
+#. TRANS: escalar aumentar
 msgid "scalar step up"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:194
-#.TRANS: El bloque Escalar aumentar devuelve el número de semitonos hasta la siguiente nota en la tecla y modo actuales.
+#. TRANS: El bloque Escalar aumentar devuelve el número de semitonos hasta la siguiente nota en la tecla y modo actuales.
 msgid "The Scalar step up block returns the number of semi-tones up to the next note in the current key and mode."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
-#.TRANS: cambio en tono
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: cambio en tono
 msgid "change in pitch"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:216
-#.TRANS: El cambio en el bloque de tono es la diferencia (en medio pasos) entre el tono actual que se está reproduciendo y el tono anterior.
+#. TRANS: El cambio en el bloque de tono es la diferencia (en medio pasos) entre el tono actual que se está reproduciendo y el tono anterior.
 msgid "The Change in pitch block is the difference (in half steps) between the current pitch being played and the previous pitch played."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
-#.TRANS: cambio en tono escalar
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: cambio en tono escalar
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -5536,111 +5536,111 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
-#.TRANS: número de tono
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: número de tono
 msgid "pitch number"
 msgstr "pu papaha"
 
 #: js/blocks/PitchBlocks.js:256
-#.TRANS: El bloque Número de tono es el valor del tono de la nota que se está reproduciendo actualmente.
+#. TRANS: El bloque Número de tono es el valor del tono de la nota que se está reproduciendo actualmente.
 msgid "The Pitch number block is the value of the pitch of the note currently being played."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
-#.TRANS: tono en hertz
+#. TRANS: the current pitch expressed in Hertz
+#. TRANS: tono en hertz
 msgid "pitch in hertz"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:334
-#.TRANS: El bloque Tono en Hertz es el valor en hercios del tono de la nota que se está reproduciendo actualmente.
+#. TRANS: El bloque Tono en Hertz es el valor en hercios del tono de la nota que se está reproduciendo actualmente.
 msgid "The Pitch in Hertz block is the value in Hertz of the pitch of the note currently being played."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:367
 #: js/turtleactions/DictActions.js:87
-#.TRANS: tono actual
+#. TRANS: tono actual
 msgid "current pitch"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:373
-#.TRANS: El bloque de tono actual se utiliza con el bloque convertidor de tono. En el ejemplo anterior, el tono actual, sol 4, se muestra como 392 hercios.
+#. TRANS: El bloque de tono actual se utiliza con el bloque convertidor de tono. En el ejemplo anterior, el tono actual, sol 4, se muestra como 392 hercios.
 msgid "The Current Pitch block is used with the Pitch Converter block. In the example above, current pitch, sol 4, is displayed as 392 hertz."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:410
-#.TRANS: Este bloque convierte el valor de tono de la última nota tocada en diferentes formatos como hertz, nombre de letra, número de tono, etc.
+#. TRANS: Este bloque convierte el valor de tono de la última nota tocada en diferentes formatos como hertz, nombre de letra, número de tono, etc.
 msgid "This block converts the pitch value of the last note played into different formats such as hertz, letter name, pitch number, et al."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:434
-#.TRANS: alfabeto
+#. TRANS: alfabeto
 msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
-#.TRANS: clase de alfabeto
+#. TRANS: Translate as "alphabet class"
+#. TRANS: clase de alfabeto
 msgid "letter class"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:437
-#.TRANS: clase de solfege
+#. TRANS: clase de solfege
 msgid "solfege class"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:438
-#.TRANS: musical y
+#. TRANS: musical y
 msgid "staff y"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:439
-#.TRANS: sílaba solfege
+#. TRANS: sílaba solfege
 msgid "solfege syllable"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:440
-#.TRANS: clase de tono
+#. TRANS: clase de tono
 msgid "pitch class"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:441
-#.TRANS: clase de escala
+#. TRANS: clase de escala
 msgid "scalar class"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:443
-#.TRANS: nth grado
+#. TRANS: nth grado
 msgid "nth degree"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:444
-#.TRANS: tono a la sombra
+#. TRANS: tono a la sombra
 msgid "pitch to shade"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:445
-#.TRANS: tono a color
+#. TRANS: tono a color
 msgid "pitch to color"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
-#.TRANS: MIDI
+#. TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
-#.TRANS: fijar offset del número de tono
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: fijar offset del número de tono
 msgid "set pitch number offset"
 msgstr "Moĩ offset pu papaha"
 
 #: js/blocks/PitchBlocks.js:645
-#.TRANS: El bloque Fijar del número de tono establecido se usa para establecer el desplazamiento para asignar números de tono a tono y octava.
+#. TRANS: El bloque Fijar del número de tono establecido se usa para establecer el desplazamiento para asignar números de tono a tono y octava.
 msgid "The Set pitch number offset block is used to set the offset for mapping pitch numbers to pitch and octave."
 msgstr ""
 
@@ -5648,213 +5648,213 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
-#.TRANS: nombre
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: nombre
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
-#.TRANS: número a tono
+#. TRANS: convert piano key number (1-88) to pitch
+#. TRANS: número a tono
 msgid "number to pitch"
 msgstr "Pu papaha"
 
 #: js/blocks/PitchBlocks.js:682
-#.TRANS: El bloque Número a tono convertirá un número de tono en un nombre pich.
+#. TRANS: El bloque Número a tono convertirá un número de tono en un nombre pich.
 msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
-#.TRANS: número a octava
+#. TRANS: convert piano key number (1-88) to octave
+#. TRANS: número a octava
 msgid "number to octave"
 msgstr "Octava papaha"
 
 #: js/blocks/PitchBlocks.js:717
-#.TRANS: El bloque Número a octava convertirá un número de tono en una octava.
+#. TRANS: El bloque Número a octava convertirá un número de tono en una octava.
 msgid "The Number to octave block will convert a pitch number to an octave."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:726
-#.TRANS: y para tono
+#. TRANS: y para tono
 msgid "y to pitch"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:729
-#.TRANS: El bloque Y a tono convertirá una posición de pentagrama y a la notación de tono correspondiente.
+#. TRANS: El bloque Y a tono convertirá una posición de pentagrama y a la notación de tono correspondiente.
 msgid "Y to pitch block will convert a staff y position to corresponding pitch notation."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:841
-#.TRANS: selector accidental
+#. TRANS: selector accidental
 msgid "accidental selector"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:844
-#.TRANS: El bloque Selector de accidental se usa para elegir entre doble filo, agudo, natural, plano y doble plano.
+#. TRANS: El bloque Selector de accidental se usa para elegir entre doble filo, agudo, natural, plano y doble plano.
 msgid "The Accidental selector block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:858
-#.TRANS: El tono puede especificarse en términos de ni dha pa ma ga re sa.
+#. TRANS: El tono puede especificarse en términos de ni dha pa ma ga re sa.
 msgid "Pitch can be specified in terms of ni dha pa ma ga re sa."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:872
-#.TRANS: El tono puede especificarse en términos de C D E F G A B.
+#. TRANS: El tono puede especificarse en términos de C D E F G A B.
 msgid "Pitch can be specified in terms of C D E F G A B."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:884
-#.TRANS: 
+#. TRANS: 
 msgid "solfege"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:887
-#.TRANS: El tono puede especificarse en términos de do re mi fa sol la si.
+#. TRANS: El tono puede especificarse en términos de do re mi fa sol la si.
 msgid "Pitch can be specified in terms of do re mi fa sol la ti."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:922
-#.TRANS: El bloque Invertir gira cualquier nota contenida alrededor de una nota de destino.
+#. TRANS: El bloque Invertir gira cualquier nota contenida alrededor de una nota de destino.
 msgid "The Invert block rotates any contained notes around a target note."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
-#.TRANS: Invertir
+#. TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: Invertir
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
-#.TRANS: invertir (impar)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: invertir (impar)
 msgid "invert (odd)"
 msgstr "Embojere (joja’ỹva)"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
-#.TRANS: invertir (par)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: invertir (par)
 msgid "invert (even)"
 msgstr "Embojere (jojava)"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
-#.TRANS: registro
+#. TRANS: register is the octave of the current pitch
+#. TRANS: registro
 msgid "register"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1026
-#.TRANS: El bloque Registro proporciona una manera fácil de modificar el registro (octava) de las notas que lo siguen.
+#. TRANS: El bloque Registro proporciona una manera fácil de modificar el registro (octava) de las notas que lo siguen.
 msgid "The Register block provides an easy way to modify the register (octave) of the notes that follow it."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
-#.TRANS: 50 centavos
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: 50 centavos
 msgid "50 cents"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1102
-#.TRANS: El bloque de transposición de semitono desplazará los pasos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) medio pasos.
+#. TRANS: El bloque de transposición de semitono desplazará los pasos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) medio pasos.
 msgid "The Semi-tone transposition block will shift the pitches contained inside Note blocks up (or down) by half steps."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1104
-#.TRANS: En el ejemplo que se muestra arriba, sol se desplaza hasta sol#.
+#. TRANS: En el ejemplo que se muestra arriba, sol se desplaza hasta sol#.
 msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
-#.TRANS: transposición semitono
+#. TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: transposición semitono
 msgid "semi-tone transpose"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1143
-#.TRANS: El bloque transponer por razón cambiará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) en una proporción
+#. TRANS: El bloque transponer por razón cambiará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) en una proporción
 msgid "The Transpose by Ratio block will shift the pitches contained inside Note blocks up (or down) by a ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
-#.TRANS: transponer por razón
+#. TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: transponer por razón
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
-#.TRANS: sexto abajo
+#. TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: sexto abajo
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
-#.TRANS: tercero abajo
+#. TRANS: down third means the note is two scale degrees below current note
+#. TRANS: tercero abajo
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
-#.TRANS: séptimo
+#. TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: séptimo
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
-#.TRANS: sexto
+#. TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sexto
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
-#.TRANS: quinto
+#. TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: quinto
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
-#.TRANS: cuarto
+#. TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: cuarto
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
-#.TRANS: tercio
+#. TRANS: third means the note is two scale degrees above current note
+#. TRANS: tercio
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
-#.TRANS: segundo
+#. TRANS: second means the note is one scale degree above current note
+#. TRANS: segundo
 msgid "second"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1407
-#.TRANS: El bloque Transposición escalar desplazará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) de la escala.
+#. TRANS: El bloque Transposición escalar desplazará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) de la escala.
 msgid "The Scalar transposition block will shift the pitches contained inside Note blocks up (or down) the scale."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1409
-#.TRANS: En el ejemplo que se muestra arriba, el sol se desplaza hacia arriba a la.
+#. TRANS: En el ejemplo que se muestra arriba, el sol se desplaza hacia arriba a la.
 msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
-#.TRANS: transposición escalar
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: transposición escalar
 msgid "scalar transpose"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1451
-#.TRANS: El bloque Accidental se utiliza para crear objetos punzantes y pisos.
+#. TRANS: El bloque Accidental se utiliza para crear objetos punzantes y pisos.
 msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
-#.TRANS: anular accidental
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: anular accidental
 msgid "accidental override"
 msgstr ""
 
@@ -5862,83 +5862,83 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
-#.TRANS: hertz
+#. TRANS: a measure of frequency: one cycle per second
+#. TRANS: hertz
 msgid "hertz"
 msgstr "hertz"
 
 #: js/blocks/PitchBlocks.js:1581
-#.TRANS: El bloque Hertz (en combinación con un bloque numérico) reproducirá un sonido a la frecuencia especificada.
+#. TRANS: El bloque Hertz (en combinación con un bloque numérico) reproducirá un sonido a la frecuencia especificada.
 msgid "The Hertz block (in combination with a Number block) will play a sound at the specified frequency."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1671
-#.TRANS: El bloque de número de tono reproducirá un tono asociado por su número, p. 0 para C y 7 para G.
+#. TRANS: El bloque de número de tono reproducirá un tono asociado por su número, p. 0 para C y 7 para G.
 msgid "The Pitch Number block will play a pitch associated by its number, e.g. 0 for C and 7 for G."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: nth tono modal
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: nth tono modal
 msgid "nth modal pitch"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
-#.TRANS: Nth Modal Pitch toma el patrón de tonos en semitonos para un modo y hace que cada punto sea un grado del modo,
+#. TRANS: Nth Modal Pitch toma el patrón de tonos en semitonos para un modo y hace que cada punto sea un grado del modo,
 msgid "nth Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1708
-#.TRANS: comenzando desde 1 e independientemente del marco tonal (es decir, no siempre 8 notas en la octava)
+#. TRANS: comenzando desde 1 e independientemente del marco tonal (es decir, no siempre 8 notas en la octava)
 msgid "starting from 1 and regardless of tonal framework (i.e. not always 8 notes in the octave)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
-#.TRANS: Nth modal tono un número como entrada como el nth grado para el modo dado. 0 es la primera posición, 1 es la segunda, -1 es la nota anterior a la primera, etc.
+#. TRANS: Nth modal tono un número como entrada como el nth grado para el modo dado. 0 es la primera posición, 1 es la segunda, -1 es la nota anterior a la primera, etc.
 msgid "Nth Modal Pitch takes a number as an input as the nth degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1751
-#.TRANS: Los tonos cambian según el modo especificado sin necesidad de grafías.
+#. TRANS: Los tonos cambian según el modo especificado sin necesidad de grafías.
 msgid "The pitches change according to the mode specified without any need for respellings."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1790
-#.TRANS: El grado de escala es una convención común en la música. El grado de ecala ofrece siete posiciones posibles en la escala (1-7) y puede modificarse mediante alteraciones.
+#. TRANS: El grado de escala es una convención común en la música. El grado de ecala ofrece siete posiciones posibles en la escala (1-7) y puede modificarse mediante alteraciones.
 msgid "Scale Degree is a common convention in music. Scale Degree offers seven possible positions in the scale (1-7) and can be modified via accidentals."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1792
-#.TRANS: El grado de la escala de 1 es siempre el primer tono de una escala determinada, independientemente de la octava.
+#. TRANS: El grado de la escala de 1 es siempre el primer tono de una escala determinada, independientemente de la octava.
 msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of octave."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
-#.TRANS: paso escalar
+#. TRANS: step some number of notes in current musical scale
+#. TRANS: paso escalar
 msgid "scalar step"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1819
-#.TRANS: El bloque Paso escalar (en combinación con un bloque numérico) reproducirá el siguiente tono en una escala,
+#. TRANS: El bloque Paso escalar (en combinación con un bloque numérico) reproducirá el siguiente tono en una escala,
 msgid "The Scalar Step block (in combination with a Number block) will play the next pitch in a scale,"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1821
-#.TRANS: por ejemplo, si la última nota tocada fue sol, el paso escalar 1 tocará la.
+#. TRANS: por ejemplo, si la última nota tocada fue sol, el paso escalar 1 tocará la.
 msgid "eg if the last note played was sol, Scalar Step 1 will play la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1857
-#.TRANS: The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note.
+#. TRANS: The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note.
 msgid "The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 #: js/widgets/timbre.js:783
-#.TRANS: Oscilador
+#. TRANS: Oscilador
 msgid "Oscillator"
 msgstr ""
 
@@ -5946,131 +5946,131 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
-#.TRANS: typo
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: typo
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
-#.TRANS: parciales
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: parciales
 msgid "partials"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:76
-#.TRANS: Está agregando varios bloques de oscilador.
+#. TRANS: Está agregando varios bloques de oscilador.
 msgid "You are adding multiple oscillator blocks."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
-#.TRANS: duo sintetizador
+#. TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: duo sintetizador
 msgid "duo synth"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:149
-#.TRANS: El bloque Sintetizador Duo es un modulador de frecuencia doble usado para definir un timbre.
+#. TRANS: El bloque Sintetizador Duo es un modulador de frecuencia doble usado para definir un timbre.
 msgid "The Duo synth block is a duo-frequency modulator used to define a timbre."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:157
 #: js/widgets/timbre.js:1468
-#.TRANS: velocidad del vibrato
+#. TRANS: velocidad del vibrato
 msgid "vibrato rate"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:157
-#.TRANS: intensidad de vibrato
+#. TRANS: intensidad de vibrato
 msgid "vibrato intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
-#.TRANS: AM sintetizador
+#. TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM sintetizador
 msgid "AM synth"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:189
-#.TRANS: El bloque Sintetizador AM es un modulador de amplitud usado para definir un timbre.
+#. TRANS: El bloque Sintetizador AM es un modulador de amplitud usado para definir un timbre.
 msgid "The AM synth block is an amplitude modulator used to define a timbre."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
-#.TRANS: FM sintetizador
+#. TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM sintetizador
 msgid "FM synth"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:228
-#.TRANS: El bloque Sintetizador de FM es un modulador de frecuencia utilizado para definir un timbre.
+#. TRANS: El bloque Sintetizador de FM es un modulador de frecuencia utilizado para definir un timbre.
 msgid "The FM synth block is a frequency modulator used to define a timbre."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:262
-#.TRANS: parcial
+#. TRANS: parcial
 msgid "partial"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:265
-#.TRANS: El bloque Parcial se utiliza para especificar un peso para un armónico parcial específico.
+#. TRANS: El bloque Parcial se utiliza para especificar un peso para un armónico parcial específico.
 msgid "The Partial block is used to specify a weight for a specific partial harmonic."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
-#.TRANS: El peso parcial debe estar entre 0 y 1.
+#. TRANS: partials are weighted components in a harmonic series
+#. TRANS: El peso parcial debe estar entre 0 y 1.
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
-#.TRANS: El bloque Parcial debe usarse dentro de un bloque de parciales ponderados.
+#. TRANS: partials are weighted components in a harmonic series
+#. TRANS: El bloque Parcial debe usarse dentro de un bloque de parciales ponderados.
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
-#.TRANS: parcial ponderada
+#. TRANS: partials are weighted components in a harmonic series
+#. TRANS: parcial ponderada
 msgid "weighted partials"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:383
-#.TRANS: El bloque Armónicos agregará armónicos a las notas contenidas.
+#. TRANS: El bloque Armónicos agregará armónicos a las notas contenidas.
 msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
-#.TRANS: armónico
+#. TRANS: A harmonic is an overtone.
+#. TRANS: armónico
 msgid "harmonic"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:431
-#.TRANS: El bloque Distorsión agrega distorsión al tono.
+#. TRANS: El bloque Distorsión agrega distorsión al tono.
 msgid "The Distortion block adds distortion to the pitch."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
-#.TRANS: distorsión
+#. TRANS: distortion is an alteration in the sound
+#. TRANS: distorsión
 msgid "distortion"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:487
-#.TRANS: El bloque Tremolo añade un efecto de vacilación.
+#. TRANS: El bloque Tremolo añade un efecto de vacilación.
 msgid "The Tremolo block adds a wavering effect."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
-#.TRANS: tremolo
+#. TRANS: a wavering effect in a musical tone
+#. TRANS: tremolo
 msgid "tremolo"
 msgstr ""
 
@@ -6082,8 +6082,8 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
-#.TRANS: velocidad
+#. TRANS: rate at which tremolo wavers
+#. TRANS: velocidad
 msgid "rate"
 msgstr "pya’ekue"
 
@@ -6091,135 +6091,135 @@ msgstr "pya’ekue"
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
-#.TRANS: intensidad
+#. TRANS: amplitude of tremolo waver
+#. TRANS: intensidad
 msgid "depth"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:559
-#.TRANS: El bloque Phaser añade un sonido de barrido.
+#. TRANS: El bloque Phaser añade un sonido de barrido.
 msgid "The Phaser block adds a sweeping sound."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
-#.TRANS: phaser
+#. TRANS: alter the phase of the sound
+#. TRANS: phaser
 msgid "phaser"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:569
 #: js/turtleactions/IntervalsActions.js:114
 #: js/widgets/timbre.js:2410
-#.TRANS: octavas
+#. TRANS: octavas
 msgid "octaves"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:569
 #: js/widgets/timbre.js:2413
-#.TRANS: frecuencia de base
+#. TRANS: frecuencia de base
 msgid "base frequency"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:619
-#.TRANS: El bloque Chorus añade un efecto chorus.
+#. TRANS: El bloque Chorus añade un efecto chorus.
 msgid "The Chorus block adds a chorus effect."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
-#.TRANS: coro
+#. TRANS: musical effect to simulate a choral sound
+#. TRANS: coro
 msgid "chorus"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2310
-#.TRANS: retraso (MS)
+#. TRANS: retraso (MS)
 msgid "delay (MS)"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:678
-#.TRANS: El bloque Vibrato agrega una variación rápida y leve en el tono.
+#. TRANS: El bloque Vibrato agrega una variación rápida y leve en el tono.
 msgid "The Vibrato block adds a rapid, slight variation in pitch."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
-#.TRANS: vibrato
+#. TRANS: a rapid, slight variation in pitch
+#. TRANS: vibrato
 msgid "vibrato"
 msgstr "vibrato"
 
 #: js/blocks/ToneBlocks.js:689
 #: js/widgets/timbre.js:2209
-#.TRANS: intensidad
+#. TRANS: intensidad
 msgid "intensity"
 msgstr "intensidad"
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
-#.TRANS: fijar synth
+#. TRANS: select synthesizer
+#. TRANS: fijar synth
 msgid "set synth"
 msgstr "emoĩ synth"
 
 #: js/blocks/ToneBlocks.js:804
-#.TRANS: nombre del sintetizador
+#. TRANS: nombre del sintetizador
 msgid "synth name"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:842
-#.TRANS: fijar instrumento predeterminado
+#. TRANS: fijar instrumento predeterminado
 msgid "set default instrument"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
-#.TRANS: fijar instrumento
+#. TRANS: set the characteristics of a custom instrument
+#. TRANS: fijar instrumento
 msgid "set instrument"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:898
 #: js/blocks/ToneBlocks.js:926
 #: js/blocks/ToneBlocks.js:932
-#.TRANS: El bloque Fijar Instrumentos selecciona una voz para el sintetizador,
+#. TRANS: El bloque Fijar Instrumentos selecciona una voz para el sintetizador,
 msgid "The Set instrument block selects a voice for the synthesizer,"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:900
 #: js/blocks/ToneBlocks.js:934
-#.TRANS: Por ejemplo, guitarra, piano, violín o cello
+#. TRANS: Por ejemplo, guitarra, piano, violín o cello
 msgid "eg guitar piano violin or cello."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:1015
-#.TRANS: Importe un archivo de sonido para usarlo como instrumento y establezca su centro de tono.
+#. TRANS: Importe un archivo de sonido para usarlo como instrumento y establezca su centro de tono.
 msgid "Import a sound file to use as an instrument and set its pitch center."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:1110
-#.TRANS: Cargue un archivo de sonido para conectarlo con el bloque de muestra.
+#. TRANS: Cargue un archivo de sonido para conectarlo con el bloque de muestra.
 msgid "Upload a sound file to connect with the sample block."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:58
-#.TRANS: El bloque Volver (Return) devolverá un valor de una acción.
+#. TRANS: El bloque Volver (Return) devolverá un valor de una acción.
 msgid "The Return block will return a value from an action."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:75
-#.TRANS: retorno
+#. TRANS: retorno
 msgid "return"
 msgstr "oú jevy"
 
 #: js/blocks/ActionBlocks.js:128
-#.TRANS: El bloque Volver a URL devolverá un valor a una página web.
+#. TRANS: El bloque Volver a URL devolverá un valor a una página web.
 msgid "The Return to URL block will return a value to a webpage."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:145
-#.TRANS: retorno a URL
+#. TRANS: retorno a URL
 msgid "return to URL"
 msgstr "oú jevy URL pe"
 
@@ -6227,14 +6227,14 @@ msgstr "oú jevy URL pe"
 #: js/blocks/ActionBlocks.js:290
 #: js/blocks/ActionBlocks.js:501
 #: js/blocks/ActionBlocks.js:688
-#.TRANS: El bloque Calcular devuelve un valor calculado por una acción.
+#. TRANS: El bloque Calcular devuelve un valor calculado por una acción.
 msgid "The Calculate block returns a value calculated by an action."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:251
 #: js/blocks/ActionBlocks.js:517
 #: js/blocks/ActionBlocks.js:707
-#.TRANS: calcular
+#. TRANS: calcular
 msgid "calculate"
 msgstr "papa"
 
@@ -6242,100 +6242,100 @@ msgstr "papa"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
-#.TRANS: El bloque Hacer se utiliza para iniciar una acción.
+#. TRANS: do is the do something or take an action.
+#. TRANS: El bloque Hacer se utiliza para iniciar una acción.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:791
 #: js/blocks/ActionBlocks.js:865
-#.TRANS: El bloque Arg contiene el valor de un argumento pasado a una acción.
+#. TRANS: El bloque Arg contiene el valor de un argumento pasado a una acción.
 msgid "The Arg block contains the value of an argument passed to an action."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:806
 #: js/blocks/ActionBlocks.js:878
-#.TRANS: arg
+#. TRANS: arg
 msgid "arg"
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:836
 #: js/blocks/ActionBlocks.js:900
 #: js/blocks/ActionBlocks.js:908
-#.TRANS: argumento no válido
+#. TRANS: argumento no válido
 msgid "Invalid argument"
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:944
-#.TRANS: En el ejemplo, se usa con el bloque Uno para elegir una fase aleatoria.
+#. TRANS: En el ejemplo, se usa con el bloque Uno para elegir una fase aleatoria.
 msgid "In the example, it is used with the One of block to choose a random phase."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:1019
 #: js/blocks/ActionBlocks.js:1026
-#.TRANS: El bloque de escucha se usa para escuchar un evento como un clic del ratón.
+#. TRANS: El bloque de escucha se usa para escuchar un evento como un clic del ratón.
 msgid "The Listen block is used to listen for an event such as a mouse click."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:1028
-#.TRANS: Cuando ocurre el evento, se realiza una acción.
+#. TRANS: Cuando ocurre el evento, se realiza una acción.
 msgid "When the event happens, an action is taken."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:1045
-#.TRANS: cuando
+#. TRANS: cuando
 msgid "on"
 msgstr "araka’e"
 
 #: js/blocks/ActionBlocks.js:1048
 #: js/blocks/ActionBlocks.js:1049
 #: js/blocks/ActionBlocks.js:1153
-#.TRANS: señal
+#. TRANS: señal
 msgid "event"
 msgstr "señal"
 
 #: js/blocks/ActionBlocks.js:1133
-#.TRANS: El bloque Emitir se utiliza para desencadenar un evento.
+#. TRANS: El bloque Emitir se utiliza para desencadenar un evento.
 msgid "The Broadcast block is used to trigger an event."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:1151
-#.TRANS: emitir
+#. TRANS: emitir
 msgid "broadcast"
 msgstr "ome’ẽ"
 
 #: js/blocks/ActionBlocks.js:1208
-#.TRANS: Cada bloque de inicio es una voz separada.
+#. TRANS: Cada bloque de inicio es una voz separada.
 msgid "Each Start block is a separate voice."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:1304
-#.TRANS: A menudo se utiliza para almacenar una frase de música que se repite.
+#. TRANS: A menudo se utiliza para almacenar una frase de música que se repite.
 msgid "It is often used for storing a phrase of music that is repeated."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:1495
-#.TRANS: definir el temperamento
+#. TRANS: definir el temperamento
 msgid "define temperament"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:87
-#.TRANS: valor en la pila de ratón
+#. TRANS: valor en la pila de ratón
 msgid "mouse index heap"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:87
-#.TRANS: valor en la pila de tortuga
+#. TRANS: valor en la pila de tortuga
 msgid "turtle index heap"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:89
-#.TRANS: El bloque de valor en la pila de ratón devuelve un valor en el almacenamiento dinámico en una ubicación específica para un mouse específico.
+#. TRANS: El bloque de valor en la pila de ratón devuelve un valor en el almacenamiento dinámico en una ubicación específica para un mouse específico.
 msgid "The Mouse index heap block returns a value in the heap at a specified location for a specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:90
-#.TRANS: El bloque de valor en la pila de tortuga devuelve un valor en el almacenamiento dinámico en una ubicación específica para un mouse específico.
+#. TRANS: El bloque de valor en la pila de tortuga devuelve un valor en el almacenamiento dinámico en una ubicación específica para un mouse específico.
 msgid "The Turtle index heap block returns a value in the heap at a specified location for a specified turtle."
 msgstr ""
 
@@ -6356,39 +6356,39 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:957
 #: js/blocks/EnsembleBlocks.js:1222
 #: js/blocks/EnsembleBlocks.js:1296
-#.TRANS: 
+#. TRANS: 
 msgid "Yertle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:96
 #: js/blocks/EnsembleBlocks.js:1083
-#.TRANS: renombrar ratón
+#. TRANS: renombrar ratón
 msgid "mouse name"
 msgstr "embohéra anguja"
 
 #: js/blocks/EnsembleBlocks.js:96
 #: js/blocks/EnsembleBlocks.js:1092
-#.TRANS: renombrar tortuga
+#. TRANS: renombrar tortuga
 msgid "turtle name"
 msgstr "karumbe mbohéra"
 
 #: js/blocks/EnsembleBlocks.js:147
-#.TRANS: parar ratón
+#. TRANS: parar ratón
 msgid "stop mouse"
 msgstr "ejoko anguja"
 
 #: js/blocks/EnsembleBlocks.js:149
-#.TRANS: El bloque parar ratón parar el ratón especificado.
+#. TRANS: El bloque parar ratón parar el ratón especificado.
 msgid "The Stop mouse block stops the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:160
-#.TRANS: detener tortuga
+#. TRANS: detener tortuga
 msgid "stop turtle"
 msgstr "ejoko karumbe"
 
 #: js/blocks/EnsembleBlocks.js:162
-#.TRANS: El bloque parar tortuga parar el ratón especificado.
+#. TRANS: El bloque parar tortuga parar el ratón especificado.
 msgid "The Stop turtle block stops the specified turtle."
 msgstr ""
 
@@ -6401,7 +6401,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:872
 #: js/blocks/EnsembleBlocks.js:1193
 #: js/blocks/EnsembleBlocks.js:1256
-#.TRANS: No se puede encontrar ratón
+#. TRANS: No se puede encontrar ratón
 msgid "Cannot find mouse"
 msgstr ""
 
@@ -6414,470 +6414,470 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:874
 #: js/blocks/EnsembleBlocks.js:1195
 #: js/blocks/EnsembleBlocks.js:1258
-#.TRANS: No se puede encontrar tortuga.
+#. TRANS: No se puede encontrar tortuga.
 msgid "Cannot find turtle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:208
-#.TRANS: comenzar ratón
+#. TRANS: comenzar ratón
 msgid "start mouse"
 msgstr "ñepyrũ anguja"
 
 #: js/blocks/EnsembleBlocks.js:211
-#.TRANS: El bloque comenzar ratón inicia el ratón especificado.
+#. TRANS: El bloque comenzar ratón inicia el ratón especificado.
 msgid "The Start mouse block starts the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:222
-#.TRANS: iniciar tortuga
+#. TRANS: iniciar tortuga
 msgid "start turtle"
 msgstr "ñepỹru karumbe"
 
 #: js/blocks/EnsembleBlocks.js:225
-#.TRANS: El bloque comenzar tortuga inicia el ratón especificado.
+#. TRANS: El bloque comenzar tortuga inicia el ratón especificado.
 msgid "The Start turtle block starts the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:258
-#.TRANS: Ratón ya ha comenzado.
+#. TRANS: Ratón ya ha comenzado.
 msgid "Mouse is already running."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:260
-#.TRANS: Tortuga ya ha comenzado.
+#. TRANS: Tortuga ya ha comenzado.
 msgid "Turtle is already running."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:284
-#.TRANS: No se puede encontrar el bloque de inicar.
+#. TRANS: No se puede encontrar el bloque de inicar.
 msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
-#.TRANS: color de ratón
+#. TRANS: pen color for this mouse
+#. TRANS: color de ratón
 msgid "mouse color"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:296
-#.TRANS: El bloque de color del ratón devuelve el color del lápiz del ratón especificado.
+#. TRANS: El bloque de color del ratón devuelve el color del lápiz del ratón especificado.
 msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
-#.TRANS: color de tortuga
+#. TRANS: pen color for this turtle
+#. TRANS: color de tortuga
 msgid "turtle color"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:310
-#.TRANS: El bloque de color de la tortuga devuelve el color del lápiz de la tortuga especificado.
+#. TRANS: El bloque de color de la tortuga devuelve el color del lápiz de la tortuga especificado.
 msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
-#.TRANS: rumbo de ratón
+#. TRANS: heading (compass direction) for this mouse
+#. TRANS: rumbo de ratón
 msgid "mouse heading"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:342
-#.TRANS: El bloque de rumbo del ratón devuelve el rumbo del lápiz del ratón especificado.
+#. TRANS: El bloque de rumbo del ratón devuelve el rumbo del lápiz del ratón especificado.
 msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
-#.TRANS: rumbo de tortuga
+#. TRANS: heading (compass direction) for this turtle
+#. TRANS: rumbo de tortuga
 msgid "turtle heading"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:356
-#.TRANS: El bloque de rumbo de la tortuga devuelve el rumbo del lápiz de la tortuga especificado.
+#. TRANS: El bloque de rumbo de la tortuga devuelve el rumbo del lápiz de la tortuga especificado.
 msgid "The Turtle heading block returns the heading of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
-#.TRANS: fijar ratón
+#. TRANS: set xy position for this mouse
+#. TRANS: fijar ratón
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
-#.TRANS: fijar tortuga
+#. TRANS: set xy position for this turtle
+#. TRANS: fijar tortuga
 msgid "set turtle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:435
-#.TRANS: El bloque de ratón establecer envía una pila de bloques para que los ejecute el ratón especificado.
+#. TRANS: El bloque de ratón establecer envía una pila de bloques para que los ejecute el ratón especificado.
 msgid "The Set mouse block sends a stack of blocks to be run by the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:448
-#.TRANS: El bloque de tortuga establecer envía una pila de bloques para que los ejecute el tortuga especificado.
+#. TRANS: El bloque de tortuga establecer envía una pila de bloques para que los ejecute el tortuga especificado.
 msgid "The Set turtle block sends a stack of blocks to be run by the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
-#.TRANS: ratón y
+#. TRANS: y position for this mouse
+#. TRANS: ratón y
 msgid "mouse y"
 msgstr "anguja y"
 
 #: js/blocks/EnsembleBlocks.js:484
-#.TRANS: El bloque del ratón Y devuelve la posición Y del ratón especificado.
+#. TRANS: El bloque del ratón Y devuelve la posición Y del ratón especificado.
 msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
-#.TRANS: tortuga y
+#. TRANS: y position for this turtle
+#. TRANS: tortuga y
 msgid "turtle y"
 msgstr "karumbe y"
 
 #: js/blocks/EnsembleBlocks.js:498
-#.TRANS: El bloque de la tortuga Y devuelve la posición Y de la tortuga especificado.
+#. TRANS: El bloque de la tortuga Y devuelve la posición Y de la tortuga especificado.
 msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
-#.TRANS: ratón x
+#. TRANS: x position for this mouse
+#. TRANS: ratón x
 msgid "mouse x"
 msgstr "anguja x"
 
 #: js/blocks/EnsembleBlocks.js:530
-#.TRANS: El bloque del ratón X devuelve la posición X del ratón especificado.
+#. TRANS: El bloque del ratón X devuelve la posición X del ratón especificado.
 msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
-#.TRANS: tortuga x
+#. TRANS: x position for this turtle
+#. TRANS: tortuga x
 msgid "turtle x"
 msgstr "karumbe x"
 
 #: js/blocks/EnsembleBlocks.js:544
-#.TRANS: El bloque de la tortuga X devuelve la posición X de la tortuga especificado.
+#. TRANS: El bloque de la tortuga X devuelve la posición X de la tortuga especificado.
 msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
-#.TRANS: notas jugadas de ratón
+#. TRANS: notes played by this mouse
+#. TRANS: notas jugadas de ratón
 msgid "mouse notes played"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:577
-#.TRANS: El bloque de notas jugadas del ratón devuelve el número de notas tocadas por el ratón especificado.
+#. TRANS: El bloque de notas jugadas del ratón devuelve el número de notas tocadas por el ratón especificado.
 msgid "The Mouse elapse notes block returns the number of notes played by the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
-#.TRANS: notas jugadas de tortuga
+#. TRANS: notes played by this turtle
+#. TRANS: notas jugadas de tortuga
 msgid "turtle notes played"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:591
-#.TRANS: El bloque de notas jugadas de la tortuga devuelve el número de notas tocadas por la tortuga especificado.
+#. TRANS: El bloque de notas jugadas de la tortuga devuelve el número de notas tocadas por la tortuga especificado.
 msgid "The Turtle elapse notes block returns the number of notes played by the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
-#.TRANS: número de tono de ratón
+#. TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: número de tono de ratón
 msgid "mouse pitch number"
 msgstr "Papaha anguja pu"
 
 #: js/blocks/EnsembleBlocks.js:631
-#.TRANS: El bloque de tono del ratón devuelve el número de tono actual que está reproduciendo el ratón especificado.
+#. TRANS: El bloque de tono del ratón devuelve el número de tono actual que está reproduciendo el ratón especificado.
 msgid "The Mouse pitch block returns the current pitch number being played by the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
-#.TRANS: número de tono de tortuga
+#. TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: número de tono de tortuga
 msgid "turtle pitch number"
 msgstr "karumbre jepoi papaha"
 
 #: js/blocks/EnsembleBlocks.js:645
-#.TRANS: El bloque de tono de la tortuga devuelve el número de tono actual que está reproduciendo la tortuga especificado.
+#. TRANS: El bloque de tono de la tortuga devuelve el número de tono actual que está reproduciendo la tortuga especificado.
 msgid "The Turtle pitch block returns the current pitch number being played by the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
-#.TRANS: valor de la nota del ratón
+#. TRANS: note value is the duration of the note played by this mouse
+#. TRANS: valor de la nota del ratón
 msgid "mouse note value"
 msgstr "anguja nota orekóva"
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
-#.TRANS: valor de la nota de la tortuga
+#. TRANS: note value is the duration of the note played by this turtle
+#. TRANS: valor de la nota de la tortuga
 msgid "turtle note value"
 msgstr "karumbe nota repy"
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
-#.TRANS: sincronizar
+#. TRANS: sync is short for synchronization
+#. TRANS: sincronizar
 msgid "mouse sync"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:834
-#.TRANS: El bloque sincronizar alinea el conteo de latidos entre ratones.
+#. TRANS: El bloque sincronizar alinea el conteo de latidos entre ratones.
 msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
-#.TRANS: sincronizar
+#. TRANS: sync is short for synchronization
+#. TRANS: sincronizar
 msgid "turtle sync"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:848
-#.TRANS: El bloque sincronizar alinea el conteo de latidos entre tortugas.
+#. TRANS: El bloque sincronizar alinea el conteo de latidos entre tortugas.
 msgid "The Turtle sync block aligns the beat count between turtles."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:889
-#.TRANS: El bloque de ratón encontrado devolverá verdadero si se puede encontrar el ratón especificado.
+#. TRANS: El bloque de ratón encontrado devolverá verdadero si se puede encontrar el ratón especificado.
 msgid "The Found mouse block will return true if the specified mouse can be found."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:895
-#.TRANS: encontré el raton
+#. TRANS: encontré el raton
 msgid "found mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:905
-#.TRANS: El bloque de tortuga encontrado devolverá verdadero si se puede encontrar el tortuga especificado.
+#. TRANS: El bloque de tortuga encontrado devolverá verdadero si se puede encontrar el tortuga especificado.
 msgid "The Found turtle block will return true if the specified turtle can be found."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:911
-#.TRANS: encontré la tortuga
+#. TRANS: encontré la tortuga
 msgid "found turtle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:934
-#.TRANS: nuevo ratón
+#. TRANS: nuevo ratón
 msgid "new mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:936
-#.TRANS: El bloque nuevo ratón crea un nuevo ratón.
+#. TRANS: El bloque nuevo ratón crea un nuevo ratón.
 msgid "The New mouse block will create a new mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:947
-#.TRANS: nuevo tortuga
+#. TRANS: nuevo tortuga
 msgid "new turtle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:949
-#.TRANS: El bloque nuevo ratón crea un nuevo tortuga.
+#. TRANS: El bloque nuevo ratón crea un nuevo tortuga.
 msgid "The New turtle block will create a new turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1013
-#.TRANS: fijar color del ratón
+#. TRANS: fijar color del ratón
 msgid "set mouse color"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1016
-#.TRANS: El bloque fijar color del ratón se usa para fijar el color de un ratón.
+#. TRANS: El bloque fijar color del ratón se usa para fijar el color de un ratón.
 msgid "The Set-mouse-color block is used to set the color of a mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1022
-#.TRANS: fijar color de la tortuga
+#. TRANS: fijar color de la tortuga
 msgid "set turtle color"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1025
-#.TRANS: El bloque fijar color de la tortuga se usa para fijar el color de una tortuga.
+#. TRANS: El bloque fijar color de la tortuga se usa para fijar el color de una tortuga.
 msgid "The Set-turtle-color block is used to set the color of a turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1086
-#.TRANS: El bloque Nombre del ratón devuelve el nombre de un ratón.
+#. TRANS: El bloque Nombre del ratón devuelve el nombre de un ratón.
 msgid "The Mouse-name block returns the name of a mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1095
-#.TRANS: El bloque Nombre de la tortuga devuelve el nombre de una tortuga.
+#. TRANS: El bloque Nombre de la tortuga devuelve el nombre de una tortuga.
 msgid "The Turtle-name block returns the name of a turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1118
-#.TRANS: recuento de ratones
+#. TRANS: recuento de ratones
 msgid "mouse count"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1121
-#.TRANS: El bloque recuento de ratones devuelve el número de ratones.
+#. TRANS: El bloque recuento de ratones devuelve el número de ratones.
 msgid "The Mouse-count block returns the number of mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1127
-#.TRANS: recuento de tortuga
+#. TRANS: recuento de tortuga
 msgid "turtle count"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1130
-#.TRANS: El bloque recuento de tortugas devuelve el número de tortugas.
+#. TRANS: El bloque recuento de tortugas devuelve el número de tortugas.
 msgid "The Turtle-count block returns the number of turtles."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1152
-#.TRANS: nombre de nth ratón
+#. TRANS: nombre de nth ratón
 msgid "nth mouse name"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1155
-#.TRANS: El bloque de nombre Nth-ratón devuelve el nombre del enésimo ratón.
+#. TRANS: El bloque de nombre Nth-ratón devuelve el nombre del enésimo ratón.
 msgid "The Nth-Mouse name block returns the name of the nth mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1161
-#.TRANS: nombre de nth tortuga
+#. TRANS: nombre de nth tortuga
 msgid "nth turtle name"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1164
-#.TRANS: El bloque de nombre Nth-tortuga devuelve el nombre del enésimo tortuga.
+#. TRANS: El bloque de nombre Nth-tortuga devuelve el nombre del enésimo tortuga.
 msgid "The Nth-Turtle name block returns the name of the nth turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1208
 #: js/blocks/EnsembleBlocks.js:1268
-#.TRANS: fijar nombre
+#. TRANS: fijar nombre
 msgid "set name"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1217
 #: js/blocks/EnsembleBlocks.js:1224
-#.TRANS: origen
+#. TRANS: origen
 msgid "source"
 msgstr "gua"
 
 #: js/blocks/EnsembleBlocks.js:1217
 #: js/blocks/EnsembleBlocks.js:1224
-#.TRANS: destino
+#. TRANS: destino
 msgid "target"
 msgstr "poravi"
 
 #: js/blocks/EnsembleBlocks.js:1274
-#.TRANS: El bloque Fijar nombre se usa para nombrar un ratón.
+#. TRANS: El bloque Fijar nombre se usa para nombrar un ratón.
 msgid "The Set-name block is used to name a mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1287
-#.TRANS: El bloque Fijar nombre se usa para nombrar una tortuga.
+#. TRANS: El bloque Fijar nombre se usa para nombrar una tortuga.
 msgid "The Set-name block is used to name a turtle."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:33
-#.TRANS: fracción
+#. TRANS: fracción
 msgid "fraction"
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:36
-#.TRANS: convertir un número racional en fracción
+#. TRANS: convertir un número racional en fracción
 msgid "Convert a float to a fraction"
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:93
-#.TRANS: guardar como ABC
+#. TRANS: guardar como ABC
 msgid "save as ABC"
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:96
 #: js/blocks/ExtrasBlocks.js:132
 #: js/blocks/ExtrasBlocks.js:168
-#.TRANS: título
+#. TRANS: título
 msgid "title"
 msgstr "téra"
 
 #: js/blocks/ExtrasBlocks.js:129
-#.TRANS: guardar como Lilypond
+#. TRANS: guardar como Lilypond
 msgid "save as Lilypond"
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:165
-#.TRANS: guardar como SVG
+#. TRANS: guardar como SVG
 msgid "save as SVG"
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:216
-#.TRANS: sin fondo
+#. TRANS: sin fondo
 msgid "no background"
 msgstr "hugua’ỹ"
 
 #: js/blocks/ExtrasBlocks.js:219
-#.TRANS: El bloque Sin fondo elimina el fondo de la salida SVG guardada.
+#. TRANS: El bloque Sin fondo elimina el fondo de la salida SVG guardada.
 msgid "The No background block eliminates the background from the saved SVG output."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:247
-#.TRANS: mostrar bloques
+#. TRANS: mostrar bloques
 msgid "show blocks"
 msgstr "oichuka vore"
 
 #: js/blocks/ExtrasBlocks.js:249
-#.TRANS: El bloque mostrar bloques muestra los bloques.
+#. TRANS: El bloque mostrar bloques muestra los bloques.
 msgid "The Show blocks block shows the blocks."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:276
-#.TRANS: El bloque ocultar esconde los bloques.
+#. TRANS: El bloque ocultar esconde los bloques.
 msgid "The Hide blocks block hides the blocks."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:305
 #: js/blocks/ExtrasBlocks.js:338
-#.TRANS: El bloque Espacio se utiliza para agregar espacio entre bloques.
+#. TRANS: El bloque Espacio se utiliza para agregar espacio entre bloques.
 msgid "The Space block is used to add space between blocks."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:376
-#.TRANS: esperar
+#. TRANS: esperar
 msgid "wait"
 msgstr "ha’ãro"
 
 #: js/blocks/ExtrasBlocks.js:379
-#.TRANS: El bloque Espera detiene el programa durante un número específico de segundos.
+#. TRANS: El bloque Espera detiene el programa durante un número específico de segundos.
 msgid "The Wait block pauses the program for a specified number of seconds."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:433
 #: plugins/facebook.rtp:30
-#.TRANS: comentar
+#. TRANS: comentar
 msgid "comment"
 msgstr "mombe’u"
 
 #: js/blocks/ExtrasBlocks.js:469
-#.TRANS: imprimir
+#. TRANS: imprimir
 msgid "print"
 msgstr "imprimir"
 
 #: js/blocks/ExtrasBlocks.js:476
-#.TRANS: El bloque Imprimir muestra texto en la parte superior de la pantalla.
+#. TRANS: El bloque Imprimir muestra texto en la parte superior de la pantalla.
 msgid "The Print block displays text at the top of the screen."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:585
-#.TRANS: mostrar cuadrícula
+#. TRANS: mostrar cuadrícula
 msgid "display grid"
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:590
-#.TRANS: Mostrar el bloque de cuadrícula cambia el tipo de cuadrícula
+#. TRANS: Mostrar el bloque de cuadrícula cambia el tipo de cuadrícula
 msgid "The Display Grid Block changes the grid type"
 msgstr ""
 
@@ -6889,7 +6889,7 @@ msgstr ""
 #: js/blocks/ExtrasBlocks.js:794
 #: js/blocks/ExtrasBlocks.js:813
 #: js/blocks/ExtrasBlocks.js:832
-#.TRANS: desconocido
+#. TRANS: desconocido
 msgid "unknown"
 msgstr "kuaa’ývã"
 
@@ -6897,77 +6897,77 @@ msgstr "kuaa’ývã"
 #: js/turtleactions/DictActions.js:77
 #: js/turtleactions/DictActions.js:144
 #: js/turtleactions/DictActions.js:173
-#.TRANS: rumbo
+#. TRANS: rumbo
 msgid "heading"
 msgstr "rumbo"
 
 #: js/blocks/GraphicsBlocks.js:56
-#.TRANS: El bloque rumbo devuelve la orientación del ratón.
+#. TRANS: El bloque rumbo devuelve la orientación del ratón.
 msgid "The Heading block returns the orientation of the mouse."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:62
-#.TRANS: El bloque rumbo devuelve la orientación de la tortuga.
+#. TRANS: El bloque rumbo devuelve la orientación de la tortuga.
 msgid "The Heading block returns the orientation of the turtle."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:133
-#.TRANS: El bloque Y devuelve la posición horizontal del ratón.
+#. TRANS: El bloque Y devuelve la posición horizontal del ratón.
 msgid "The Y block returns the vertical position of the mouse."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:140
-#.TRANS: El bloque Y devuelve la posición horizontal de la tortuga.
+#. TRANS: El bloque Y devuelve la posición horizontal de la tortuga.
 msgid "The Y block returns the vertical position of the turtle."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:149
-#.TRANS: y
+#. TRANS: y
 msgid "y3"
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:219
-#.TRANS: El bloque X devuelve la posición horizontal del ratón.
+#. TRANS: El bloque X devuelve la posición horizontal del ratón.
 msgid "The X block returns the horizontal position of the mouse."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:226
-#.TRANS: El bloque X devuelve la posición horizontal de la tortuga.
+#. TRANS: El bloque X devuelve la posición horizontal de la tortuga.
 msgid "The X block returns the horizontal position of the turtle."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:235
-#.TRANS: x
+#. TRANS: x
 msgid "x3"
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:295
-#.TRANS: desplazar xy
+#. TRANS: desplazar xy
 msgid "scroll xy"
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:303
-#.TRANS: El bloque Desplazar XY mueve el lienzo.
+#. TRANS: El bloque Desplazar XY mueve el lienzo.
 msgid "The Scroll XY block moves the canvas."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:313
-#.TRANS: x
+#. TRANS: x
 msgid "x2"
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:313
-#.TRANS: y
+#. TRANS: y
 msgid "y2"
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:417
-#.TRANS: El bloque Control-point 2 establece el segundo punto de control para la curva Bezier.
+#. TRANS: El bloque Control-point 2 establece el segundo punto de control para la curva Bezier.
 msgid "The Control-point 2 block sets the second control point for the Bezier curve."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:424
-#.TRANS: punto de control 2
+#. TRANS: punto de control 2
 msgid "control point 2"
 msgstr "kyta ñemañaha 2"
 
@@ -6975,7 +6975,7 @@ msgstr "kyta ñemañaha 2"
 #: js/blocks/GraphicsBlocks.js:478
 #: js/blocks/GraphicsBlocks.js:525
 #: js/blocks/GraphicsBlocks.js:741
-#.TRANS: x
+#. TRANS: x
 msgid "x1"
 msgstr ""
 
@@ -6983,47 +6983,47 @@ msgstr ""
 #: js/blocks/GraphicsBlocks.js:478
 #: js/blocks/GraphicsBlocks.js:525
 #: js/blocks/GraphicsBlocks.js:741
-#.TRANS: y
+#. TRANS: y
 msgid "y1"
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:468
-#.TRANS: El bloque Control-point 1 establece el segundo punto de control para la curva Bezier.
+#. TRANS: El bloque Control-point 1 establece el segundo punto de control para la curva Bezier.
 msgid "The Control-point 1 block sets the first control point for the Bezier curve."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:475
-#.TRANS: punto de control 1
+#. TRANS: punto de control 1
 msgid "control point 1"
 msgstr "kyta ñemañaha 1"
 
 #: js/blocks/GraphicsBlocks.js:518
-#.TRANS: El bloque bezier dibuja una curva bezier.
+#. TRANS: El bloque bezier dibuja una curva bezier.
 msgid "The Bezier block draws a Bezier curve."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:522
-#.TRANS: bezier
+#. TRANS: bezier
 msgid "bezier"
 msgstr "bezier"
 
 #: js/blocks/GraphicsBlocks.js:583
-#.TRANS: El bloque Arco mueve la tortuga en un arco.
+#. TRANS: El bloque Arco mueve la tortuga en un arco.
 msgid "The Arc block moves the turtle in an arc."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:591
-#.TRANS: arco
+#. TRANS: arco
 msgid "arc"
 msgstr "yvyrapã"
 
 #: js/blocks/GraphicsBlocks.js:594
-#.TRANS: ángulo
+#. TRANS: ángulo
 msgid "angle"
 msgstr "takamby"
 
 #: js/blocks/GraphicsBlocks.js:594
-#.TRANS: radio
+#. TRANS: radio
 msgid "radius"
 msgstr "radio (geometría)"
 
@@ -7031,7 +7031,7 @@ msgstr "radio (geometría)"
 #: js/blocks/GraphicsBlocks.js:758
 #: js/blocks/GraphicsBlocks.js:1001
 #: js/blocks/GraphicsBlocks.js:1084
-#.TRANS: El valor debe estar entre -5000 y 5000 cuando el modo Wrap está desactivado.
+#. TRANS: El valor debe estar entre -5000 y 5000 cuando el modo Wrap está desactivado.
 msgid "Value must be within -5000 to 5000 when Wrap Mode is off."
 msgstr ""
 
@@ -7039,47 +7039,47 @@ msgstr ""
 #: js/blocks/GraphicsBlocks.js:760
 #: js/blocks/GraphicsBlocks.js:1003
 #: js/blocks/GraphicsBlocks.js:1086
-#.TRANS: El valor debe estar entre -20000 y 20000 cuando el modo Wrap está activado.
+#. TRANS: El valor debe estar entre -20000 y 20000 cuando el modo Wrap está activado.
 msgid "Value must be within -20000 to 20000 when Wrap Mode is on."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:651
-#.TRANS: fijar rumbo
+#. TRANS: fijar rumbo
 msgid "set heading"
 msgstr "amoĩ rumbo"
 
 #: js/blocks/GraphicsBlocks.js:664
-#.TRANS: El bloque fijar rumbo establece el rumbo de la tortuga.
+#. TRANS: El bloque fijar rumbo establece el rumbo de la tortuga.
 msgid "The Set heading block sets the heading of the turtle."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:724
-#.TRANS: El bloque Fijar XY mueve el ratón a una posición específica en la pantalla.
+#. TRANS: El bloque Fijar XY mueve el ratón a una posición específica en la pantalla.
 msgid "The Set XY block moves the mouse to a specific position on the screen."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:730
-#.TRANS: El bloque Fijar XY mueve la tortuga a una posición específica en la pantalla.
+#. TRANS: El bloque Fijar XY mueve la tortuga a una posición específica en la pantalla.
 msgid "The Set XY block moves the turtle to a specific position on the screen."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:738
-#.TRANS: fijar xy
+#. TRANS: fijar xy
 msgid "set xy"
 msgstr "emoĩ xy"
 
 #: js/blocks/GraphicsBlocks.js:810
-#.TRANS: El bloque Derecha gira el ratón hacia la derecha.
+#. TRANS: El bloque Derecha gira el ratón hacia la derecha.
 msgid "The Right block turns the mouse to the right."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:817
-#.TRANS: El bloque Derecha gira la tortuga hacia la derecha.
+#. TRANS: El bloque Derecha gira la tortuga hacia la derecha.
 msgid "The Right block turns the turtle to the right."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:826
-#.TRANS: derecha
+#. TRANS: derecha
 msgid "right1"
 msgstr ""
 
@@ -7087,22 +7087,22 @@ msgstr ""
 #: plugins/rodi.rtp:77
 #: plugins/rodi.rtp:340
 #: plugins/rodi.rtp:375
-#.TRANS: derecha
+#. TRANS: derecha
 msgid "right"
 msgstr "akatúa"
 
 #: js/blocks/GraphicsBlocks.js:890
-#.TRANS: El bloque izquierdo gira el ratón hacia la izquierda.
+#. TRANS: El bloque izquierdo gira el ratón hacia la izquierda.
 msgid "The Left block turns the mouse to the left."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:897
-#.TRANS: El bloque izquierdo gira la tortuga hacia la izquierda.
+#. TRANS: El bloque izquierdo gira la tortuga hacia la izquierda.
 msgid "The Left block turns the turtle to the left."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:906
-#.TRANS: izquierda
+#. TRANS: izquierda
 msgid "left1"
 msgstr ""
 
@@ -7110,7 +7110,7 @@ msgstr ""
 #: plugins/rodi.rtp:79
 #: plugins/rodi.rtp:339
 #: plugins/rodi.rtp:362
-#.TRANS: izquierda
+#. TRANS: izquierda
 msgid "left"
 msgstr "asúpe"
 
@@ -7119,174 +7119,174 @@ msgstr "asúpe"
 #: js/widgets/temperament.js:1033
 #: plugins/rodi.rtp:69
 #: plugins/rodi.rtp:387
-#.TRANS: atrás
+#. TRANS: atrás
 msgid "back"
 msgstr "tapykuépe"
 
 #: js/blocks/GraphicsBlocks.js:967
-#.TRANS: El bloque Atrás mueve el ratón hacia atrás.
+#. TRANS: El bloque Atrás mueve el ratón hacia atrás.
 msgid "The Back block moves the mouse backward."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:974
-#.TRANS: El bloque Atrás mueve la tortuga hacia atrás.
+#. TRANS: El bloque Atrás mueve la tortuga hacia atrás.
 msgid "The Back block moves the turtle backward."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:1041
 #: plugins/rodi.rtp:71
 #: plugins/rodi.rtp:400
-#.TRANS: adelante
+#. TRANS: adelante
 msgid "forward"
 msgstr "tenondépe"
 
 #: js/blocks/GraphicsBlocks.js:1050
-#.TRANS: El bloque Adelante mueve el ratón hacia adelante.
+#. TRANS: El bloque Adelante mueve el ratón hacia adelante.
 msgid "The Forward block moves the mouse forward."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:1057
-#.TRANS: El bloque Adelante mueve la tortuga hacia adelante.
+#. TRANS: El bloque Adelante mueve la tortuga hacia adelante.
 msgid "The Forward block moves the turtle forward."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:1145
 #: js/blocks/GraphicsBlocks.js:1163
-#.TRANS: envolver
+#. TRANS: envolver
 msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
-#.TRANS: derecha
+#. TRANS: right side of the screen
+#. TRANS: derecha
 msgid "right (screen)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:45
 #: js/blocks/MediaBlocks.js:56
-#.TRANS: El bloque Derecha devuelve la posición de la derecha del lienzo.
+#. TRANS: El bloque Derecha devuelve la posición de la derecha del lienzo.
 msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
-#.TRANS: izquierdo
+#. TRANS: left side of the screen
+#. TRANS: izquierdo
 msgid "left (screen)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:107
 #: js/blocks/MediaBlocks.js:118
-#.TRANS: El bloque Izquierdo devuelve la posición de la izquierda del lienzo.
+#. TRANS: El bloque Izquierdo devuelve la posición de la izquierda del lienzo.
 msgid "The Left block returns the position of the left of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:158
-#.TRANS: superior
+#. TRANS: superior
 msgid "top (screen)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:168
 #: js/blocks/MediaBlocks.js:179
-#.TRANS: El bloque superior devuelve la posición de la parte superior del lienzo.
+#. TRANS: El bloque superior devuelve la posición de la parte superior del lienzo.
 msgid "The Top block returns the position of the top of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:219
-#.TRANS: inferior
+#. TRANS: inferior
 msgid "bottom (screen)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:229
 #: js/blocks/MediaBlocks.js:240
-#.TRANS: El bloque Inferior devuelve la posición de la parte inferior del lienzo.
+#. TRANS: El bloque Inferior devuelve la posición de la parte inferior del lienzo.
 msgid "The Bottom block returns the position of the bottom of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:282
-#.TRANS: anchura
+#. TRANS: anchura
 msgid "width"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:291
-#.TRANS: El bloque ancho devuelve el ancho del lienzo.
+#. TRANS: El bloque ancho devuelve el ancho del lienzo.
 msgid "The Width block returns the width of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:325
-#.TRANS: altura
+#. TRANS: altura
 msgid "height"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:334
-#.TRANS: El bloque altura devuelve la altura del lienzo.
+#. TRANS: El bloque altura devuelve la altura del lienzo.
 msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
-#.TRANS: detener
+#. TRANS: stops playback of an audio recording
+#. TRANS: detener
 msgid "stop play"
 msgstr "ejoko"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
-#.TRANS: borrar medios
+#. TRANS: Erases the images and text
+#. TRANS: borrar medios
 msgid "erase media"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:409
-#.TRANS: El bloque Erase Media borra texto e imágenes.
+#. TRANS: El bloque Erase Media borra texto e imágenes.
 msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
-#.TRANS: reproducir
+#. TRANS: play an audio recording
+#. TRANS: reproducir
 msgid "play back"
 msgstr "emboguata"
 
 #: js/blocks/MediaBlocks.js:487
-#.TRANS: hablar
+#. TRANS: hablar
 msgid "speak"
 msgstr "ñe’ẽ"
 
 #: js/blocks/MediaBlocks.js:495
-#.TRANS: El bloque Habla emite al sintetizador de texto a voz.
+#. TRANS: El bloque Habla emite al sintetizador de texto a voz.
 msgid "The Speak block outputs to the text-to-speech synthesizer"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:546
-#.TRANS: 
+#. TRANS: 
 msgid "camera"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:551
-#.TRANS: El bloque cámara conecta una cámara web al bloque mostrar.
+#. TRANS: El bloque cámara conecta una cámara web al bloque mostrar.
 msgid "The Camera block connects a webcam to the Show block."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:574
-#.TRANS: 
+#. TRANS: 
 msgid "video"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:579
-#.TRANS: El bloque video selecciona video para al bloque mostrar.
+#. TRANS: El bloque video selecciona video para al bloque mostrar.
 msgid "The Video block selects video for use with the Show block."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:607
-#.TRANS: El bloque Abrir archivo abre un archivo para usar con el bloque Mostrar.
+#. TRANS: El bloque Abrir archivo abre un archivo para usar con el bloque Mostrar.
 msgid "The Open file block opens a file for use with the Show block."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:645
-#.TRANS: detener medios
+#. TRANS: detener medios
 msgid "stop media"
 msgstr "ejoko medios"
 
 #: js/blocks/MediaBlocks.js:650
-#.TRANS: El bloque detener medios detiene la reproducción de audio o video.
+#. TRANS: El bloque detener medios detiene la reproducción de audio o video.
 msgid "The Stop media block stops audio or video playback."
 msgstr ""
 
@@ -7298,136 +7298,136 @@ msgstr ""
 #: js/widgets/temperament.js:590
 #: js/widgets/temperament.js:1446
 #: js/widgets/timbre.js:1834
-#.TRANS: frecuencia
+#. TRANS: frecuencia
 msgid "frequency"
 msgstr "osyryha"
 
 #: js/blocks/MediaBlocks.js:692
 #: plugins/rodi.rtp:193
-#.TRANS: 
+#. TRANS: 
 msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
-#.TRANS: nota a frecuencia
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: nota a frecuencia
 msgid "note to frequency"
 msgstr "nota de frecuancia"
 
 #: js/blocks/MediaBlocks.js:736
-#.TRANS: El bloque A frecuencia convierte un nombre de tono y una octava a Hertz.
+#. TRANS: El bloque A frecuencia convierte un nombre de tono y una octava a Hertz.
 msgid "The To frequency block converts a pitch name and octave to Hertz."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:812
-#.TRANS: El bloque Avatar se usa para cambiar la apariencia del ratón.
+#. TRANS: El bloque Avatar se usa para cambiar la apariencia del ratón.
 msgid "The Avatar block is used to change the appearance of the mouse."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:819
-#.TRANS: El bloque Avatar se usa para cambiar la apariencia de la tortuga.
+#. TRANS: El bloque Avatar se usa para cambiar la apariencia de la tortuga.
 msgid "The Avatar block is used to change the appearance of the turtle."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
-#.TRANS: tamaño
+#. TRANS: a media object
+#. TRANS: tamaño
 msgid "size"
 msgstr "jakatuha"
 
 #: js/blocks/MediaBlocks.js:831
-#.TRANS: imagen
+#. TRANS: imagen
 msgid "image"
 msgstr "ta’anga"
 
 #: js/blocks/MediaBlocks.js:880
-#.TRANS: El bloque Mostrar se utiliza para mostrar texto o imágenes en el lienzo.
+#. TRANS: El bloque Mostrar se utiliza para mostrar texto o imágenes en el lienzo.
 msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
-#.TRANS: mostrar
+#. TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: mostrar
 msgid "show1"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: objeto
+#. TRANS: objeto
 msgid "obj"
 msgstr "mba’e"
 
 #: js/blocks/MediaBlocks.js:938
-#.TRANS: El bloque Medios se utiliza para importar una imagen.
+#. TRANS: El bloque Medios se utiliza para importar una imagen.
 msgid "The Media block is used to import an image."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:973
-#.TRANS: El bloque Texto contiene una cadena de texto.
+#. TRANS: El bloque Texto contiene una cadena de texto.
 msgid "The Text block holds a text string."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:30
-#.TRANS: morado
+#. TRANS: morado
 msgid "purple"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:48
 #: js/blocks/SensorsBlocks.js:521
 #: plugins/rodi.rtp:219
-#.TRANS: azur
+#. TRANS: azur
 msgid "blue"
 msgstr "hovy"
 
 #: js/blocks/PenBlocks.js:64
 #: js/blocks/SensorsBlocks.js:577
 #: plugins/rodi.rtp:218
-#.TRANS: verde
+#. TRANS: verde
 msgid "green"
 msgstr "hovy hũ"
 
 #: js/blocks/PenBlocks.js:80
-#.TRANS: amarillo
+#. TRANS: amarillo
 msgid "yellow"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:96
 #: plugins/nutrition.rtp:164
-#.TRANS: naranja
+#. TRANS: naranja
 msgid "orange"
 msgstr "narãha"
 
 #: js/blocks/PenBlocks.js:112
 #: js/blocks/SensorsBlocks.js:633
 #: plugins/rodi.rtp:217
-#.TRANS: rojo
+#. TRANS: rojo
 msgid "red"
 msgstr "pytã"
 
 #: js/blocks/PenBlocks.js:128
-#.TRANS: blanco
+#. TRANS: blanco
 msgid "white"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:144
-#.TRANS: negro
+#. TRANS: negro
 msgid "black"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:163
-#.TRANS: iniciar relleno
+#. TRANS: iniciar relleno
 msgid "begin fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:188
-#.TRANS: Cargar proyecto desde archivo
+#. TRANS: Cargar proyecto desde archivo
 msgid "end fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
-#.TRANS: rellenar pantalla
+#. TRANS: set the background color
+#. TRANS: rellenar pantalla
 msgid "background"
 msgstr "emyenyhe tendahesaperã"
 
@@ -7435,12 +7435,12 @@ msgstr "emyenyhe tendahesaperã"
 #: js/turtleactions/DictActions.js:71
 #: js/turtleactions/DictActions.js:138
 #: js/turtleactions/DictActions.js:170
-#.TRANS: gris
+#. TRANS: gris
 msgid "grey"
 msgstr "hungy"
 
 #: js/blocks/PenBlocks.js:261
-#.TRANS: El bloque gris devuelve el valor gris actual de la pluma.
+#. TRANS: El bloque gris devuelve el valor gris actual de la pluma.
 msgid "The Grey block returns the current pen grey value."
 msgstr ""
 
@@ -7448,12 +7448,12 @@ msgstr ""
 #: js/turtleactions/DictActions.js:69
 #: js/turtleactions/DictActions.js:136
 #: js/turtleactions/DictActions.js:169
-#.TRANS: sombra
+#. TRANS: sombra
 msgid "shade"
 msgstr "ã"
 
 #: js/blocks/PenBlocks.js:326
-#.TRANS: El bloque sombra devuelve la sombra actual de la pluma.
+#. TRANS: El bloque sombra devuelve la sombra actual de la pluma.
 msgid "The Shade block returns the current pen shade value."
 msgstr ""
 
@@ -7461,12 +7461,12 @@ msgstr ""
 #: js/turtleactions/DictActions.js:67
 #: js/turtleactions/DictActions.js:134
 #: js/turtleactions/DictActions.js:168
-#.TRANS: color
+#. TRANS: color
 msgid "color"
 msgstr "sa’y"
 
 #: js/blocks/PenBlocks.js:394
-#.TRANS: El bloque color devuelve el color actual de la pluma.
+#. TRANS: El bloque color devuelve el color actual de la pluma.
 msgid "The Color block returns the current pen color."
 msgstr ""
 
@@ -7474,541 +7474,541 @@ msgstr ""
 #: js/turtleactions/DictActions.js:73
 #: js/turtleactions/DictActions.js:140
 #: js/turtleactions/DictActions.js:171
-#.TRANS: tamaño de la pluma
+#. TRANS: tamaño de la pluma
 msgid "pen size"
 msgstr "jakatuha haiha"
 
 #: js/blocks/PenBlocks.js:453
-#.TRANS: El bloque tamaño de la pluma devuelve el tamaño actual de la pluma.
+#. TRANS: El bloque tamaño de la pluma devuelve el tamaño actual de la pluma.
 msgid "The Pen size block returns the current pen size value."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:492
-#.TRANS: fijar font
+#. TRANS: fijar font
 msgid "set font"
 msgstr "emoĩ fuente"
 
 #: js/blocks/PenBlocks.js:497
-#.TRANS: El bloque fijar font establece el font utilizada por el bloque mostrar.
+#. TRANS: El bloque fijar font establece el font utilizada por el bloque mostrar.
 msgid "The Set font block sets the font used by the Show block."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:544
-#.TRANS: El bloque Fondo establece el color de fondo de la ventana.
+#. TRANS: El bloque Fondo establece el color de fondo de la ventana.
 msgid "The Background block sets the window background color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:575
-#.TRANS: El bloque de línea sin relleno crea una línea con un centro hueco.
+#. TRANS: El bloque de línea sin relleno crea una línea con un centro hueco.
 msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
-#.TRANS: linea sin relleno
+#. TRANS: draw a line logo has a hollow space down its center
+#. TRANS: linea sin relleno
 msgid "hollow line"
 msgstr "rysýi emyenyhe ýre"
 
 #: js/blocks/PenBlocks.js:652
-#.TRANS: El bloque relleno rellena una forma con un color.
+#. TRANS: El bloque relleno rellena una forma con un color.
 msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
-#.TRANS: relleno
+#. TRANS: fill in as a solid color
+#. TRANS: relleno
 msgid "fill"
 msgstr "myenyhe"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
-#.TRANS: subir pluma
+#. TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: subir pluma
 msgid "pen up"
 msgstr "ehupi haiha"
 
 #: js/blocks/PenBlocks.js:745
-#.TRANS: El bloque Subir pluma levanta la pluma para que no dibuje.
+#. TRANS: El bloque Subir pluma levanta la pluma para que no dibuje.
 msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
-#.TRANS: bajar pluma
+#. TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: bajar pluma
 msgid "pen down"
 msgstr "emboguejy haiha"
 
 #: js/blocks/PenBlocks.js:787
-#.TRANS: El bloque de Haciar pluma abajo baja la pluma para que dibuje.
+#. TRANS: El bloque de Haciar pluma abajo baja la pluma para que dibuje.
 msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
-#.TRANS: fijar pluma
+#. TRANS: set the width of the line drawn by the pen
+#. TRANS: fijar pluma
 msgid "set pen size"
 msgstr "emoĩ haiha"
 
 #: js/blocks/PenBlocks.js:831
-#.TRANS: El bloque Fijar tamaño de la pluma de ajuste cambia el tamaño de la pluma.
+#. TRANS: El bloque Fijar tamaño de la pluma de ajuste cambia el tamaño de la pluma.
 msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
-#.TRANS: fijar translucidez
+#. TRANS: set degree of translucence of the pen color
+#. TRANS: fijar translucidez
 msgid "set translucency"
 msgstr "emoĩ translucidez"
 
 #: js/blocks/PenBlocks.js:898
-#.TRANS: El bloque fijar translucidez cambia la opacidad de la pluma.
+#. TRANS: El bloque fijar translucidez cambia la opacidad de la pluma.
 msgid "The Set translucency block changes the opacity of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:958
-#.TRANS: fijar matiz
+#. TRANS: fijar matiz
 msgid "set hue"
 msgstr "emoĩ matiz"
 
 #: js/blocks/PenBlocks.js:966
-#.TRANS: El bloque fijar matiz cambia la color de la pluma.
+#. TRANS: El bloque fijar matiz cambia la color de la pluma.
 msgid "The Set hue block changes the color of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1024
-#.TRANS: fijar sombra
+#. TRANS: fijar sombra
 msgid "set shade"
 msgstr "emo ã"
 
 #: js/blocks/PenBlocks.js:1034
-#.TRANS: El bloque Fijar sombra cambia el color de la pluma de oscuro a claro.
+#. TRANS: El bloque Fijar sombra cambia el color de la pluma de oscuro a claro.
 msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
-#.TRANS: fijar gris
+#. TRANS: set the level of vividness of the pen color
+#. TRANS: fijar gris
 msgid "set grey"
 msgstr "embo hungy"
 
 #: js/blocks/PenBlocks.js:1096
-#.TRANS: El bloque fijar gris cambia la intensidad de la pluma.
+#. TRANS: El bloque fijar gris cambia la intensidad de la pluma.
 msgid "The Set grey block changes the vividness of the pen color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1149
-#.TRANS: fijar color
+#. TRANS: fijar color
 msgid "set color"
 msgstr "embo sa’y"
 
 #: js/blocks/PenBlocks.js:1159
-#.TRANS: El bloque fijar color cambia el color de la pluma.
+#. TRANS: El bloque fijar color cambia el color de la pluma.
 msgid "The Set-color block changes the pen color."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:36
-#.TRANS: El bloque de entrada solicita la entrada del teclado.
+#. TRANS: El bloque de entrada solicita la entrada del teclado.
 msgid "The Input block prompts for keyboard input."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:46
-#.TRANS: el input
+#. TRANS: el input
 msgid "input"
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:64
-#.TRANS: ingrese un valor
+#. TRANS: ingrese un valor
 msgid "Input a value"
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:126
-#.TRANS: valor de entrada
+#. TRANS: valor de entrada
 msgid "input value"
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:131
-#.TRANS: El bloque de valor de entrada almacena la entrada.
+#. TRANS: El bloque de valor de entrada almacena la entrada.
 msgid "The Input-value block stores the input."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:238
-#.TRANS: volumen
+#. TRANS: volumen
 msgid "loudness"
 msgstr "pu hatãngue"
 
 #: js/blocks/SensorsBlocks.js:245
-#.TRANS: El bloque Volumen devuelve el volumen detectado por el micrófono.
+#. TRANS: El bloque Volumen devuelve el volumen detectado por el micrófono.
 msgid "The Loudness block returns the volume detected by the microphone."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:300
-#.TRANS: click
+#. TRANS: click
 msgid "click"
 msgstr "click"
 
 #: js/blocks/SensorsBlocks.js:306
-#.TRANS: El bloque Click activa un evento si se ha hecho clic en un ratón.
+#. TRANS: El bloque Click activa un evento si se ha hecho clic en un ratón.
 msgid "The Click block triggers an event if a mouse has been clicked."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:313
-#.TRANS: El bloque Click activa un evento si se ha hecho clic en una tortuga.
+#. TRANS: El bloque Click activa un evento si se ha hecho clic en una tortuga.
 msgid "The Click block triggers an event if a turtle has been clicked."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:342
-#.TRANS: cursor sobre
+#. TRANS: cursor sobre
 msgid "cursor over"
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:387
-#.TRANS: cursor fuera
+#. TRANS: cursor fuera
 msgid "cursor out"
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:433
-#.TRANS: el botón presionado
+#. TRANS: el botón presionado
 msgid "cursor button down"
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:477
-#.TRANS: el botón arriba
+#. TRANS: el botón arriba
 msgid "cursor button up"
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:638
-#.TRANS: El bloque Obtener rojo devuelve el componente rojo del píxel debajo del ratón.
+#. TRANS: El bloque Obtener rojo devuelve el componente rojo del píxel debajo del ratón.
 msgid "The Get red block returns the red component of the pixel under the mouse."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:644
-#.TRANS: El bloque Obtener rojo devuelve el componente rojo del píxel debajo de la tortuga.
+#. TRANS: El bloque Obtener rojo devuelve el componente rojo del píxel debajo de la tortuga.
 msgid "The Get red block returns the red component of the pixel under the turtle."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:685
 #: plugins/rodi.rtp:216
-#.TRANS: color del pixel
+#. TRANS: color del pixel
 msgid "pixel color"
 msgstr "pixel sa’y"
 
 #: js/blocks/SensorsBlocks.js:690
-#.TRANS: El bloque Obtener píxel devuelve el color del píxel debajo del ratón.
+#. TRANS: El bloque Obtener píxel devuelve el color del píxel debajo del ratón.
 msgid "The Get pixel block returns the color of the pixel under the mouse."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:696
-#.TRANS: El bloque Obtener píxel devuelve el color del píxel debajo de la tortuga.
+#. TRANS: El bloque Obtener píxel devuelve el color del píxel debajo de la tortuga.
 msgid "The Get pixel block returns the color of the pixel under the turtle."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:759
-#.TRANS: tiempo
+#. TRANS: tiempo
 msgid "time"
 msgstr "ára"
 
 #: js/blocks/SensorsBlocks.js:805
-#.TRANS: cursor y
+#. TRANS: cursor y
 msgid "cursor y"
 msgstr "mbo’esyryha y"
 
 #: js/blocks/SensorsBlocks.js:810
-#.TRANS: El bloque Cursor Y devuelve la posición vertical del cursor.
+#. TRANS: El bloque Cursor Y devuelve la posición vertical del cursor.
 msgid "The Cursor Y block returns the vertical position of the mouse."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:846
-#.TRANS: cursor x
+#. TRANS: cursor x
 msgid "cursor x"
 msgstr "mbo’esyryha x"
 
 #: js/blocks/SensorsBlocks.js:851
-#.TRANS: El bloque Cursor X devuelve la posición horizontal del ratón.
+#. TRANS: El bloque Cursor X devuelve la posición horizontal del ratón.
 msgid "The Cursor X block returns the horizontal position of the mouse."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:887
-#.TRANS: botón del ratón
+#. TRANS: botón del ratón
 msgid "mouse button"
 msgstr "anguja votõ"
 
 #: js/blocks/SensorsBlocks.js:889
-#.TRANS: El bloque Botón del ratón devuelve Verdadero si se presiona el botón del ratón.
+#. TRANS: El bloque Botón del ratón devuelve Verdadero si se presiona el botón del ratón.
 msgid "The Mouse-button block returns True if the mouse button is pressed."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:935
-#.TRANS: a ASCII
+#. TRANS: a ASCII
 msgid "to ASCII"
 msgstr "ASCII pe"
 
 #: js/blocks/SensorsBlocks.js:939
-#.TRANS: El bloque a ASCII convierte números a letras.
+#. TRANS: El bloque a ASCII convierte números a letras.
 msgid "The To ASCII block converts numbers to letters."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:1006
-#.TRANS: El bloque teclado devuelve entrada de teclado.
+#. TRANS: El bloque teclado devuelve entrada de teclado.
 msgid "The Keyboard block returns computer keyboard input."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
-#.TRANS: Envolvente
+#. TRANS: sound envelope (ADSR)
+#. TRANS: Envolvente
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
-#.TRANS: atacar
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: atacar
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
-#.TRANS: decaer
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: decaer
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
-#.TRANS: sostener
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: sostener
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
-#.TRANS: liberar
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: liberar
 msgid "release"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:113
-#.TRANS: El valor de atacar debe estar entre 0 y 100.
+#. TRANS: El valor de atacar debe estar entre 0 y 100.
 msgid "Attack value should be from 0 to 100."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:116
-#.TRANS: El valor de decaer debe estar entre 0 y 100.
+#. TRANS: El valor de decaer debe estar entre 0 y 100.
 msgid "Decay value should be from 0 to 100."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:119
-#.TRANS: El valor de sostener debe estar entre 0 y 100.
+#. TRANS: El valor de sostener debe estar entre 0 y 100.
 msgid "Sustain value should be from 0 to 100."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:122
-#.TRANS: El valor de liberar debe estar entre 0 y 100.
+#. TRANS: El valor de liberar debe estar entre 0 y 100.
 msgid "Release value should be from 0-100."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:140
-#.TRANS: Está agregando varios bloques de envolvente.
+#. TRANS: Está agregando varios bloques de envolvente.
 msgid "You are adding multiple envelope blocks."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
-#.TRANS: Filtrar
+#. TRANS: a filter removes some unwanted components from a signal
+#. TRANS: Filtrar
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
-#.TRANS: rodar
+#. TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rodar
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
-#.TRANS: Roll off valor debe ser -12, -24, -48, o -96 decibelios.
+#. TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: Roll off valor debe ser -12, -24, -48, o -96 decibelios.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:252
-#.TRANS: La Herramienta temperamento se utiliza para definir la afinación personalizada.
+#. TRANS: La Herramienta temperamento se utiliza para definir la afinación personalizada.
 msgid "The Temperament tool is used to define custom tuning."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:332
 #: js/blocks/WidgetBlocks.js:1574
 #: js/widgets/sampler.js:501
-#.TRANS: Sube una muestra de audio y ajusta su centro de tono.
+#. TRANS: Sube una muestra de audio y ajusta su centro de tono.
 msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
-#.TRANS: muestreador de audio
+#. TRANS: the speed at music is should be played.
+#. TRANS: muestreador de audio
 msgid "sampler"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:517
-#.TRANS: El bloque Meter abre una herramienta para seleccionar golpes fuertes para el metro.
+#. TRANS: El bloque Meter abre una herramienta para seleccionar golpes fuertes para el metro.
 msgid "The Meter block opens a tool to select strong beats for the meter."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:573
-#.TRANS: El bloque del osciloscopio abre una herramienta para visualizar formas de onda.
+#. TRANS: El bloque del osciloscopio abre una herramienta para visualizar formas de onda.
 msgid "The oscilloscope block opens a tool to visualize waveforms."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:578
-#.TRANS: osciloscopio
+#. TRANS: osciloscopio
 msgid "oscilloscope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:645
-#.TRANS: El bloque Modo personalizado abre una herramienta para explorar el modo musical (el espaciado de las notas en una escala).
+#. TRANS: El bloque Modo personalizado abre una herramienta para explorar el modo musical (el espaciado de las notas en una escala).
 msgid "The Custom mode block opens a tool to explore musical mode (the spacing of the notes in a scale)."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
-#.TRANS: modo personalizado
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: modo personalizado
 msgid "custom mode"
 msgstr "kokatu avateĩgua"
 
 #: js/blocks/WidgetBlocks.js:700
-#.TRANS: El bloque Tempo abre un metrónomo para visualizar el ritmo.
+#. TRANS: El bloque Tempo abre un metrónomo para visualizar el ritmo.
 msgid "The Tempo block opens a metronome to visualize the beat."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:762
-#.TRANS: El Arpegio Widget se usa para componer secuencias de acordes.
+#. TRANS: El Arpegio Widget se usa para componer secuencias de acordes.
 msgid "The Arpeggio Widget is used to compose chord sequences."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:837
-#.TRANS: La Matriz de percusión de tono se utiliza para asignar tonos a los sonidos de tambor.
+#. TRANS: La Matriz de percusión de tono se utiliza para asignar tonos a los sonidos de tambor.
 msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
-#.TRANS: matriz de tono en tambor
+#. TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: matriz de tono en tambor
 msgid "pitch-drum mapper"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:891
-#.TRANS: Debe tener al menos un bloque de tono y un bloque de tambor en la matriz.
+#. TRANS: Debe tener al menos un bloque de tono y un bloque de tambor en la matriz.
 msgid "You must have at least one pitch block and one drum block in the matrix."
 msgstr "Oreko vaerã mbovyetéramo peteĩ vore ipuva ha peteĩ vore angu’atarara moñepyrũmbyguape"
 
 #: js/blocks/WidgetBlocks.js:920
-#.TRANS: La Herramienta de control deslizante tono se utiliza para generar tonos en las frecuencias seleccionadas.
+#. TRANS: La Herramienta de control deslizante tono se utiliza para generar tonos en las frecuencias seleccionadas.
 msgid "The Pitch slider tool to is used to generate pitches at selected frequencies."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
-#.TRANS: deslizante de tono
+#. TRANS: widget to generate pitches using a slider
+#. TRANS: deslizante de tono
 msgid "pitch slider"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:977
-#.TRANS: teclado cromático
+#. TRANS: teclado cromático
 msgid "chromatic keyboard"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
-#.TRANS: teclado musical
+#. TRANS: widget to generate pitches using a slider
+#. TRANS: teclado musical
 msgid "music keyboard"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1062
 #: js/blocks/WidgetBlocks.js:1069
-#.TRANS: El bloque Teclado de música abre un teclado de piano que puede usarse para crear notas.
+#. TRANS: El bloque Teclado de música abre un teclado de piano que puede usarse para crear notas.
 msgid "The Music keyboard block opens a piano keyboard that can be used to create notes."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1128
-#.TRANS: La Herramienta escalera de tono se utiliza para generar tonos a partir de una relación dada.
+#. TRANS: La Herramienta escalera de tono se utiliza para generar tonos a partir de una relación dada.
 msgid "The Pitch staircase tool to is used to generate pitches from a given ratio."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
-#.TRANS: escalera de tono
+#. TRANS: generate a progressive sequence of pitches
+#. TRANS: escalera de tono
 msgid "pitch staircase"
 msgstr "jupiguejyha pu"
 
 #: js/blocks/WidgetBlocks.js:1222
-#.TRANS: El bloque Hacer un ritmo abre una herramienta para crear cajas de ritmos.
+#. TRANS: El bloque Hacer un ritmo abre una herramienta para crear cajas de ritmos.
 msgid "The Rhythm Maker block opens a tool to create drum machines."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1291
-#.TRANS: escala mayor G
+#. TRANS: escala mayor G
 msgid "G major scale"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1326
-#.TRANS: escala mayor C
+#. TRANS: escala mayor C
 msgid "C major scale"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1366
-#.TRANS: El bloque Matriz de tono y tiempo abre una herramienta para crear frases musicales.
+#. TRANS: El bloque Matriz de tono y tiempo abre una herramienta para crear frases musicales.
 msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
-#.TRANS: matriz de tono en tiempo
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: matriz de tono en tiempo
 msgid "phrase maker"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1445
-#.TRANS: Debe tener al menos un bloque de tono y un bloque de ritmo en la matriz.
+#. TRANS: Debe tener al menos un bloque de tono y un bloque de ritmo en la matriz.
 msgid "You must have at least one pitch block and one rhythm block in the matrix."
 msgstr "Oreko vaerã mbovyetéramo peteĩ vore ipuva ha peteĩ vore orekova rítmo moñepyrũmbyguape"
 
 #: js/blocks/WidgetBlocks.js:1504
-#.TRANS: El bloque Estado abre una herramienta para inspeccionar el estado de Bloques de Música mientras se ejecuta.
+#. TRANS: El bloque Estado abre una herramienta para inspeccionar el estado de Bloques de Música mientras se ejecuta.
 msgid "The Status block opens a tool for inspecting the status of Music Blocks as it is running."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
-#.TRANS: Música de IA
+#. TRANS: AI-generated music
+#. TRANS: Música de IA
 msgid "AI Music"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:35
-#.TRANS: volumen del sintetizador
+#. TRANS: volumen del sintetizador
 msgid "synth volume"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:39
-#.TRANS: El bloque de volumen sintetizador devuelve el volumen actual del sintetizador actual.
+#. TRANS: El bloque de volumen sintetizador devuelve el volumen actual del sintetizador actual.
 msgid "The Synth volume block returns the current volume of the current synthesizer."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:105
-#.TRANS: volumen maestro
+#. TRANS: volumen maestro
 msgid "master volume"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:109
-#.TRANS: El bloque volumen maestro devuelve nivel de volumen maestro.
+#. TRANS: El bloque volumen maestro devuelve nivel de volumen maestro.
 msgid "The Master volume block returns the master volume."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:355
 #: js/blocks/VolumeBlocks.js:524
-#.TRANS: fijar volumen del sintetizador
+#. TRANS: fijar volumen del sintetizador
 msgid "set synth volume"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:362
 #: js/blocks/VolumeBlocks.js:545
-#.TRANS: sintetizador
+#. TRANS: sintetizador
 msgid "synth"
 msgstr ""
 
@@ -8016,209 +8016,209 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:577
 #: js/blocks/VolumeBlocks.js:740
 #: js/turtleactions/VolumeActions.js:173
-#.TRANS: Ajuste el volumen a 0
+#. TRANS: Ajuste el volumen a 0
 msgid "Setting volume to 0."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:440
-#.TRANS: No se encuentra el sintetizador.
+#. TRANS: No se encuentra el sintetizador.
 msgid "Synth not found"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:494
-#.TRANS: filar volumen del tambor
+#. TRANS: filar volumen del tambor
 msgid "set drum volume"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:530
-#.TRANS: El bloque Ajuste volumen del sintetizador cambiará el volumen de un sintetizador particular,
+#. TRANS: El bloque Ajuste volumen del sintetizador cambiará el volumen de un sintetizador particular,
 msgid "The Set synth volume block will change the volume of a particular synth,"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:532
-#.TRANS: por ejemplo, guitarra, violín, tambor
+#. TRANS: por ejemplo, guitarra, violín, tambor
 msgid "eg guitar violin snare drum etc."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:534
-#.TRANS: El volumen predeterminado es 50.
+#. TRANS: El volumen predeterminado es 50.
 msgid "The default volume is 50."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:536
-#.TRANS: El rango es de 0 para el silencio a 100 para el volumen completo.
+#. TRANS: El rango es de 0 para el silencio a 100 para el volumen completo.
 msgid "The range is 0 for silence to 100 for full volume."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:597
-#.TRANS: establecer panorámica
+#. TRANS: establecer panorámica
 msgid "set panning"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:603
-#.TRANS: El bloque Establecer Panorámica establece el panorama para todos los sintetizadores.
+#. TRANS: El bloque Establecer Panorámica establece el panorama para todos los sintetizadores.
 msgid "The Set Panning block sets the panning for all synthesizers."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:625
-#.TRANS: Advertencia: El sonido sale solo del lado izquierdo o derecho.
+#. TRANS: Advertencia: El sonido sale solo del lado izquierdo o derecho.
 msgid "Warning: Sound is coming out from only the left or right side."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:647
 #: js/blocks/VolumeBlocks.js:695
-#.TRANS: filar volumen maestro
+#. TRANS: filar volumen maestro
 msgid "set master volume"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:653
-#.TRANS: El bloque Ajuste volumen maestro establece el volumen para todos los sintetizadores.
+#. TRANS: El bloque Ajuste volumen maestro establece el volumen para todos los sintetizadores.
 msgid "The Set master volume block sets the volume for all synthesizers."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:784
-#.TRANS: El bloque Fijar volumen relativo cambia el volumen de las notas contenidas.
+#. TRANS: El bloque Fijar volumen relativo cambia el volumen de las notas contenidas.
 msgid "The Set relative volume block changes the volume of the contained notes."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:791
-#.TRANS: fijar volumen relativo
+#. TRANS: fijar volumen relativo
 msgid "set relative volume"
 msgstr "emoĩ volume relativo"
 
 #: js/blocks/VolumeBlocks.js:857
-#.TRANS: decrescendo
+#. TRANS: decrescendo
 msgid "decrescendo"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:921
-#.TRANS: crescendo
+#. TRANS: crescendo
 msgid "crescendo"
 msgstr "crescendo"
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: uno
+#. TRANS: uno
 msgid "one"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: dos
+#. TRANS: dos
 msgid "two"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: tres
+#. TRANS: tres
 msgid "three"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: cuatro
+#. TRANS: cuatro
 msgid "four"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: cinco
+#. TRANS: cinco
 msgid "five"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: seis
+#. TRANS: seis
 msgid "six"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: siete
+#. TRANS: siete
 msgid "seven"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: ocho
+#. TRANS: ocho
 msgid "eight"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: nueve
+#. TRANS: nueve
 msgid "nine"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:140
-#.TRANS: abajo
+#. TRANS: abajo
 msgid "below"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: arriba
+#. TRANS: arriba
 msgid "above"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:131
-#.TRANS: más
+#. TRANS: más
 msgid "plus"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:258
-#.TRANS: Agregar el número de tono que falta 0.
+#. TRANS: Agregar el número de tono que falta 0.
 msgid "Adding missing pitch number 0."
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:266
-#.TRANS: Ignorando los números de tono menos de cero o más de once.
+#. TRANS: Ignorando los números de tono menos de cero o más de once.
 msgid "Ignoring pitch numbers less than zero or greater than eleven."
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:272
-#.TRANS: Ignorando números de tono duplicados.
+#. TRANS: Ignorando números de tono duplicados.
 msgid "Ignoring duplicate pitch numbers."
 msgstr ""
 
 #: js/turtleactions/DictActions.js:75
 #: js/turtleactions/DictActions.js:142
 #: js/turtleactions/DictActions.js:172
-#.TRANS: fuente
+#. TRANS: fuente
 msgid "font"
 msgstr ""
 
 #: js/turtleactions/DictActions.js:255
-#.TRANS: No existe diccionario con este nombre
+#. TRANS: No existe diccionario con este nombre
 msgid "Dictionary with this name does not exist"
 msgstr ""
 
 #: js/turtleactions/DictActions.js:259
-#.TRANS: La clave con este nombre no existe en 
+#. TRANS: La clave con este nombre no existe en 
 msgid "Key with this name does not exist in "
 msgstr ""
 
 #: js/turtleactions/DrumActions.js:227
-#.TRANS: Bloque de ruido: Quizás quiso decir utilizar un bloque de nota?
+#. TRANS: Bloque de ruido: Quizás quiso decir utilizar un bloque de nota?
 msgid "Noise Block: Did you mean to use a Note block?"
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:134
-#.TRANS: La intensidad del vibrato debe estar entre 1 y 100.
+#. TRANS: La intensidad del vibrato debe estar entre 1 y 100.
 msgid "Vibrato intensity must be between 1 and 100."
 msgstr "Vibrato mbarete oime vaerã peteĩ ha sa apytepe"
 
 #: js/turtleactions/ToneActions.js:139
-#.TRANS: La velocidad del vibrato debe ser mayor que 0.
+#. TRANS: La velocidad del vibrato debe ser mayor que 0.
 msgid "Vibrato rate must be greater than 0."
 msgstr "Vibrato pya’ekue tuichave vaerã mba’evegui"
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
-#.TRANS: El valor de profundidad está fuera de rango.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: El valor de profundidad está fuera de rango.
 msgid "Depth is out of range."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:301
-#.TRANS: El valor de distorsión debe ser de 0 a 100.
+#. TRANS: El valor de distorsión debe ser de 0 a 100.
 msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
-#.TRANS: Parcial debe ser mayor o igual a 0.
+#. TRANS: partials components in a harmonic series
+#. TRANS: Parcial debe ser mayor o igual a 0.
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -8226,31 +8226,31 @@ msgstr ""
 #: js/turtleactions/ToneActions.js:417
 #: js/turtleactions/ToneActions.js:456
 #: js/widgets/timbre.js:776
-#.TRANS: No se puede usar el sintetizador debido al bloqueo del oscilador.
+#. TRANS: No se puede usar el sintetizador debido al bloqueo del oscilador.
 msgid "Unable to use synth due to existing oscillator"
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:388
 #: js/turtleactions/ToneActions.js:427
-#.TRANS: La entrada no puede ser negativa.
+#. TRANS: La entrada no puede ser negativa.
 msgid "The input cannot be negative."
 msgstr ""
 
 #: js/turtleactions/MeterActions.js:101
 #: js/turtleactions/MeterActions.js:139
-#.TRANS: latidos por minuto deben ser mayores que
+#. TRANS: latidos por minuto deben ser mayores que
 msgid "beats per minute must be greater than"
 msgstr ""
 
 #: js/turtleactions/MeterActions.js:111
 #: js/turtleactions/MeterActions.js:149
-#.TRANS: máximo
+#. TRANS: máximo
 msgid "maximum"
 msgstr ""
 
 #: js/turtleactions/MeterActions.js:117
 #: js/turtleactions/MeterActions.js:155
-#.TRANS: latidos por minuto es
+#. TRANS: latidos por minuto es
 msgid "beats per minute is"
 msgstr ""
 
@@ -8260,7 +8260,7 @@ msgstr ""
 #: js/widgets/help.js:158
 #: js/widgets/help.js:378
 #: js/widgets/help.js:393
-#.TRANS: Hacer un recorrido
+#. TRANS: Hacer un recorrido
 msgid "Take a tour"
 msgstr ""
 
@@ -8275,40 +8275,40 @@ msgstr ""
 #: js/widgets/tempo.js:78
 #: js/widgets/tempo.js:97
 #: js/widgets/tempo.js:98
-#.TRANS: Pausa
+#. TRANS: Pausa
 msgid "Pause"
 msgstr ""
 
 #: js/widgets/aiwidget.js:179
 #: js/widgets/sampler.js:225
-#.TRANS: Advertencia: la muestra es más grande que 1 MB.
+#. TRANS: Advertencia: la muestra es más grande que 1 MB.
 msgid "Warning: Sample is bigger than 1MB."
 msgstr ""
 
 #: js/widgets/aiwidget.js:538
-#.TRANS: Nuevo bloque de inicio generado
+#. TRANS: Nuevo bloque de inicio generado
 msgid "New start block generated"
 msgstr ""
 
 #: js/widgets/aiwidget.js:540
-#.TRANS: Carga MIDI. Esto puede tardar un tiempo dependiendo de la cantidad de notas en la pista.
+#. TRANS: Carga MIDI. Esto puede tardar un tiempo dependiendo de la cantidad de notas en la pista.
 msgid "MIDI loading. This may take some time depending upon the number of notes in the track"
 msgstr ""
 
 #: js/widgets/aiwidget.js:550
 #: js/widgets/sampler.js:252
-#.TRANS: Error en la carga: la muestra no es un archivo .WAV.
+#. TRANS: Error en la carga: la muestra no es un archivo .WAV.
 msgid "Upload failed: Sample is not a .wav file."
 msgstr ""
 
 #: js/widgets/aiwidget.js:677
 #: js/widgets/sampler.js:430
-#.TRANS: Guardar muestra de audio
+#. TRANS: Guardar muestra de audio
 msgid "Save sample"
 msgstr ""
 
 #: js/widgets/arpeggio.js:241
-#.TRANS: Haga clic en la cuadrícula para agregar pasos al arpegio.
+#. TRANS: Haga clic en la cuadrícula para agregar pasos al arpegio.
 msgid "Click in the grid to add steps to the arpeggio."
 msgstr ""
 
@@ -8326,27 +8326,27 @@ msgstr ""
 #: js/widgets/rhythmruler.js:1809
 #: js/widgets/rhythmruler.js:1810
 #: js/widgets/temperament.js:2165
-#.TRANS: Jugar todo
+#. TRANS: Jugar todo
 msgid "Play all"
 msgstr ""
 
 #: js/widgets/meterwidget.js:269
-#.TRANS: Reiniciar
+#. TRANS: Reiniciar
 msgid "Reset"
 msgstr ""
 
 #: js/widgets/meterwidget.js:295
-#.TRANS: Haga clic en el círculo para seleccionar ritmos fuertes para el medidor.
+#. TRANS: Haga clic en el círculo para seleccionar ritmos fuertes para el medidor.
 msgid "Click in the circle to select strong beats for the meter."
 msgstr ""
 
 #: js/widgets/modewidget.js:125
-#.TRANS: Girar en sentido antihorario
+#. TRANS: Girar en sentido antihorario
 msgid "Rotate counter clockwise"
 msgstr ""
 
 #: js/widgets/modewidget.js:131
-#.TRANS: Girar en sentido horario
+#. TRANS: Girar en sentido horario
 msgid "Rotate clockwise"
 msgstr ""
 
@@ -8354,13 +8354,13 @@ msgstr ""
 #: js/widgets/pitchstaircase.js:676
 #: js/widgets/rhythmruler.js:578
 #: js/widgets/timbre.js:957
-#.TRANS: Deshacer
+#. TRANS: Deshacer
 msgid "Undo"
 msgstr "Mosarambi"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
-#.TRANS: Haga clic en el círculo para seleccionar notas para el modo.
+#. TRANS: A circle of notes represents the musical mode.
+#. TRANS: Haga clic en el círculo para seleccionar notas para el modo.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -8372,18 +8372,18 @@ msgstr ""
 #: js/widgets/temperament.js:1862
 #: js/widgets/tempo.js:412
 #: js/widgets/phrasemaker.js:5467
-#.TRANS: Nuevo bloque de acción creado.
+#. TRANS: Nuevo bloque de acción creado.
 msgid "New action block generated."
 msgstr ""
 
 #: js/widgets/musickeyboard.js:743
 #: js/widgets/phrasemaker.js:595
-#.TRANS: Agrega una nota
+#. TRANS: Agrega una nota
 msgid "Add note"
 msgstr ""
 
 #: js/widgets/musickeyboard.js:762
-#.TRANS: Metrónomo
+#. TRANS: Metrónomo
 msgid "Metronome"
 msgstr ""
 
@@ -8392,80 +8392,80 @@ msgid "Note value"
 msgstr ""
 
 #: js/widgets/musickeyboard.js:3209
-#.TRANS: Nuevo bloques de acción creado.
+#. TRANS: Nuevo bloques de acción creado.
 msgid "New action blocks generated."
 msgstr ""
 
 #: js/widgets/musickeyboard.js:3393
 #: js/widgets/musickeyboard.js:3401
-#.TRANS: Dispositivo MIDI presente.
+#. TRANS: Dispositivo MIDI presente.
 msgid "MIDI device present."
 msgstr ""
 
 #: js/widgets/musickeyboard.js:3404
-#.TRANS: No se encontró ningún dispositivo MIDI.
+#. TRANS: No se encontró ningún dispositivo MIDI.
 msgid "No MIDI device found."
 msgstr ""
 
 #: js/widgets/musickeyboard.js:3414
-#.TRANS: Error al obtener acceso MIDI en el navegador.
+#. TRANS: Error al obtener acceso MIDI en el navegador.
 msgid "Failed to get MIDI access in browser."
 msgstr ""
 
 #: js/widgets/pitchdrummatrix.js:356
 #: js/widgets/pitchdrummatrix.js:741
-#.TRANS: Haga clic en la cuadrícula para asignar notas a sonidos de tambors
+#. TRANS: Haga clic en la cuadrícula para asignar notas a sonidos de tambors
 msgid "Click in the grid to map notes to drums."
 msgstr ""
 
 #: js/widgets/pitchslider.js:103
-#.TRANS: Ascender
+#. TRANS: Ascender
 msgid "Move up"
 msgstr ""
 
 #: js/widgets/pitchslider.js:114
-#.TRANS: Descender
+#. TRANS: Descender
 msgid "Move down"
 msgstr ""
 
 #: js/widgets/pitchslider.js:136
-#.TRANS: Haga clic en el control deslizante para crear un bloque de notas.
+#. TRANS: Haga clic en el control deslizante para crear un bloque de notas.
 msgid "Click on the slider to create a note block."
 msgstr ""
 
 #: js/widgets/pitchstaircase.js:622
-#.TRANS: Tocar un acorde
+#. TRANS: Tocar un acorde
 msgid "Play chord"
 msgstr ""
 
 #: js/widgets/pitchstaircase.js:630
-#.TRANS: Tocar una escala
+#. TRANS: Tocar una escala
 msgid "Play scale"
 msgstr ""
 
 #: js/widgets/pitchstaircase.js:694
-#.TRANS: Haga clic en una nota para crear un nuevo paso.
+#. TRANS: Haga clic en una nota para crear un nuevo paso.
 msgid "Click on a note to create a new step."
 msgstr ""
 
 #: js/widgets/rhythmruler.js:486
-#.TRANS: Guardar ritmos
+#. TRANS: Guardar ritmos
 msgid "Save rhythms"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:512
-#.TRANS: Guardar la caja de ritmos
+#. TRANS: Guardar la caja de ritmos
 msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
-#.TRANS: Toca un ritmo
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: Toca un ritmo
 msgid "Tap a rhythm"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:813
-#.TRANS: Haga clic en la regla para dividirla.
+#. TRANS: Haga clic en la regla para dividirla.
 msgid "Click on the ruler to divide it."
 msgstr ""
 
@@ -8475,63 +8475,63 @@ msgstr ""
 #: js/widgets/rhythmruler.js:1149
 #: js/widgets/rhythmruler.js:1760
 #: js/widgets/rhythmruler.js:1761
-#.TRANS: tocar un ritmo
+#. TRANS: tocar un ritmo
 msgid "tap a rhythm"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:1453
-#.TRANS: Se ha superado el valor máximo de 256.
+#. TRANS: Se ha superado el valor máximo de 256.
 msgid "Maximum value of 256 has been exceeded."
 msgstr ""
 
 #: js/widgets/sampler.js:235
-#.TRANS: grabación comenzada
+#. TRANS: grabación comenzada
 msgid "Recording started"
 msgstr ""
 
 #: js/widgets/sampler.js:243
-#.TRANS: grabación completa
+#. TRANS: grabación completa
 msgid "Recording complete"
 msgstr ""
 
 #: js/widgets/sampler.js:281
-#.TRANS: Se generó un nuevo bloque de muestra de audio.
+#. TRANS: Se generó un nuevo bloque de muestra de audio.
 msgid "A new sample block was generated."
 msgstr ""
 
 #: js/widgets/sampler.js:376
-#.TRANS: Subir muestra de audio
+#. TRANS: Subir muestra de audio
 msgid "Upload sample"
 msgstr ""
 
 #: js/widgets/sampler.js:397
-#.TRANS: Advertencia: Su muestra no se puede cargar porque es >1 MB.
+#. TRANS: Advertencia: Su muestra no se puede cargar porque es >1 MB.
 msgid "Warning: Your sample cannot be loaded because it is >1MB."
 msgstr ""
 
 #: js/widgets/sampler.js:446
-#.TRANS: Alternar el micrófono
+#. TRANS: Alternar el micrófono
 msgid "Toggle Mic"
 msgstr ""
 
 #: js/widgets/sampler.js:453
-#.TRANS: Reproducir
+#. TRANS: Reproducir
 msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
-#.TRANS: tono de referencia
+#. TRANS: The reference tone is a sound used for comparison.
+#. TRANS: tono de referencia
 msgid "reference tone"
 msgstr ""
 
 #: js/widgets/temperament.js:319
-#.TRANS: volver al espacio de octava 2: 1
+#. TRANS: volver al espacio de octava 2: 1
 msgid "back to 2:1 octave space"
 msgstr ""
 
 #: js/widgets/temperament.js:445
-#.TRANS: editar
+#. TRANS: editar
 msgid "edit"
 msgstr ""
 
@@ -8545,39 +8545,39 @@ msgstr ""
 #: js/widgets/temperament.js:1379
 #: js/widgets/temperament.js:1448
 #: js/widgets/temperament.js:1529
-#.TRANS: terminado
+#. TRANS: terminado
 msgid "done"
 msgstr ""
 
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:587
 #: js/widgets/temperament.js:1021
-#.TRANS: proporción
+#. TRANS: proporción
 msgid "ratio"
 msgstr ""
 
 #: js/widgets/temperament.js:588
-#.TRANS: intervalo
+#. TRANS: intervalo
 msgid "interval"
 msgstr "intervalo"
 
 #: js/widgets/temperament.js:716
-#.TRANS: no escalar
+#. TRANS: no escalar
 msgid "non scalar"
 msgstr ""
 
 #: js/widgets/temperament.js:757
-#.TRANS: proporcións
+#. TRANS: proporcións
 msgid "ratios"
 msgstr ""
 
 #: js/widgets/temperament.js:757
-#.TRANS: arbitrario
+#. TRANS: arbitrario
 msgid "arbitrary"
 msgstr ""
 
 #: js/widgets/temperament.js:828
-#.TRANS: número de divisiones
+#. TRANS: número de divisiones
 msgid "number of divisions"
 msgstr ""
 
@@ -8585,278 +8585,278 @@ msgstr ""
 #: js/widgets/temperament.js:958
 #: js/widgets/temperament.js:1037
 #: js/widgets/temperament.js:1128
-#.TRANS: preestreno
+#. TRANS: preestreno
 msgid "preview"
 msgstr ""
 
 #: js/widgets/temperament.js:888
-#.TRANS: El número de divisiones es demasiado grande.
+#. TRANS: El número de divisiones es demasiado grande.
 msgid "The Number of divisions is too large."
 msgstr ""
 
 #: js/widgets/temperament.js:1023
-#.TRANS: recursividad
+#. TRANS: recursividad
 msgid "recursion"
 msgstr ""
 
 #: js/widgets/temperament.js:1549
-#.TRANS: La proporción de octavas ha cambiado. Esto cambia el temperamento de manera significativa.
+#. TRANS: La proporción de octavas ha cambiado. Esto cambia el temperamento de manera significativa.
 msgid "The octave ratio has changed. This changes temperament significantly."
 msgstr ""
 
 #: js/widgets/temperament.js:2177
-#.TRANS: Tabla
+#. TRANS: Tabla
 msgid "Table"
 msgstr ""
 
 #: js/widgets/temperament.js:2285
-#.TRANS: añadir tonos
+#. TRANS: añadir tonos
 msgid "Add pitches"
 msgstr ""
 
 #: js/widgets/tempo.js:111
-#.TRANS: Guardar tempo
+#. TRANS: Guardar tempo
 msgid "Save tempo"
 msgstr ""
 
 #: js/widgets/tempo.js:142
-#.TRANS: acelerar
+#. TRANS: acelerar
 msgid "speed up"
 msgstr ""
 
 #: js/widgets/tempo.js:148
-#.TRANS: retardar
+#. TRANS: retardar
 msgid "slow down"
 msgstr "mohã’arõ"
 
 #: js/widgets/tempo.js:192
-#.TRANS: Ajusta el tempo con los botones.
+#. TRANS: Ajusta el tempo con los botones.
 msgid "Adjust the tempo with the buttons."
 msgstr ""
 
 #: js/widgets/tempo.js:259
-#.TRANS: Por favor, introduzca un número entre 30 y 1000.
+#. TRANS: Por favor, introduzca un número entre 30 y 1000.
 msgid "Please enter a number between 30 and 1000"
 msgstr ""
 
 #: js/widgets/tempo.js:266
 #: js/widgets/tempo.js:269
-#.TRANS: Los latidos por minuto deben estar entre 30 y 1000.
+#. TRANS: Los latidos por minuto deben estar entre 30 y 1000.
 msgid "The beats per minute must be between 30 and 1000."
 msgstr ""
 
 #: js/widgets/tempo.js:285
-#.TRANS: Los latidos por minuto deben estar por debajo de 1000.
+#. TRANS: Los latidos por minuto deben estar por debajo de 1000.
 msgid "The beats per minute must be below 1000."
 msgstr ""
 
 #: js/widgets/tempo.js:301
-#.TRANS: Los latidos por minuto deben ser superiores a 30.
+#. TRANS: Los latidos por minuto deben ser superiores a 30.
 msgid "The beats per minute must be above 30"
 msgstr ""
 
 #: js/widgets/timbre.js:760
-#.TRANS: Sintetizador
+#. TRANS: Sintetizador
 msgid "Synthesizer"
 msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: Efectos
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: Efectos
 msgid "Effects"
 msgstr ""
 
 #: js/widgets/timbre.js:940
-#.TRANS: Agregar un filtro
+#. TRANS: Agregar un filtro
 msgid "Add filter"
 msgstr ""
 
 #: js/widgets/timbre.js:981
-#.TRANS: Haga clic en los botones para abrir las herramientas de diseño de timbre.
+#. TRANS: Haga clic en los botones para abrir las herramientas de diseño de timbre.
 msgid "Click on buttons to open the timbre design tools."
 msgstr ""
 
 #: js/widgets/timbre.js:1265
-#.TRANS: armonía
+#. TRANS: armonía
 msgid "harmonicity"
 msgstr ""
 
 #: js/widgets/timbre.js:1332
 #: js/widgets/timbre.js:1398
-#.TRANS: índice de modulación
+#. TRANS: índice de modulación
 msgid "modulation index"
 msgstr ""
 
 #: js/widgets/timbre.js:1476
-#.TRANS: cantidad de vibrato
+#. TRANS: cantidad de vibrato
 msgid "vibrato amount"
 msgstr ""
 
 #: js/widgets/timbre.js:1911
-#.TRANS: filtro ya presente
+#. TRANS: filtro ya presente
 msgid "Filter already present."
 msgstr ""
 
 #: js/widgets/timbre.js:2495
-#.TRANS: cantidad de distorsión
+#. TRANS: cantidad de distorsión
 msgid "distortion amount"
 msgstr ""
 
 #: js/widgets/oscilloscope.js:79
-#.TRANS: Hacer zoom
+#. TRANS: Hacer zoom
 msgid "Zoom In"
 msgstr ""
 
 #: js/widgets/oscilloscope.js:88
-#.TRANS: Alejar
+#. TRANS: Alejar
 msgid "Zoom Out"
 msgstr ""
 
 #: js/widgets/phrasemaker.js:585
-#.TRANS: Exportar
+#. TRANS: Exportar
 msgid "Export"
 msgstr ""
 
 #: js/widgets/phrasemaker.js:592
-#.TRANS: Ordenar
+#. TRANS: Ordenar
 msgid "Sort"
 msgstr ""
 
 #: js/widgets/phrasemaker.js:1061
-#.TRANS: Haga clic en la tabla para agregar notas.
+#. TRANS: Haga clic en la tabla para agregar notas.
 msgid "Click on the table to add notes."
 msgstr ""
 
 #: js/widgets/phrasemaker.js:2755
 #: js/widgets/phrasemaker.js:2891
-#.TRANS: valor del tuplet
+#. TRANS: valor del tuplet
 msgid "tuplet value"
 msgstr "tuplet repy"
 
 #: planet/js/GlobalCard.js:68
-#.TRANS: Compartir
+#. TRANS: Compartir
 msgid "Share"
 msgstr "mboja’o"
 
 #: planet/js/GlobalCard.js:74
-#.TRANS: Banderas
+#. TRANS: Banderas
 msgid "Flags"
 msgstr ""
 
 #: planet/js/GlobalPlanet.js:35
-#.TRANS: No se han encontrado resultados.
+#. TRANS: No se han encontrado resultados.
 msgid "No results found."
 msgstr ""
 
 #: planet/js/GlobalPlanet.js:51
-#.TRANS: Remix de
+#. TRANS: Remix de
 msgid "Remix of"
 msgstr ""
 
 #: planet/js/GlobalPlanet.js:509
-#.TRANS: No es posible conectar con el servidor.
+#. TRANS: No es posible conectar con el servidor.
 msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: todos los proyectos
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: todos los proyectos
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: Mis proyectos
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: Mis proyectos
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: ejemplos
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: ejemplos
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: arte
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: arte
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: mates
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: mates
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: interactivo
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: interactivo
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: diseño
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: diseño
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: juego
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: juego
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: fragmento de código
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: fragmento de código
 msgid "Code Snippet"
 msgstr ""
 
 #: planet/js/LocalCard.js:36
-#.TRANS: Ver proyecto publicado
+#. TRANS: Ver proyecto publicado
 msgid "View published project"
 msgstr ""
 
 #: planet/js/LocalCard.js:42
 #: planet/js/StringHelper.js:38
-#.TRANS: Publicar proyecto
+#. TRANS: Publicar proyecto
 msgid "Publish project"
 msgstr ""
 
 #: planet/js/LocalCard.js:51
-#.TRANS: Editar proyecto
+#. TRANS: Editar proyecto
 msgid "Edit project"
 msgstr ""
 
 #: planet/js/LocalCard.js:52
-#.TRANS: Borrar proyecto
+#. TRANS: Borrar proyecto
 msgid "Delete project"
 msgstr ""
 
 #: planet/js/LocalCard.js:53
-#.TRANS: Descargar proyecto
+#. TRANS: Descargar proyecto
 msgid "Download project"
 msgstr ""
 
 #: planet/js/LocalCard.js:55
-#.TRANS: Duplucar proyecto
+#. TRANS: Duplucar proyecto
 msgid "Duplicate project"
 msgstr ""
 
 #: planet/js/ProjectStorage.js:243
-#.TRANS: anónimo
+#. TRANS: anónimo
 msgid "anonymous"
 msgstr ""
 
 #: planet/js/ProjectViewer.js:30
-#.TRANS: Error: No se pudo enviar el informe. Inténtalo de nuevo más tarde.
+#. TRANS: Error: No se pudo enviar el informe. Inténtalo de nuevo más tarde.
 msgid "Error: Report could not be submitted. Try again later."
 msgstr ""
 
 #: planet/js/ProjectViewer.js:31
-#.TRANS: Gracias por reportar este proyecto. Un moderador revisará el proyecto en breve para verificar la violación del Código de conducta de Sugar Labs.
+#. TRANS: Gracias por reportar este proyecto. Un moderador revisará el proyecto en breve para verificar la violación del Código de conducta de Sugar Labs.
 msgid "Thank you for reporting this project. A moderator will review the project shortly, to verify violation of the Sugar Labs Code of Conduct."
 msgstr ""
 
@@ -8864,527 +8864,527 @@ msgstr ""
 #: planet/js/StringHelper.js:62
 #: planet/js/StringHelper.js:64
 #: planet/js/StringHelper.js:68
-#.TRANS: Informe de proyecto
+#. TRANS: Informe de proyecto
 msgid "Report Project"
 msgstr ""
 
 #: planet/js/ProjectViewer.js:33
 #: planet/js/StringHelper.js:63
-#.TRANS: Proyecto informado
+#. TRANS: Proyecto informado
 msgid "Project Reported"
 msgstr ""
 
 #: planet/js/ProjectViewer.js:34
-#.TRANS: Descripción requerida
+#. TRANS: Descripción requerida
 msgid "Report description required"
 msgstr ""
 
 #: planet/js/ProjectViewer.js:35
-#.TRANS: La descripción es demasiado larga.
+#. TRANS: La descripción es demasiado larga.
 msgid "Report description too long"
 msgstr ""
 
 #: planet/js/Publisher.js:30
-#.TRANS: Característica no disponible: no se puede conectar al servidor. Vuelve a cargar Bloques de Música para intentarlo de nuevo.
+#. TRANS: Característica no disponible: no se puede conectar al servidor. Vuelve a cargar Bloques de Música para intentarlo de nuevo.
 msgid "Feature unavailable - cannot connect to server. Reload Music Blocks to try again."
 msgstr ""
 
 #: planet/js/Publisher.js:220
 #: planet/js/Publisher.js:237
-#.TRANS: Este campo es requerido.
+#. TRANS: Este campo es requerido.
 msgid "This field is required"
 msgstr ""
 
 #: planet/js/Publisher.js:227
-#.TRANS: Título es demasiado largo.
+#. TRANS: Título es demasiado largo.
 msgid "Title too long"
 msgstr ""
 
 #: planet/js/Publisher.js:244
-#.TRANS: La descripción es demasiado largo.
+#. TRANS: La descripción es demasiado largo.
 msgid "Description too long"
 msgstr ""
 
 #: planet/js/Publisher.js:341
-#.TRANS: Error del Servidor
+#. TRANS: Error del Servidor
 msgid "Server Error"
 msgstr ""
 
 #: planet/js/Publisher.js:341
-#.TRANS: Inténtalo de nuevo
+#. TRANS: Inténtalo de nuevo
 msgid "Try Again"
 msgstr ""
 
 #: planet/js/SaveInterface.js:34
-#.TRANS: Abrir en Bloques de Música
+#. TRANS: Abrir en Bloques de Música
 msgid "Open in Music Blocks"
 msgstr ""
 
 #: planet/js/SaveInterface.js:35
-#.TRANS: Abierto en TortuBloques
+#. TRANS: Abierto en TortuBloques
 msgid "Open in Turtle Blocks"
 msgstr ""
 
 #: planet/js/helper.js:149
 #: planet/js/StringHelper.js:49
-#.TRANS: Mostrar más etiquetas
+#. TRANS: Mostrar más etiquetas
 msgid "Show more tags"
 msgstr ""
 
 #: planet/js/helper.js:150
-#.TRANS: Mostrar menos etiquetas
+#. TRANS: Mostrar menos etiquetas
 msgid "Show fewer tags"
 msgstr ""
 
 #: planet/js/StringHelper.js:30
-#.TRANS: Planeta
+#. TRANS: Planeta
 msgid "Planet"
 msgstr "Mbyja kuarahyre ojereva"
 
 #: planet/js/StringHelper.js:31
-#.TRANS: Cerrar Planeta
+#. TRANS: Cerrar Planeta
 msgid "Close Planet"
 msgstr ""
 
 #: planet/js/StringHelper.js:32
-#.TRANS: Abrir proyecto desde archivo
+#. TRANS: Abrir proyecto desde archivo
 msgid "Open project from file"
 msgstr ""
 
 #: planet/js/StringHelper.js:34
-#.TRANS: Local
+#. TRANS: Local
 msgid "Local"
 msgstr ""
 
 #: planet/js/StringHelper.js:35
-#.TRANS: Global
+#. TRANS: Global
 msgid "Global"
 msgstr ""
 
 #: planet/js/StringHelper.js:36
-#.TRANS: Buscar un proyecto
+#. TRANS: Buscar un proyecto
 msgid "Search for a project"
 msgstr ""
 
 #: planet/js/StringHelper.js:40
-#.TRANS: Etiquetas (max 5)
+#. TRANS: Etiquetas (max 5)
 msgid "Tags (max 5)"
 msgstr ""
 
 #: planet/js/StringHelper.js:41
 #: planet/js/StringHelper.js:61
-#.TRANS: Descripción
+#. TRANS: Descripción
 msgid "Description"
 msgstr ""
 
 #: planet/js/StringHelper.js:42
 #: planet/js/StringHelper.js:67
-#.TRANS: Presentar
+#. TRANS: Presentar
 msgid "Submit"
 msgstr ""
 
 #: planet/js/StringHelper.js:43
 #: planet/js/StringHelper.js:47
-#.TRANS: Cancelar
+#. TRANS: Cancelar
 msgid "Cancel"
 msgstr ""
 
 #: planet/js/StringHelper.js:44
-#.TRANS: Borrar \\"<span id=\\"deleter-title\\"></span>\\"?
+#. TRANS: Borrar \\"<span id=\\"deleter-title\\"></span>\\"?
 msgid "Delete \\"<span id=\\"deleter-title\\"></span>\\"?"
 msgstr ""
 
 #: planet/js/StringHelper.js:45
-#.TRANS: Eliminar permanentemente el proyecto \\"<span id=\\"deleter-name\\"></span>\\"?
+#. TRANS: Eliminar permanentemente el proyecto \\"<span id=\\"deleter-name\\"></span>\\"?
 msgid "Permanently delete project \\"<span id=\\"deleter-name\\"></span>\\"?"
 msgstr ""
 
 #: planet/js/StringHelper.js:48
-#.TRANS: Explorar proyectos
+#. TRANS: Explorar proyectos
 msgid "Explore Projects"
 msgstr ""
 
 #: planet/js/StringHelper.js:50
-#.TRANS: Más reciente
+#. TRANS: Más reciente
 msgid "Most recent"
 msgstr ""
 
 #: planet/js/StringHelper.js:51
-#.TRANS: Más gustado
+#. TRANS: Más gustado
 msgid "Most liked"
 msgstr ""
 
 #: planet/js/StringHelper.js:52
-#.TRANS: Más descargados
+#. TRANS: Más descargados
 msgid "Most downloaded"
 msgstr ""
 
 #: planet/js/StringHelper.js:53
-#.TRANS: A-Z
+#. TRANS: A-Z
 msgid "A-Z"
 msgstr ""
 
 #: planet/js/StringHelper.js:54
-#.TRANS: Ordenar por
+#. TRANS: Ordenar por
 msgid "Sort by"
 msgstr ""
 
 #: planet/js/StringHelper.js:55
-#.TRANS: Cargar más proyectos
+#. TRANS: Cargar más proyectos
 msgid "Load More Projects"
 msgstr ""
 
 #: planet/js/StringHelper.js:56
-#.TRANS: ÃÂltima actualización
+#. TRANS: ÃÂltima actualización
 msgid "Last Updated"
 msgstr ""
 
 #: planet/js/StringHelper.js:57
-#.TRANS: Fecha de creación
+#. TRANS: Fecha de creación
 msgid "Creation Date"
 msgstr ""
 
 #: planet/js/StringHelper.js:58
-#.TRANS: Numero de descargas:
+#. TRANS: Numero de descargas:
 msgid "Number of Downloads:"
 msgstr ""
 
 #: planet/js/StringHelper.js:59
-#.TRANS: Número de me gusta:
+#. TRANS: Número de me gusta:
 msgid "Number of Likes:"
 msgstr ""
 
 #: planet/js/StringHelper.js:60
-#.TRANS: Etiquetas:
+#. TRANS: Etiquetas:
 msgid "Tags:"
 msgstr ""
 
 #: planet/js/StringHelper.js:65
-#.TRANS: Reportar proyectos que violen <a href=\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">el código de conducta de Sugar Labs</a>.
+#. TRANS: Reportar proyectos que violen <a href=\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">el código de conducta de Sugar Labs</a>.
 msgid "Report projects which violate the <a href=\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">Sugar Labs Code of Conduct</a>."
 msgstr ""
 
 #: planet/js/StringHelper.js:66
-#.TRANS: Razón para informar el proyecto
+#. TRANS: Razón para informar el proyecto
 msgid "Reason for reporting project"
 msgstr ""
 
 #: planet/js/StringHelper.js:70
-#.TRANS: Descargar como archivo
+#. TRANS: Descargar como archivo
 msgid "Download as File"
 msgstr ""
 
 #: plugins/accelerometer.rtp:48
-#.TRANS: x del acelerómetro
+#. TRANS: x del acelerómetro
 msgid "motion x"
 msgstr "x del acelerómetro"
 
 #: plugins/accelerometer.rtp:56
-#.TRANS: y del acelerómetro
+#. TRANS: y del acelerómetro
 msgid "motion y"
 msgstr "y del acelerómetro"
 
 #: plugins/accelerometer.rtp:64
-#.TRANS: z del acelerómetro
+#. TRANS: z del acelerómetro
 msgid "motion z"
 msgstr "z del acelerómetro"
 
 #: plugins/facebook.rtp:27
-#.TRANS: publicar
+#. TRANS: publicar
 msgid "publish"
 msgstr "mbojekuaa"
 
 #: plugins/maths.rtp:62
-#.TRANS: poder
+#. TRANS: poder
 msgid "power"
 msgstr "mbarete"
 
 #: plugins/maths.rtp:62
-#.TRANS: base
+#. TRANS: base
 msgid "base"
 msgstr "topyta"
 
 #: plugins/maths.rtp:62
-#.TRANS: exp
+#. TRANS: exp
 msgid "exp"
 msgstr "exp"
 
 #: plugins/maths.rtp:99
-#.TRANS: piso
+#. TRANS: piso
 msgid "floor"
 msgstr "yvy atã"
 
 #: plugins/maths.rtp:104
-#.TRANS: techo
+#. TRANS: techo
 msgid "ceiling"
 msgstr "ogahoja"
 
 #: plugins/maths.rtp:109
-#.TRANS: a grados
+#. TRANS: a grados
 msgid "to degrees"
 msgstr "a grados"
 
 #: plugins/maths.rtp:114
-#.TRANS: a radianes
+#. TRANS: a radianes
 msgid "to radians"
 msgstr "a radianes"
 
 #: plugins/nutrition.rtp:104
-#.TRANS: obtener calorías
+#. TRANS: obtener calorías
 msgid "get calories"
 msgstr "calorías ohypytyva"
 
 #: plugins/nutrition.rtp:107
-#.TRANS: obtener proteínas
+#. TRANS: obtener proteínas
 msgid "get protein"
 msgstr "proteínas ohypytyva"
 
 #: plugins/nutrition.rtp:110
-#.TRANS: obtener carbohidratos
+#. TRANS: obtener carbohidratos
 msgid "get carbs"
 msgstr "carbohidratos ohypytyva"
 
 #: plugins/nutrition.rtp:113
-#.TRANS: obtener fibra
+#. TRANS: obtener fibra
 msgid "get fiber"
 msgstr "fibra ohypytyva"
 
 #: plugins/nutrition.rtp:116
-#.TRANS: obtener grasas
+#. TRANS: obtener grasas
 msgid "get fat"
 msgstr "kyrakue ohypytyva"
 
 #: plugins/nutrition.rtp:119
-#.TRANS: obtener nombre
+#. TRANS: obtener nombre
 msgid "get name"
 msgstr "téra ohypytyva"
 
 #: plugins/nutrition.rtp:122
-#.TRANS: calorías
+#. TRANS: calorías
 msgid "calories"
 msgstr "calorías"
 
 #: plugins/nutrition.rtp:128
-#.TRANS: proteína
+#. TRANS: proteína
 msgid "protein"
 msgstr "proteínas"
 
 #: plugins/nutrition.rtp:134
-#.TRANS: carbohidratos
+#. TRANS: carbohidratos
 msgid "carbs"
 msgstr "carbohidratos"
 
 #: plugins/nutrition.rtp:140
-#.TRANS: fibra
+#. TRANS: fibra
 msgid "fiber"
 msgstr "fibra"
 
 #: plugins/nutrition.rtp:146
-#.TRANS: grasa
+#. TRANS: grasa
 msgid "fat"
 msgstr "kyrakue"
 
 #: plugins/nutrition.rtp:152
-#.TRANS: comer
+#. TRANS: comer
 msgid "eat"
 msgstr "karu"
 
 #: plugins/nutrition.rtp:155
-#.TRANS: digerir
+#. TRANS: digerir
 msgid "digest meal"
 msgstr "mboguapy"
 
 #: plugins/nutrition.rtp:158
-#.TRANS: manzana
+#. TRANS: manzana
 msgid "apple"
 msgstr "yva"
 
 #: plugins/nutrition.rtp:161
-#.TRANS: banana
+#. TRANS: banana
 msgid "banana"
 msgstr "pakova"
 
 #: plugins/nutrition.rtp:167
-#.TRANS: pan
+#. TRANS: pan
 msgid "wheat bread"
 msgstr "mbujape"
 
 #: plugins/nutrition.rtp:170
-#.TRANS: maíz
+#. TRANS: maíz
 msgid "corn"
 msgstr "avatí"
 
 #: plugins/nutrition.rtp:173
-#.TRANS: papa
+#. TRANS: papa
 msgid "potato"
 msgstr "avy’a"
 
 #: plugins/nutrition.rtp:176
-#.TRANS: boñato
+#. TRANS: boñato
 msgid "sweet potato"
 msgstr "jety"
 
 #: plugins/nutrition.rtp:179
-#.TRANS: tomate
+#. TRANS: tomate
 msgid "tomato"
 msgstr "tomate"
 
 #: plugins/nutrition.rtp:182
-#.TRANS: brócoli
+#. TRANS: brócoli
 msgid "broccoli"
 msgstr "brócoli"
 
 #: plugins/nutrition.rtp:185
-#.TRANS: arroz y frijoles
+#. TRANS: arroz y frijoles
 msgid "rice and beans"
 msgstr "arró ha kumanda"
 
 #: plugins/nutrition.rtp:188
-#.TRANS: tamal
+#. TRANS: tamal
 msgid "tamale"
 msgstr "tamal"
 
 #: plugins/nutrition.rtp:191
-#.TRANS: queso
+#. TRANS: queso
 msgid "cheese"
 msgstr "kesú"
 
 #: plugins/nutrition.rtp:194
-#.TRANS: pollo
+#. TRANS: pollo
 msgid "chicken"
 msgstr "ryguasu"
 
 #: plugins/nutrition.rtp:197
-#.TRANS: pescado
+#. TRANS: pescado
 msgid "fish"
 msgstr "pira"
 
 #: plugins/nutrition.rtp:200
-#.TRANS: carne de res
+#. TRANS: carne de res
 msgid "beef"
 msgstr "vaka so’o"
 
 #: plugins/nutrition.rtp:203
-#.TRANS: pastel
+#. TRANS: pastel
 msgid "cake"
 msgstr "pastel"
 
 #: plugins/nutrition.rtp:206
-#.TRANS: galleta
+#. TRANS: galleta
 msgid "cookie"
 msgstr "mbujape apu’a"
 
 #: plugins/nutrition.rtp:209
-#.TRANS: agua
+#. TRANS: agua
 msgid "water"
 msgstr "y"
 
 #: plugins/weather.rtp:68
 #: plugins/weather.rtp:97
-#.TRANS: Los días siguientes deben estar en el rango de -1 a 5.
+#. TRANS: Los días siguientes deben estar en el rango de -1 a 5.
 msgid "Days ahead must be in the range of -1 to 5."
 msgstr "Ára kuéra tenondegua oĩvaerã -1 ha 5 peve"
 
 #: plugins/weather.rtp:122
-#.TRANS: pronóstico
+#. TRANS: pronóstico
 msgid "forecast"
 msgstr "pronóstico"
 
 #: plugins/weather.rtp:123
 #: plugins/weather.rtp:137
 #: plugins/weather.rtp:150
-#.TRANS: ciudad
+#. TRANS: ciudad
 msgid "city"
 msgstr "táva"
 
 #: plugins/weather.rtp:124
 #: plugins/weather.rtp:138
 #: plugins/weather.rtp:151
-#.TRANS: día
+#. TRANS: día
 msgid "day"
 msgstr "ára"
 
 #: plugins/weather.rtp:136
-#.TRANS: alta
+#. TRANS: alta
 msgid "high"
 msgstr "yvaté"
 
 #: plugins/weather.rtp:149
-#.TRANS: baja
+#. TRANS: baja
 msgid "low"
 msgstr "karapé"
 
 #: plugins/rodi.rtp:172
-#.TRANS: parpadear
+#. TRANS: parpadear
 msgid "blink"
 msgstr "sapymi"
 
 #: plugins/rodi.rtp:246
-#.TRANS: LED
+#. TRANS: LED
 msgid "led"
 msgstr "led"
 
 #: plugins/rodi.rtp:265
-#.TRANS: intensidad de luz
+#. TRANS: intensidad de luz
 msgid "light intensity"
 msgstr "tendy mbarete kué"
 
 #: plugins/rodi.rtp:282
-#.TRANS: luz infrarroja (izquierda)
+#. TRANS: luz infrarroja (izquierda)
 msgid "infrared light (left)"
 msgstr "hendy pytã (asúpe)"
 
 #: plugins/rodi.rtp:296
-#.TRANS: luz infrarroja (derecha)
+#. TRANS: luz infrarroja (derecha)
 msgid "infrared light (right)"
 msgstr "hendy pytã (akatúa)"
 
 #: plugins/rodi.rtp:338
-#.TRANS: mover
+#. TRANS: mover
 msgid "move"
 msgstr "mongu’e"
 
 #: js/activity.js:3323
 
-#.TRANS: Nada en la basura para restaurar.
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#. TRANS: Nada en la basura para restaurar.
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#.TRANS: Guarda audio de tu proyecto como WAV.
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#. TRANS: Guarda audio de tu proyecto como WAV.
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#.TRANS: Guarda tu proyecto como un archivo ABC.
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#. TRANS: Guarda tu proyecto como un archivo ABC.
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#.TRANS: Guarde el proyecto como un archivo de LilyPond.
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "Eñongatu jejaposéva ñongatuhápe LilyPond pe"
+#. TRANS: Guarde el proyecto como un archivo de LilyPond.
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "Eñongatu jejaposéva ñongatuhápe LilyPond pe"
 
 #: js/turtledefs.js:620
 
-#.TRANS: Mostrar u ocultar las rejillas de coordenadas.
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#. TRANS: Mostrar u ocultar las rejillas de coordenadas.
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#.TRANS: Expandir/contraer los bloques
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#. TRANS: Expandir/contraer los bloques
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#.TRANS: Mostrar estos mensajes.
-#~msgid "Show these messages."
-#~msgstr "Eichuka ñe’ẽmondo kuéra"
+#. TRANS: Mostrar estos mensajes.
+#~ msgid "Show these messages."
+#~ msgstr "Eichuka ñe’ẽmondo kuéra"
 
 #: js/rubrics.js:531
 
@@ -9392,8 +9392,8 @@ msgstr "mongu’e"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "andúva"
+#~ msgid "sensors"
+#~ msgstr "andúva"
 
 #: js/rubrics.js:532
 
@@ -9403,8 +9403,8 @@ msgstr "mongu’e"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "omombyte"
+#~ msgid "media"
+#~ msgstr "omombyte"
 
 #: js/block-verbose.js:3837
 
@@ -9416,35 +9416,35 @@ msgstr "mongu’e"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "hechauka"
+#~ msgid "show"
+#~ msgstr "hechauka"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -9458,69 +9458,69 @@ msgstr "mongu’e"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr "ñongatu"
+#~ msgid "save"
+#~ msgstr "ñongatu"
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Mopot ĩ"
+#~ msgid "Clean"
+#~ msgstr "Mopot ĩ"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "Ejapo mbegueve"
+#~ msgid "Run slow"
+#~ msgstr "Ejapo mbegueve"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr "Mboavarekoha"
+#~ msgid "Custom"
+#~ msgstr "Mboavarekoha"
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "oñongatu vore"
+#~ msgid "hide blocks"
+#~ msgstr "oñongatu vore"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -9540,13 +9540,13 @@ msgstr "mongu’e"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "joko"
+#~ msgid "stop"
+#~ msgstr "joko"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "pukukué"
+#~ msgid "duration (ms)"
+#~ msgstr "pukukué"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -9554,58 +9554,58 @@ msgstr "mongu’e"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "mopotĩ"
+#~ msgid "clear"
+#~ msgstr "mopotĩ"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "Embojere"
+#~ msgid "invert"
+#~ msgstr "Embojere"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -9621,25 +9621,25 @@ msgstr "mongu’e"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "pukukué"
+#~ msgid "duration"
+#~ msgstr "pukukué"
 
 #: js/widgets/temperament.js:454
 
@@ -9649,46 +9649,46 @@ msgstr "mongu’e"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr "mboty"
+#~ msgid "close"
+#~ msgstr "mboty"
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr "mbopu"
+#~ msgid "play"
+#~ msgstr "mbopu"
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
-#~msgid ""Toggle Fullscreen"
-#~msgstr ""Tekove pantalla oî"
+#~ msgid "Toggle Fullscreen"
+#~ msgstr "Tekove pantalla oî"
 
 #: js/toolbar.js:70
 
@@ -9698,190 +9698,190 @@ msgstr "mongu’e"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -9891,305 +9891,305 @@ msgstr "mongu’e"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr "Vore Hertz mba’e: He’ise mo’ã eipuru vore kuatia’ihai"
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr "Vore Hertz mba’e: He’ise mo’ã eipuru vore kuatia’ihai"
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "Ejapo pya’eve"
+#~ msgid "Run fast"
+#~ msgstr "Ejapo pya’eve"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "Emuasãi tér ã omboapa vore mboapakuaáva"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "Emuasãi tér ã omboapa vore mboapakuaáva"
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10199,97 +10199,97 @@ msgstr "mongu’e"
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "pirapire"
+#~ msgid "currency"
+#~ msgstr "pirapire"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "guive"
+#~ msgid "from"
+#~ msgstr "guive"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "tembiapo repy"
+#~ msgid "stock price"
+#~ msgstr "tembiapo repy"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "traducir"
+#~ msgid "translate"
+#~ msgstr "traducir"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "maitei"
+#~ msgid "hello"
+#~ msgstr "maitei"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "eikuaa ñe’ẽ"
+#~ msgid "detect lang"
+#~ msgstr "eikuaa ñe’ẽ"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "moambue ñe’ẽ"
+#~ msgid "set lang"
+#~ msgstr "moambue ñe’ẽ"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "tava latitud"
+#~ msgid "city latitude"
+#~ msgstr "tava latitud"
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "tava longitud"
+#~ msgid "city longitude"
+#~ msgstr "tava longitud"
 
 #: plugins/gmap.rtp:71
 
@@ -10299,144 +10299,144 @@ msgstr "mongu’e"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "Coordinar datos no disponibles"
+#~ msgid "Coordinate data not available."
+#~ msgstr "Coordinar datos no disponibles"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "Mapa de Google"
+#~ msgid "Google map"
+#~ msgstr "Mapa de Google"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "coordenadas"
+#~ msgid "coordinates"
+#~ msgstr "coordenadas"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "factor de zoom"
+#~ msgid "zoom factor"
+#~ msgstr "factor de zoom"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "enfocar"
+#~ msgid "zoom"
+#~ msgstr "enfocar"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "latitud"
+#~ msgid "latitude"
+#~ msgstr "latitud"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "longitud"
+#~ msgid "longitude"
+#~ msgstr "longitud"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "grados"
+#~ msgid "degrees"
+#~ msgstr "grados"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "radianes"
+#~ msgid "radians"
+#~ msgstr "radianes"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "myesakã"
+#~ msgid "define"
+#~ msgstr "myesakã"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "bitcoin"
+#~ msgid "bitcoin"
+#~ msgstr "bitcoin"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr "eiporavo vaerã peteĩ ñongatuha"
+#~ msgid "You need to select a file."
+#~ msgstr "eiporavo vaerã peteĩ ñongatuha"
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -10446,15 +10446,15 @@ msgstr "mongu’e"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr "mo’ã"
+#~ msgid "hide"
+#~ msgstr "mo’ã"
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -10464,23 +10464,23 @@ msgstr "mongu’e"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr "jekuaa"
+#~ msgid "popout"
+#~ msgstr "jekuaa"
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr "Vore angu’atarara: He’ise mo’ã eipuru vore haiha"
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr "Vore angu’atarara: He’ise mo’ã eipuru vore haiha"
 
 #: js/pitchtracker.js:181
 
@@ -10490,8 +10490,8 @@ msgstr "mongu’e"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -10499,120 +10499,120 @@ msgstr "mongu’e"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr "eñongatu ritmos"
+#~ msgid "save rhythms"
+#~ msgstr "eñongatu ritmos"
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr "mbotyryry"
+#~ msgid "drag"
+#~ msgstr "mbotyryry"
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr "Vore ipuha: He’ise mo’ã eipuru vore kuatia’ihai"
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr "Vore ipuha: He’ise mo’ã eipuru vore kuatia’ihai"
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:3177
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3185
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4700
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8277
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:11324
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2005
 
 #: js/palette.js:2062
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:282
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -10620,117 +10620,117 @@ msgstr "mongu’e"
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:410
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:472
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:564
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:2339
 
 #: js/basicblocks.js:2350
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2405
 
 #: js/basicblocks.js:2416
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3687
 
-#~msgid "eval"
-#~msgstr "emomba’e"
+#~ msgid "eval"
+#~ msgstr "emomba’e"
 
 #: js/basicblocks.js:4031
 
-#~msgid "100"
-#~msgstr "sa"
+#~ msgid "100"
+#~ msgstr "sa"
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -10758,37 +10758,37 @@ msgstr "mongu’e"
 
 #: js/pitchstaircase.js:589
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:223
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -10802,8 +10802,8 @@ msgstr "mongu’e"
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -10813,55 +10813,55 @@ msgstr "mongu’e"
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr "japonés"
+#~ msgid "japanese"
+#~ msgstr "japonés"
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/palette.js:1843
 
@@ -10869,8 +10869,8 @@ msgstr "mongu’e"
 
 #: js/basicblocks.js:1293
 
-#~msgid "chine"
-#~msgstr "chino"
+#~ msgid "chine"
+#~ msgstr "chino"
 
 #: js/timbre.js:743
 
@@ -10880,107 +10880,107 @@ msgstr "mongu’e"
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr "momba"
+#~ msgid "undo"
+#~ msgstr "momba"
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:752
 
 #: js/basicblocks.js:920
 
-#~msgid "set volume"
-#~msgstr "emoĩ volume (sonido)"
+#~ msgid "set volume"
+#~ msgstr "emoĩ volume (sonido)"
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr "Blues guasuve"
+#~ msgid "Major Blues"
+#~ msgstr "Blues guasuve"
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr "Enigmático"
+#~ msgid "Enigmatic"
+#~ msgstr "Enigmático"
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr "ml"
+#~ msgid "ml"
+#~ msgstr "ml"
 
 #: js/turtledefs.js:251
 
@@ -10988,707 +10988,707 @@ msgstr "mongu’e"
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr "Japonés"
+#~ msgid "Japanese"
+#~ msgstr "Japonés"
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr "itapu mbohapy takamby"
+#~ msgid "triangle-bell"
+#~ msgstr "itapu mbohapy takamby"
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr "Gitano español"
+#~ msgid "Spanish Gypsy"
+#~ msgstr "Gitano español"
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr "eñongatu ritmos ryru"
+#~ msgid "save drum machine"
+#~ msgstr "eñongatu ritmos ryru"
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/basicblocks.js:777
 
-#~msgid "note volume"
-#~msgstr "volumen nota"
+#~ msgid "note volume"
+#~ msgstr "volumen nota"
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "Eipe’a ybyra pe moha’anga ha Vore Pupoty"
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "Eipe’a ybyra pe moha’anga ha Vore Pupoty"
 
 #: js/turtledefs.js:121
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "Emongañy tera eichuka Yvyra pe vorekuera"
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "Emongañy tera eichuka Yvyra pe vorekuera"
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:133
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr "Votõ Eñongatu aty oñongatu peteĩ aty yvyra pe ári"
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr "Votõ Eñongatu aty oñongatu peteĩ aty yvyra pe ári"
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr "Egipcio"
+#~ msgid "Egyptian"
+#~ msgstr "Egipcio"
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr " votõ mbojaha oiko, upéicharõ oĩ vore mboheseguaha kuatiaryrúpe"
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr " votõ mbojaha oiko, upéicharõ oĩ vore mboheseguaha kuatiaryrúpe"
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr "Argelino"
+#~ msgid "Algerian"
+#~ msgstr "Argelino"
 
 #: js/basicblocks.js:813
 
-#~msgid "denominator"
-#~msgstr "denominador"
+#~ msgid "denominator"
+#~ msgstr "denominador"
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "Nde ikatu ehupi vore pyahu ñongatuha rire"
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "Nde ikatu ehupi vore pyahu ñongatuha rire"
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr "Moha’angá"
+#~ msgid "Settings"
+#~ msgstr "Moha’angá"
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr "guejy"
+#~ msgid "move down"
+#~ msgstr "guejy"
 
 #: js/basicblocks.js:148
 
-#~msgid "consonant step up"
-#~msgstr "Pundie pyrũ yvatéotyo "
+#~ msgid "consonant step up"
+#~ msgstr "Pundie pyrũ yvatéotyo "
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:497
 
-#~msgid "pitchslider"
-#~msgstr "Mbosyryryha pu"
+#~ msgid "pitchslider"
+#~ msgstr "Mbosyryryha pu"
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr "Fibonacci"
+#~ msgid "Fibonacci"
+#~ msgstr "Fibonacci"
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr "castañuelas"
+#~ msgid "finger-cymbals"
+#~ msgstr "castañuelas"
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr "ñepyrũha angu’atarara pu"
+#~ msgid "pitch-drum matrix"
+#~ msgstr "ñepyrũha angu’atarara pu"
 
 #: js/logo.js:4202
 
 #: js/logo.js:4226
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr "Vore tuplet mba’e: He’ise mo’ã eipuru vore moñepyrũmbygua"
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr "Vore tuplet mba’e: He’ise mo’ã eipuru vore moñepyrũmbygua"
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr "Mbogue pa"
+#~ msgid "Delete all"
+#~ msgstr "Mbogue pa"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr "Cromático"
+#~ msgid "Chromatic"
+#~ msgstr "Cromático"
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr "mbojere horario"
+#~ msgid "rotate clockwise"
+#~ msgstr "mbojere horario"
 
 #: js/logo.js:3609
 
 #: js/logo.js:3630
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr "Eikeha vore michĩveva ha’e vaerã mokoĩ, mbohapy, poteĩ terã pokoĩ "
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr "Eikeha vore michĩveva ha’e vaerã mokoĩ, mbohapy, poteĩ terã pokoĩ "
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:813
 
-#~msgid "numerator"
-#~msgstr "numerador"
+#~ msgid "numerator"
+#~ msgstr "numerador"
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr "angu’atarara mba’yru’I apu’a"
+#~ msgid "cup-drum"
+#~ msgstr "angu’atarara mba’yru’I apu’a"
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr " hi hat "
+#~ msgid "hi-hat"
+#~ msgstr " hi hat "
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr "Frigio"
+#~ msgid "Phrygian"
+#~ msgstr "Frigio"
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr "Mbopu pya’e / Ejopy are embopu mbegue haguã / Ejopy areve embopu haguã pupoty mbeguemi"
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr "Mbopu pya’e / Ejopy are embopu mbegue haguã / Ejopy areve embopu haguã pupoty mbeguemi"
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1229
 
-#~msgid "relative interval"
-#~msgstr "interval relativa"
+#~ msgid "relative interval"
+#~ msgstr "interval relativa"
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr "Ejoko puporã (karumbe kuéra avei"
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr "Ejoko puporã (karumbe kuéra avei"
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr "Húngaro"
+#~ msgid "Hungarian"
+#~ msgstr "Húngaro"
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr "mbohesarai acorde"
+#~ msgid "play chord"
+#~ msgstr "mbohesarai acorde"
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11696,112 +11696,112 @@ msgstr "mongu’e"
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
 #: js/basicblocks.js:664
 
-#~msgid "multiply beat value"
-#~msgstr "embohetave ritmo"
+#~ msgid "multiply beat value"
+#~ msgstr "embohetave ritmo"
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr "pu oĩmbáva"
+#~ msgid "Whole Tone"
+#~ msgstr "pu oĩmbáva"
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:116
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr "Eyopy clic ejapo haguã puporã añoite mbeguemi"
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr "Eyopy clic ejapo haguã puporã añoite mbeguemi"
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:3516
 
 #: js/logo.js:3537
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "Eikeha vore tuichaha ha’e vaerã peteĩ, mokoĩ, mbohapy, irundy, po, poteĩ, pokoĩ terã poapy"
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "Eikeha vore tuichaha ha’e vaerã peteĩ, mokoĩ, mbohapy, irundy, po, poteĩ, pokoĩ terã poapy"
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr "eñongatu lilypond icha"
+#~ msgid "save as lilypond"
+#~ msgstr "eñongatu lilypond icha"
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr "mo michĩmbyre"
+#~ msgid "Diminished"
+#~ msgstr "mo michĩmbyre"
 
 #: js/turtledefs.js:187
 
@@ -11809,112 +11809,112 @@ msgstr "mongu’e"
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "karumbe"
+#~ msgid "turtle"
+#~ msgstr "karumbe"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/musicutils.js:295
 
-#~msgid "basse"
-#~msgstr "basse"
+#~ msgid "basse"
+#~ msgstr "basse"
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr "440 hertz"
+#~ msgid "440 hertz"
+#~ msgstr "440 hertz"
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -11924,124 +11924,124 @@ msgstr "mongu’e"
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr "mbohesarai paite"
+#~ msgid "play all"
+#~ msgstr "mbohesarai paite"
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:140
 
-#~msgid "consonant step down"
-#~msgstr "Pundie pyrũ yvýotyo"
+#~ msgid "consonant step down"
+#~ msgstr "Pundie pyrũ yvýotyo"
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr "myatyrõ itapu"
+#~ msgid "ride-bell"
+#~ msgstr "myatyrõ itapu"
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr "Lydian"
+#~ msgid "Lydian"
+#~ msgstr "Lydian"
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr "mbojekuaa"
+#~ msgid "Publish"
+#~ msgstr "mbojekuaa"
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr "Rumano michĩvea"
+#~ msgid "Romanian Minor"
+#~ msgstr "Rumano michĩvea"
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12049,372 +12049,372 @@ msgstr "mongu’e"
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr "Maymáva yvyári"
+#~ msgid "Worldwide"
+#~ msgstr "Maymáva yvyári"
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1272
 
-#~msgid "pluck"
-#~msgstr "motenonde"
+#~ msgid "pluck"
+#~ msgstr "motenonde"
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:558
 
-#~msgid "skip factor"
-#~msgstr "ypy mopa’ũha"
+#~ msgid "skip factor"
+#~ msgstr "ypy mopa’ũha"
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "pe’a"
+#~ msgid "Open"
+#~ msgstr "pe’a"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr "tom tom"
+#~ msgid "tom-tom"
+#~ msgstr "tom tom"
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr "Jónico"
+#~ msgid "Ionian"
+#~ msgstr "Jónico"
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr "ch"
+#~ msgid "ch"
+#~ msgstr "ch"
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr "cb"
+#~ msgid "cb"
+#~ msgstr "cb"
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr "Eyopy clic embopuhaguã ñe’ẽjoapy"
+#~ msgid "Click to run the music note by note."
+#~ msgstr "Eyopy clic embopuhaguã ñe’ẽjoapy"
 
 #: js/musicutils.js:297
 
-#~msgid "poly"
-#~msgstr "polifónico"
+#~ msgid "poly"
+#~ msgstr "polifónico"
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr "jupi"
+#~ msgid "move up"
+#~ msgstr "jupi"
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr "moañetẽ"
+#~ msgid "confirm"
+#~ msgstr "moañetẽ"
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr "Maqan"
+#~ msgid "Maqam"
+#~ msgstr "Maqan"
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr "Eólico"
+#~ msgid "Aeolian"
+#~ msgstr "Eólico"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr "Locrian"
+#~ msgid "Locrian"
+#~ msgstr "Locrian"
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr "Blues"
+#~ msgid "Blues"
+#~ msgstr "Blues"
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr "m"
+#~ msgid "m"
+#~ msgstr "m"
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr "rs"
+#~ msgid "rs"
+#~ msgstr "rs"
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr "michĩve"
+#~ msgid "Minor"
+#~ msgstr "michĩve"
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr "Bizantino"
+#~ msgid "Byzantine"
+#~ msgstr "Bizantino"
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr "Jazz michĩve"
+#~ msgid "Jazz Minor"
+#~ msgstr "Jazz michĩve"
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -12426,181 +12426,181 @@ msgstr "mongu’e"
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr "angu’atarara miliko michĩa"
+#~ msgid "snare-drum"
+#~ msgstr "angu’atarara miliko michĩa"
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr "Octatónico"
+#~ msgid "Octatonic"
+#~ msgstr "Octatónico"
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr "jazz michĩve"
+#~ msgid "jazz-minor"
+#~ msgstr "jazz michĩve"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr "itapu"
+#~ msgid "cow-bell"
+#~ msgstr "itapu"
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr "fs"
+#~ msgid "fs"
+#~ msgstr "fs"
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr "ára oscilador"
+#~ msgid "osctime"
+#~ msgstr "ára oscilador"
 
 #: js/basicblocks.js:673
 
-#~msgid "divide beat value"
-#~msgstr "emopa’ũndy ára"
+#~ msgid "divide beat value"
+#~ msgstr "emopa’ũndy ára"
 
 #: js/turtledefs.js:187
 
@@ -12608,129 +12608,129 @@ msgstr "mongu’e"
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:273
 
-#~msgid "blues"
-#~msgstr "blues"
+#~ msgid "blues"
+#~ msgstr "blues"
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr "Dorio"
+#~ msgid "Dorian"
+#~ msgstr "Dorio"
 
 #: js/turtledefs.js:113
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr "Koa ko mba’e puku tembipuru ryru oreko Yvyra pe votõkuera Matrix, Notas, Tono, Tortuga ha heta mba’e ve"
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr "Koa ko mba’e puku tembipuru ryru oreko Yvyra pe votõkuera Matrix, Notas, Tono, Tortuga ha heta mba’e ve"
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr "angu’atarara guasu"
+#~ msgid "kick-drum"
+#~ msgstr "angu’atarara guasu"
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12738,433 +12738,433 @@ msgstr "mongu’e"
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3163
 
-#~msgid "Note value must be greater than 0"
-#~msgstr "Kuatia’ihai tepy nda tuchavei vaerã mba’evéigui"
+#~ msgid "Note value must be greater than 0"
+#~ msgstr "Kuatia’ihai tepy nda tuchavei vaerã mba’evéigui"
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr " ñepyrũha pu árape"
+#~ msgid "pitch-time matrix"
+#~ msgstr " ñepyrũha pu árape"
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr " Ehechauka tera eñongatu rejilla de coordenadas polares"
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr " Ehechauka tera eñongatu rejilla de coordenadas polares"
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "Embogue tendahesaperã ha emoĩ karumbe kuéra oñepyrũ haguépe"
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "Embogue tendahesaperã ha emoĩ karumbe kuéra oñepyrũ haguépe"
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:2520
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr "Vore pu pegua eipuru vaerã vore haiha ryepype"
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr "Vore pu pegua eipuru vaerã vore haiha ryepype"
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr "Geez"
+#~ msgid "Geez"
+#~ msgstr "Geez"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr "Arábica"
+#~ msgid "Arabic"
+#~ msgstr "Arábica"
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr "blues guasuve"
+#~ msgid "major-blues"
+#~ msgstr "blues guasuve"
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr "Hindú"
+#~ msgid "Hindu"
+#~ msgstr "Hindú"
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr "gs"
+#~ msgid "gs"
+#~ msgstr "gs"
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:317
 
-#~msgid "step pitch"
-#~msgstr "pyrũ pu"
+#~ msgid "step pitch"
+#~ msgstr "pyrũ pu"
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr "bk"
+#~ msgid "bk"
+#~ msgstr "bk"
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr "bt"
+#~ msgid "bt"
+#~ msgstr "bt"
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr "br"
+#~ msgid "br"
+#~ msgstr "br"
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr "mbojere antihorario"
+#~ msgid "rotate counter clockwise"
+#~ msgstr "mbojere antihorario"
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr "mohenda"
+#~ msgid "sort"
+#~ msgstr "mohenda"
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr "emoĩ ñe’ẽ"
+#~ msgid "set voice"
+#~ msgstr "emoĩ ñe’ẽ"
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr "Polar"
+#~ msgid "Polar"
+#~ msgstr "Polar"
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr "Pu ko’ãgagua"
+#~ msgid "current pitch name"
+#~ msgstr "Pu ko’ãgagua"
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "Ehechauka tera eñongatu cuadrí­cula en coordenadas cartesianas"
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "Ehechauka tera eñongatu cuadrí­cula en coordenadas cartesianas"
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr "gp"
+#~ msgid "gp"
+#~ msgstr "gp"
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr "Mixolidio"
+#~ msgid "Mixolydian"
+#~ msgstr "Mixolidio"
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr "Ehupi plugin ñongatuha rire"
+#~ msgid "Load plugin from file"
+#~ msgstr "Ehupi plugin ñongatuha rire"
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr "Chino"
+#~ msgid "Chinese"
+#~ msgstr "Chino"
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -13174,110 +13174,110 @@ msgstr "mongu’e"
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr "Mboguejy"
+#~ msgid "Download"
+#~ msgstr "Mboguejy"
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr " darbuka "
+#~ msgid "darbuka-drum"
+#~ msgstr " darbuka "
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr " Solfeo "
+#~ msgid "Solfa"
+#~ msgstr " Solfeo "
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2149
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr "Karumbe chovi ndorekói heta oikóva"
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr "Karumbe chovi ndorekói heta oikóva"
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr " Ehechauka tér ã emokañy yvyra pe"
+#~ msgid "Show/hide palettes"
+#~ msgstr " Ehechauka tér ã emokañy yvyra pe"
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:278
 
-#~msgid "pentatonic"
-#~msgstr "pentatónico"
+#~ msgid "pentatonic"
+#~ msgstr "pentatónico"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -13285,50 +13285,50 @@ msgstr "mongu’e"
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr "ritmo mbojojaha"
+#~ msgid "rhythm ruler"
+#~ msgstr "ritmo mbojojaha"
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr "Pentatónico"
+#~ msgid "Pentatonic"
+#~ msgstr "Pentatónico"
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:3562
 
 #: js/logo.js:3584
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr "Eikeha vore tuichaveva ha’e vaerã mokoĩ, mbohapy, poteĩ terã pokoĩ"
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr "Eikeha vore tuichaveva ha’e vaerã mokoĩ, mbohapy, poteĩ terã pokoĩ"
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr "articulación"
+#~ msgid "articulation"
+#~ msgstr "articulación"
 
 #: js/turtledefs.js:387
 
@@ -13338,30 +13338,30 @@ msgstr "mongu’e"
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13369,102 +13369,102 @@ msgstr "mongu’e"
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr "Eñongatu purahéi haipyre"
+#~ msgid "Save sheet music"
+#~ msgstr "Eñongatu purahéi haipyre"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr "romano michĩve"
+#~ msgid "romanian-minor"
+#~ msgstr "romano michĩve"
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:259
 
-#~msgid "adjust transposition"
-#~msgstr "Moĩ porã ombohasa hi’ari "
+#~ msgid "adjust transposition"
+#~ msgstr "Moĩ porã ombohasa hi’ari "
 
 #: js/turtledefs.js:114
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "Eyopy clic ejapo haguã jejaposéva pya’eve"
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "Eyopy clic ejapo haguã jejaposéva pya’eve"
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr "Embopu ñe’ ẽjapy pupotyicha"
+#~ msgid "Run note by note"
+#~ msgstr "Embopu ñe’ ẽjapy pupotyicha"
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr "ijape"
+#~ msgid "shell"
+#~ msgstr "ijape"
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -13472,259 +13472,259 @@ msgstr "mongu’e"
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr "pa’ũ"
+#~ msgid "pause"
+#~ msgstr "pa’ũ"
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:588
 
-#~msgid "free time"
-#~msgstr "ára sãso"
+#~ msgid "free time"
+#~ msgstr "ára sãso"
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr "pu oĩmbava"
+#~ msgid "whole-tone"
+#~ msgstr "pu oĩmbava"
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr "Etíope"
+#~ msgid "Ethiopian"
+#~ msgstr "Etíope"
 
 #: js/turtledefs.js:133
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr "Ojekuaa peteĩ are jopyrire atype"
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr "Ojekuaa peteĩ are jopyrire atype"
 
 #: js/logo.js:3424
 
 #: js/logo.js:3445
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr "Eikeha vore porã jepéva pe ha’e vaerã peteĩ, irundy, po terã poapy"
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr "Eikeha vore porã jepéva pe ha’e vaerã peteĩ, irundy, po terã poapy"
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr "cp"
+#~ msgid "cp"
+#~ msgstr "cp"
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr "gitana española"
+#~ msgid "spanish-gypsy"
+#~ msgstr "gitana española"
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr "Be-bop"
+#~ msgid "Bebop"
+#~ msgstr "Be-bop"
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr "votõ mbojaha jeichuka"
+#~ msgid "The Paste Button will highlight."
+#~ msgstr "votõ mbojaha jeichuka"
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "Eipe’a opakatu canvas, vore kuéra avei"
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "Eipe’a opakatu canvas, vore kuéra avei"
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr "eñongatu SVG icha"
+#~ msgid "save svg"
+#~ msgstr "eñongatu SVG icha"
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr "Che papahape"
+#~ msgid "On my device"
+#~ msgstr "Che papahape"
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:3470
 
 #: js/logo.js:3491
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "Eikeha vore michĩha ha’e vaerã peteĩ, mokoĩ, mbohapy, irundy, po, poteĩ, pokoĩ terã poapy"
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "Eikeha vore michĩha ha’e vaerã peteĩ, mokoĩ, mbohapy, irundy, po, poteĩ, pokoĩ terã poapy"
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr "Ejapo pupoty mbegueve"
+#~ msgid "Run music slow"
+#~ msgstr "Ejapo pupoty mbegueve"
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr "Embohesegua haguã kuatiaryru atype, eyopy are atype"
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr "Embohesegua haguã kuatiaryru atype, eyopy are atype"
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr "mondo"
+#~ msgid "export"
+#~ msgstr "mondo"
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13732,13 +13732,13 @@ msgstr "mongu’e"
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -13746,91 +13746,91 @@ msgstr "mongu’e"
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr "guasuve"
+#~ msgid "Major"
+#~ msgstr "guasuve"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:655
 
-#~msgid "duplicate notes"
-#~msgstr "emomokoĩ notas"
+#~ msgid "duplicate notes"
+#~ msgstr "emomokoĩ notas"
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr "moĩngohỹ scroll"
+#~ msgid "Disable scrolling"
+#~ msgstr "moĩngohỹ scroll"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:3106
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr " Vore rítmo: He’ise mo’ã eipuru vore moñepyrũmbygua"
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr " Vore rítmo: He’ise mo’ã eipuru vore moñepyrũmbygua"
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr "Octava ko’ãgagua"
+#~ msgid "current pitch octave"
+#~ msgstr "Octava ko’ãgagua"
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr "Hirajoshi"
+#~ msgid "Hirajoshi"
+#~ msgstr "Hirajoshi"
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr "Español"
+#~ msgid "Spanish"
+#~ msgstr "Español"
 

--- a/po/ha.po
+++ b/po/ha.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -99,7 +99,7 @@ msgstr "פעולה"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr "ברווז"
 
@@ -166,7 +166,7 @@ msgstr "להתחבא"
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "הפרויקט שלי"
 
@@ -180,33 +180,33 @@ msgid "Your recording is in progress."
 msgstr "ההקלטה שלך בעיצומה."
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "שם קובץ"
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "כותרת הפרויקט"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "מחבר הפרויקט"
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "כולל פלט MIDI"
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "כלול פלט טבלטור גיטרה"
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "שמור בתור Lilypond"
 
@@ -228,7 +228,7 @@ msgstr "שמור בתור Lilypond"
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "מר עכבר"
 
@@ -306,7 +306,7 @@ msgstr "להראות קואורדינטות קרטזיות"
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -535,8 +535,8 @@ msgstr "שמור עזרה לחסום"
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr "סַרְגֵל"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "גָוֶן"
 
@@ -705,14 +705,14 @@ msgstr "מַדרֵגָה"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "טֶמפּוֹ"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "מצב מוזיקלי"
 
@@ -743,7 +743,7 @@ msgstr "תוֹף"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "יוצר קצב"
 
@@ -768,7 +768,7 @@ msgstr "יוצר קצב"
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "ערך תו מוזיקלי"
 
@@ -777,7 +777,7 @@ msgstr "ערך תו מוזיקלי"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "מרווח סקלרי"
 
@@ -798,7 +798,7 @@ msgid "silence"
 msgstr "דְמָמָה"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "מטה"
 
@@ -816,8 +816,8 @@ msgstr "מַעְלָה"
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "מגרש מוזיקלי"
 
@@ -919,7 +919,7 @@ msgstr "טֶנוֹר"
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "בַּס"
 
@@ -1053,14 +1053,14 @@ msgstr "לא נבחר בלוק."
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "גִלגוּל"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "דוּגמָה"
 
@@ -1135,7 +1135,7 @@ msgstr "להתחיל תוף"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "קֶצֶב"
 
@@ -1171,7 +1171,7 @@ msgstr "זרם"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -1180,7 +1180,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -1671,7 +1671,7 @@ msgstr "ההשמעה מוכנה."
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "חד כפול"
 
@@ -1683,8 +1683,8 @@ msgstr "חד כפול"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "חַד"
 
@@ -1694,7 +1694,7 @@ msgstr "חַד"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -1706,8 +1706,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr " זוגי"
 
@@ -1717,15 +1717,15 @@ msgstr " זוגי"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "שטוח זוגי"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -1734,14 +1734,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -1750,14 +1750,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -1798,7 +1798,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -1807,7 +1807,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr "כתובת אתר"
 
@@ -1824,7 +1824,7 @@ msgstr "לחפש"
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "קֶצֶב"
 
@@ -1893,8 +1893,8 @@ msgstr "אקסטרה"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "תכנית"
 
@@ -1916,7 +1916,7 @@ msgstr "לוגיקה"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -2202,7 +2202,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -2533,21 +2533,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -2556,12 +2556,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -2574,62 +2574,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -2642,7 +2642,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -2651,7 +2651,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -2664,7 +2664,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -2673,17 +2673,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -2692,12 +2692,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -2710,7 +2710,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -2719,17 +2719,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -2746,56 +2746,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -2803,7 +2803,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -2820,7 +2820,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -2828,7 +2828,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -2837,8 +2837,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -2846,7 +2846,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -2860,116 +2860,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -2988,19 +2988,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -3008,61 +3008,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -3072,149 +3072,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -3223,7 +3223,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3302,22 +3302,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -3474,7 +3474,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -3507,7 +3507,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -3545,7 +3545,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -3578,7 +3578,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -3588,7 +3588,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "רוקן מחסנית FILO"
 
@@ -3597,7 +3597,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -3606,7 +3606,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -3629,13 +3629,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -3644,7 +3644,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "שלוף\\טען ערך"
 
@@ -3653,7 +3653,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "דחוף\\שמור ערך"
 
@@ -3673,7 +3673,7 @@ msgstr "להגדיר מזג"
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "אוֹקְטָבָה"
 
@@ -3698,7 +3698,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr "מדידת מרווח חצי טון"
 
@@ -3712,7 +3712,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr "מרווח חצי טון"
 
@@ -3760,7 +3760,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr "להגדיר מצב"
 
@@ -3769,7 +3769,7 @@ msgid "movable Do"
 msgstr "DO מטלטלין"
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "אורך מצב"
 
@@ -3782,18 +3782,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "מצב נוכחי"
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -3933,7 +3933,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -3942,7 +3942,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -3972,7 +3972,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "פתח FILO"
 
@@ -4001,7 +4001,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "טען מילון"
 
@@ -4024,7 +4024,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -4041,7 +4041,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "שמור FILO"
 
@@ -4050,7 +4050,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr "לשמור מילון"
 
@@ -4067,7 +4067,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -4076,7 +4076,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -4110,7 +4110,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -4119,7 +4119,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -4136,7 +4136,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -4151,7 +4151,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "הערה"
 
@@ -4185,12 +4185,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -4199,12 +4199,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -4213,13 +4213,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -4237,7 +4237,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -4269,8 +4269,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "קֶצֶב"
 
@@ -4326,7 +4326,7 @@ msgstr "פתק שלם"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "טופלת"
 
@@ -4483,12 +4483,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -4498,8 +4498,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -4507,12 +4507,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -4521,7 +4521,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -4538,7 +4538,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -4548,12 +4548,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -4563,7 +4563,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -4572,7 +4572,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -4622,7 +4622,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -4655,7 +4655,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -4664,12 +4664,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -4678,7 +4678,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -4687,7 +4687,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -4696,7 +4696,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -4707,8 +4707,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -4718,7 +4718,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -4744,7 +4744,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -4782,12 +4782,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -4799,12 +4799,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "כִּנוּי"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -4813,7 +4813,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -4859,22 +4859,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -4883,7 +4883,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -4896,7 +4896,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -4905,47 +4905,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -4958,7 +4958,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -4975,7 +4975,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -4989,8 +4989,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -5019,7 +5019,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -5044,14 +5044,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -5061,7 +5061,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -5080,7 +5080,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -5090,7 +5090,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -5107,17 +5107,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -5126,7 +5126,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -5136,7 +5136,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -5146,7 +5146,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -5158,7 +5158,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -5166,7 +5166,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -5176,7 +5176,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -5197,7 +5197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -5212,7 +5212,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -5222,7 +5222,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -5236,7 +5236,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -5292,7 +5292,7 @@ msgstr "לְחַשֵׁב"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -5470,7 +5470,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "צבע עכבר"
 
@@ -5479,7 +5479,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "צבע צב"
 
@@ -5488,7 +5488,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "כותרת עכבר"
 
@@ -5497,7 +5497,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "כותרת צב"
 
@@ -5507,13 +5507,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -5526,7 +5526,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "עכבר y"
 
@@ -5535,7 +5535,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "y צב"
 
@@ -5544,7 +5544,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "עכבר x"
 
@@ -5553,7 +5553,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "צב x"
 
@@ -5562,7 +5562,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -5571,7 +5571,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -5580,7 +5580,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -5589,7 +5589,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -5599,17 +5599,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -5618,7 +5618,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -6045,7 +6045,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -6099,12 +6099,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "הפסקת נגן"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -6113,7 +6113,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "נגן"
 
@@ -6170,7 +6170,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -6188,7 +6188,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "גודל"
 
@@ -6201,7 +6201,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "לְהַצִיג"
 
@@ -6266,7 +6266,7 @@ msgstr "סיים מילוי"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "מלא מסך"
 
@@ -6331,7 +6331,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -6340,12 +6340,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "הרם עט"
 
@@ -6354,7 +6354,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "הורד עט"
 
@@ -6363,7 +6363,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "קבע עובי עט"
 
@@ -6372,7 +6372,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -6397,7 +6397,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "קבע אפור"
 
@@ -6532,27 +6532,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "הַתקָפָה"
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "בְּלִי"
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "לָשֵׂאת"
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "לְשַׁחְרֵר"
 
@@ -6578,18 +6578,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -6604,7 +6604,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "מצב מותאם אישית"
 
@@ -6642,7 +6642,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "ממפה גובה-תוף"
 
@@ -6655,7 +6655,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "מחוון הגובה"
 
@@ -6665,7 +6665,7 @@ msgstr "מקלדת כרומטית"
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr "מקלדת כרומטית"
 
@@ -6679,7 +6679,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "גרם מדרגות במגרש"
 
@@ -6700,7 +6700,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "יצרן ביטויים"
 
@@ -6714,7 +6714,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -6901,7 +6901,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -6910,7 +6910,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -7032,7 +7032,7 @@ msgid "Undo"
 msgstr "לבטל"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -7115,7 +7115,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -7165,7 +7165,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -7361,48 +7361,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -7835,38 +7835,38 @@ msgstr "זוז"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr "שמור אודיו מהפרויקט שלך כ-WAV."
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr "שמור אודיו מהפרויקט שלך כ-WAV."
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr "שמור את הפרויקט שלך כקובץ ABC."
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr "שמור את הפרויקט שלך כקובץ ABC."
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "שמור את הפרויקט שלך כקובץ Lilypond."
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "שמור את הפרויקט שלך כקובץ Lilypond."
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr "הצג או הסתר רשת קואורדינטות."
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr "הצג או הסתר רשת קואורדינטות."
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr "הרחב/כווץ בלוקים הניתנים לכיווץ"
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr "הרחב/כווץ בלוקים הניתנים לכיווץ"
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "הצג את הודעות אלה"
+#~ msgid "Show these messages."
+#~ msgstr "הצג את הודעות אלה"
 
 #: js/rubrics.js:531
 
@@ -7874,8 +7874,8 @@ msgstr "זוז"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "חיישנים"
+#~ msgid "sensors"
+#~ msgstr "חיישנים"
 
 #: js/rubrics.js:532
 
@@ -7885,8 +7885,8 @@ msgstr "זוז"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "מדיה"
+#~ msgid "media"
+#~ msgstr "מדיה"
 
 #: js/block-verbose.js:3837
 
@@ -7898,35 +7898,35 @@ msgstr "זוז"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr "הקוטב והקרטזאי"
+#~ msgid "Cartesian+polar"
+#~ msgstr "הקוטב והקרטזאי"
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "הצג"
+#~ msgid "show"
+#~ msgstr "הצג"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr "הצג או הסתר בלוק"
+#~ msgid "Show/hide block"
+#~ msgstr "הצג או הסתר בלוק"
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "רֶשֶׁת"
+#~ msgid "grid"
+#~ msgstr "רֶשֶׁת"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr "אתה בחרת"
+#~ msgid "You have chosen key "
+#~ msgstr "אתה בחרת"
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -7940,69 +7940,69 @@ msgstr "זוז"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr "מוּסִיקָה"
+#~ msgid "music"
+#~ msgstr "מוּסִיקָה"
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr "שמור"
+#~ msgid "save"
+#~ msgstr "שמור"
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "נקה"
+#~ msgid "Clean"
+#~ msgstr "נקה"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "הרצה איטית"
+#~ msgid "Run slow"
+#~ msgstr "הרצה איטית"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "הסתר בלוקים"
+#~ msgid "hide blocks"
+#~ msgstr "הסתר בלוקים"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8022,13 +8022,13 @@ msgstr "זוז"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "עצור"
+#~ msgid "stop"
+#~ msgstr "עצור"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8036,58 +8036,58 @@ msgstr "זוז"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "נקה"
+#~ msgid "clear"
+#~ msgstr "נקה"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr "מעטפת קול"
+#~ msgid "envelope"
+#~ msgstr "מעטפת קול"
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr "לְסַנֵן"
+#~ msgid "filter"
+#~ msgstr "לְסַנֵן"
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -8103,25 +8103,25 @@ msgstr "זוז"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "משך זמן"
+#~ msgid "duration"
+#~ msgstr "משך זמן"
 
 #: js/widgets/temperament.js:454
 
@@ -8131,43 +8131,43 @@ msgstr "זוז"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr "Lilypond לא יכול לעבד איסוף"
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr "Lilypond לא יכול לעבד איסוף"
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr "רענן את הדפדפן כדי לעבור למצב מתקדם."
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr "רענן את הדפדפן כדי לעבור למצב מתקדם."
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr "רענן את הדפדפן שלך כדי לעבור למצב מתחיל."
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr "רענן את הדפדפן שלך כדי לעבור למצב מתחיל."
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -8177,190 +8177,190 @@ msgstr "זוז"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr "החלף את עורך JavaScript"
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr "החלף את עורך JavaScript"
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -8370,305 +8370,305 @@ msgstr "זוז"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "הרצה מהירה"
+#~ msgid "Run fast"
+#~ msgstr "הרצה מהירה"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "צמצם/הרחב את הבלוקים הניתנים לצמצום"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "צמצם/הרחב את הבלוקים הניתנים לצמצום"
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -8678,97 +8678,97 @@ msgstr "זוז"
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "מטבע"
+#~ msgid "currency"
+#~ msgstr "מטבע"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "מ"
+#~ msgid "from"
+#~ msgstr "מ"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "מחיר מניה"
+#~ msgid "stock price"
+#~ msgstr "מחיר מניה"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "תרגם"
+#~ msgid "translate"
+#~ msgstr "תרגם"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "שלום"
+#~ msgid "hello"
+#~ msgstr "שלום"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "זיהוי שפה"
+#~ msgid "detect lang"
+#~ msgstr "זיהוי שפה"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "קבע שפה"
+#~ msgid "set lang"
+#~ msgstr "קבע שפה"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "קו רוחב של עיר"
+#~ msgid "city latitude"
+#~ msgstr "קו רוחב של עיר"
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "קו אורך של עיר"
+#~ msgid "city longitude"
+#~ msgstr "קו אורך של עיר"
 
 #: plugins/gmap.rtp:71
 
@@ -8778,144 +8778,144 @@ msgstr "זוז"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "נתוני הקואורדינטות אינם זמינים"
+#~ msgid "Coordinate data not available."
+#~ msgstr "נתוני הקואורדינטות אינם זמינים"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "גוגל מפות"
+#~ msgid "Google map"
+#~ msgstr "גוגל מפות"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "קואורדינטות"
+#~ msgid "coordinates"
+#~ msgstr "קואורדינטות"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "גורם זום"
+#~ msgid "zoom factor"
+#~ msgstr "גורם זום"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "זום"
+#~ msgid "zoom"
+#~ msgstr "זום"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "קו רוחב"
+#~ msgid "latitude"
+#~ msgstr "קו רוחב"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "קו אורך"
+#~ msgid "longitude"
+#~ msgstr "קו אורך"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "מעלות"
+#~ msgid "degrees"
+#~ msgstr "מעלות"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "רדיאנים"
+#~ msgid "radians"
+#~ msgstr "רדיאנים"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "הגדר"
+#~ msgid "define"
+#~ msgstr "הגדר"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "ביטקוין"
+#~ msgid "bitcoin"
+#~ msgstr "ביטקוין"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -8925,15 +8925,15 @@ msgstr "זוז"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -8943,23 +8943,23 @@ msgstr "זוז"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -8969,8 +8969,8 @@ msgstr "זוז"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -8978,224 +8978,224 @@ msgstr "זוז"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -9211,37 +9211,37 @@ msgstr "זוז"
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -9249,28 +9249,28 @@ msgstr "זוז"
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -9284,8 +9284,8 @@ msgstr "זוז"
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -9295,65 +9295,65 @@ msgstr "זוז"
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -9361,8 +9361,8 @@ msgstr "זוז"
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -9372,127 +9372,127 @@ msgstr "זוז"
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -9500,608 +9500,608 @@ msgstr "זוז"
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr "לאכול"
+#~ msgid "eatme"
+#~ msgstr "לאכול"
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "פתיחת פאנל להתאמת בלוקים"
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "פתיחת פאנל להתאמת בלוקים"
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr "כפתור הדבק פעיל כאשר ישנם בלוקים שהועתקו אל הלוח"
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr "כפתור הדבק פעיל כאשר ישנם בלוקים שהועתקו אל הלוח"
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "ניתן להעלות בלוקים חדשים מתוך מערכת הקבצים"
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "ניתן להעלות בלוקים חדשים מתוך מערכת הקבצים"
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr "הגדרות"
+#~ msgid "Settings"
+#~ msgstr "הגדרות"
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr "מחק הכל"
+#~ msgid "Delete all"
+#~ msgstr "מחק הכל"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -10111,165 +10111,165 @@ msgstr "זוז"
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -10283,28 +10283,28 @@ msgstr "זוז"
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10312,133 +10312,133 @@ msgstr "זוז"
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr "שמור את הפרויקט שלך בשרת"
+#~ msgid "Save your project to a server."
+#~ msgstr "שמור את הפרויקט שלך בשרת"
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr "הרחב/כווץ את סרגל הכלים"
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr "הרחב/כווץ את סרגל הכלים"
 
 #: js/turtledefs.js:187
 
@@ -10446,136 +10446,136 @@ msgstr "זוז"
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "צב"
+#~ msgid "turtle"
+#~ msgstr "צב"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -10585,127 +10585,127 @@ msgstr "זוז"
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr "פרסום"
+#~ msgid "Publish"
+#~ msgstr "פרסום"
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -10713,397 +10713,397 @@ msgstr "זוז"
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr "בעולם כולו"
+#~ msgid "Worldwide"
+#~ msgstr "בעולם כולו"
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr "סיים קו"
+#~ msgid "end hollow line"
+#~ msgstr "סיים קו"
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "פתיחה"
+#~ msgid "Open"
+#~ msgstr "פתיחה"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr "אישור"
+#~ msgid "confirm"
+#~ msgstr "אישור"
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -11115,196 +11115,196 @@ msgstr "זוז"
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "הצג או הסתר את סרגלי הכלים"
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "הצג או הסתר את סרגלי הכלים"
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr "מזון"
+#~ msgid "food"
+#~ msgstr "מזון"
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11312,155 +11312,155 @@ msgstr "זוז"
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr "מתמטיקה"
+#~ msgid "maths"
+#~ msgstr "מתמטיקה"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11468,257 +11468,257 @@ msgstr "זוז"
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "הצג או הסתר רשת קוארדינטות פולריות"
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "הצג או הסתר רשת קוארדינטות פולריות"
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "נקה את המסך והחזר את הצבים למיקום הראשוני"
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "נקה את המסך והחזר את הצבים למיקום הראשוני"
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr "התחל קו"
+#~ msgid "begin hollow line"
+#~ msgstr "התחל קו"
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -11732,223 +11732,223 @@ msgstr "זוז"
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr "קוארדינטות פולריות"
+#~ msgid "Polar"
+#~ msgstr "קוארדינטות פולריות"
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "הצג או הסתר רשת של קואורדינטות קרטזיות"
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "הצג או הסתר רשת של קואורדינטות קרטזיות"
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr "העלאת פלאגין מקובץ"
+#~ msgid "Load plugin from file"
+#~ msgstr "העלאת פלאגין מקובץ"
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr "לשיר"
+#~ msgid "sing"
+#~ msgstr "לשיר"
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -11958,144 +11958,144 @@ msgstr "זוז"
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr "הורדה"
+#~ msgid "Download"
+#~ msgstr "הורדה"
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr "ענן"
+#~ msgid "cloud"
+#~ msgstr "ענן"
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr "הצג/הראה "
+#~ msgid "Show/hide palettes"
+#~ msgstr "הצג/הראה "
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr "RoDi"
+#~ msgid "rodi"
+#~ msgstr "RoDi"
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr "בלוקים"
+#~ msgid "blocks"
+#~ msgstr "בלוקים"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -12103,57 +12103,57 @@ msgstr "זוז"
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -12163,30 +12163,30 @@ msgstr "זוז"
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12194,112 +12194,112 @@ msgstr "זוז"
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "לחצו כדי להריץ את הפרויקט במצב מהיר"
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "לחצו כדי להריץ את הפרויקט במצב מהיר"
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr "שריון"
+#~ msgid "shell"
+#~ msgstr "שריון"
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -12307,287 +12307,287 @@ msgstr "זוז"
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr "כפתור זה פותח וסוגר את סרגל הכלים הראשי"
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr "כפתור זה פותח וסוגר את סרגל הכלים הראשי"
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "הסר את כל תוכן הקנבס, כולל הבלוקים"
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "הסר את כל תוכן הקנבס, כולל הבלוקים"
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr "שמור SVG"
+#~ msgid "save svg"
+#~ msgstr "שמור SVG"
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr "במכשיר שלי"
+#~ msgid "On my device"
+#~ msgstr "במכשיר שלי"
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12595,13 +12595,13 @@ msgstr "זוז"
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -12609,86 +12609,86 @@ msgstr "זוז"
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -13,10 +13,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.0.5\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -99,7 +99,7 @@ msgstr "क्रिया"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:206
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr "बतख"
 
@@ -166,7 +166,7 @@ msgstr "छुपाएँ"
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "मेरा परियोजना"
 
@@ -180,33 +180,33 @@ msgid "Your recording is in progress."
 msgstr "आपका रिकॉर्डिंग प्रगति में है।"
 
 #: js/SaveInterface.js:527
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "फ़ाइल का नाम"
 
 #: js/SaveInterface.js:529
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "परियोजना का शीर्षक"
 
 #: js/SaveInterface.js:531
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "परियोजना का लेखक"
 
 #: js/SaveInterface.js:533
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "MIDI आउटपुट शामिल करें?"
 
 #: js/SaveInterface.js:535
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "गिटार टैब्लेचर आउटपुट शामिल करें?"
 
 #: js/SaveInterface.js:537
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "लिलीपॉंड के रूप में सहेजें"
 
@@ -228,7 +228,7 @@ msgstr "लिलीपॉंड के रूप में सहेजें"
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "श्री माउस"
 
@@ -306,7 +306,7 @@ msgstr "कार्टेशियन दिखाएँ"
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr "स्केल डिग्री"
 
@@ -535,8 +535,8 @@ msgstr "ब्लॉक सहायता सहेजें"
 #: js/block.js:3450
 #: js/utils/musicutils.js:4111
 #: js/utils/musicutils.js:5623
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "ती ला सोल फा मी रे दो"
 
@@ -695,7 +695,7 @@ msgstr "रूलर"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "टिम्बर"
 
@@ -705,14 +705,14 @@ msgstr "सीढ़ी"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "टेम्पो"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "मोड"
 
@@ -743,7 +743,7 @@ msgstr "ढोल"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "रिदम बनाने वाला"
 
@@ -768,7 +768,7 @@ msgstr "रिदम बनाने वाला"
 #: js/widgets/phrasemaker.js:2745
 #: js/widgets/phrasemaker.js:2788
 #: js/widgets/phrasemaker.js:2893
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "नोट मूल्य"
 
@@ -777,7 +777,7 @@ msgstr "नोट मूल्य"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "स्केलर इंटरवल"
 
@@ -798,7 +798,7 @@ msgid "silence"
 msgstr "मौन"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "नीचे"
 
@@ -816,8 +816,8 @@ msgstr "ऊपर"
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:2017
 #: js/widgets/phrasemaker.js:1133
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "पिच"
 
@@ -919,7 +919,7 @@ msgstr "टेनर"
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "बास"
 
@@ -1053,14 +1053,14 @@ msgstr "कोई ब्लॉक चयन नहीं किया गया 
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "अवतार"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:946
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "सैम्पल"
 
@@ -1172,7 +1172,7 @@ msgstr "पिच कनवर्टर"
 #: js/widgets/musickeyboard.js:2431
 #: js/widgets/phrasemaker.js:2002
 #: js/widgets/sampler.js:781
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "डबल शार्प"
 
@@ -1184,8 +1184,8 @@ msgstr "डबल शार्प"
 #: js/widgets/musickeyboard.js:2432
 #: js/widgets/phrasemaker.js:2003
 #: js/widgets/sampler.js:782
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "शार्प"
 
@@ -1195,7 +1195,7 @@ msgstr "शार्प"
 #: js/widgets/musickeyboard.js:2433
 #: js/widgets/phrasemaker.js:2004
 #: js/widgets/sampler.js:783
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "नैचुरल"
 
@@ -1207,8 +1207,8 @@ msgstr "नैचुरल"
 #: js/widgets/musickeyboard.js:2434
 #: js/widgets/phrasemaker.js:2005
 #: js/widgets/sampler.js:784
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "फ्लैट"
 
@@ -1218,15 +1218,15 @@ msgstr "फ्लैट"
 #: js/widgets/musickeyboard.js:2435
 #: js/widgets/phrasemaker.js:2006
 #: js/widgets/sampler.js:785
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "डबल फ्लैट"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1002
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr "एकस्वरता"
 
@@ -1235,14 +1235,14 @@ msgstr "एकस्वरता"
 #: js/utils/musicutils.js:1010
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1372
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "मेजर"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr "आयनियन"
 
@@ -1251,14 +1251,14 @@ msgstr "आयनियन"
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1188
 #: js/utils/musicutils.js:1369
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "माइनर"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr "एोलियन"
 
@@ -1318,7 +1318,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "रिद्धम"
 
@@ -1354,7 +1354,7 @@ msgstr "बहाव"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr "सेंसर्स"
 
@@ -1363,7 +1363,7 @@ msgstr "सेंसर्स"
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr "मीडिया"
 
@@ -1832,7 +1832,7 @@ msgid "Are you sure you want to create a new project?"
 msgstr ""
 
 #: js/turtle-singer.js:1365
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "आपके पास एक से अधिक पांचिक ब्लॉक के अंदर कम से कम एक आंशिक ब्लॉक होना चाहिए"
 
@@ -1841,7 +1841,7 @@ msgid "synth cannot play chords."
 msgstr "सिंथ कोड नहीं बजा सकता है।"
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr "गाइड url"
 
@@ -1858,7 +1858,7 @@ msgstr "खोज"
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "मीटर"
 
@@ -1927,7 +1927,7 @@ msgstr "अतिरिक्त"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:245
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "प्रोग्राम"
 
@@ -1949,7 +1949,7 @@ msgstr "तर्क"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:282
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr "संगीत"
 
@@ -2229,7 +2229,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:720
 #: js/widgets/phrasemaker.js:578
 #: js/widgets/pitchstaircase.js:684
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr "हटाएं"
 
@@ -2538,21 +2538,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr "घटित सप्तम, साथ में एक सप्तक"
 
 #: js/utils/musicutils.js:838
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "1वा 2वा 3वा 4वा 5वा 6वा 7वा 8वा 9वा 10वा 11वा 12वा"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1189
 #: js/utils/musicutils.js:1371
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "बढ़ाया हुआ"
 
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1190
 #: js/utils/musicutils.js:1370
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "कम"
 
@@ -2561,12 +2561,12 @@ msgstr "कम"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "पूर्ण"
 
 #: js/utils/musicutils.js:1014
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "क्रोमैटिक"
 
@@ -2579,62 +2579,62 @@ msgid "spanish"
 msgstr "स्पेनिश"
 
 #: js/utils/musicutils.js:1018
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr "ऑक्टाटॉनिक"
 
 #: js/utils/musicutils.js:1020
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "हार्मोनिक मेजर"
 
 #: js/utils/musicutils.js:1022
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "नैचुरल माइनर"
 
 #: js/utils/musicutils.js:1024
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "हार्मोनिक माइनर"
 
 #: js/utils/musicutils.js:1026
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "मेलोडिक माइनर"
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr "डोरियन"
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr "फ्रिजियन"
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr "लिडियन"
 
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "मिक्सोलिडियन"
 
 #: js/utils/musicutils.js:1040
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr "लोक्रियन"
 
 #: js/utils/musicutils.js:1042
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "जैज माइनर"
 
 #: js/utils/musicutils.js:1044
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr "बीबॉप"
 
@@ -2647,7 +2647,7 @@ msgid "byzantine"
 msgstr "बाइज़ंटाइन"
 
 #: js/utils/musicutils.js:1048
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "एनिगमैटिक"
 
@@ -2656,7 +2656,7 @@ msgid "ethiopian"
 msgstr "इथियोपियन"
 
 #: js/utils/musicutils.js:1051
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "गीज़"
 
@@ -2669,7 +2669,7 @@ msgid "hungarian"
 msgstr "हंगेरियन"
 
 #: js/utils/musicutils.js:1055
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "रोमानियन माइनर"
 
@@ -2678,17 +2678,17 @@ msgid "spanish gypsy"
 msgstr "स्पैनिश जिप्सी"
 
 #: js/utils/musicutils.js:1058
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "मकाम"
 
 #: js/utils/musicutils.js:1060
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "माइनर ब्लूज"
 
 #: js/utils/musicutils.js:1062
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr "मेजर ब्लूज"
 
@@ -2697,12 +2697,12 @@ msgid "whole tone"
 msgstr "होल टोन"
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "माइनर पेंटाटॉनिक"
 
 #: js/utils/musicutils.js:1067
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "मेजर पेंटाटॉनिक"
 
@@ -2715,7 +2715,7 @@ msgid "egyptian"
 msgstr "इज़िप्शियन"
 
 #: js/utils/musicutils.js:1071
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "हिराजोशी"
 
@@ -2724,17 +2724,17 @@ msgid "Japan"
 msgstr "जापान"
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "मिन्यो"
 
 #: js/utils/musicutils.js:1078
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "फिबोनाची"
 
@@ -2751,56 +2751,56 @@ msgstr "फिबोनाची"
 #: js/blocks/WidgetBlocks.js:404
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr "अनुकूलित"
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1577
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr "हाईपास"
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1578
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr "लोपास"
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1579
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr "बैंडपास"
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1580
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr "हाईशेल्फ"
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1581
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr "लोशेल्फ"
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1582
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr "नॉच"
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1583
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr "ऑलपास"
 
 #: js/utils/musicutils.js:1095
 #: js/utils/musicutils.js:1584
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr "पीकिंग"
 
@@ -2808,7 +2808,7 @@ msgstr "पीकिंग"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "साइन"
 
@@ -2816,7 +2816,7 @@ msgstr "साइन"
 #: js/utils/musicutils.js:1593
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "वर्ग"
 
@@ -2825,7 +2825,7 @@ msgstr "वर्ग"
 #: js/utils/synthutils.js:136
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "त्रिकोण"
 
@@ -2833,7 +2833,7 @@ msgstr "त्रिकोण"
 #: js/utils/musicutils.js:1595
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "सॉटूथ"
 
@@ -2842,8 +2842,8 @@ msgstr "सॉटूथ"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr "सम"
 
@@ -2851,7 +2851,7 @@ msgstr "सम"
 #: js/utils/musicutils.js:1359
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr "विषम"
 
@@ -2865,56 +2865,56 @@ msgstr "स्कैलर"
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr "पियानो"
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr "वायलिन"
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr "वायोला"
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:118
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "क्सीलोफ़ोन"
 
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:140
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "वाइब्राफ़ोन"
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr "चेलो"
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr "डबल बास"
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr "गिटार"
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
@@ -2924,61 +2924,61 @@ msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr "एकॉस्टिक गिटार"
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr "बांसुरी"
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr "क्लैरिनेट"
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr "सैक्सोफोन"
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr "ट्यूबा"
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr "ट्रंपेट"
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr "ओबो"
 
 #: js/utils/musicutils.js:1123
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr "ट्रॉम्बोन"
 
 #: js/utils/musicutils.js:1124
 #: js/utils/synthutils.js:120
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr "इलेक्ट्रॉनिक सिंथ"
 
 #: js/utils/musicutils.js:1125
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "सिम्पल 1"
 
@@ -2997,19 +2997,19 @@ msgstr "सिम्पल 4"
 #: js/utils/musicutils.js:1129
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1130
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "ब्राउन नॉइज़"
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "पिंक नॉइज़"
 
@@ -3017,61 +3017,61 @@ msgstr "पिंक नॉइज़"
 #: js/utils/synthutils.js:152
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr "स्नेयर ड्रम"
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr "किक ड्रम"
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr "टॉम टॉम"
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr "फ्लोर टॉम"
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:160
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr "बेस ड्रम"
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:162
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "कप ड्रम"
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr "दरबूका ड्रम"
 
 #: js/utils/musicutils.js:1140
 #: js/utils/synthutils.js:168
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr "हाई हैट"
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:170
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr "राइड बेल"
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr "काउ बेल"
 
@@ -3081,149 +3081,149 @@ msgstr "जापानी ड्रम"
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr "जापानी बेल"
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr "त्रिकोण बेल"
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr "फिंगर सिम्बल्स"
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:180
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "चाइम"
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:182
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr "गॉंग"
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr "क्लैंग"
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr "क्रैश"
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr "बॉटल"
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr "क्लैप"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr "स्लैप"
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr "स्प्लैश"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr "बबल्स"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:198
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr "रेनड्रॉप"
 
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr "बिल्ली"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr "क्रिकेट"
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr "कुत्ता"
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr "बैंजो"
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr "कोतो"
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr "डल्सिमर"
 
 #: js/utils/musicutils.js:1164
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr "इलेक्ट्रिक गिटार"
 
 #: js/utils/musicutils.js:1165
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr "बैसून"
 
 #: js/utils/musicutils.js:1166
 #: js/utils/synthutils.js:116
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr "सेलेस्ट"
 
 #: js/utils/musicutils.js:1168
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr "इक्वल"
 
 #: js/utils/musicutils.js:1170
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "पिथागोरियन"
 
 #: js/utils/musicutils.js:1172
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr "जस्ट इंटोनेशन"
 
@@ -3232,7 +3232,7 @@ msgstr "जस्ट इंटोनेशन"
 #: js/utils/musicutils.js:1611
 #: js/utils/musicutils.js:1626
 #: js/utils/musicutils.js:1627
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3311,27 +3311,27 @@ msgid "previous"
 msgstr "पिछला"
 
 #: js/utils/synthutils.js:86
-#.TRANS: harmonium musical instrument
+#. TRANS: harmonium musical instrument
 msgid "harmonium"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "सिंपल-2"
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "सिंपल-3"
 
 #: js/utils/synthutils.js:128
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "सिंपल-4"
 
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr "ताइको"
 
@@ -3488,7 +3488,7 @@ msgstr "गेट-डिक्ट ब्लॉक एक निर्दिष�
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "मूल्य प्राप्त करें"
 
@@ -3510,7 +3510,7 @@ msgstr "कुंजी2"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "कुंजी"
 
@@ -3521,7 +3521,7 @@ msgstr "सेट-डिक्ट ब्लॉक निर्दिष्ट �
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr "मूल्य सेट करें"
 
@@ -3550,7 +3550,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr "पिच के प्रत्येक उदाहरण को ड्रम ध्वनि से बदलें।"
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "पिच को ड्रम से मानचित्रण करें"
 
@@ -3559,7 +3559,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "उपरोक्त उदाहरण में, सोल के बजाय एक किक ड्रम ध्वनि बजाई जाएगी।"
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "ड्रम सेट करें"
 
@@ -3592,7 +3592,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "हीप-खाली? ब्लॉक हीप खाली है तो true लौटाता है।"
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "हीप खाली है?"
 
@@ -3602,7 +3602,7 @@ msgstr "खाली-हीप ब्लॉक हीप को खाली क
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "खाली हीप"
 
@@ -3611,7 +3611,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr "रिवर्स-हीप ब्लॉक हीप का क्रम उलटा करता है।"
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr "हीप उलटें"
 
@@ -3620,7 +3620,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr "इंडेक्स-हीप ब्लॉक निर्दिष्ट स्थान पर हीप में एक मूल्य लौटाता है।"
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "हीप में स्थिति में से मूल्य प्राप्त करें"
 
@@ -3643,13 +3643,13 @@ msgstr "सेट-हीप एंट्री ब्लॉक निर्द�
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "ढेर लगाओ"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "सूची"
 
@@ -3658,7 +3658,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr "पॉप ब्लॉक हीप के शीर्ष पर मूल्य को हटा देता है।"
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "पॉप"
 
@@ -3667,7 +3667,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr "पुश ब्लॉक हीप के शीर्ष पर मूल्य जोड़ता है।"
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "दबाएँ"
 
@@ -3687,7 +3687,7 @@ msgstr "ताम्बुल सेट करें"
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "ऑक्टेव"
 
@@ -3712,7 +3712,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr "सेमी-टोन इंटरवल माप"
 
@@ -3726,7 +3726,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr "स्केलर इंटरवल ब्लॉक वर्तमान कुंजी और मोड में दो नोट्स के बीच की दूरी को मापता है।"
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr "स्केलर इंटरवल माप"
 
@@ -3736,7 +3736,7 @@ msgstr "चित्र में, हम sol# को sol में जोड़
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr "सेमी-टोन इंटरवल"
 
@@ -3774,7 +3774,7 @@ msgid "In the figure, we add la to sol."
 msgstr "चित्र में, हम la को sol में जोड़ते हैं।"
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr "मोड परिभाषित करें"
 
@@ -3783,7 +3783,7 @@ msgid "movable Do"
 msgstr "मूवेबल डो"
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "मोड लंबाई"
 
@@ -3796,18 +3796,18 @@ msgid "Most Western scales have 7 notes."
 msgstr "अधिकांश पश्चिमी स्केल में 7 स्वर होते हैं।"
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "वर्तमान मोड"
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr "वर्तमान कुंजी"
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "कुंजी सेट करें"
 
@@ -3928,7 +3928,7 @@ msgstr "स्लर कारक"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr "पड़ोसी"
 
@@ -3947,7 +3947,7 @@ msgstr "स्लर"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "स्टाकेटो"
 
@@ -3956,7 +3956,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr "लोड-हीप-फ्रॉम-ऐप ब्लॉक एक वेब पेज से हीप को लोड करता है।"
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr "ऐप से हीप लोड करें"
 
@@ -3973,7 +3973,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr "सेव-हीप-टू-ऐप ब्लॉक एक वेब पेज पर हीप को सेव करता है।"
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr "ऐप में हीप सेव करें"
 
@@ -3986,7 +3986,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr "लोड-हीप ब्लॉक एक फाइल से हीप को लोड करता है।"
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "हीप लोड करें"
 
@@ -4015,7 +4015,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr "लोड-डिक्शनरी ब्लॉक एक फाइल से एक शब्दकोश को लोड करता है।"
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "शब्दकोश लोड करें"
 
@@ -4038,7 +4038,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr "सेट-डिक्शनरी ब्लॉक एक शब्दकोश को लोड करता है।"
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr "शब्दकोश सेट करें"
 
@@ -4055,7 +4055,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr "सेव-हीप ब्लॉक एक फाइल में हीप को सेव करता है।"
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "हीप सेव करें"
 
@@ -4064,7 +4064,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr "सेव-डिक्शनरी ब्लॉक एक फाइल में एक शब्दकोश को सेव करता है।"
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr "शब्दकोश सेव करें"
 
@@ -4081,7 +4081,7 @@ msgid "The Delete block block removes a block."
 msgstr "डिलीट ब्लॉक ब्लॉक एक ब्लॉक को हटाता है।"
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr "ब्लॉक हटाएं"
 
@@ -4090,7 +4090,7 @@ msgid "The Move block block moves a block."
 msgstr "मूव ब्लॉक ब्लॉक एक ब्लॉक को स्थानांतरित करता है।"
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr "ब्लॉक स्थानांतरित करें"
 
@@ -4124,7 +4124,7 @@ msgid "y"
 msgstr "वाई"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr "रन ब्लॉक"
 
@@ -4133,7 +4133,7 @@ msgid "The Dock block block connections two blocks."
 msgstr "डॉक ब्लॉक ब्लॉक दो ब्लॉकों को जोड़ता है।"
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr "ब्लॉकों को जोड़ें"
 
@@ -4150,7 +4150,7 @@ msgid "The Make block block creates a new block."
 msgstr "मेक ब्लॉक ब्लॉक एक नया ब्लॉक बनाता है।"
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr "नया ब्लॉक बनाएं"
 
@@ -4165,7 +4165,7 @@ msgstr "नया ब्लॉक बनाएं"
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "नोट"
 
@@ -4199,12 +4199,12 @@ msgstr "नोट मान 0 से अधिक होना चाहिए�
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "स्विंग"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "स्विंग मान"
 
@@ -4213,12 +4213,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr "स्किप नोट्स ब्लॉक नोट्स को छोड़ने का कारण बनेगा।"
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "नोट्स को छोड़ें"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "नोट मान को गुणा करें"
 
@@ -4227,13 +4227,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr "टाई ब्लॉक नोट्स के जोड़ों पर काम करता है, उन्हें एक नोट में मिलाकर।"
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "टाई"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "डॉट"
 
@@ -4251,7 +4251,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr "उदा, एक डॉटेड क्वार्टर नोट 3/8 (1/4 + 1/8) बीट के लिए बजेगा।"
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr "नोट मूल्य ड्रम"
 
@@ -4283,8 +4283,8 @@ msgstr "ऑक्टेव स्थान"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "ताल1"
 
@@ -4340,7 +4340,7 @@ msgstr "पूरा नोट"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "टुपलेट"
 
@@ -4497,12 +4497,12 @@ msgid "duplicate factor"
 msgstr "प्रतिलिपि कारक"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr "वर्तमान मीटर"
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "बीट कारक"
 
@@ -4512,8 +4512,8 @@ msgstr "बीट्स पर मिनट ब्लॉक वर्तमा�
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "मिनट प्रति बीट"
 
@@ -4521,12 +4521,12 @@ msgstr "मिनट प्रति बीट"
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "मिनट प्रति बीट"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr "माप की गणना"
 
@@ -4535,7 +4535,7 @@ msgid "The Measure count block returns the current measure."
 msgstr "मेजर काउंट ब्लॉक वर्तमान माप को लौटाता है।"
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr "बीट काउंट"
 
@@ -4552,7 +4552,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr "उदाहरण के लिए 1, 2, 3, या 4।"
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr "नोट मूल्यों की गणना"
 
@@ -4562,12 +4562,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr "नोट काउंटर ब्लॉक का उपयोग शामिल नोट्स की संख्या को गिनने के लिए किया जा सकता है।"
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr "नोट काउंटर"
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr "पूरे नोट बजे"
 
@@ -4577,7 +4577,7 @@ msgstr "व्होल नोट्स प्लेड ब्लॉक प्�
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr "नोट्स बजे"
 
@@ -4586,7 +4586,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr "नो क्लॉक ब्लॉक नोट्स को मास्टर क्लॉक से अलग करता है।"
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "कोई घड़ी नहीं"
 
@@ -4636,7 +4636,7 @@ msgstr "ऑन-एवरी-नोट ब्लॉक आपको प्रत�
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr "मास्टर बीट्स प्रति मिनट"
 
@@ -4669,7 +4669,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr "प्रति मिनट 1/4 नोट्स की संख्या सेट करने के लिए बीट्स प्रति मिनट ब्लॉक।"
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr "पिकअप"
 
@@ -4678,12 +4678,12 @@ msgid "number of beats"
 msgstr "बीट्स की संख्या"
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "स्वर स्थानांतरण"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr "स्केलर स्टेप डाउन"
 
@@ -4692,7 +4692,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr "स्केलर स्टेप डाउन ब्लॉक वर्तमान कुंजी और मोड में पिछले नोट तक की सेमी-टोन की संख्या लौटाता है।"
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr "स्केलर स्टेप अप"
 
@@ -4701,7 +4701,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr "स्केलर स्टेप अप ब्लॉक वर्तमान कुंजी और मोड में अगले नोट तक की सेमी-टोन की संख्या लौटाता है।"
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr "स्वर में परिवर्तन"
 
@@ -4710,7 +4710,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr "चेंज इन पिच ब्लॉक वह अंतर है (हैफ स्टेप में) जो वर्तमान पिच बजा रहा है और पिछले पिच बजा रहा है।"
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr "स्केलर स्वर में परिवर्तन"
 
@@ -4721,8 +4721,8 @@ msgstr "स्केलर स्वर में परिवर्तन"
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr "स्वर संख्या"
 
@@ -4732,7 +4732,7 @@ msgstr "पिच नंबर ब्लॉक वह मूल्य है ज
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr "हर्ट्ज में स्वर"
 
@@ -4758,7 +4758,7 @@ msgid "alphabet"
 msgstr "वर्णमाला"
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr "अक्षर वर्ग"
 
@@ -4796,12 +4796,12 @@ msgstr "स्वर को रंग में"
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:759
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr "मिडी"
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr "पिच नंबर ऑफसेट सेट करें"
 
@@ -4813,12 +4813,12 @@ msgstr "सेट पिच नंबर ऑफसेट ब्लॉक का 
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "नाम2"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "संख्या से पिच"
 
@@ -4827,7 +4827,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr "नंबर टू पिच ब्लॉक पिच नंबर को पिच नाम में बदल देगा।"
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "संख्या से ऑक्टेव"
 
@@ -4873,22 +4873,22 @@ msgstr "इनवर्ट ब्लॉक एक लक्ष्य नोट �
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr "उलटाएं"
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "इनवर्ट (विषम)"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "इनवर्ट (सम)"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr "रजिस्टर"
 
@@ -4897,7 +4897,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr "रजिस्टर ब्लॉक निर्दिष्ट किए गए नोट के रजिस्टर (ऑक्टेव) को संशोधित करने का एक आसान तरीका प्रदान करता है।"
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr "50 सेंट्स"
 
@@ -4910,7 +4910,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr "ऊपर दिखाए गए उदाहरण में, सोल को सोल# की ओर स्थानांतरित किया गया है।"
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr "सेमी-टोन स्थानांतरण"
 
@@ -4919,47 +4919,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr "ट्रांसपोज़ बाय रेशियो ब्लॉक नोट ब्लॉक्स में शामिल पिच को एक अनुपात से ऊपर (या नीचे) करेगा"
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr "मात्रा के अनुसार समायोजित करें"
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr "डाउन सिक्स्थ"
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr "डाउन थर्ड"
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr "सेवेंथ"
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr "सिक्सथ"
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr "फिफ्थ"
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr "फोर्थ"
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr "थर्ड"
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr "सेकंड"
 
@@ -4972,7 +4972,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr "ऊपर दिखाए गए उदाहरण में, सोल को सोल# की ओर स्थानांतरित किया गया है।"
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr "स्केलर स्थानांतरण"
 
@@ -4981,7 +4981,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr "अक्सीडेंटल ब्लॉक का उपयोग शार्प और फ्लैट बनाने के लिए किया जाता है"
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr "एक्सीडेंटल ओवरराइड"
 
@@ -4989,7 +4989,7 @@ msgstr "एक्सीडेंटल ओवरराइड"
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:2018
 #: js/widgets/phrasemaker.js:1134
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr "हर्ट्ज़"
 
@@ -5003,8 +5003,8 @@ msgstr "पिच नंबर ब्लॉक उसकी संख्या �
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr "एनथ मोडल पिच"
 
@@ -5033,7 +5033,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr "स्केल डिग्री 1 हमेशा एक दिए गए स्केल में पहला पिच है, ऑक्टेव की परवाह किए बिना।"
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr "स्केलर स्टेप"
 
@@ -5058,14 +5058,14 @@ msgstr "ऑस्सिलेटर"
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr "प्रकार"
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr "अंश"
 
@@ -5075,7 +5075,7 @@ msgstr "आप कई ऑस्किलेटर ब्लॉक जोड़ �
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr "ड्यूओ सिंथ"
 
@@ -5094,7 +5094,7 @@ msgstr "विब्रेटो तीव्रता"
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr "ए.एम. सिंथ"
 
@@ -5104,7 +5104,7 @@ msgstr "ए.एम. सिंथ ब्लॉक एक एम्प्लीट
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr "एफ.एम. सिंथ"
 
@@ -5121,17 +5121,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr "पार्शियल वजन 0 और 1 के बीच होना चाहिए।"
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr "पार्शियल ब्लॉक को वेटेड-पार्शियल्स ब्लॉक के अंदर उपयोग किया जाना चाहिए।"
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr "वेटेड पार्शियल्स"
 
@@ -5140,7 +5140,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr "हारमोनिक ब्लॉक नोट्स में हारमोनिक जोड़ेगा।"
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr "हारमोनिक"
 
@@ -5150,7 +5150,7 @@ msgstr "डिस्टोर्शन ब्लॉक ध्वनि में
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr "विकृति"
 
@@ -5160,7 +5160,7 @@ msgstr "ट्रेमोलो ब्लॉक एक हिलने के �
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr "ट्रेमोलो"
 
@@ -5172,7 +5172,7 @@ msgstr "ट्रेमोलो"
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr "दर"
 
@@ -5180,7 +5180,7 @@ msgstr "दर"
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr "गहराई"
 
@@ -5190,7 +5190,7 @@ msgstr "फेजर ब्लॉक एक स्वीपिंग साउ�
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr "फेजर"
 
@@ -5211,7 +5211,7 @@ msgstr "कोरस ब्लॉक कोरस प्रभाव जोड�
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr "कोरस"
 
@@ -5226,7 +5226,7 @@ msgstr "विब्रेटो ब्लॉक ध्वनि में त�
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr "विब्रेटो"
 
@@ -5236,7 +5236,7 @@ msgid "intensity"
 msgstr "तीव्रता"
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr "सिंथ सेट करें"
 
@@ -5250,7 +5250,7 @@ msgstr "डिफ़ॉल्ट इंस्ट्रुमेंट सेट 
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr "इंस्ट्रुमेंट सेट करें"
 
@@ -5306,7 +5306,7 @@ msgstr "गणना"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr "डू ब्लॉक का उपयोग क्रिया आरंभ करने के लिए किया जाता है।"
 
@@ -5484,7 +5484,7 @@ msgid "Cannot find start block"
 msgstr "स्टार्ट ब्लॉक नहीं मिल सकता"
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "माउस कलर"
 
@@ -5493,7 +5493,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr "माउस कलर ब्लॉक निर्दिष्ट माउस का पेन कलर वापस करता है।"
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "कछुआ कलर"
 
@@ -5502,7 +5502,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr "कछुआ कलर ब्लॉक निर्दिष्ट कछुए का पेन कलर वापस करता है।"
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "माउस हेडिंग"
 
@@ -5511,7 +5511,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr "माउस हेडिंग ब्लॉक निर्दिष्ट माउस की हेडिंग वापस करता है।"
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "कछुआ हेडिंग"
 
@@ -5521,13 +5521,13 @@ msgstr "कछुआ हेडिंग ब्लॉक निर्दिष्
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr "माउस सेट करें"
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr "कछुआ सेट करें"
 
@@ -5540,7 +5540,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr "सेट कछुआ ब्लॉक एक स्टैक ब्लॉक को निर्दिष्ट कछुआ द्वारा चलाए जाने के लिए भेजता है।"
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "माउस वाई"
 
@@ -5549,7 +5549,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr "Y माउस ब्लॉक निर्दिष्ट माउस की Y स्थिति वापस करता है।"
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "कछुआ वाई"
 
@@ -5558,7 +5558,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr "Y कछुआ ब्लॉक निर्दिष्ट कछुए की Y स्थिति वापस करता है।"
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "माउस एक्स"
 
@@ -5567,7 +5567,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr "X माउस ब्लॉक निर्दिष्ट माउस की X स्थिति वापस करता है।"
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "कछुआ एक्स"
 
@@ -5576,7 +5576,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr "X कछुआ ब्लॉक निर्दिष्ट कछुए की X स्थिति वापस करता है।"
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "माउस बजाए गए स्वर"
 
@@ -5585,7 +5585,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr "माउस इलैप्स स्वर ब्लॉक निर्दिष्ट माउस द्वारा बजाए गए स्वरों की संख्या वापस करता है।"
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "कछुआ बजाए गए स्वर"
 
@@ -5594,7 +5594,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr "कछुआ इलैप्स स्वर ब्लॉक निर्दिष्ट कछुए द्वारा बजाए गए स्वरों की संख्या वापस करता है।"
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "माउस पिच नंबर"
 
@@ -5603,7 +5603,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr "माउस पिच ब्लॉक विशिष्ट माउस द्वारा बजाए जा रहे वर्तमान पिच नंबर को वापस करता है।"
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "कछुआ पिच नंबर"
 
@@ -5613,17 +5613,17 @@ msgstr "टर्टल पिच ब्लॉक विशिष्ट कछ�
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr "माउस नोट मूल्य"
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "कछुआ नोट मूल्य"
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "माउस सिंक"
 
@@ -5632,7 +5632,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "माउस सिंक ब्लॉक माउस के बीट गिनती को समरेखित करता है।"
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "कछुआ सिंक"
 
@@ -6059,7 +6059,7 @@ msgid "wrap"
 msgstr "लपेटें"
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr "दाएं (स्क्रीन)"
 
@@ -6069,7 +6069,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr "राइट ब्लॉक कैनवास के दाएं की स्थिति लौटाता है।"
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "बाएं (स्क्रीन)"
 
@@ -6113,12 +6113,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr "हाइट ब्लॉक कैनवास की ऊचाई लौटाता है।"
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "रुको प्ले"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr "मीडिया मिटाओ"
 
@@ -6127,7 +6127,7 @@ msgid "The Erase Media block erases text and images."
 msgstr "इरेस मीडिया ब्लॉक टेक्स्ट और छवियाँ मिटाता है।"
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "प्ले बैक"
 
@@ -6184,7 +6184,7 @@ msgid "duration (MS)"
 msgstr "अवधि (एमएस)"
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "नोट को आवृत्ति में बदलें"
 
@@ -6202,7 +6202,7 @@ msgstr "अवतार ब्लॉक का उपयोग कछुए क�
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "आकार"
 
@@ -6215,7 +6215,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr "शो ब्लॉक का उपयोग कैनवास पर टेक्स्ट या छवियों को प्रदर्शित करने के लिए किया जाता है।"
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "शो1"
 
@@ -6280,7 +6280,7 @@ msgstr "अंत भरें"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "पृष्ठभूमि"
 
@@ -6345,7 +6345,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr "होलो लाइन ब्लॉक एक होलो केंद्र के साथ एक रेखा बनाता है।"
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "होलो रेखा"
 
@@ -6354,12 +6354,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr "फिल ब्लॉक एक रंग के साथ एक आकृति को भरता है।"
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "भरें"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "पेन ऊपर"
 
@@ -6368,7 +6368,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "पेन-अप ब्लॉक पेन को उठाता है ताकि यह ड्रा न करे।"
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "पेन नीचे"
 
@@ -6377,7 +6377,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "पेन-डाउन ब्लॉक पेन को नीचे ले जाता है ताकि यह ड्रा करे।"
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "पेन आकार सेट करें"
 
@@ -6386,7 +6386,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr "सेट-पेन-साइज ब्लॉक पेन के आकार को बदलता है।"
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "पारदर्शिता सेट करें"
 
@@ -6411,7 +6411,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr "सेट-शेड ब्लॉक पेन का रंग काले से लाइट में बदलता है।"
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "ग्रे सेट करें"
 
@@ -6640,27 +6640,27 @@ msgstr "क्रेशेंडो"
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr "एनवेलप"
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "आक्रमण"
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "क्षय"
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "सस्टेन"
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "रिलीज"
 
@@ -6686,18 +6686,18 @@ msgstr "आप कई एनवेलोप ब्लॉक जोड़ रह�
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr "फ़िल्टर"
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr "रोलऑफ"
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr "रोलऑफ मूल्य -12, -24, -48, या -96 डेसिबल्स/ऑक्टेव होना चाहिए।"
 
@@ -6712,7 +6712,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr "एक सैंपल अपलोड करें और इसके पिच केंद्र को समायोजित करें।"
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "सैम्पलर"
 
@@ -6733,7 +6733,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr "कस्टम मोड ब्लॉक एक उपकरण खोलता है जिससे संगीतिक मोड (स्केल में नोट्स की जगह) का अन्वेषण किया जा सकता है।"
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "कस्टम मोड"
 
@@ -6750,7 +6750,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr "पिच ड्रम मैट्रिक्स का उपयोग पिच को ड्रम साउंड्स से मैप करने के लिए किया जाता है।"
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "पिच-ड्रम मैपर"
 
@@ -6763,7 +6763,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr "पिच स्लाइडर उपकरण का उपयोग चयनित आवृत्तियों पर पिच उत्पन्न करने के लिए किया जाता है।"
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "पिच स्लाइडर"
 
@@ -6773,7 +6773,7 @@ msgstr "क्रोमेटिक कीबोर्ड"
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr "संगीत कीबोर्ड"
 
@@ -6787,7 +6787,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr "पिच सीढ़ी उपकरण का उपयोग किसी दिए गए अनुपात से पिच उत्पन्न करने के लिए किया जाता है।"
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "पिच स्टेयरकेस"
 
@@ -6808,7 +6808,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr "फ्रेज मेकर ब्लॉक एक उपकरण खोलता है जिससे संगीतिक वाक्य बनाए जा सकते हैं।"
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "वाक्य निर्माता"
 
@@ -6822,7 +6822,7 @@ msgstr "स्थिति ब्लॉक एक उपकरण खोलत�
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr "एआई म्यूजिक"
 
@@ -6915,7 +6915,7 @@ msgstr "विब्राटो दर 0 से अधिक होनी च�
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr "गहराई सीमा से बाहर है।"
 
@@ -6924,7 +6924,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr "विरुपण 0 से 100 के बीच होना चाहिए।"
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr "आंश 0 से अधिक या इसके बराबर होना चाहिए।"
 
@@ -7046,7 +7046,7 @@ msgid "Undo"
 msgstr "पूर्ववत् करें"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr "संगीतिक मोड के लिए नोट्स का चयन करने के लिए वृत्त में क्लिक करें."
 
@@ -7087,7 +7087,7 @@ msgid "Save drum machine"
 msgstr "ड्रम मशीन सहेजें"
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr "एक ताल पर टैप करें"
 
@@ -7221,7 +7221,7 @@ msgstr "सिंथेसाइज़र"
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr "प्रभाव"
 
@@ -7350,7 +7350,7 @@ msgid "Playback"
 msgstr "प्लेबैक"
 
 #: js/widgets/sampler.js:950
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr "संदर्भ स्वर"
 
@@ -7375,48 +7375,48 @@ msgid "Cannot connect to server"
 msgstr "सर्वर से कनेक्ट नहीं हो सकता"
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr "सभी परियोजनाएं"
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr "मेरी परियोजनाएं"
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr "उदाहरण"
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr "कला"
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr "गणित"
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr "इंटरएक्टिव"
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr "डिज़ाइन"
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr "खेल"
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr "कोड स्निपेट"
 
@@ -7849,53 +7849,53 @@ msgstr "सरकाय"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:522
 
-#~msgid "To delete a block, just right-click on it, then you will be able to see the delete option"
-#~msgstr "किसी ब्लॉक को डिलीट करने के लिए बस उस पर राइट क्लिक करें फिर आपको डिलीट का ऑप्शन दिखाई देगा"
+#~ msgid "To delete a block, just right-click on it, then you will be able to see the delete option"
+#~ msgstr "किसी ब्लॉक को डिलीट करने के लिए बस उस पर राइट क्लिक करें फिर आपको डिलीट का ऑप्शन दिखाई देगा"
 
 #: js/turtledefs.js:528
 
-#~msgid "To copy a block, just right-click on it, then you will be able to see the copy option"
-#~msgstr "किसी ब्लॉक को डिलीट करने के लिए बस उस पर राइट क्लिक करें फिर आपको डिलीट का ऑप्शन दिखाई देगा"
+#~ msgid "To copy a block, just right-click on it, then you will be able to see the copy option"
+#~ msgstr "किसी ब्लॉक को डिलीट करने के लिए बस उस पर राइट क्लिक करें फिर आपको डिलीट का ऑप्शन दिखाई देगा"
 
 #: js/turtledefs.js:534
 
-#~msgid "To extract a block, just right-click on it, then you will be able to see the extract option"
-#~msgstr "एक ब्लॉक निकालने के लिए, बस उस पर राइट-क्लिक करें, फिर आप एक्सट्रैक्ट विकल्प देख पाएंगे"
+#~ msgid "To extract a block, just right-click on it, then you will be able to see the extract option"
+#~ msgstr "एक ब्लॉक निकालने के लिए, बस उस पर राइट-क्लिक करें, फिर आप एक्सट्रैक्ट विकल्प देख पाएंगे"
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr "अपनी परियोजना से ऑडियो को डब्लूएवी के रूप में सहेजें।"
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr "अपनी परियोजना से ऑडियो को डब्लूएवी के रूप में सहेजें।"
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr "अपनी परियोजना को एक एबीसी फ़ाइल के रूप में सहेजें।"
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr "अपनी परियोजना को एक एबीसी फ़ाइल के रूप में सहेजें।"
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "अपनी परियोजना को एक लिलीपॉंड फ़ाइल के रूप में सहेजें।"
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "अपनी परियोजना को एक लिलीपॉंड फ़ाइल के रूप में सहेजें।"
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr "कोआर्डिनेट ग्रिड दिखाएँ या छुपाएँ।"
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr "कोआर्डिनेट ग्रिड दिखाएँ या छुपाएँ।"
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr "विकल्प/संकुचन योग्य ब्लॉक्स को विस्तृत/संकुचित करें"
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr "विकल्प/संकुचन योग्य ब्लॉक्स को विस्तृत/संकुचित करें"
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "इन संदेशों को दिखाएँ।"
+#~ msgid "Show these messages."
+#~ msgstr "इन संदेशों को दिखाएँ।"
 
 #: js/rubrics.js:531
 
@@ -7903,8 +7903,8 @@ msgstr "सरकाय"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "सेंसर"
+#~ msgid "sensors"
+#~ msgstr "सेंसर"
 
 #: js/rubrics.js:532
 
@@ -7914,8 +7914,8 @@ msgstr "सरकाय"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "मीडिया"
+#~ msgid "media"
+#~ msgstr "मीडिया"
 
 #: js/block-verbose.js:3837
 
@@ -7927,35 +7927,35 @@ msgstr "सरकाय"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr "कार्टेसियन + पोलर"
+#~ msgid "Cartesian+polar"
+#~ msgstr "कार्टेसियन + पोलर"
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "दिखाएँ"
+#~ msgid "show"
+#~ msgstr "दिखाएँ"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr "ब्लॉक दिखाएँ/छुपाएँ"
+#~ msgid "Show/hide block"
+#~ msgstr "ब्लॉक दिखाएँ/छुपाएँ"
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "ग्रिड"
+#~ msgid "grid"
+#~ msgstr "ग्रिड"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr "आपने कुंजी चयन की है "
+#~ msgid "You have chosen key "
+#~ msgstr "आपने कुंजी चयन की है "
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr " आपके पिच पूर्वावलोकन के लिए."
+#~ msgid " for your pitch preview."
+#~ msgstr " आपके पिच पूर्वावलोकन के लिए."
 
 #: js/toolbar.js:113
 
@@ -7969,69 +7969,69 @@ msgstr "सरकाय"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr "पूर्ण स्क्रीन"
+#~ msgid "Full Screen"
+#~ msgstr "पूर्ण स्क्रीन"
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr "नई परियोजना"
+#~ msgid "New Project"
+#~ msgstr "नई परियोजना"
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr "संगीत"
+#~ msgid "music"
+#~ msgstr "संगीत"
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr "सहेजें"
+#~ msgid "save"
+#~ msgstr "सहेजें"
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "साफ"
+#~ msgid "Clean"
+#~ msgstr "साफ"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "धीमे चलाएं"
+#~ msgid "Run slow"
+#~ msgstr "धीमे चलाएं"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr "मींटोन"
+#~ msgid "meantone"
+#~ msgstr "मींटोन"
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "खण्ड छुपाएँ"
+#~ msgid "hide blocks"
+#~ msgstr "खण्ड छुपाएँ"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr "डुप्लीकेट"
+#~ msgid "duplicate"
+#~ msgstr "डुप्लीकेट"
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8051,13 +8051,13 @@ msgstr "सरकाय"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "रोकें"
+#~ msgid "stop"
+#~ msgstr "रोकें"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8065,58 +8065,58 @@ msgstr "सरकाय"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "साफ़ करें"
+#~ msgid "clear"
+#~ msgstr "साफ़ करें"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "इनवर्ट"
+#~ msgid "invert"
+#~ msgstr "इनवर्ट"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr "एनथ मोडल पिच एक मोड के लिए सेमिटोन्स में पिच का पैटर्न लेता है और हर बिंदु को मोड का डिग्री बनाता है,"
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr "एनथ मोडल पिच एक मोड के लिए सेमिटोन्स में पिच का पैटर्न लेता है और हर बिंदु को मोड का डिग्री बनाता है,"
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr "एनथ मोडल पिच एक दिए गए मोड के लिए एनथ डिग्री के रूप में एक संख्या लेता है। 0 पहली पोज़िशन है, 1 दूसरी है, -1 पहले से पहले का नोट है इत्यादि।"
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr "एनथ मोडल पिच एक दिए गए मोड के लिए एनथ डिग्री के रूप में एक संख्या लेता है। 0 पहली पोज़िशन है, 1 दूसरी है, -1 पहले से पहले का नोट है इत्यादि।"
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr "ऑस्किलेटर"
+#~ msgid "oscillator"
+#~ msgstr "ऑस्किलेटर"
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr "विलंब"
+#~ msgid "delay"
+#~ msgstr "विलंब"
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr "एनवेलोप"
+#~ msgid "envelope"
+#~ msgstr "एनवेलोप"
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr "फ़िल्टर"
+#~ msgid "filter"
+#~ msgstr "फ़िल्टर"
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr "एक"
+#~ msgid "a"
+#~ msgstr "एक"
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr "नीचे"
+#~ msgid " below"
+#~ msgstr "नीचे"
 
 #: js/widgets/modewidget.js:1017
 
@@ -8132,25 +8132,25 @@ msgstr "सरकाय"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr "नया क्रिया ब्लॉक उत्पन्न हुआ!"
+#~ msgid "New action block generated!"
+#~ msgstr "नया क्रिया ब्लॉक उत्पन्न हुआ!"
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr "रिकॉर्डिंग शुरू हुई..."
+#~ msgid "Recording started..."
+#~ msgstr "रिकॉर्डिंग शुरू हुई..."
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr "रिकॉर्डिंग पूरी हुई..."
+#~ msgid "Recording complete..."
+#~ msgstr "रिकॉर्डिंग पूरी हुई..."
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "अवधि"
+#~ msgid "duration"
+#~ msgstr "अवधि"
 
 #: js/widgets/temperament.js:454
 
@@ -8160,46 +8160,46 @@ msgstr "सरकाय"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr "बंद करें"
+#~ msgid "close"
+#~ msgstr "बंद करें"
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr "परियोजना प्रकाशित करें"
+#~ msgid "Publish Project"
+#~ msgstr "परियोजना प्रकाशित करें"
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr "लिलीपॉंड को पिकअप प्रोसेस करने में समर्थ नहीं"
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr "लिलीपॉंड को पिकअप प्रोसेस करने में समर्थ नहीं"
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr "उन्नत मोड में बदलने के लिए अपने ब्राउज़र को रिफ़्रेश करें।"
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr "उन्नत मोड में बदलने के लिए अपने ब्राउज़र को रिफ़्रेश करें।"
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr "शुरुआती मोड में बदलने के लिए अपने ब्राउज़र को रिफ़्रेश करें।"
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr "शुरुआती मोड में बदलने के लिए अपने ब्राउज़र को रिफ़्रेश करें।"
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr "नया एक्शन ब्लॉक जनरेट किया गया"
+#~ msgid "New action blocks generated"
+#~ msgstr "नया एक्शन ब्लॉक जनरेट किया गया"
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr "नया एक्शन ब्लॉक जनरेट किया गया"
+#~ msgid "New action block generated"
+#~ msgstr "नया एक्शन ब्लॉक जनरेट किया गया"
 
-#~msgid ""Toggle Fullscreen"
-#~msgstr ""पूर्ण स्क्रीन टॉगल करें"
+#~ msgid "Toggle Fullscreen"
+#~ msgstr "पूर्ण स्क्रीन टॉगल करें"
 
 #: js/toolbar.js:70
 
@@ -8209,210 +8209,210 @@ msgstr "सरकाय"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr "जावास्क्रिप्ट संपादक को टॉगल करें"
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr "जावास्क्रिप्ट संपादक को टॉगल करें"
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr "टर्ल पिच ब्लॉक निर्दिष्ट कछुए द्वारा खेली जा रही वर्तमान पिच संख्या लौटाता है।"
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr "टर्ल पिच ब्लॉक निर्दिष्ट कछुए द्वारा खेली जा रही वर्तमान पिच संख्या लौटाता है।"
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr "स्केलर स्टेप ब्लॉक को एक नोट ब्लॉक के अंदर उपयोग करना चाहिए।"
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr "स्केलर स्टेप ब्लॉक को एक नोट ब्लॉक के अंदर उपयोग करना चाहिए।"
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr "स्केलर स्टेप ब्लॉक को पिच ब्लॉक से पहले आना चाहिए।"
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr "स्केलर स्टेप ब्लॉक को पिच ब्लॉक से पहले आना चाहिए।"
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr "नए एक्शन ब्लॉक उत्पन्न हुए!"
+#~ msgid "New action blocks generated!"
+#~ msgstr "नए एक्शन ब्लॉक उत्पन्न हुए!"
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr "पूर्ण स्क्रीन"
+#~ msgid "FullScreen"
+#~ msgstr "पूर्ण स्क्रीन"
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr "पूर्ण स्क्रीन मोड को टॉगल करें।"
+#~ msgid "Toggle full screen mode."
+#~ msgstr "पूर्ण स्क्रीन मोड को टॉगल करें।"
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr "सहायक टूलबार को विस्तारित या संकुचित करने के लिए इस बटन पर क्लिक करें।"
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr "सहायक टूलबार को विस्तारित या संकुचित करने के लिए इस बटन पर क्लिक करें।"
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr "टुपलेट ब्लॉक का उपयोग संक्षेपित समय में बजाए जाने वाले नोट्स के समूह बनाने के लिए किया जाता है।"
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr "टुपलेट ब्लॉक का उपयोग संक्षेपित समय में बजाए जाने वाले नोट्स के समूह बनाने के लिए किया जाता है।"
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr "टुपलेट्स का उपयोग करके वे नोट्स के समूह बनाना आसान होता है जो 2 के गुणनक पर आधारित नहीं हैं।"
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr "टुपलेट्स का उपयोग करके वे नोट्स के समूह बनाना आसान होता है जो 2 के गुणनक पर आधारित नहीं हैं।"
 
 #: js/WidgetBlocks.js:746
 
-#~msgid "The Pitch slider tool is used to generate pitches at selected frequencies."
-#~msgstr "पिच स्लाइडर टूल का उपयोग चयनित फ़्रीक्वेंसी पर पिच उत्पन्न करने के लिए किया जाता है।"
+#~ msgid "The Pitch slider tool is used to generate pitches at selected frequencies."
+#~ msgstr "पिच स्लाइडर टूल का उपयोग चयनित फ़्रीक्वेंसी पर पिच उत्पन्न करने के लिए किया जाता है।"
 
 #: js/WidgetBlocks.js:910
 
-#~msgid "The Pitch staircase tool is used to generate pitches from a given ratio."
-#~msgstr "पिच स्टेयरकेस टूल का उपयोग एक दिए गए अनुपात से पिच उत्पन्न करने के लिए किया जाता है।"
+#~ msgid "The Pitch staircase tool is used to generate pitches from a given ratio."
+#~ msgstr "पिच स्टेयरकेस टूल का उपयोग एक दिए गए अनुपात से पिच उत्पन्न करने के लिए किया जाता है।"
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr "सेट ताम्बुल ब्लॉक का उपयोग संगीत ब्लॉक्स द्वारा उपयोग किए जाने वाले सुर सिस्टम को चुनने के लिए किया जाता है।"
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr "सेट ताम्बुल ब्लॉक का उपयोग संगीत ब्लॉक्स द्वारा उपयोग किए जाने वाले सुर सिस्टम को चुनने के लिए किया जाता है।"
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr "इंटरवल नंबर ब्लॉक वर्तमान इंटरवल में स्केलर कदमों की संख्या लौटाता है।"
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr "इंटरवल नंबर ब्लॉक वर्तमान इंटरवल में स्केलर कदमों की संख्या लौटाता है।"
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr "सेमी-टोन इंटरवल ब्लॉक दो नोट्स के बीच की दूरी को सेमी-टोन में मापता है।"
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr "सेमी-टोन इंटरवल ब्लॉक दो नोट्स के बीच की दूरी को सेमी-टोन में मापता है।"
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr "सेमी-टोन इंटरवल ब्लॉक आधारित है जो आधे कदमों पर आधारित है।"
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr "सेमी-टोन इंटरवल ब्लॉक आधारित है जो आधे कदमों पर आधारित है।"
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr "आर्पेजियो ब्लॉक हर नोट ब्लॉक को कई बार चलाएगा, जिसमें निर्दिष्ट किए गए स्वर के आधार पर एक ट्रांसपोज़िशन जोड़ा जाएगा।"
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr "आर्पेजियो ब्लॉक हर नोट ब्लॉक को कई बार चलाएगा, जिसमें निर्दिष्ट किए गए स्वर के आधार पर एक ट्रांसपोज़िशन जोड़ा जाएगा।"
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr "स्केलर इंटरवल ब्लॉक मौजूदा मोड पर आधारित एक सापेक्ष इंटरवल की गणना करता है, जो मोड के बाहर के सभी स्वरों को छोड़ता है।"
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr "स्केलर इंटरवल ब्लॉक मौजूदा मोड पर आधारित एक सापेक्ष इंटरवल की गणना करता है, जो मोड के बाहर के सभी स्वरों को छोड़ता है।"
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you to define a custom mode by specifying pitch numbers."
-#~msgstr "डिफ़ाइन मोड ब्लॉक आपको पिच नंबर की विशेषण करके एक कस्टम मोड को निर्धारित करने की अनुमति देता है।"
+#~ msgid "The Define mode block allows you to define a custom mode by specifying pitch numbers."
+#~ msgstr "डिफ़ाइन मोड ब्लॉक आपको पिच नंबर की विशेषण करके एक कस्टम मोड को निर्धारित करने की अनुमति देता है।"
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable Do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr "जब मूवेबल डो गलत है, तो सोल्फेज नोट नामें हमेशा विशिष्ट पिच के साथ जुड़े होते हैं,"
+#~ msgid "When Movable Do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr "जब मूवेबल डो गलत है, तो सोल्फेज नोट नामें हमेशा विशिष्ट पिच के साथ जुड़े होते हैं,"
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "e.g., \"do\" is always \"C-natural\" when Movable Do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr "उदाहरण के लिए, \"do\" हमेशा \"C-natural\" होता है जब मूवेबल डो सही है, सोल्फेज नोट नामें स्केल डिग्रीज को आवंटित की जाती हैं, \"do\" हमेशा मेजर स्केल के पहले डिग्री होता है।"
+#~ msgid "e.g., \"do\" is always \"C-natural\" when Movable Do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr "उदाहरण के लिए, \"do\" हमेशा \"C-natural\" होता है जब मूवेबल डो सही है, सोल्फेज नोट नामें स्केल डिग्रीज को आवंटित की जाती हैं, \"do\" हमेशा मेजर स्केल के पहले डिग्री होता है।"
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr "एक्शन ब्लॉक ब्लॉक्स को समूह में जोड़ने के लिए किया जाता है ताकि उन्हें एक से अधिक बार उपयोग किया जा सके।"
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr "एक्शन ब्लॉक ब्लॉक्स को समूह में जोड़ने के लिए किया जाता है ताकि उन्हें एक से अधिक बार उपयोग किया जा सके।"
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr "ग्रेटर-थैन ब्लॉक टॉप नंबर बॉटम नंबर से अधिक है तो True लौटाता है।"
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr "ग्रेटर-थैन ब्लॉक टॉप नंबर बॉटम नंबर से अधिक है तो True लौटाता है।"
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr "लेस-थैन ब्लॉक टॉप नंबर बॉटम नंबर से कम है तो True लौटाता है।"
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr "लेस-थैन ब्लॉक टॉप नंबर बॉटम नंबर से कम है तो True लौटाता है।"
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "इस उदाहरण में, माउस दाएं जाता है जब तक यह कैनवास के दाएं किनारे तक पहुंचता है; फिर यह कैनवास के बाएं में पुनः प्रकट होता है।"
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "इस उदाहरण में, माउस दाएं जाता है जब तक यह कैनवास के दाएं किनारे तक पहुंचता है; फिर यह कैनवास के बाएं में पुनः प्रकट होता है।"
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "इस उदाहरण में, कछुआ दाएं जाता है जब तक यह कैनवास के दाएं किनारे तक पहुंचता है; फिर यह कैनवास के बाएं में पुनः प्रकट होता है।"
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "इस उदाहरण में, कछुआ दाएं जाता है जब तक यह कैनवास के दाएं किनारे तक पहुंचता है; फिर यह कैनवास के बाएं में पुनः प्रकट होता है।"
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "इस उदाहरण में, माउस ऊपर जाता है जब तक यह कैनवास के शीर्ष किनारे तक पहुंचता है; फिर यह कैनवास के नीचे पुनः प्रकट होता है।"
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "इस उदाहरण में, माउस ऊपर जाता है जब तक यह कैनवास के शीर्ष किनारे तक पहुंचता है; फिर यह कैनवास के नीचे पुनः प्रकट होता है।"
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "इस उदाहरण में, कछुआ ऊपर जाता है जब तक यह कैनवास के शीर्ष किनारे तक पहुंचता है; फिर यह कैनवास के नीचे पुनः प्रकट होता है।"
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "इस उदाहरण में, कछुआ ऊपर जाता है जब तक यह कैनवास के शीर्ष किनारे तक पहुंचता है; फिर यह कैनवास के नीचे पुनः प्रकट होता है।"
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr "वीडियो सामग्री"
+#~ msgid "video material"
+#~ msgstr "वीडियो सामग्री"
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr "रन ब्लॉक ब्लॉक एक ब्लॉक चलाता है। यह दो प्रकार के तर्कों को स्वीकार करता है: ब्लॉक संख्या या ब्लॉक नाम।"
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr "रन ब्लॉक ब्लॉक एक ब्लॉक चलाता है। यह दो प्रकार के तर्कों को स्वीकार करता है: ब्लॉक संख्या या ब्लॉक नाम।"
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr "सेट ड्रम ब्लॉक किसी भी शामिल नोट्स की पिच को बदलने के लिए एक ड्रम ध्वनि का चयन करेगा।"
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr "सेट ड्रम ब्लॉक किसी भी शामिल नोट्स की पिच को बदलने के लिए एक ड्रम ध्वनि का चयन करेगा।"
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr "नोट वैल्यू ब्लॉक वर्तमान में चल रहे नोट की अवधि का मान है।"
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr "नोट वैल्यू ब्लॉक वर्तमान में चल रहे नोट की अवधि का मान है।"
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr "मिलीसेकंड्स ब्लॉक एक नोट ब्लॉक के समान है सिवाय इसके कि यह नोट की अवधि निर्दिष्ट करने के लिए समय (एमएस में) का उपयोग करता है।"
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr "मिलीसेकंड्स ब्लॉक एक नोट ब्लॉक के समान है सिवाय इसके कि यह नोट की अवधि निर्दिष्ट करने के लिए समय (एमएस में) का उपयोग करता है।"
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr "स्विंग ब्लॉक नोट्स की जोड़ी पर काम करता है (नोट वैल्यू द्वारा निर्दिष्ट), पहले नोट में कुछ अवधि (स्विंग वैल्यू द्वारा निर्दिष्ट) जोड़ता है और दूसरे नोट से समान मात्रा लेता है।"
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr "स्विंग ब्लॉक नोट्स की जोड़ी पर काम करता है (नोट वैल्यू द्वारा निर्दिष्ट), पहले नोट में कुछ अवधि (स्विंग वैल्यू द्वारा निर्दिष्ट) जोड़ता है और दूसरे नोट से समान मात्रा लेता है।"
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr "मल्टीप्लाई नोट वैल्यू ब्लॉक उनके नोट मानों को बदलकर नोट्स की अवधि बदलता है।"
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr "मल्टीप्लाई नोट वैल्यू ब्लॉक उनके नोट मानों को बदलकर नोट्स की अवधि बदलता है।"
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr "निर्दिष्ट नोट मूल्य अवधि की शांति ब्लॉक का उपयोग करके बना सकते हैं।"
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr "निर्दिष्ट नोट मूल्य अवधि की शांति ब्लॉक का उपयोग करके बना सकते हैं।"
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr "Show-heap ब्लॉक हीप की सामग्री को स्क्रीन के शीर्ष पर प्रदर्शित करता है।"
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr "Show-heap ब्लॉक हीप की सामग्री को स्क्रीन के शीर्ष पर प्रदर्शित करता है।"
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr "उदाहरण का आउटपुट है: सोल, सोल, सोल, सोल, रे, रे, रे, रे, सोल, सोल, सोल, सोल।"
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr "उदाहरण का आउटपुट है: सोल, सोल, सोल, सोल, रे, रे, रे, रे, सोल, सोल, सोल, सोल।"
 
 #: js/FlowBlocks.js:679
 
@@ -8422,325 +8422,325 @@ msgstr "सरकाय"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr "शर्ताओं से आपका प्रोग्राम शर्त के आधार पर विभिन्न क्रियाएँ कर सकता है।"
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr "शर्ताओं से आपका प्रोग्राम शर्त के आधार पर विभिन्न क्रियाएँ कर सकता है।"
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr "इस उदाहरण में यदि माउस बटन दबाया जाता है तो एक स्नेयर ड्रम बजेगा, अन्यथा एक किक ड्रम बजेगा।"
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr "इस उदाहरण में यदि माउस बटन दबाया जाता है तो एक स्नेयर ड्रम बजेगा, अन्यथा एक किक ड्रम बजेगा।"
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr "इस साधारित ड्रम मशीन के उदाहरण में, एक किक ड्रम हमेशा के लिए 1/4 नोट बजेगा।"
+#~ msgid "In this example of a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr "इस साधारित ड्रम मशीन के उदाहरण में, एक किक ड्रम हमेशा के लिए 1/4 नोट बजेगा।"
 
 #: js/FlowBlocks.js:791
 
-#~msgid "In this example, the note will be played 4 times."
-#~msgstr "इस उदाहरण में, नोट को 4 बार बजाया जाएगा।"
+#~ msgid "In this example, the note will be played 4 times."
+#~ msgstr "इस उदाहरण में, नोट को 4 बार बजाया जाएगा।"
 
 #: js/PitchBlocks.js:373
 
-#~msgid "The Current Pitch block is used with the Pitch Converter block. In the example above, the current pitch, sol 4, is displayed as 392 hertz."
-#~msgstr "करंट पिच ब्लॉक पिच कनवर्टर ब्लॉक के साथ उपयोग किया जाता है। उपरोक्त उदाहरण में, वर्तमान पिच, सॉल 4, 392 हर्ट्ज के रूप में प्रदर्शित है।"
+#~ msgid "The Current Pitch block is used with the Pitch Converter block. In the example above, the current pitch, sol 4, is displayed as 392 hertz."
+#~ msgstr "करंट पिच ब्लॉक पिच कनवर्टर ब्लॉक के साथ उपयोग किया जाता है। उपरोक्त उदाहरण में, वर्तमान पिच, सॉल 4, 392 हर्ट्ज के रूप में प्रदर्शित है।"
 
 #: js/PitchBlocks.js:670
 
-#~msgid "The Number to pitch block will convert a pitch number to a pitch name."
-#~msgstr "नंबर टू पिच ब्लॉक एक पिच नंबर को पिच नाम में परिवर्तित करेगा।"
+#~ msgid "The Number to pitch block will convert a pitch number to a pitch name."
+#~ msgstr "नंबर टू पिच ब्लॉक एक पिच नंबर को पिच नाम में परिवर्तित करेगा।"
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr "आर्क ब्लॉक माउस को एक चाप में ले जाता है।"
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr "आर्क ब्लॉक माउस को एक चाप में ले जाता है।"
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr "आर्क ब्लॉक कछुए को एक चाप में ले जाता है।"
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr "आर्क ब्लॉक कछुए को एक चाप में ले जाता है।"
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr "सेट हेडिंग ब्लॉक माउस की हेडिंग सेट करता है।"
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr "सेट हेडिंग ब्लॉक माउस की हेडिंग सेट करता है।"
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr "रैप ब्लॉक इसके भीतर ग्राफिक्स क्रियाओं के लिए स्क्रीन रैपिंग को सक्षम या अक्षम करता है।"
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr "रैप ब्लॉक इसके भीतर ग्राफिक्स क्रियाओं के लिए स्क्रीन रैपिंग को सक्षम या अक्षम करता है।"
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr "स्लर ब्लॉक नोट्स के सस्तेन को बढ़ाता है जबकि नोट्स के निर्दिष्ट ताल मूल्य को बनाए रखता है।"
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr "स्लर ब्लॉक नोट्स के सस्तेन को बढ़ाता है जबकि नोट्स के निर्दिष्ट ताल मूल्य को बनाए रखता है।"
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr "स्टाकेटो ब्लॉक वास्तविक नोट की लंबाई को कम करता है जबकि सुनिश्चित करता है कि नोट्स का निर्दिष्ट तालमूल्य बना रहता है।"
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr "स्टाकेटो ब्लॉक वास्तविक नोट की लंबाई को कम करता है जबकि सुनिश्चित करता है कि नोट्स का निर्दिष्ट तालमूल्य बना रहता है।"
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr "डेक्रेसेंडो ब्लॉक नोट्स की वॉल्यूम को प्रति बजी हुई नोट के लिए एक निर्दिष्ट मात्रा से कम करेगा।"
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "डेक्रेसेंडो ब्लॉक नोट्स की वॉल्यूम को प्रति बजी हुई नोट के लिए एक निर्दिष्ट मात्रा से कम करेगा।"
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr "उदाहरण के लिए, यदि आपके पास एक डेक्रेसेंडो ब्लॉक में 5 की मान के साथ एक क्रम में 7 नोट्स हैं, तो अंतिम नोट प्रारंभ वॉल्यूम से 35% कम होगा।"
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr "उदाहरण के लिए, यदि आपके पास एक डेक्रेसेंडो ब्लॉक में 5 की मान के साथ एक क्रम में 7 नोट्स हैं, तो अंतिम नोट प्रारंभ वॉल्यूम से 35% कम होगा।"
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr "क्रेशेंडो ब्लॉक हर बजी हुई नोट के लिए एक निर्दिष्ट मात्रा से नोट्स की वॉल्यूम बढ़ाएगा।"
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "क्रेशेंडो ब्लॉक हर बजी हुई नोट के लिए एक निर्दिष्ट मात्रा से नोट्स की वॉल्यूम बढ़ाएगा।"
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr "उदाहरण के लिए, यदि आपके पास 7 नोट्स के साथ एक क्रम में 5 की मान के साथ क्रेशेंडो ब्लॉक है, तो अंतिम नोट प्रारंभ वॉल्यूम से 35% ज्यादा होगा।"
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr "उदाहरण के लिए, यदि आपके पास 7 नोट्स के साथ एक क्रम में 5 की मान के साथ क्रेशेंडो ब्लॉक है, तो अंतिम नोट प्रारंभ वॉल्यूम से 35% ज्यादा होगा।"
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr "पार्शियल ब्लॉक का उपयोग विशिष्ट आंशिक सद्वाद के लिए एक वजन निर्दिष्ट करने के लिए किया जाता है।"
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr "पार्शियल ब्लॉक का उपयोग विशिष्ट आंशिक सद्वाद के लिए एक वजन निर्दिष्ट करने के लिए किया जाता है।"
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr "वेटेड-पार्शियल्स ब्लॉक एक टिम्बर के साथ संबंधित पार्शियल्स को निर्दिष्ट करने के लिए उपयोग किया जाता है।"
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr "वेटेड-पार्शियल्स ब्लॉक एक टिम्बर के साथ संबंधित पार्शियल्स को निर्दिष्ट करने के लिए उपयोग किया जाता है।"
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr "सेट डिफ़ॉल्ट इंस्ट्रुमेंट ब्लॉक डिफ़ॉल्ट इलेक्ट्रॉनिक सिंथ से आपके चयन के इंस्ट्रुमेंट पर बदलता है।"
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr "सेट डिफ़ॉल्ट इंस्ट्रुमेंट ब्लॉक डिफ़ॉल्ट इलेक्ट्रॉनिक सिंथ से आपके चयन के इंस्ट्रुमेंट पर बदलता है।"
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr "बीट कारक ब्लॉक नोट मूल्य के सापेक्ष मीटर नोट मूल्य का अनुपात लौटाता है।"
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr "बीट कारक ब्लॉक नोट मूल्य के सापेक्ष मीटर नोट मूल्य का अनुपात लौटाता है।"
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr "चित्र में, इसे प्रत्येक माप के पहले बीट पर क्रिया करने के लिए उपयोग किया जाता है।"
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr "चित्र में, इसे प्रत्येक माप के पहले बीट पर क्रिया करने के लिए उपयोग किया जाता है।"
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr "(डिफ़ॉल्ट रूप से, यह क्वॉर्टर नोट्स की गिनती करता है।)"
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr "(डिफ़ॉल्ट रूप से, यह क्वॉर्टर नोट्स की गिनती करता है।)"
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr "शो-डिक्शनरी ब्लॉक डिक्शनरी की सामग्री को स्क्रीन के शीर्ष पर प्रदर्शित करता है।"
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr "शो-डिक्शनरी ब्लॉक डिक्शनरी की सामग्री को स्क्रीन के शीर्ष पर प्रदर्शित करता है।"
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr "कमेंट ब्लॉक कार्यक्रम धीमे मोड में चल रहा है जब स्क्रीन के शीर्ष पर एक कमेंट प्रिंट करता है।"
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr "कमेंट ब्लॉक कार्यक्रम धीमे मोड में चल रहा है जब स्क्रीन के शीर्ष पर एक कमेंट प्रिंट करता है।"
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr "कर्सर ओवर ब्लॉक जब कर्सर माउस पर चलाया जाता है तो एक घटना को ट्रिगर करता है।"
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr "कर्सर ओवर ब्लॉक जब कर्सर माउस पर चलाया जाता है तो एक घटना को ट्रिगर करता है।"
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr "कर्सर ओवर ब्लॉक जब कर्सर कछुआ पर चलाया जाता है तो एक घटना को ट्रिगर करता है।"
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr "कर्सर ओवर ब्लॉक जब कर्सर कछुआ पर चलाया जाता है तो एक घटना को ट्रिगर करता है।"
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr "कर्सर आउट ब्लॉक जब कर्सर माउस से हटाया जाता है तो एक घटना को ट्रिगर करता है।"
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr "कर्सर आउट ब्लॉक जब कर्सर माउस से हटाया जाता है तो एक घटना को ट्रिगर करता है।"
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr "कर्सर आउट ब्लॉक जब कर्सर कछुआ से हटाया जाता है तो एक घटना को ट्रिगर करता है।"
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr "कर्सर आउट ब्लॉक जब कर्सर कछुआ से हटाया जाता है तो एक घटना को ट्रिगर करता है।"
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr "कर्सर बटन डाउन ब्लॉक जब माउस पर बटन दबाया जाता है तो एक घटना को ट्रिगर करता है।"
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr "कर्सर बटन डाउन ब्लॉक जब माउस पर बटन दबाया जाता है तो एक घटना को ट्रिगर करता है।"
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr "कर्सर बटन डाउन ब्लॉक जब कछुआ पर बटन दबाया जाता है तो एक घटना को ट्रिगर करता है।"
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr "कर्सर बटन डाउन ब्लॉक जब कछुआ पर बटन दबाया जाता है तो एक घटना को ट्रिगर करता है।"
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr "कर्सर बटन अप ब्लॉक जब माउस पर होकर बटन रिलीज़ होता है तो एक घटना को ट्रिगर करता है।"
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr "कर्सर बटन अप ब्लॉक जब माउस पर होकर बटन रिलीज़ होता है तो एक घटना को ट्रिगर करता है।"
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr "कर्सर बटन अप ब्लॉक" एक घटना को ट्रिगर करता है जब कर्सर बटन टर्टिल के ऊपर होते हुए रिलीज़ होता है"
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr "कर्सर बटन अप ब्लॉक\" एक घटना को ट्रिगर करता है जब कर्सर बटन टर्टिल के ऊपर होते हुए रिलीज़ होता है"
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr "गेट ब्लू ब्लॉक माउस के नीचे पिक्सेल का नीला घटक वापस करता है।"
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr "गेट ब्लू ब्लॉक माउस के नीचे पिक्सेल का नीला घटक वापस करता है।"
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr "गेट ब्लू ब्लॉक कछुआ के नीचे पिक्सेल का नीला घटक वापस करता है।"
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr "गेट ब्लू ब्लॉक कछुआ के नीचे पिक्सेल का नीला घटक वापस करता है।"
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr "गेट ग्रीन ब्लॉक माउस के नीचे पिक्सेल का हरित घटक वापस करता है।"
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr "गेट ग्रीन ब्लॉक माउस के नीचे पिक्सेल का हरित घटक वापस करता है।"
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr "गेट ग्रीन ब्लॉक कछुआ के नीचे पिक्सेल का हरित घटक वापस करता है।"
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr "गेट ग्रीन ब्लॉक कछुआ के नीचे पिक्सेल का हरित घटक वापस करता है।"
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr "टाइम ब्लॉक प्रोग्राम के चलने के समय की सेकंड्स की संख्या वापस करता है।"
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr "टाइम ब्लॉक प्रोग्राम के चलने के समय की सेकंड्स की संख्या वापस करता है।"
 
 #: js/musicutils.js:700
 
-#~msgid "in""
-#~msgstr "में""
+#~ msgid "in"
+#~ msgstr "में"
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr "अधिक विवरण"
+#~ msgid "More Details"
+#~ msgstr "अधिक विवरण"
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr "परियोजना साझा करें"
+#~ msgid "Share project"
+#~ msgstr "परियोजना साझा करें"
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr "क्लिपबोर्ड पर लिंक कॉपी करें"
+#~ msgid "Copy link to clipboard"
+#~ msgstr "क्लिपबोर्ड पर लिंक कॉपी करें"
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr "स्टार्टअप पर परियोजना चलाएं।"
+#~ msgid "Run project on startup."
+#~ msgstr "स्टार्टअप पर परियोजना चलाएं।"
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr "स्टार्टअप पर कोड ब्लॉक्स दिखाएं।"
+#~ msgid "Show code blocks on startup."
+#~ msgstr "स्टार्टअप पर कोड ब्लॉक्स दिखाएं।"
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr "स्टार्टअप पर कोड ब्लॉक्स को संक्षेपित करें।"
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr "स्टार्टअप पर कोड ब्लॉक्स को संक्षेपित करें।"
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr "उन्नत विकल्प"
+#~ msgid "Advanced Options"
+#~ msgstr "उन्नत विकल्प"
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr "हर्ट्ज़ ब्लॉक: क्या आप नोट ब्लॉक का उपयोग करना चाहते थे?"
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr "हर्ट्ज़ ब्लॉक: क्या आप नोट ब्लॉक का उपयोग करना चाहते थे?"
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr "प्रोजेक्ट को नापसंद करें"
+#~ msgid "Unlike project"
+#~ msgstr "प्रोजेक्ट को नापसंद करें"
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr "प्रोजेक्ट को पसंद करें"
+#~ msgid "Like project"
+#~ msgstr "प्रोजेक्ट को पसंद करें"
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr "विशेषता अनुपलब्ध - सर्वर से कनेक्ट नहीं हो सकता। पुनः प्रयास करने के लिए टर्टल ब्लॉक्स को पुनः लोड करें।"
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr "विशेषता अनुपलब्ध - सर्वर से कनेक्ट नहीं हो सकता। पुनः प्रयास करने के लिए टर्टल ब्लॉक्स को पुनः लोड करें।"
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr "प्रोजेक्ट को पुनः प्रकाशित करें"
+#~ msgid "Republish Project"
+#~ msgstr "प्रोजेक्ट को पुनः प्रकाशित करें"
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr "ऑडियो फाइल 1"
+#~ msgid "audio file1"
+#~ msgstr "ऑडियो फाइल 1"
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr "ऑडियो फाइल 2"
+#~ msgid "audio file2"
+#~ msgstr "ऑडियो फाइल 2"
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr "चेतावनी: नोट मान 2 से अधिक है।"
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr "चेतावनी: नोट मान 2 से अधिक है।"
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr "कॉर्ड 5"
+#~ msgid "chord5"
+#~ msgstr "कॉर्ड 5"
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr "कॉर्ड 4"
+#~ msgid "chord4"
+#~ msgstr "कॉर्ड 4"
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr "कॉर्ड 1"
+#~ msgid "chord1"
+#~ msgstr "कॉर्ड 1"
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr "कर्सर वाई ब्लॉक कछुए की लंबवत स्थिति लौटाता है।"
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr "कर्सर वाई ब्लॉक कछुए की लंबवत स्थिति लौटाता है।"
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr "कर्सर एक्स ब्लॉक कछुए की क्षैतिज स्थिति लौटाता है।"
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr "कर्सर एक्स ब्लॉक कछुए की क्षैतिज स्थिति लौटाता है।"
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr "एनथ-टर्टल नाम ब्लॉक एनवें कछुए का नाम लौटाता है।"
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr "एनथ-टर्टल नाम ब्लॉक एनवें कछुए का नाम लौटाता है।"
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "तेज चलिए"
+#~ msgid "Run fast"
+#~ msgstr "तेज चलिए"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "खुलने और बंधने वाले ब्लॉक को खोलें या बंद करें"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "खुलने और बंधने वाले ब्लॉक को खोलें या बंद करें"
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr "एनथ-माउस नाम ब्लॉक एनवें माउस का नाम लौटाता है।"
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr "एनथ-माउस नाम ब्लॉक एनवें माउस का नाम लौटाता है।"
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr "ब्लॉक्स खोजें"
+#~ msgid "search for blocks"
+#~ msgstr "ब्लॉक्स खोजें"
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr "कृपया ब्राउज़र ज़ूम स्तर को 100% पर सेट करें"
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr "कृपया ब्राउज़र ज़ूम स्तर को 100% पर सेट करें"
 
 #: js/toolbar.js:54
 
@@ -8750,97 +8750,97 @@ msgstr "सरकाय"
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr "सहायक मेनू"
+#~ msgid "Auxilary menu"
+#~ msgstr "सहायक मेनू"
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr "इस प्रोजेक्ट को चलाने के लिए, वेब ब्राउज़र में म्यूजिक ब्लॉक्स खोलें और इस फाइल को ब्राउज़र विंडो में खींचें और छोड़ें।"
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr "इस प्रोजेक्ट को चलाने के लिए, वेब ब्राउज़र में म्यूजिक ब्लॉक्स खोलें और इस फाइल को ब्राउज़र विंडो में खींचें और छोड़ें।"
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr "आपके पास हमेशा कम से कम एक स्टार्ट ब्लॉक होना चाहिए।"
+#~ msgid "You must always have at least one start block."
+#~ msgstr "आपके पास हमेशा कम से कम एक स्टार्ट ब्लॉक होना चाहिए।"
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr "पिच ऊपर"
+#~ msgid "pitch up"
+#~ msgstr "पिच ऊपर"
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr "पिच नीचे"
+#~ msgid "pitch down"
+#~ msgstr "पिच नीचे"
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr "एक्सीडेंटल ऊपर"
+#~ msgid "accidental up"
+#~ msgstr "एक्सीडेंटल ऊपर"
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr "एक्सीडेंटल नीचे"
+#~ msgid "accidental down"
+#~ msgstr "एक्सीडेंटल नीचे"
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr "ऑक्टेव ऊपर"
+#~ msgid "octave up"
+#~ msgstr "ऑक्टेव ऊपर"
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr "ऑक्टेव नीचे"
+#~ msgid "octave down"
+#~ msgstr "ऑक्टेव नीचे"
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "मुद्रा"
+#~ msgid "currency"
+#~ msgstr "मुद्रा"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "से"
+#~ msgid "from"
+#~ msgstr "से"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "मूलधन कीमत"
+#~ msgid "stock price"
+#~ msgstr "मूलधन कीमत"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "अनुवाद करें"
+#~ msgid "translate"
+#~ msgstr "अनुवाद करें"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "नमस्ते"
+#~ msgid "hello"
+#~ msgstr "नमस्ते"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "भाषा पता लगएं"
+#~ msgid "detect lang"
+#~ msgstr "भाषा पता लगएं"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "भाषा स्थित करें"
+#~ msgid "set lang"
+#~ msgstr "भाषा स्थित करें"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "शहर अक्षांश"
+#~ msgid "city latitude"
+#~ msgstr "शहर अक्षांश"
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "शहर देशांतर"
+#~ msgid "city longitude"
+#~ msgstr "शहर देशांतर"
 
 #: plugins/gmap.rtp:71
 
@@ -8850,144 +8850,144 @@ msgstr "सरकाय"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "डेटा उपलब्ध नहीं है समन्वय"
+#~ msgid "Coordinate data not available."
+#~ msgstr "डेटा उपलब्ध नहीं है समन्वय"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "गूगल मानचित्र"
+#~ msgid "Google map"
+#~ msgstr "गूगल मानचित्र"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "निर्देशांक"
+#~ msgid "coordinates"
+#~ msgstr "निर्देशांक"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "ज़ूम गुणक"
+#~ msgid "zoom factor"
+#~ msgstr "ज़ूम गुणक"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "ज़ूम"
+#~ msgid "zoom"
+#~ msgstr "ज़ूम"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "अक्षांश"
+#~ msgid "latitude"
+#~ msgstr "अक्षांश"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "देशान्तर"
+#~ msgid "longitude"
+#~ msgstr "देशान्तर"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "डिग्री"
+#~ msgid "degrees"
+#~ msgstr "डिग्री"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "तेज"
+#~ msgid "radians"
+#~ msgstr "तेज"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "परिभाषित करें"
+#~ msgid "define"
+#~ msgstr "परिभाषित करें"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "बिटकॉइन"
+#~ msgid "bitcoin"
+#~ msgstr "बिटकॉइन"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr "आपको एक फ़ाइल का चयन करना होगा."
+#~ msgid "You need to select a file."
+#~ msgstr "आपको एक फ़ाइल का चयन करना होगा."
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr "त्रेबल दिखाएं"
+#~ msgid "show treble"
+#~ msgstr "त्रेबल दिखाएं"
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr "पोलार छुपाएं"
+#~ msgid "hide Polar"
+#~ msgstr "पोलार छुपाएं"
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr "बास दिखाएं"
+#~ msgid "show bass"
+#~ msgstr "बास दिखाएं"
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr "मेज़्ज़ो-सोप्रान दिखाएं"
+#~ msgid "show mezzo-soprano"
+#~ msgstr "मेज़्ज़ो-सोप्रान दिखाएं"
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr "आल्टो दिखाएं"
+#~ msgid "show alto"
+#~ msgstr "आल्टो दिखाएं"
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr "टेनर दिखाएं"
+#~ msgid "show tenor"
+#~ msgstr "टेनर दिखाएं"
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr "बास छुपाएं"
+#~ msgid "hide bass"
+#~ msgstr "बास छुपाएं"
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr "पोलार दिखाएं"
+#~ msgid "show Polar"
+#~ msgstr "पोलार दिखाएं"
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr "कार्टीशियन छुपाएं"
+#~ msgid "hide Cartesian"
+#~ msgstr "कार्टीशियन छुपाएं"
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr "लिलीपॉंड ताल को प्रोसेस कर नहीं सकता"
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr "लिलीपॉंड ताल को प्रोसेस कर नहीं सकता"
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr "पीडीएफ में सहेजें"
+#~ msgid "Save as PDF"
+#~ msgstr "पीडीएफ में सहेजें"
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr "लिलीपॉंड मोड को नज़रअंदाज़ कर रहा है"
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr "लिलीपॉंड मोड को नज़रअंदाज़ कर रहा है"
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr "ज़ूम इन"
+#~ msgid "ZOOM IN"
+#~ msgstr "ज़ूम इन"
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr "ज़ूम आउट"
+#~ msgid "ZOOM OUT"
+#~ msgstr "ज़ूम आउट"
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr "ब्लॉक का चयन करने के लिए क्लिक करें।"
+#~ msgid "Click to select a block."
+#~ msgstr "ब्लॉक का चयन करने के लिए क्लिक करें।"
 
 #: js/palette.js:1205
 
@@ -8997,15 +8997,15 @@ msgstr "सरकाय"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr "छुपाएं"
+#~ msgid "hide"
+#~ msgstr "छुपाएं"
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr "दिखाएं"
+#~ msgid "show2"
+#~ msgstr "दिखाएं"
 
 #: js/palette.js:1222
 
@@ -9015,23 +9015,23 @@ msgstr "सरकाय"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr "पॉपआउट"
+#~ msgid "popout"
+#~ msgstr "पॉपआउट"
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr "मेरे ब्लॉक्स"
+#~ msgid "myblocks"
+#~ msgstr "मेरे ब्लॉक्स"
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr "क्या आप अपनी परियोजना को सहेजना चाहते हैं?"
+#~ msgid "Do you want to save your project?"
+#~ msgstr "क्या आप अपनी परियोजना को सहेजना चाहते हैं?"
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr "ड्रम ब्लॉक: क्या आपने नोट ब्लॉक का इस्तेमाल करने का इरादा किया है?"
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr "ड्रम ब्लॉक: क्या आपने नोट ब्लॉक का इस्तेमाल करने का इरादा किया है?"
 
 #: js/pitchtracker.js:181
 
@@ -9041,8 +9041,8 @@ msgstr "सरकाय"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr "रिकॉर्डिंग शुरू करें"
+#~ msgid "Start Recording"
+#~ msgstr "रिकॉर्डिंग शुरू करें"
 
 #: js/pitchtracker.js:188
 
@@ -9050,219 +9050,219 @@ msgstr "सरकाय"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr "रिकॉर्डिंग बंद करें"
+#~ msgid "Stop Recording"
+#~ msgstr "रिकॉर्डिंग बंद करें"
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr "लयें सहेजें"
+#~ msgid "save rhythms"
+#~ msgstr "लयें सहेजें"
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr "खींचें"
+#~ msgid "drag"
+#~ msgstr "खींचें"
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr "पिच ब्लॉक: क्या आपने नोट ब्लॉक का इस्तेमाल करने का इरादा किया है?"
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr "पिच ब्लॉक: क्या आपने नोट ब्लॉक का इस्तेमाल करने का इरादा किया है?"
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr "श्री माउस\", 0, 0)]"
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr "श्री माउस\", 0, 0)]"
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr "क्लिक ब्लॉक एक माउस को क्लिक किया गया है तो सत्य लौटाता है।"
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr "क्लिक ब्लॉक एक माउस को क्लिक किया गया है तो सत्य लौटाता है।"
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr "बॉक्स2 ब्लॉक बॉक्स2 में स्टोर किए गए मूल्य को लौटाता है।"
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr "बॉक्स2 ब्लॉक बॉक्स2 में स्टोर किए गए मूल्य को लौटाता है।"
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr "बॉक्स1 ब्लॉक उस वैल्यू को लौटाता है जो बॉक्स1 में स्टोर किया गया है।"
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr "बॉक्स1 ब्लॉक उस वैल्यू को लौटाता है जो बॉक्स1 में स्टोर किया गया है।"
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr "ब्लॉक छुपाएं।"
+#~ msgid "Hide blocks."
+#~ msgstr "ब्लॉक छुपाएं।"
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr "और भी कम किया जा सकता है नहीं"
+#~ msgid "Cannot be further decreased"
+#~ msgstr "और भी कम किया जा सकता है नहीं"
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr "और भी बढ़ाया जा सकता है नहीं"
+#~ msgid "Cannot be further increased"
+#~ msgstr "और भी बढ़ाया जा सकता है नहीं"
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr "त्रुटि: सहेजने में असमर्थ क्योंकि आपके स्थानीय संग्रहण से बाहर हो गए हैं। कुछ सहेजी गई परियोजनाओं को हटाने का प्रयास करें।"
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr "त्रुटि: सहेजने में असमर्थ क्योंकि आपके स्थानीय संग्रहण से बाहर हो गए हैं। कुछ सहेजी गई परियोजनाओं को हटाने का प्रयास करें।"
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr "माउस ब्लिंक बंद; FPS को 10 पर सेट कर रहा है।"
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr "माउस ब्लिंक बंद; FPS को 10 पर सेट कर रहा है।"
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr "माउस ब्लिंक शुरू; FPS को 30 पर सेट कर रहा है।"
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr "माउस ब्लिंक शुरू; FPS को 30 पर सेट कर रहा है।"
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr "स्केलर ट्रांसपोजिशन्स कस्टम टेम्परमेंट के लिए सीमिटोन ट्रांसपोजिशन्स के बराबर हैं।"
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr "स्केलर ट्रांसपोजिशन्स कस्टम टेम्परमेंट के लिए सीमिटोन ट्रांसपोजिशन्स के बराबर हैं।"
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr "आप सिर्फ एक ही पिच के नोट्स को बांध सकते हैं। क्या आपने स्लर का उपयोग करने का इरादा किया है?"
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr "आप सिर्फ एक ही पिच के नोट्स को बांध सकते हैं। क्या आपने स्लर का उपयोग करने का इरादा किया है?"
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr "चेतावनी: नोट मूल्य 2 से अधिक है।"
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr "चेतावनी: नोट मूल्य 2 से अधिक है।"
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr "नोट नाम A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ या A♭ में से एक होना चाहिए।"
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr "नोट नाम A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ या A♭ में से एक होना चाहिए।"
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr "\"%s\" पैलेट से सभी स्टैक्स को हटाना चाहते हैं?"
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr "\"%s\" पैलेट से सभी स्टैक्स को हटाना चाहते हैं?"
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr "यह बटन परियोजनाओं को साझा करने और उदाहरण परियोजनाएं खोजने के लिए एक दर्शक खोलता है।"
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr "यह बटन परियोजनाओं को साझा करने और उदाहरण परियोजनाएं खोजने के लिए एक दर्शक खोलता है।"
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr "संगीत की ताल मीटर ब्लॉक द्वारा निर्धारित की जाती है (डिफ़ॉल्ट रूप से, प्रति माप में 4 1/4 नोट्स)"
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr "संगीत की ताल मीटर ब्लॉक द्वारा निर्धारित की जाती है (डिफ़ॉल्ट रूप से, प्रति माप में 4 1/4 नोट्स)"
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr "मास्टर प्रति मिनट बीट्स ब्लॉक हर आवाज के लिए प्रति मिनट 1/4 नोट्स की संख्या सेट करता है।"
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr "मास्टर प्रति मिनट बीट्स ब्लॉक हर आवाज के लिए प्रति मिनट 1/4 नोट्स की संख्या सेट करता है।"
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr "हर नोट पर क्रियाएँ निर्दिष्ट करने के लिए हर-नोट ब्लॉक का उपयोग करें।"
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr "हर नोट पर क्रियाएँ निर्दिष्ट करने के लिए हर-नोट ब्लॉक का उपयोग करें।"
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr "प्लेयर्ड नोट्स ब्लॉक में वह नोट्स की संख्या है जो बजा चुके हैं।"
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr "प्लेयर्ड नोट्स ब्लॉक में वह नोट्स की संख्या है जो बजा चुके हैं।"
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr "पिच नंबर ब्लॉक एक नंबर से संबंधित पिच बजाएगा, जैसे कि 0 से C और 7 से G।"
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr "पिच नंबर ब्लॉक एक नंबर से संबंधित पिच बजाएगा, जैसे कि 0 से C और 7 से G।"
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr "पिच-स्लाइडर ब्लॉक एक उपकरण खोलता है जिससे विविध पिच उत्पन्न किए जा सकते हैं।"
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr "पिच-स्लाइडर ब्लॉक एक उपकरण खोलता है जिससे विविध पिच उत्पन्न किए जा सकते हैं।"
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr "सभी स्टार्ट ब्लॉक्स एक साथ चलते हैं जब प्ले बटन दबाया जाता है।"
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr "सभी स्टार्ट ब्लॉक्स एक साथ चलते हैं जब प्ले बटन दबाया जाता है।"
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr "बॉक्स1 में मूल्य स्टोर करने के लिए स्टोर इन बॉक्स1 ब्लॉक का उपयोग किया जाता है।"
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr "बॉक्स1 में मूल्य स्टोर करने के लिए स्टोर इन बॉक्स1 ब्लॉक का उपयोग किया जाता है।"
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr "बॉक्स2 में मूल्य स्टोर करने के लिए स्टोर इन बॉक्स2 ब्लॉक का उपयोग किया जाता है।"
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr "बॉक्स2 में मूल्य स्टोर करने के लिए स्टोर इन बॉक्स2 ब्लॉक का उपयोग किया जाता है।"
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr "शैल ब्लॉक का उपयोग माउस के रूप को बदलने के लिए किया जाता है।"
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr "शैल ब्लॉक का उपयोग माउस के रूप को बदलने के लिए किया जाता है।"
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr "पिकअप ब्लॉक उसी बीट से पहले आने वाली किसी भी नोट्स को समर्थित करने के लिए किया जाता है।"
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr "पिकअप ब्लॉक उसी बीट से पहले आने वाली किसी भी नोट्स को समर्थित करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr "बीट्स प्रति मिनट ब्लॉक निहित किए गए किसी भी नोट्स की प्रति मिनट बीट्स को बदलता है।"
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr "बीट्स प्रति मिनट ब्लॉक निहित किए गए किसी भी नोट्स की प्रति मिनट बीट्स को बदलता है।"
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr "ओन-स्ट्रॉन्ग-बीट ब्लॉक आपको निर्दिष्ट बीट्स पर कार्रवाईयाँ निर्दिष्ट करने की अनुमति देता है।"
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr "ओन-स्ट्रॉन्ग-बीट ब्लॉक आपको निर्दिष्ट बीट्स पर कार्रवाईयाँ निर्दिष्ट करने की अनुमति देता है।"
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr "ओन-वीक-बीट ब्लॉक आपको कमजोर (बंद) बीट्स पर कार्रवाईयाँ निर्दिष्ट करने की अनुमति देता है।"
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr "ओन-वीक-बीट ब्लॉक आपको कमजोर (बंद) बीट्स पर कार्रवाईयाँ निर्दिष्ट करने की अनुमति देता है।"
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "उदाहरण के लिए \"do\" हमेशा \"C-natural\" होता है); जब जंगम डो सच होता है, तो सॉल्फेज नोट नाम स्केल डिग्री को सौंपा जाता है (\"do\" हमेशा प्रमुख पैमाने की पहली डिग्री होती है)।"
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "उदाहरण के लिए \"do\" हमेशा \"C-natural\" होता है); जब जंगम डो सच होता है, तो सॉल्फेज नोट नाम स्केल डिग्री को सौंपा जाता है (\"do\" हमेशा प्रमुख पैमाने की पहली डिग्री होती है)।"
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr "नोट वॉल्यूम ब्लॉक वर्तमान सिंथाइज़र की वर्तमान आवाज़ को लौटाता है।"
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr "नोट वॉल्यूम ब्लॉक वर्तमान सिंथाइज़र की वर्तमान आवाज़ को लौटाता है।"
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr "डिफ़ॉल्ट ब्लॉक एक स्विच के अंदर एक डिफ़ॉल्ट क्रिया को परिभाषित करने के लिए उपयोग किया जाता है।"
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr "डिफ़ॉल्ट ब्लॉक एक स्विच के अंदर एक डिफ़ॉल्ट क्रिया को परिभाषित करने के लिए उपयोग किया जाता है।"
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr "माउस नोट ब्लॉक निर्दिष्ट माउस द्वारा बजाए जा रहे होते हुए वर्तमान नोट मूल्य को लौटाता है।"
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr "माउस नोट ब्लॉक निर्दिष्ट माउस द्वारा बजाए जा रहे होते हुए वर्तमान नोट मूल्य को लौटाता है।"
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr "माइनर के लिए नीचे"
+#~ msgid "down minor"
+#~ msgstr "माइनर के लिए नीचे"
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr "मेजर के लिए नीचे"
+#~ msgid "down major"
+#~ msgstr "मेजर के लिए नीचे"
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr "मूल्यांकन"
+#~ msgid "eval"
+#~ msgstr "मूल्यांकन"
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr "100"
+#~ msgid "100"
+#~ msgstr "100"
 
 #: js/playback.js:87
 
@@ -9278,37 +9278,37 @@ msgstr "सरकाय"
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr "खींचें"
+#~ msgid "Drag"
+#~ msgstr "खींचें"
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr "प्ले बैक संगीत"
+#~ msgid "playback music"
+#~ msgstr "प्ले बैक संगीत"
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr "प्ले बैक रोकें"
+#~ msgid "pause playback"
+#~ msgstr "प्ले बैक रोकें"
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr "प्ले बैक पुनः प्रारंभ करें"
+#~ msgid "restart playback"
+#~ msgstr "प्ले बैक पुनः प्रारंभ करें"
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr "प्ले बैक के लिए संगीत तैयार करें"
+#~ msgid "prepare music for playback"
+#~ msgstr "प्ले बैक के लिए संगीत तैयार करें"
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr "ब्लॉक्स लोड करें"
+#~ msgid "Load blocks"
+#~ msgstr "ब्लॉक्स लोड करें"
 
 #: js/turtledefs.js:304
 
@@ -9316,28 +9316,28 @@ msgstr "सरकाय"
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr "सेट टिंबर ब्लॉक सिंथेसाइज़र के लिए एक आवाज़ चुनता है,"
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr "सेट टिंबर ब्लॉक सिंथेसाइज़र के लिए एक आवाज़ चुनता है,"
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr "रन ब्लॉक ब्लॉक एक ब्लॉक चलाता है।"
+#~ msgid "The Run block block runs a block."
+#~ msgstr "रन ब्लॉक ब्लॉक एक ब्लॉक चलाता है।"
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr "टिंबर सेट करें"
+#~ msgid "set timbre"
+#~ msgstr "टिंबर सेट करें"
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr "दायाँ 2"
+#~ msgid "right2"
+#~ msgstr "दायाँ 2"
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr "बायाँ 2"
+#~ msgid "left2"
+#~ msgstr "बायाँ 2"
 
 #: js/pitchtimematrix.js:323
 
@@ -9351,8 +9351,8 @@ msgstr "सरकाय"
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr "विस्तारित करें"
+#~ msgid "expand"
+#~ msgstr "विस्तारित करें"
 
 #: js/pitchtimematrix.js:338
 
@@ -9362,65 +9362,65 @@ msgstr "सरकाय"
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr "संक्षिप्त करें"
+#~ msgid "collapse"
+#~ msgstr "संक्षिप्त करें"
 
-#~msgid "crescendo factor"
-#~msgstr "क्रेसेंडो फैक्टर"
+#~ msgid "crescendo factor"
+#~ msgstr "क्रेसेंडो फैक्टर"
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr "म्यूजिक ब्लॉक्स के केंद्र में <em>नोट</em> ब्लॉक है। <em>नोट</em> ब्लॉक एक <em>पिच</em> ब्लॉक के लिए एक कंटेनर है जो पिच की अवधि (नोट मान) को निर्दिष्ट करता है।"
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr "म्यूजिक ब्लॉक्स के केंद्र में <em>नोट</em> ब्लॉक है। <em>नोट</em> ब्लॉक एक <em>पिच</em> ब्लॉक के लिए एक कंटेनर है जो पिच की अवधि (नोट मान) को निर्दिष्ट करता है।"
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr "<em>टाइम</em> ब्लॉक उस समय की संख्या लौटाता है जो प्रोग्राम चल रहा है।"
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr "<em>टाइम</em> ब्लॉक उस समय की संख्या लौटाता है जो प्रोग्राम चल रहा है।"
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr "<em>स्टोर इन बॉक्स1</em> ब्लॉक का उपयोग <em>बॉक्स1</em> में एक मान संग्रहीत करने के लिए किया जाता है।"
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr "<em>स्टोर इन बॉक्स1</em> ब्लॉक का उपयोग <em>बॉक्स1</em> में एक मान संग्रहीत करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr "<em>मल्टीप्लाई</em> ब्लॉक का उपयोग गुणा करने के लिए किया जाता है।"
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr "<em>मल्टीप्लाई</em> ब्लॉक का उपयोग गुणा करने के लिए किया जाता है।"
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr "कोई ब्लॉक चयनित नहीं है।"
+#~ msgid "There is no block is selected."
+#~ msgstr "कोई ब्लॉक चयनित नहीं है।"
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr "<em>स्केलर ट्रांसपोजिशन</em> ब्लॉक <em>नोट</em> ब्लॉकों के अंदर निहित पिचों को ऊपर (या नीचे) स्केल में स्थानांतरित करेगा। ऊपर दिखाए गए उदाहरण में, <em>सोल</em> को <em>ला</em> तक स्थानांतरित किया गया है।"
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr "<em>स्केलर ट्रांसपोजिशन</em> ब्लॉक <em>नोट</em> ब्लॉकों के अंदर निहित पिचों को ऊपर (या नीचे) स्केल में स्थानांतरित करेगा। ऊपर दिखाए गए उदाहरण में, <em>सोल</em> को <em>ला</em> तक स्थानांतरित किया गया है।"
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr "नई परियोजना को प्रारंभ करें।"
+#~ msgid "Initialise a new project."
+#~ msgstr "नई परियोजना को प्रारंभ करें।"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr "जापानी"
+#~ msgid "japanese"
+#~ msgstr "जापानी"
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr "7वा"
+#~ msgid "7th"
+#~ msgstr "7वा"
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr "कॉर्ड' + ' ' + 'V"
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr "कॉर्ड' + ' ' + 'V"
 
 #: js/musicutils.js:345
 
@@ -9428,8 +9428,8 @@ msgstr "सरकाय"
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr "चीन"
+#~ msgid "chine"
+#~ msgstr "चीन"
 
 #: js/timbre.js:743
 
@@ -9439,127 +9439,127 @@ msgstr "सरकाय"
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr "पूर्ववत"
+#~ msgid "undo"
+#~ msgstr "पूर्ववत"
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr "कॉर्ड' + ' ' + 'I"
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr "कॉर्ड' + ' ' + 'I"
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr "प्लेसहोल्डर"
+#~ msgid "placeholder"
+#~ msgstr "प्लेसहोल्डर"
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr "<em>मूव ब्लॉक</em> ब्लॉक एक ब्लॉक को मूव करता है।"
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr "<em>मूव ब्लॉक</em> ब्लॉक एक ब्लॉक को मूव करता है।"
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr "<em>एक्सीडेंटल</em> ब्लॉक का उपयोग <em>शार्प्स</em> और <em>फ्लैट्स</em> बनाने के लिए किया जाता "
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr "<em>एक्सीडेंटल</em> ब्लॉक का उपयोग <em>शार्प्स</em> और <em>फ्लैट्स</em> बनाने के लिए किया जाता "
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr "<em>ब्लॉक छुपाएं</em> ब्लॉक छुपाता है।"
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr "<em>ब्लॉक छुपाएं</em> ब्लॉक छुपाता है।"
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr "<em>वेटफॉर</em> ब्लॉक तब तक प्रतीति सत्य नहीं हो जाती है जब तक प्रतीति सत्य नहीं होती है।"
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr "<em>वेटफॉर</em> ब्लॉक तब तक प्रतीति सत्य नहीं हो जाती है जब तक प्रतीति सत्य नहीं होती है।"
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr "आवाज़ सेट करें"
+#~ msgid "set volume"
+#~ msgstr "आवाज़ सेट करें"
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr "<em>प्ले नॉयज़</em> ब्लॉक सफेद, पिंक, या भूरा शोर उत्पन्न करेगा।"
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr "<em>प्ले नॉयज़</em> ब्लॉक सफेद, पिंक, या भूरा शोर उत्पन्न करेगा।"
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr "<em>बेज़ियर</em> ब्लॉक एक बेज़ियर कर्व ड्रॉ करता है।"
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr "<em>बेज़ियर</em> ब्लॉक एक बेज़ियर कर्व ड्रॉ करता है।"
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr "घंटे पहले"
+#~ msgid "hours ago"
+#~ msgstr "घंटे पहले"
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr "मेजर ब्लूज़"
+#~ msgid "Major Blues"
+#~ msgstr "मेजर ब्लूज़"
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr "<em>बैक</em> ब्लॉक माउस को पीछे की ओर मूव करता है।"
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr "<em>बैक</em> ब्लॉक माउस को पीछे की ओर मूव करता है।"
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr "<em>सेट-नाम</em> ब्लॉक का उपयोग माउस का नाम रखने के लिए किया जाता है।"
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr "<em>सेट-नाम</em> ब्लॉक का उपयोग माउस का नाम रखने के लिए किया जाता है।"
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr "<em>स्टेटस</em> ब्लॉक संगीत ब्लॉक्स के स्थिति की जाँच करने के लिए एक उपकरण खोलता है जब यह चलरहा"
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr "<em>स्टेटस</em> ब्लॉक संगीत ब्लॉक्स के स्थिति की जाँच करने के लिए एक उपकरण खोलता है जब यह चलरहा"
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr "स्केल बजाएं"
+#~ msgid "play scale"
+#~ msgstr "स्केल बजाएं"
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr "<em>प्रति मिनट बीट्स</em> ब्लॉक वर्तमान प्रति मिनट बीट्स को लौटाता है।"
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr "<em>प्रति मिनट बीट्स</em> ब्लॉक वर्तमान प्रति मिनट बीट्स को लौटाता है।"
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr "एनिग्मेटिक"
+#~ msgid "Enigmatic"
+#~ msgstr "एनिग्मेटिक"
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr "पाँचवा"
+#~ msgid "fifths"
+#~ msgstr "पाँचवा"
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr "एमएल"
+#~ msgid "ml"
+#~ msgstr "एमएल"
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr "मी"
+#~ msgid "mi"
+#~ msgstr "मी"
 
 #: js/turtledefs.js:251
 
@@ -9567,603 +9567,603 @@ msgstr "सरकाय"
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr "<em>डू</em> ब्लॉक का उपयोग क्रिया प्रारंभ करने के लिए किया जाता है।"
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr "<em>डू</em> ब्लॉक का उपयोग क्रिया प्रारंभ करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr "इंडेक्सहीप ब्लॉक निर्दिष्ट स्थान पर हीप में एक मूल्य लौटाता है।"
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr "इंडेक्सहीप ब्लॉक निर्दिष्ट स्थान पर हीप में एक मूल्य लौटाता है।"
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr "<em>पेन-अप</em> ब्लॉक पेन को उठाता है ताकि यह चित्रित नहीं करता है।"
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr "<em>पेन-अप</em> ब्लॉक पेन को उठाता है ताकि यह चित्रित नहीं करता है।"
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr "<em>न्यू माउस</em> ब्लॉक एक नया माउस बनाएगा।"
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr "<em>न्यू माउस</em> ब्लॉक एक नया माउस बनाएगा।"
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr "प्लेबैक"
+#~ msgid "playback"
+#~ msgstr "प्लेबैक"
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr "फ़ाइल से परियोजना को मर्ज करें"
+#~ msgid "Merge project from file"
+#~ msgstr "फ़ाइल से परियोजना को मर्ज करें"
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr "<em>बाएं</em> ब्लॉक कैनवास के बाएं की स्थिति को लौटाता है।"
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr "<em>बाएं</em> ब्लॉक कैनवास के बाएं की स्थिति को लौटाता है।"
 
-#~msgid "eatme"
-#~msgstr "मुझे खाओ"
+#~ msgid "eatme"
+#~ msgstr "मुझे खाओ"
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr "<em>प्लेड हुई पूरी नोट्स</em> ब्लॉक पूरी बजी हुई नोट्स की कुल संख्या लौटाता है।"
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr "<em>प्लेड हुई पूरी नोट्स</em> ब्लॉक पूरी बजी हुई नोट्स की कुल संख्या लौटाता है।"
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr "चल"
+#~ msgid "movable"
+#~ msgstr "चल"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr "ब्राउन-शोर"
+#~ msgid "brown-noise"
+#~ msgstr "ब्राउन-शोर"
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr "जापानी"
+#~ msgid "Japanese"
+#~ msgstr "जापानी"
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr "त्रिकोण-घंटी"
+#~ msgid "triangle-bell"
+#~ msgstr "त्रिकोण-घंटी"
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr "ग्रिड छुपाएं"
+#~ msgid "Hide grid"
+#~ msgstr "ग्रिड छुपाएं"
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr "<em>एफएम सिंथ</em> ब्लॉक एक आवृत्ति मॉड्यूलेटर है जिसका उपयोग एक स्वर को परिभाषित करने के लिए किया जाता है।"
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr "<em>एफएम सिंथ</em> ब्लॉक एक आवृत्ति मॉड्यूलेटर है जिसका उपयोग एक स्वर को परिभाषित करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr "शो हीप ब्लॉक स्क्रीन के शीर्ष पर हीप की सामग्री को प्रदर्शित करता है।"
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr "शो हीप ब्लॉक स्क्रीन के शीर्ष पर हीप की सामग्री को प्रदर्शित करता है।"
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr "<em>नंबर</em> ब्लॉक एक संख्या रखता है।"
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr "<em>नंबर</em> ब्लॉक एक संख्या रखता है।"
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr "<em>केस</em> ब्लॉक का उपयोग <em>स्विच</em> के अंदर मेलों को परिभाषित करने के लिए किया जाता है।"
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr "<em>केस</em> ब्लॉक का उपयोग <em>स्विच</em> के अंदर मेलों को परिभाषित करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr "बैकग्राउंड ब्लॉक पृष्ठभूमि का रंग सेट करता है।"
+#~ msgid "The Background block sets the background color."
+#~ msgstr "बैकग्राउंड ब्लॉक पृष्ठभूमि का रंग सेट करता है।"
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr "पिछला पृष्ठ"
+#~ msgid "Previous page"
+#~ msgstr "पिछला पृष्ठ"
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr "<em>ओपन फाइल</em> ब्लॉक <em>शो</em> ब्लॉक के साथ उपयोग के लिए एक फाइल खोलता है।"
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr "<em>ओपन फाइल</em> ब्लॉक <em>शो</em> ब्लॉक के साथ उपयोग के लिए एक फाइल खोलता है।"
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr "<em>सेट-कलर</em> ब्लॉक पेन का रंग बदलता है।"
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr "<em>सेट-कलर</em> ब्लॉक पेन का रंग बदलता है।"
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr "कॉर्ड' + ' ' + 'IV"
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr "कॉर्ड' + ' ' + 'IV"
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr "प्रभाव"
+#~ msgid "effects"
+#~ msgstr "प्रभाव"
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr "फ्लोर-टॉम"
+#~ msgid "floor-tom"
+#~ msgstr "फ्लोर-टॉम"
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr "<em>हाइट</em> ब्लॉक कैनवास की ऊंचाई लौटाता है।"
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr "<em>हाइट</em> ब्लॉक कैनवास की ऊंचाई लौटाता है।"
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr "फेसबुक पर साझा करें"
+#~ msgid "Share on Facebook"
+#~ msgstr "फेसबुक पर साझा करें"
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr "<em>शेड</em> ब्लॉक वर्तमान पेन शेड मान लौटाता है।"
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr "<em>शेड</em> ब्लॉक वर्तमान पेन शेड मान लौटाता है।"
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr "ऑन-एवरी-बीट ब्लॉक आपको हर बीट पर लेने के लिए क्रियाएँ निर्दिष्ट करने देता है।"
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr "ऑन-एवरी-बीट ब्लॉक आपको हर बीट पर लेने के लिए क्रियाएँ निर्दिष्ट करने देता है।"
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr "मिस्टर माउस हमारे म्यूजिक ब्लॉक्स कंडक्टर हैं। मिस्टर माउस आपको म्यूजिक ब्लॉक्स का अन्वेषण करने के लिए प्रोत्साहित करते हैं। चलो हमारी यात्रा शुरू करते हैं!"
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr "मिस्टर माउस हमारे म्यूजिक ब्लॉक्स कंडक्टर हैं। मिस्टर माउस आपको म्यूजिक ब्लॉक्स का अन्वेषण करने के लिए प्रोत्साहित करते हैं। चलो हमारी यात्रा शुरू करते हैं!"
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr "रे"
+#~ msgid "re"
+#~ msgstr "रे"
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr "स्पेनिश जिप्सी"
+#~ msgid "Spanish Gypsy"
+#~ msgstr "स्पेनिश जिप्सी"
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr "नोट मान विभाजित करें"
+#~ msgid "divide note value"
+#~ msgstr "नोट मान विभाजित करें"
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr "संगीत को धीरे-धीरे चलाने के लिए अतिरिक्त लंबा दबाएं"
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr "संगीत को धीरे-धीरे चलाने के लिए अतिरिक्त लंबा दबाएं"
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr "ड्रम मशीन सहेजें"
+#~ msgid "save drum machine"
+#~ msgstr "ड्रम मशीन सहेजें"
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr "क्षैतिज स्क्रॉलिंग सक्षम करें"
+#~ msgid "enable horizontal scrolling"
+#~ msgstr "क्षैतिज स्क्रॉलिंग सक्षम करें"
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr "<em>पिकअप</em> ब्लॉक का उपयोग किसी भी नोट्स को समायोजित करने के लिए किया जाता है जो बीट से पहले आते हैं।"
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr "<em>पिकअप</em> ब्लॉक का उपयोग किसी भी नोट्स को समायोजित करने के लिए किया जाता है जो बीट से पहले आते हैं।"
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr "<em>होलो लाइन</em> ब्लॉक एक खोखले केंद्र के साथ एक रेखा बनाता है।"
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr "<em>होलो लाइन</em> ब्लॉक एक खोखले केंद्र के साथ एक रेखा बनाता है।"
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr "स्टैक को क्लिपबोर्ड पर कॉपी करने के लिए, स्टैक पर राइट-क्लिक करें।"
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr "स्टैक को क्लिपबोर्ड पर कॉपी करने के लिए, स्टैक पर राइट-क्लिक करें।"
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr "<em>स्टॉपप्लेबैक</em> ब्लॉक"
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr "<em>स्टॉपप्लेबैक</em> ब्लॉक"
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr "एबीसी के रूप में सहेजें"
+#~ msgid "Save as abc"
+#~ msgstr "एबीसी के रूप में सहेजें"
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr "<em>टू फ्रीक्वेंसी</em> ब्लॉक एक पिच नाम और ऑक्टेव को हर्ट्ज़ में परिवर्तित करता है।"
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr "<em>टू फ्रीक्वेंसी</em> ब्लॉक एक पिच नाम और ऑक्टेव को हर्ट्ज़ में परिवर्तित करता है।"
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr "शीर्ष"
+#~ msgid "top"
+#~ msgstr "शीर्ष"
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "म्यूजिक ब्लॉक्स को कॉन्फ़िगर करने के लिए एक पैनल खोलें।"
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "म्यूजिक ब्लॉक्स को कॉन्फ़िगर करने के लिए एक पैनल खोलें।"
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr "<em>और</em> ब्लॉक तार्किक और ऑपरेटर है।"
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr "<em>और</em> ब्लॉक तार्किक और ऑपरेटर है।"
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ".wav के रूप में सहेजें"
+#~ msgid "Save as .wav"
+#~ msgstr ".wav के रूप में सहेजें"
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr "प्लैनेट अनुपलब्ध है।"
+#~ msgid "The Planet is unavailable."
+#~ msgstr "प्लैनेट अनुपलब्ध है।"
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr "आप एक <em>नोट</em> ब्लॉक के भीतर एकाधिक <em>ड्रम</em> ब्लॉकों का उपयोग कर सकते हैं।"
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr "आप एक <em>नोट</em> ब्लॉक के भीतर एकाधिक <em>ड्रम</em> ब्लॉकों का उपयोग कर सकते हैं।"
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr "आप ब्लॉकों के स्टैक को पेस्ट करने के लिए Alt+V का भी उपयोग कर सकते हैं।"
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr "आप ब्लॉकों के स्टैक को पेस्ट करने के लिए Alt+V का भी उपयोग कर सकते हैं।"
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr "<em>वीडियो</em> ब्लॉक <em>शो</em> ब्लॉक के साथ उपयोग के लिए वीडियो का चयन करता है।"
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr "<em>वीडियो</em> ब्लॉक <em>शो</em> ब्लॉक के साथ उपयोग के लिए वीडियो का चयन करता है।"
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "जब <em>मूवेबल डो</em> गलत है, तो सोल्फेज नोट नाम हमेशा विशिष्ट पिचों से जुड़े होते हैं (उदा. \"डो\" हमेशा \"सी-नेचुरल\" होता है); जब <em>मूवेबल डो</em> सही है, तो सोल्फेज नोट नाम स्केल डिग्री को सौंपे जाते हैं (\"डो\" हमेशा मेजर स्केल की पहली डिग्री होती है)।"
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "जब <em>मूवेबल डो</em> गलत है, तो सोल्फेज नोट नाम हमेशा विशिष्ट पिचों से जुड़े होते हैं (उदा. \"डो\" हमेशा \"सी-नेचुरल\" होता है); जब <em>मूवेबल डो</em> सही है, तो सोल्फेज नोट नाम स्केल डिग्री को सौंपे जाते हैं (\"डो\" हमेशा मेजर स्केल की पहली डिग्री होती है)।"
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr "<em>पॉप</em> ब्लॉक हीप के शीर्ष पर मान को हटा देता है।"
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr "<em>पॉप</em> ब्लॉक हीप के शीर्ष पर मान को हटा देता है।"
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr "<em>डिक्रेशेंडो</em> ब्लॉक हर बजाए गए नोट के लिए निर्दिष्ट मात्रा से निहित नोट्स की मात्रा को कम करेगा। उदाहरण के लिए, यदि आपके पास एक <em>डिक्रेशेंडो</em> ब्लॉक में 5 के मूल्य के साथ 7 नोट्स अनुक्रम में हैं, तो अंतिम नोट प्रारंभिक मात्रा से 35% कम होगा।"
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr "<em>डिक्रेशेंडो</em> ब्लॉक हर बजाए गए नोट के लिए निर्दिष्ट मात्रा से निहित नोट्स की मात्रा को कम करेगा। उदाहरण के लिए, यदि आपके पास एक <em>डिक्रेशेंडो</em> ब्लॉक में 5 के मूल्य के साथ 7 नोट्स अनुक्रम में हैं, तो अंतिम नोट प्रारंभिक मात्रा से 35% कम होगा।"
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr "सेव-स्टैक बटन एक स्टैक को एक कस्टम पैलेट पर सहेजता है।"
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr "सेव-स्टैक बटन एक स्टैक को एक कस्टम पैलेट पर सहेजता है।"
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr "मिस्र का"
+#~ msgid "Egyptian"
+#~ msgstr "मिस्र का"
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr "जब क्लिपबोर्ड पर ब्लॉक कॉपी किए जाते हैं तो पेस्ट बटन सक्षम हो जाता है।"
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr "जब क्लिपबोर्ड पर ब्लॉक कॉपी किए जाते हैं तो पेस्ट बटन सक्षम हो जाता है।"
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr "अल्जीरियाई"
+#~ msgid "Algerian"
+#~ msgstr "अल्जीरियाई"
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr "हर"
+#~ msgid "denominator"
+#~ msgstr "हर"
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr "एम्प्टीहीप ब्लॉक हीप को खाली करता है।"
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr "एम्प्टीहीप ब्लॉक हीप को खाली करता है।"
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr "<em>फेजर</em> ब्लॉक एक स्विपिंग ध्वनि जोड़ता है।"
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr "<em>फेजर</em> ब्लॉक एक स्विपिंग ध्वनि जोड़ता है।"
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr "<em>ओपन प्रोजेक्ट</em> ब्लॉक का उपयोग वेब पेज से प्रोजेक्ट खोलने के लिए किया जाता है।"
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr "<em>ओपन प्रोजेक्ट</em> ब्लॉक का उपयोग वेब पेज से प्रोजेक्ट खोलने के लिए किया जाता है।"
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr "प्रभाव डेटा उपलब्ध नहीं है।"
+#~ msgid "Impact data not available."
+#~ msgstr "प्रभाव डेटा उपलब्ध नहीं है।"
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr "संगीत को धीमी गति में चलाने के लिए रन बटन को अतिरिक्त लंबा दबाएं।"
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr "संगीत को धीमी गति में चलाने के लिए रन बटन को अतिरिक्त लंबा दबाएं।"
 
-#~msgid "mashape"
-#~msgstr "माशप"
+#~ msgid "mashape"
+#~ msgstr "माशप"
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr "तिहाई"
+#~ msgid "thirds"
+#~ msgstr "तिहाई"
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr "<em>एक्स</em> ब्लॉक माउस की क्षैतिज स्थिति लौटाता है।"
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr "<em>एक्स</em> ब्लॉक माउस की क्षैतिज स्थिति लौटाता है।"
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr "<em>डिलीट ब्लॉक</em> ब्लॉक एक ब्लॉक को हटा देता है।"
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr "<em>डिलीट ब्लॉक</em> ब्लॉक एक ब्लॉक को हटा देता है।"
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr "<em>स्क्रॉल एक्सवाई</em> ब्लॉक कैनवास को स्थानांतरित करता है।"
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr "<em>स्क्रॉल एक्सवाई</em> ब्लॉक कैनवास को स्थानांतरित करता है।"
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr "<em>रिटर्न टू यूआरएल</em> ब्लॉक एक वेबपेज पर एक मान लौटाएगा।"
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr "<em>रिटर्न टू यूआरएल</em> ब्लॉक एक वेबपेज पर एक मान लौटाएगा।"
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr "<em>लेफ्ट</em> ब्लॉक माउस को बाईं ओर घुमाता है।"
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr "<em>लेफ्ट</em> ब्लॉक माउस को बाईं ओर घुमाता है।"
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr "चलाएँ"
+#~ msgid "Run"
+#~ msgstr "चलाएँ"
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "आप फाइल सिस्टम से नए ब्लॉक लोड कर सकते हैं।"
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "आप फाइल सिस्टम से नए ब्लॉक लोड कर सकते हैं।"
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr "सेटिंग्स"
+#~ msgid "Settings"
+#~ msgstr "सेटिंग्स"
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr "<em>बूलियन</em> ब्लॉक का उपयोग सही या गलत निर्दिष्ट करने के लिए किया जाता है।"
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr "<em>बूलियन</em> ब्लॉक का उपयोग सही या गलत निर्दिष्ट करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr "<em>ऑन-स्टॉन्ग-बीट</em> ब्लॉक आपको निर्दिष्ट बीट्स पर लेने के लिए क्रियाएँ निर्दिष्ट करने देता है।"
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr "<em>ऑन-स्टॉन्ग-बीट</em> ब्लॉक आपको निर्दिष्ट बीट्स पर लेने के लिए क्रियाएँ निर्दिष्ट करने देता है।"
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr "<em>इंडेक्सहीप</em> ब्लॉक निर्दिष्ट स्थान पर हीप में एक मान लौटाता है।"
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr "<em>इंडेक्सहीप</em> ब्लॉक निर्दिष्ट स्थान पर हीप में एक मान लौटाता है।"
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr "<em>आर्ग</em> ब्लॉक एक क्रिया को पास किए गए तर्क का मान शामिल करता है।"
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr "<em>आर्ग</em> ब्लॉक एक क्रिया को पास किए गए तर्क का मान शामिल करता है।"
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr "नीचे ले जाएं"
+#~ msgid "move down"
+#~ msgstr "नीचे ले जाएं"
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr "व्यंजन कदम ऊपर"
+#~ msgid "consonant step up"
+#~ msgstr "व्यंजन कदम ऊपर"
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr "<em>एम्प्टीहीप</em> ब्लॉक हीप को खाली करता है।"
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr "<em>एम्प्टीहीप</em> ब्लॉक हीप को खाली करता है।"
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr "<em>डिफ़ॉल्ट</em> ब्लॉक का उपयोग <em>स्विच</em> के अंदर एक डिफ़ॉल्ट क्रिया को परिभाषित करने के लिए किया जाता है।"
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr "<em>डिफ़ॉल्ट</em> ब्लॉक का उपयोग <em>स्विच</em> के अंदर एक डिफ़ॉल्ट क्रिया को परिभाषित करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr "<em>स्केलर स्टेप अप</em> ब्लॉक वर्तमान कुंजी और मोड में अगले नोट तक के अर्ध-स्वरों की संख्या लौटाता है।"
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr "<em>स्केलर स्टेप अप</em> ब्लॉक वर्तमान कुंजी और मोड में अगले नोट तक के अर्ध-स्वरों की संख्या लौटाता है।"
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr "<em>रिदम मेकर</em> ब्लॉक ड्रम मशीन बनाने के लिए एक उपकरण खोलता है।"
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr "<em>रिदम मेकर</em> ब्लॉक ड्रम मशीन बनाने के लिए एक उपकरण खोलता है।"
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr "<em>माउस हेडिंग</em> ब्लॉक निर्दिष्ट माउस की हेडिंग लौटाता है।"
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr "<em>माउस हेडिंग</em> ब्लॉक निर्दिष्ट माउस की हेडिंग लौटाता है।"
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr "पिच स्लाइडर"
+#~ msgid "pitchslider"
+#~ msgstr "पिच स्लाइडर"
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr "और देखें"
+#~ msgid "View More"
+#~ msgstr "और देखें"
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr "संक्ष"
+#~ msgid "collpase"
+#~ msgstr "संक्ष"
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr "हीप-खाली? ब्लॉक हाँ लाएगा अगर हीप खाली है।"
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr "हीप-खाली? ब्लॉक हाँ लाएगा अगर हीप खाली है।"
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr "फाइबोनाची"
+#~ msgid "Fibonacci"
+#~ msgstr "फाइबोनाची"
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr "धीरे से संगीत चलाएं"
+#~ msgid "Run music slowly"
+#~ msgstr "धीरे से संगीत चलाएं"
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr "ट्रांसलूसेंसी सेट करने वाले ब्लॉक पेन की अपारदर्शिता को बदलता है।"
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr "ट्रांसलूसेंसी सेट करने वाले ब्लॉक पेन की अपारदर्शिता को बदलता है।"
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr "<em>पिच</em> ब्लॉक नोट की आवृत्ति तथा आवृत्ति के ऑक्टेव को निर्धारित करता है जो नोट की आवृत्ति को निर्धारित करता है।"
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr "<em>पिच</em> ब्लॉक नोट की आवृत्ति तथा आवृत्ति के ऑक्टेव को निर्धारित करता है जो नोट की आवृत्ति को निर्धारित करता है।"
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr "<em>स्टेकाटो</em> ब्लॉक वास्तविक नोट की लंबाई को कम करता है—इससे वे जोरदार बर्स्ट बनते हैं—जबकि नोट की निर्धारित ताल मूल्य को बनाए रखता है।"
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr "<em>स्टेकाटो</em> ब्लॉक वास्तविक नोट की लंबाई को कम करता है—इससे वे जोरदार बर्स्ट बनते हैं—जबकि नोट की निर्धारित ताल मूल्य को बनाए रखता है।"
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr "पिच बदलने के लिए स्लाइडर का उपयोग करें।"
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr "पिच बदलने के लिए स्लाइडर का उपयोग करें।"
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr "<em>राइट</em> ब्लॉक कैनवास के दाएं हिस्से की स्थिति लौटाता है।"
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr "<em>राइट</em> ब्लॉक कैनवास के दाएं हिस्से की स्थिति लौटाता है।"
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr "<em>सेट सिंथ वॉल्यूम</em> ब्लॉक किसी विशिष्ट सिंथ के वॉल्यूम को बदलेगा, जैसे कि गिटार, वायलिन, स्नेयर ड्रम, आदि। डिफ़ॉल्ट वॉल्यूम 50 है; सीमा 0 (शांति) से 100 (पूर्ण वॉल्यूम) है।"
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr "<em>सेट सिंथ वॉल्यूम</em> ब्लॉक किसी विशिष्ट सिंथ के वॉल्यूम को बदलेगा, जैसे कि गिटार, वायलिन, स्नेयर ड्रम, आदि। डिफ़ॉल्ट वॉल्यूम 50 है; सीमा 0 (शांति) से 100 (पूर्ण वॉल्यूम) है।"
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr "<em>क्रेशेंडो</em> ब्लॉक हर बजाए गए हर नोट के लिए निर्धारित मात्रा से आवृत्ति बढ़ाएगा। उदाहरण के लिए, यदि आपके पास एक <em>क्रेशेंडो</em> ब्लॉक के साथ 5 के मूल्य के साथ एक क्रम में 7 नोट हैं, तो अंतिम नोट प्रारंभ वॉल्यूम से 35% अधिक होगा।"
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr "<em>क्रेशेंडो</em> ब्लॉक हर बजाए गए हर नोट के लिए निर्धारित मात्रा से आवृत्ति बढ़ाएगा। उदाहरण के लिए, यदि आपके पास एक <em>क्रेशेंडो</em> ब्लॉक के साथ 5 के मूल्य के साथ एक क्रम में 7 नोट हैं, तो अंतिम नोट प्रारंभ वॉल्यूम से 35% अधिक होगा।"
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr "नोट वॉल्यूम"
+#~ msgid "note volume"
+#~ msgstr "नोट वॉल्यूम"
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr "उँगली झनझनी"
+#~ msgid "finger-cymbals"
+#~ msgstr "उँगली झनझनी"
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr "पिच-ड्रम मैट्रिक्स"
+#~ msgid "pitch-drum matrix"
+#~ msgstr "पिच-ड्रम मैट्रिक्स"
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr "टुपलेट ब्लॉक: क्या आपने मैट्रिक्स ब्लॉक का उपयोग करना चाहा था?"
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr "टुपलेट ब्लॉक: क्या आपने मैट्रिक्स ब्लॉक का उपयोग करना चाहा था?"
 
-#~msgid "set beats per minute"
-#~msgstr "मिनट प्रति बीट सेट करें"
+#~ msgid "set beats per minute"
+#~ msgstr "मिनट प्रति बीट सेट करें"
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr "सभी मिटाएं"
+#~ msgid "Delete all"
+#~ msgstr "सभी मिटाएं"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr "गुलाबी शोर"
+#~ msgid "pink-noise"
+#~ msgstr "गुलाबी शोर"
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr "यूआईडी"
+#~ msgid "UID"
+#~ msgstr "यूआईडी"
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr "क्रोमैटिक"
+#~ msgid "Chromatic"
+#~ msgstr "क्रोमैटिक"
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr "घड़ी की दिशा में घूमाएं"
+#~ msgid "rotate clockwise"
+#~ msgstr "घड़ी की दिशा में घूमाएं"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr "हिराजोशी (जापान)"
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr "हिराजोशी (जापान)"
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr "माइनर ब्लॉक के लिए इनपुट 2, 3, 6, या 7 होना चाहिए"
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr "माइनर ब्लॉक के लिए इनपुट 2, 3, 6, या 7 होना चाहिए"
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr "नीचे"
+#~ msgid "bottom"
+#~ msgstr "नीचे"
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr "<em>सेट की</em> ब्लॉक का उपयोग कुंजी और मोड़ सेट करने के लिए किया जाता है, उदाहरण के लिए,"
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr "<em>सेट की</em> ब्लॉक का उपयोग कुंजी और मोड़ सेट करने के लिए किया जाता है, उदाहरण के लिए,"
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr "<em>नोट मूल्य को गुणा करें</em> ब्लॉक नोट के मूल्य को बदलकर नोट की अवधि को बदलता है।"
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr "<em>नोट मूल्य को गुणा करें</em> ब्लॉक नोट के मूल्य को बदलकर नोट की अवधि को बदलता है।"
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr "<em>वाई</em> ब्लॉक माउस की ऊर्ध्वाधिक स्थिति लौटाता है।"
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr "<em>वाई</em> ब्लॉक माउस की ऊर्ध्वाधिक स्थिति लौटाता है।"
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr "नुमरेटर"
+#~ msgid "numerator"
+#~ msgstr "नुमरेटर"
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr "कप-ड्रम"
+#~ msgid "cup-drum"
+#~ msgstr "कप-ड्रम"
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr "हाय-हैट"
+#~ msgid "hi-hat"
+#~ msgstr "हाय-हैट"
 
 #: js/palette.js:1763
 
@@ -10173,165 +10173,165 @@ msgstr "सरकाय"
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr "सोल"
+#~ msgid "sol"
+#~ msgstr "सोल"
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr "<em>आर्क</em> ब्लॉक माउस को एक चाप में ले जाता है।"
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr "<em>आर्क</em> ब्लॉक माउस को एक चाप में ले जाता है।"
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr "<em>पिच सीढ़ी</em> उपकरण का उपयोग किसी दिए गए अनुपात से पिच उत्पन्न करने के लिए किया जाता है।"
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr "<em>पिच सीढ़ी</em> उपकरण का उपयोग किसी दिए गए अनुपात से पिच उत्पन्न करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr "<em>नोट वॉल्यूम</em> ब्लॉक वर्तमान सिंथेसाइज़र की वर्तमान मात्रा को लौटाता है।"
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr "<em>नोट वॉल्यूम</em> ब्लॉक वर्तमान सिंथेसाइज़र की वर्तमान मात्रा को लौटाता है।"
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr "संगीत की ताल <em>मीटर</em> ब्लॉक द्वारा निर्धारित की जाती है (डिफ़ॉल्ट रूप से, प्रति माप 4 1/4 नोट)।"
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr "संगीत की ताल <em>मीटर</em> ब्लॉक द्वारा निर्धारित की जाती है (डिफ़ॉल्ट रूप से, प्रति माप 4 1/4 नोट)।"
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr "<em>एक्सीडेंटल चयनकर्ता</em> ब्लॉक का उपयोग डबल-शार्प, शार्प, नैचुरल, फ्लैट और डबल-फ्लैट के बीच चयन करने के लिए किया जाता है।"
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr "<em>एक्सीडेंटल चयनकर्ता</em> ब्लॉक का उपयोग डबल-शार्प, शार्प, नैचुरल, फ्लैट और डबल-फ्लैट के बीच चयन करने के लिए किया जाता है।"
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr "फ्राईजियन"
+#~ msgid "Phrygian"
+#~ msgstr "फ्राईजियन"
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr "<em>डिफाइन मोड</em> ब्लॉक आपको पिच नंबर निर्दिष्ट करके एक कस्टम मोड परिभाषित करने की अनुमति देता है।"
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr "<em>डिफाइन मोड</em> ब्लॉक आपको पिच नंबर निर्दिष्ट करके एक कस्टम मोड परिभाषित करने की अनुमति देता है।"
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr "तेज चलाएं / धीरे चलाने के लिए लंबे समय तक दबाएं / संगीत को धीरे चलाने के लिए अतिरिक्त लंबे समय तक दबाएं"
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr "तेज चलाएं / धीरे चलाने के लिए लंबे समय तक दबाएं / संगीत को धीरे चलाने के लिए अतिरिक्त लंबे समय तक दबाएं"
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr "म्यूज़िक ब्लॉक्स एक मनिपुलेटिव टूल का संग्रह है जो सुंदर और मजेदार तरीके से मौसिकी के मौलिक अवधारणाओं की खोज करने के लिए बनाया गया है।"
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr "म्यूज़िक ब्लॉक्स एक मनिपुलेटिव टूल का संग्रह है जो सुंदर और मजेदार तरीके से मौसिकी के मौलिक अवधारणाओं की खोज करने के लिए बनाया गया है।"
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr "ला"
+#~ msgid "la"
+#~ msgstr "ला"
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr "दूरी देखें"
+#~ msgid "see distance"
+#~ msgstr "दूरी देखें"
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr "<em>टुप्लेट</em> ब्लॉक का उपयोग संक्षेपित समय में बजाए जाने वाले नोट्स के समूह को उत्पन्न करने के लिए किया जाता है।"
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr "<em>टुप्लेट</em> ब्लॉक का उपयोग संक्षेपित समय में बजाए जाने वाले नोट्स के समूह को उत्पन्न करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr "स्विच ब्लॉक में कोड को मैचिंग केस में चलाया जाएगा।"
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr "स्विच ब्लॉक में कोड को मैचिंग केस में चलाया जाएगा।"
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr "सांगतिक अंतर"
+#~ msgid "relative interval"
+#~ msgstr "सांगतिक अंतर"
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr "<em>मिनट प्रति बीट</em> ब्लॉक मिनट में 1/4 नोट्स की संख्या सेट करता है।"
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr "<em>मिनट प्रति बीट</em> ब्लॉक मिनट में 1/4 नोट्स की संख्या सेट करता है।"
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr "<em>विड्थ</em> ब्लॉक कैनवास की चौड़ाई लौटाता है।"
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr "<em>विड्थ</em> ब्लॉक कैनवास की चौड़ाई लौटाता है।"
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr "संगीत को रोकें (और कछुए भी)।"
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr "संगीत को रोकें (और कछुए भी)।"
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr "फ्लोर टॉम-टॉम"
+#~ msgid "floor-tom-tom"
+#~ msgstr "फ्लोर टॉम-टॉम"
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr "<em>टाई</em> ब्लॉक नोट्स के जोड़ों पर काम करता है, उन्हें एक नोट में मिलाकर।"
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr "<em>टाई</em> ब्लॉक नोट्स के जोड़ों पर काम करता है, उन्हें एक नोट में मिलाकर।"
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr "पिच <em>दो रे मि फा सोल ला टी</em> की शर्तों में निर्दिष्ट की जा सकती है।"
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr "पिच <em>दो रे मि फा सोल ला टी</em> की शर्तों में निर्दिष्ट की जा सकती है।"
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr "<em>शो</em> ब्लॉक का उपयोग कैनवास पर टेक्स्ट या छवियां प्रदर्शित करने के लिए किया जाता है।"
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr "<em>शो</em> ब्लॉक का उपयोग कैनवास पर टेक्स्ट या छवियां प्रदर्शित करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr "<em>बैकग्राउंड</em> ब्लॉक बैकग्राउंड का रंग सेट करता है।"
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr "<em>बैकग्राउंड</em> ब्लॉक बैकग्राउंड का रंग सेट करता है।"
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr "कछुआ नोट"
+#~ msgid "turtle note"
+#~ msgstr "कछुआ नोट"
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr "इस टूलबार में पैलेट बटन्स शामिल हैं, जिनमें रिदम पिच टोन कछुआ और अधिक शामिल हैं।"
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr "इस टूलबार में पैलेट बटन्स शामिल हैं, जिनमें रिदम पिच टोन कछुआ और अधिक शामिल हैं।"
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr "<em>व्हाइल</em> ब्लॉक यदि स्थिति सत्य है तो दोहराएगा।"
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr "<em>व्हाइल</em> ब्लॉक यदि स्थिति सत्य है तो दोहराएगा।"
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr "<em>माइनस</em> ब्लॉक का उपयोग घटाने के लिए किया जाता है।"
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr "<em>माइनस</em> ब्लॉक का उपयोग घटाने के लिए किया जाता है।"
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr "ब्लॉक कला"
+#~ msgid "block artwork"
+#~ msgstr "ब्लॉक कला"
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr "<em>नेबर</em> ब्लॉक बड़े तेजी से पड़ोसी पिचेज़ के बीच स्विच करता है।"
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr "<em>नेबर</em> ब्लॉक बड़े तेजी से पड़ोसी पिचेज़ के बीच स्विच करता है।"
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr "<em>डिस्टोर्शन</em> ब्लॉक पिच में डिस्टोर्शन जोड़ता है।"
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr "<em>डिस्टोर्शन</em> ब्लॉक पिच में डिस्टोर्शन जोड़ता है।"
 
 #: js/lilypond.js:21
 
-#~msgid "br""
-#~msgstr "ब्र"
+#~ msgid "br"
+#~ msgstr "ब्र"
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr "पहला"
+#~ msgid "1st"
+#~ msgstr "पहला"
 
 #: js/logo.js:2177
 
@@ -10345,28 +10345,28 @@ msgstr "सरकाय"
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr "कछुआ नहीं मिला"
+#~ msgid "Could not find turtle"
+#~ msgstr "कछुआ नहीं मिला"
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr "<em>स्लर</em> ब्लॉक नोट्स की स्थिरता को लंबा करता है जबकि नोट्स के निर्दिष्ट ताल मूल्य को बनाए रखता है।"
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr "<em>स्लर</em> ब्लॉक नोट्स की स्थिरता को लंबा करता है जबकि नोट्स के निर्दिष्ट ताल मूल्य को बनाए रखता है।"
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr "हंगेरियन"
+#~ msgid "Hungarian"
+#~ msgstr "हंगेरियन"
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr "कॉर्ड बजाएं"
+#~ msgid "play chord"
+#~ msgstr "कॉर्ड बजाएं"
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr "प्रतिक्रिया को अनुकूलित करें"
+#~ msgid "Optimize feedback"
+#~ msgstr "प्रतिक्रिया को अनुकूलित करें"
 
 #: js/turtledefs.js:187
 
@@ -10374,133 +10374,133 @@ msgstr "सरकाय"
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr "ब्लॉक आर्टवर्क सहेजें"
+#~ msgid "Save block artwork"
+#~ msgstr "ब्लॉक आर्टवर्क सहेजें"
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitrary pitches."
-#~msgstr "<em>पिच-स्लाइडर</em> ब्लॉक एक उपकरण खोलता है जो मनमानी पिचें उत्पन्न करता है।"
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitrary pitches."
+#~ msgstr "<em>पिच-स्लाइडर</em> ब्लॉक एक उपकरण खोलता है जो मनमानी पिचें उत्पन्न करता है।"
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr "स्केलर स्टेप ब्लॉक का उपयोग नोट ब्लॉक के अंदर किया जाना चाहिए।"
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr "स्केलर स्टेप ब्लॉक का उपयोग नोट ब्लॉक के अंदर किया जाना चाहिए।"
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr "म्यूजिक ब्लॉक्स संगीत अवधारणाओं का पता लगाने के लिए उपकरणों का एक ओपन सोर्स संग्रह है। योगदानकर्ताओं की पूरी सूची म्यूजिक ब्लॉक्स गिटहब रिपॉजिटरी में पाई जा सकती है। म्यूजिक ब्लॉक्स एजीपीएल के तहत लाइसेंस प्राप्त है। वर्तमान संस्करण है:"
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr "म्यूजिक ब्लॉक्स संगीत अवधारणाओं का पता लगाने के लिए उपकरणों का एक ओपन सोर्स संग्रह है। योगदानकर्ताओं की पूरी सूची म्यूजिक ब्लॉक्स गिटहब रिपॉजिटरी में पाई जा सकती है। म्यूजिक ब्लॉक्स एजीपीएल के तहत लाइसेंस प्राप्त है। वर्तमान संस्करण है:"
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr "चौथा"
+#~ msgid "fourths"
+#~ msgstr "चौथा"
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr "<em>कर्सर वाई</em> ब्लॉक माउस की ऊर्ध्वाधर स्थिति लौटाता है।"
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr "<em>कर्सर वाई</em> ब्लॉक माउस की ऊर्ध्वाधर स्थिति लौटाता है।"
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr "क्रेसेंडो ब्लॉक हर बजाए गए नोट के लिए निर्धारित मात्रा से नोट्स की मात्रा को बढ़ाएगा (या घटाएगा)। उदाहरण के लिए, यदि आपके पास एक <em>क्रेसेंडो</em> ब्लॉक में 5 के मूल्य के साथ 7 नोट्स अनुक्रम में हैं, तो अंतिम नोट प्रारंभिक मात्रा से 35% अधिक होगा।"
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr "क्रेसेंडो ब्लॉक हर बजाए गए नोट के लिए निर्धारित मात्रा से नोट्स की मात्रा को बढ़ाएगा (या घटाएगा)। उदाहरण के लिए, यदि आपके पास एक <em>क्रेसेंडो</em> ब्लॉक में 5 के मूल्य के साथ 7 नोट्स अनुक्रम में हैं, तो अंतिम नोट प्रारंभिक मात्रा से 35% अधिक होगा।"
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr "<em>कीबोर्ड</em> ब्लॉक कंप्यूटर कीबोर्ड इनपुट लौटाता है।"
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr "<em>कीबोर्ड</em> ब्लॉक कंप्यूटर कीबोर्ड इनपुट लौटाता है।"
 
-#~msgid "Save your project to a server."
-#~msgstr "अपने प्रोजेक्ट को सर्वर पर सहेजें"
+#~ msgid "Save your project to a server."
+#~ msgstr "अपने प्रोजेक्ट को सर्वर पर सहेजें"
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr "बीट मान गुणा करें"
+#~ msgid "multiply beat value"
+#~ msgstr "बीट मान गुणा करें"
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr "पूरा टोन"
+#~ msgid "Whole Tone"
+#~ msgstr "पूरा टोन"
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr "<em>इंट</em> ब्लॉक एक पूर्णांक लौटाता है।"
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr "<em>इंट</em> ब्लॉक एक पूर्णांक लौटाता है।"
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr "<em>बॉक्स2</em> ब्लॉक <em>बॉक्स2</em> में संग्रहीत मान लौटाता है।"
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr "<em>बॉक्स2</em> ब्लॉक <em>बॉक्स2</em> में संग्रहीत मान लौटाता है।"
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr "सिर्फ संगीत को धीमी गति में चलाने के लिए क्लिक करें।"
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr "सिर्फ संगीत को धीमी गति में चलाने के लिए क्लिक करें।"
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr "<em>स्पीक</em> ब्लॉक टेक्स्ट-टू-स्पीच सिंथेसाइज़र को आउटपुट करता है।"
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr "<em>स्पीक</em> ब्लॉक टेक्स्ट-टू-स्पीच सिंथेसाइज़र को आउटपुट करता है।"
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr "<em>ग्रे</em> ब्लॉक वर्तमान पेन ग्रे मान लौटाता है।"
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr "<em>ग्रे</em> ब्लॉक वर्तमान पेन ग्रे मान लौटाता है।"
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr "छठा"
+#~ msgid "6th"
+#~ msgstr "छठा"
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "ऑगमेंटेड ब्लॉक के लिए इनपुट 1, 2, 3, 4, 5, 6, 7, या 8 होना चाहिए"
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "ऑगमेंटेड ब्लॉक के लिए इनपुट 1, 2, 3, 4, 5, 6, 7, या 8 होना चाहिए"
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr "<em>ड्रम नाम</em> ब्लॉक का उपयोग ड्रम का चयन करने के लिए किया जाता है।"
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr "<em>ड्रम नाम</em> ब्लॉक का उपयोग ड्रम का चयन करने के लिए किया जाता है।"
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr "तेज़ चलाएँ / धीरे चलाने के लिए लंबा दबाएँ / संगीत को धीरे चलाने के लिए अतिरिक्त लंबा दबाएँ"
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr "तेज़ चलाएँ / धीरे चलाने के लिए लंबा दबाएँ / संगीत को धीरे चलाने के लिए अतिरिक्त लंबा दबाएँ"
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr "लिलीपॉन्ड के रूप में सहेजें"
+#~ msgid "save as lilypond"
+#~ msgstr "लिलीपॉन्ड के रूप में सहेजें"
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr "<em>डिवाइड</em> ब्लॉक का उपयोग विभाजित करने के लिए किया जाता है।"
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr "<em>डिवाइड</em> ब्लॉक का उपयोग विभाजित करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partial harmonic."
-#~msgstr "<em>पार्शियल</em> ब्लॉक का उपयोग एक विशिष्ट आंशिक हार्मोनिक के लिए एक वजन निर्दिष्ट करने के लिए किया जाता है।"
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partial harmonic."
+#~ msgstr "<em>पार्शियल</em> ब्लॉक का उपयोग एक विशिष्ट आंशिक हार्मोनिक के लिए एक वजन निर्दिष्ट करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr "<em>टेम्परामेंट नाम</em> ब्लॉक का उपयोग ट्यूनिंग विधि का चयन करने के लिए किया जाता है।"
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr "<em>टेम्परामेंट नाम</em> ब्लॉक का उपयोग ट्यूनिंग विधि का चयन करने के लिए किया जाता है।"
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr "घटित"
+#~ msgid "Diminished"
+#~ msgstr "घटित"
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr "उपकरण पट्टी को खोलें या बंद करें"
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr "उपकरण पट्टी को खोलें या बंद करें"
 
 #: js/turtledefs.js:187
 
@@ -10508,136 +10508,136 @@ msgstr "सरकाय"
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr "SVG के रूप में सहेजें"
+#~ msgid "Save as SVG"
+#~ msgstr "SVG के रूप में सहेजें"
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr "लोडहीप ब्लॉक एक फाइल से हीप लोड करता है।"
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr "लोडहीप ब्लॉक एक फाइल से हीप लोड करता है।"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr "में (जापान)"
+#~ msgid "in (Japan)"
+#~ msgstr "में (जापान)"
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr "वैकल्पिक रूप से, आप ENTER या RETURN कुंजी दबा सकते हैं।"
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr "वैकल्पिक रूप से, आप ENTER या RETURN कुंजी दबा सकते हैं।"
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr "<em>सेट टिम्बर</em> ब्लॉक संथेसाइज़र के लिए एक आवाज़ का चयन करता है, जैसे कि गिटार, पियानो, वायलिन, या चेलो।"
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr "<em>सेट टिम्बर</em> ब्लॉक संथेसाइज़र के लिए एक आवाज़ का चयन करता है, जैसे कि गिटार, पियानो, वायलिन, या चेलो।"
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "कछुआ"
+#~ msgid "turtle"
+#~ msgstr "कछुआ"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr "<em>Y माउस</em> ब्लॉक निर्दिष्ट माउस की Y स्थिति लौटाता है।"
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr "<em>Y माउस</em> ब्लॉक निर्दिष्ट माउस की Y स्थिति लौटाता है।"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr "मिन्यो (जापान)"
+#~ msgid "minyo (Japan)"
+#~ msgstr "मिन्यो (जापान)"
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr "प्रभाव समय नहीं मिला।"
+#~ msgid "Impact Time not found."
+#~ msgstr "प्रभाव समय नहीं मिला।"
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr "<em>मिनट प्रति बीट</em> ब्लॉक किसी भी शामिल नोट्स की मिनट प्रति बीट बदलता है।"
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr "<em>मिनट प्रति बीट</em> ब्लॉक किसी भी शामिल नोट्स की मिनट प्रति बीट बदलता है।"
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr "<em>माउस को रोकें</em> ब्लॉक निर्दिष्ट माउस को रोकता है।"
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr "<em>माउस को रोकें</em> ब्लॉक निर्दिष्ट माउस को रोकता है।"
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr "तीसरा"
+#~ msgid "3rd"
+#~ msgstr "तीसरा"
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr "<em>डुप्लीकेट</em> ब्लॉक प्रत्येक ब्लॉक को कई बार चलाएगा। उदाहरण का आउटपुट है: सोल, सोल, सोल, सोल, रे, रे, रे, रे, सोल, सोल, सोल, सोल।"
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr "<em>डुप्लीकेट</em> ब्लॉक प्रत्येक ब्लॉक को कई बार चलाएगा। उदाहरण का आउटपुट है: सोल, सोल, सोल, सोल, रे, रे, रे, रे, सोल, सोल, सोल, सोल।"
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr "<em>डबली</em> ब्लॉक किसी अंतराल का आकार दोगुना करेगा।"
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr "<em>डबली</em> ब्लॉक किसी अंतराल का आकार दोगुना करेगा।"
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr "<em>रन ब्लॉक</em> ब्लॉक चलाता है।"
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr "<em>रन ब्लॉक</em> ब्लॉक चलाता है।"
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr "आगे बजाएं"
+#~ msgid "play forward"
+#~ msgstr "आगे बजाएं"
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr "बैस"
+#~ msgid "basse"
+#~ msgstr "बैस"
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr "<em>हर्ट्ज़</em> ब्लॉक (नंबर ब्लॉक के साथ मेलजोल करके) निर्दिष्ट ताक़त पर एक ध्वनि बजाएगा।"
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr "<em>हर्ट्ज़</em> ब्लॉक (नंबर ब्लॉक के साथ मेलजोल करके) निर्दिष्ट ताक़त पर एक ध्वनि बजाएगा।"
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr "<em>स्टाकाटो</em> ब्लॉक वास्तविक नोट की लंबाई को कम करता है जबकि नोट्स की निर्दिष्ट रैद्ऱीमिक मूल्य को बनाए रखता है।"
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr "<em>स्टाकाटो</em> ब्लॉक वास्तविक नोट की लंबाई को कम करता है जबकि नोट्स की निर्दिष्ट रैद्ऱीमिक मूल्य को बनाए रखता है।"
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr "<em>टू एसीआई</em> ब्लॉक नंबर्स को अक्षरों में बदलता है।"
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr "<em>टू एसीआई</em> ब्लॉक नंबर्स को अक्षरों में बदलता है।"
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr "<em>मोड लंबाई</em> ब्लॉक मौजूदा स्केल में नोट्स की संख्या है। अधिकांश <em>पश्चिमी</em> स्केल्स में 7 नोट्स होते हैं।"
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr "<em>मोड लंबाई</em> ब्लॉक मौजूदा स्केल में नोट्स की संख्या है। अधिकांश <em>पश्चिमी</em> स्केल्स में 7 नोट्स होते हैं।"
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr "<em>1 जोड़ने के लिए</em> ब्लॉक एक बॉक्स में संग्रहित मूल्य में एक जोड़ता है।"
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr "<em>1 जोड़ने के लिए</em> ब्लॉक एक बॉक्स में संग्रहित मूल्य में एक जोड़ता है।"
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr "440 हर्ट्ज़"
+#~ msgid "440 hertz"
+#~ msgstr "440 हर्ट्ज़"
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr "<em>सेट एक्स वाई</em> ब्लॉक माउस को स्क्रीन पर एक विशिष्ट स्थान पर मूव करता है।"
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr "<em>सेट एक्स वाई</em> ब्लॉक माउस को स्क्रीन पर एक विशिष्ट स्थान पर मूव करता है।"
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr "प्रदर्शन को अनुकूलित करें"
+#~ msgid "Optimize performance"
+#~ msgstr "प्रदर्शन को अनुकूलित करें"
 
 #: js/playback.js:31
 
@@ -10647,127 +10647,127 @@ msgstr "सरकाय"
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr "सभी चलाएं"
+#~ msgid "play all"
+#~ msgstr "सभी चलाएं"
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr "<em>कैमरा</em> ब्लॉक एक वेबकैम को <em>शो</em> ब्लॉक से जोड़ता है।"
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr "<em>कैमरा</em> ब्लॉक एक वेबकैम को <em>शो</em> ब्लॉक से जोड़ता है।"
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr "उंगली झांझ"
+#~ msgid "finger cymbols"
+#~ msgstr "उंगली झांझ"
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr "सरल-1"
+#~ msgid "simple-1"
+#~ msgstr "सरल-1"
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr "व्यंजन चरण नीचे"
+#~ msgid "consonant step down"
+#~ msgstr "व्यंजन चरण नीचे"
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr "राइड-बेल"
+#~ msgid "ride-bell"
+#~ msgstr "राइड-बेल"
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr "म्यूज़िक ब्लॉक्स एक संगीत संदर्भों का अन्वेषण करने के लिए उपकरणों का संग्रह है।"
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr "म्यूज़िक ब्लॉक्स एक संगीत संदर्भों का अन्वेषण करने के लिए उपकरणों का संग्रह है।"
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr "पिक्सेल रंग पढ़ा नहीं जा सकता"
+#~ msgid "Cannot read pixel color"
+#~ msgstr "पिक्सेल रंग पढ़ा नहीं जा सकता"
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr "<em>रिदम रूलर</em> ब्लॉक एक उपकरण खोलता है जिससे ड्रम मशीन बनाई जा सकती है।"
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr "<em>रिदम रूलर</em> ब्लॉक एक उपकरण खोलता है जिससे ड्रम मशीन बनाई जा सकती है।"
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr "<em>वर्गमूल</em> ब्लॉक वर्गमूल लौटाता है।"
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr "<em>वर्गमूल</em> ब्लॉक वर्गमूल लौटाता है।"
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr "<em>नोट काउंटर</em> ब्लॉक का उपयोग शामिल नोट्स की संख्या को गिनने के लिए किया जा सकता है।"
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr "<em>नोट काउंटर</em> ब्लॉक का उपयोग शामिल नोट्स की संख्या को गिनने के लिए किया जा सकता है।"
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr "<em>हीप खाली है?</em> ब्लॉक सच है लौटाता है अगर हीप खाली है।"
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr "<em>हीप खाली है?</em> ब्लॉक सच है लौटाता है अगर हीप खाली है।"
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr "लिडियन"
+#~ msgid "Lydian"
+#~ msgstr "लिडियन"
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr "<em>नॉइज़ नाम</em> ब्लॉक एक शोर सिंथेसाइज़र का चयन करने के लिए उपयोग होता है।"
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr "<em>नॉइज़ नाम</em> ब्लॉक एक शोर सिंथेसाइज़र का चयन करने के लिए उपयोग होता है।"
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr "<em>पिच ड्रम मैट्रिक्स</em> पिच को ड्रम साउंड्स से मैप करने के लिए उपयोग होता है।"
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr "<em>पिच ड्रम मैट्रिक्स</em> पिच को ड्रम साउंड्स से मैप करने के लिए उपयोग होता है।"
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr "<em>डॉट</em> ब्लॉक एक नोट की अवधि को 50% बढ़ाता है। उदाहरण के लिए, डॉटेड क्वार्टर नोट 3/8 (1/4 + 1/8) बीट के लिए बजेगा।"
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr "<em>डॉट</em> ब्लॉक एक नोट की अवधि को 50% बढ़ाता है। उदाहरण के लिए, डॉटेड क्वार्टर नोट 3/8 (1/4 + 1/8) बीट के लिए बजेगा।"
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr "<em>बॉक्स2</em> में संग्रहित मूल्य को लौटाता है।"
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr "<em>बॉक्स2</em> में संग्रहित मूल्य को लौटाता है।"
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr "पिच नंबर ब्लॉक एक पिच को इसके नंबर से जोड़ता है, उदाहरण के लिए, C के लिए 1, G के लिए 7।"
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr "पिच नंबर ब्लॉक एक पिच को इसके नंबर से जोड़ता है, उदाहरण के लिए, C के लिए 1, G के लिए 7।"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr "हारमोनिक-मेजर"
+#~ msgid "harmonic-major"
+#~ msgstr "हारमोनिक-मेजर"
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr "सहायक मेन्यू"
+#~ msgid "Auxillary menu"
+#~ msgstr "सहायक मेन्यू"
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr "प्रकाशित करें"
+#~ msgid "Publish"
+#~ msgstr "प्रकाशित करें"
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr "<em>पुश</em> ब्लॉक हीप के शीर्ष पर एक मूल्य जोड़ता है।"
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr "<em>पुश</em> ब्लॉक हीप के शीर्ष पर एक मूल्य जोड़ता है।"
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr "रोमानियन माइनर"
+#~ msgid "Romanian Minor"
+#~ msgstr "रोमानियन माइनर"
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr "उदाहरण में, इसका उपयोग <em>वन ऑफ</em> ब्लॉक के साथ एक यादृच्छिक चरण का चयन करने के लिए किया जाता है।"
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr "उदाहरण में, इसका उपयोग <em>वन ऑफ</em> ब्लॉक के साथ एक यादृच्छिक चरण का चयन करने के लिए किया जाता है।"
 
 #: js/activity.js:2433
 
@@ -10775,392 +10775,392 @@ msgstr "सरकाय"
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr "अभिनामक"
+#~ msgid "untitled"
+#~ msgstr "अभिनामक"
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr "दुनिया भर में"
+#~ msgid "Worldwide"
+#~ msgstr "दुनिया भर में"
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr "उदाहरण के लिए, डॉटेड क्वार्टर नोट 3/8 (1/4 + 1/8) बीट के लिए बजेगा।"
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr "उदाहरण के लिए, डॉटेड क्वार्टर नोट 3/8 (1/4 + 1/8) बीट के लिए बजेगा।"
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr "धीरे चलाने के लिए लंबा दबाएं"
+#~ msgid "long press to run slowly"
+#~ msgstr "धीरे चलाने के लिए लंबा दबाएं"
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr "सेव हीप टू एप ब्लॉक हीप को एक वेब पेज पर सहेजता है।"
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr "सेव हीप टू एप ब्लॉक हीप को एक वेब पेज पर सहेजता है।"
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr "चुटकुला"
+#~ msgid "pluck"
+#~ msgstr "चुटकुला"
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr "<em>माउस नोट</em> ब्लॉक निर्दिष्ट माउस द्वारा बजाए जा रहे वर्तमान नोट मूल्य लौटाता है।"
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr "<em>माउस नोट</em> ब्लॉक निर्दिष्ट माउस द्वारा बजाए जा रहे वर्तमान नोट मूल्य लौटाता है।"
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr "<em>स्लर</em> ब्लॉक नोट्स के सस्टेन को बढ़ाता है—उचित अवधि से लंबा चलता है और इसे अगले नोट में मिश्रित करता है—जबकि नोट्स के निर्दिष्ट तालमय मूल्य को बनाए रखता है।"
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr "<em>स्लर</em> ब्लॉक नोट्स के सस्टेन को बढ़ाता है—उचित अवधि से लंबा चलता है और इसे अगले नोट में मिश्रित करता है—जबकि नोट्स के निर्दिष्ट तालमय मूल्य को बनाए रखता है।"
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr "कमजोर बीट पर"
+#~ msgid "on weak beat"
+#~ msgstr "कमजोर बीट पर"
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr "<em>नो क्लॉक</em> ब्लॉक नोट्स को मास्टर क्लॉक से अलग करता है।"
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr "<em>नो क्लॉक</em> ब्लॉक नोट्स को मास्टर क्लॉक से अलग करता है।"
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr "<em>सेट-पेन-साइज़</em> ब्लॉक पेन का आकार बदलता है।"
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr "<em>सेट-पेन-साइज़</em> ब्लॉक पेन का आकार बदलता है।"
 
-#~msgid "end hollow line"
-#~msgstr "अंत खोखली रेखा"
+#~ msgid "end hollow line"
+#~ msgstr "अंत खोखली रेखा"
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr "<em>फिल</em> ब्लॉक एक आकार को रंग से भरता है।"
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr "<em>फिल</em> ब्लॉक एक आकार को रंग से भरता है।"
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr "छोड़ें कारक"
+#~ msgid "skip factor"
+#~ msgstr "छोड़ें कारक"
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr "<em>वाइब्रेटो</em> ब्लॉक पिच में तेजी से, हल्का बदलाव जोड़ता है।"
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr "<em>वाइब्रेटो</em> ब्लॉक पिच में तेजी से, हल्का बदलाव जोड़ता है।"
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr "<em>माउस-सिंक</em> ब्लॉक चूहों के बीच बीट काउंट को संरेखित करता है।"
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr "<em>माउस-सिंक</em> ब्लॉक चूहों के बीच बीट काउंट को संरेखित करता है।"
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "खोलें"
+#~ msgid "Open"
+#~ msgstr "खोलें"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr "<em>स्केलर स्टेप</em> ब्लॉक (एक <em>नंबर</em> ब्लॉक के संयोजन में) स्केल में अगली पिच बजाएगा, उदाहरण के लिए, यदि अंतिम नोट <em>सोल</em> था, तो <em>स्केलर स्टेप 1</em> <em>ला</em> बजाएगा।"
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr "<em>स्केलर स्टेप</em> ब्लॉक (एक <em>नंबर</em> ब्लॉक के संयोजन में) स्केल में अगली पिच बजाएगा, उदाहरण के लिए, यदि अंतिम नोट <em>सोल</em> था, तो <em>स्केलर स्टेप 1</em> <em>ला</em> बजाएगा।"
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr "टेम्परामेंटX को परिभाषित करें"
+#~ msgid "define temperamentX"
+#~ msgstr "टेम्परामेंटX को परिभाषित करें"
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr "<em>स्विंग</em> ब्लॉक नोट्स की जोड़ी पर काम करता है (नोट मान द्वारा निर्दिष्ट), पहले नोट में कुछ अवधि (स्विंग मान द्वारा निर्दिष्ट) जोड़ता है और दूसरे नोट से समान मात्रा लेता है।"
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr "<em>स्विंग</em> ब्लॉक नोट्स की जोड़ी पर काम करता है (नोट मान द्वारा निर्दिष्ट), पहले नोट में कुछ अवधि (स्विंग मान द्वारा निर्दिष्ट) जोड़ता है और दूसरे नोट से समान मात्रा लेता है।"
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr "आवाज सेट करें"
+#~ msgid "set voice"
+#~ msgstr "आवाज सेट करें"
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr "अन्यथा एक किक ड्रम बजेगा।"
+#~ msgid "Else a kick drum will play."
+#~ msgstr "अन्यथा एक किक ड्रम बजेगा।"
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr "wav के रूप में सहेजें"
+#~ msgid "Save as wav"
+#~ msgstr "wav के रूप में सहेजें"
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr "यहां पेस्ट करने के लिए क्लिक करें।"
+#~ msgid "Click here to paste."
+#~ msgstr "यहां पेस्ट करने के लिए क्लिक करें।"
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr "<em>पिच</em> ब्लॉक नोट के पिच नाम और ऑक्टेव को निर्दिष्ट करता है जो मिलकर नोट की आवृत्ति निर्धारित करते हैं।"
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr "<em>पिच</em> ब्लॉक नोट के पिच नाम और ऑक्टेव को निर्दिष्ट करता है जो मिलकर नोट की आवृत्ति निर्धारित करते हैं।"
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr "टॉम-टॉम"
+#~ msgid "tom-tom"
+#~ msgstr "टॉम-टॉम"
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr "आयोनियन"
+#~ msgid "Ionian"
+#~ msgstr "आयोनियन"
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr "ch"
+#~ msgid "ch"
+#~ msgstr "ch"
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr "पिच जोड़ें"
+#~ msgid "add pitches"
+#~ msgstr "पिच जोड़ें"
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr "<em>एक्स माउस</em> ब्लॉक निर्दिष्ट माउस की एक्स स्थिति लौटाता है।"
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr "<em>एक्स माउस</em> ब्लॉक निर्दिष्ट माउस की एक्स स्थिति लौटाता है।"
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr "म्यूजिक ब्लॉक्स संगीत अवधारणाओं का पता लगाने के लिए उपकरणों का एक ओपन सोर्स संग्रह है। योगदानकर्ताओं की पूरी सूची म्यूजिक ब्लॉक्स गिटहब रिपॉजिटरी में पाई जा सकती है। म्यूजिक ब्लॉक्स एजीपीएल के तहत लाइसेंस प्राप्त है। वर्तमान संस्करण है:' + ' ' + संस्करण), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr "म्यूजिक ब्लॉक्स संगीत अवधारणाओं का पता लगाने के लिए उपकरणों का एक ओपन सोर्स संग्रह है। योगदानकर्ताओं की पूरी सूची म्यूजिक ब्लॉक्स गिटहब रिपॉजिटरी में पाई जा सकती है। म्यूजिक ब्लॉक्स एजीपीएल के तहत लाइसेंस प्राप्त है। वर्तमान संस्करण है:' + ' ' + संस्करण), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr "cb"
+#~ msgid "cb"
+#~ msgstr "cb"
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr "संदर्भ पिच"
+#~ msgid "reference pitch"
+#~ msgstr "संदर्भ पिच"
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr "संगीत को नोट दर नोट चलाने के लिए क्लिक करें।"
+#~ msgid "Click to run the music note by note."
+#~ msgstr "संगीत को नोट दर नोट चलाने के लिए क्लिक करें।"
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr "पोली"
+#~ msgid "poly"
+#~ msgstr "पोली"
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr "एक प्रोजेक्ट खोजें\","
+#~ msgid "Search for a project\","
+#~ msgstr "एक प्रोजेक्ट खोजें\","
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr "ऊपर जाएं"
+#~ msgid "move up"
+#~ msgstr "ऊपर जाएं"
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr "पुष्टि करें"
+#~ msgid "confirm"
+#~ msgstr "पुष्टि करें"
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr "<em>स्पेस</em> ब्लॉक का उपयोग ब्लॉकों के बीच स्थान जोड़ने के लिए किया जाता है।"
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr "<em>स्पेस</em> ब्लॉक का उपयोग ब्लॉकों के बीच स्थान जोड़ने के लिए किया जाता है।"
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr "<em>माउस सिंक</em> ब्लॉक चूहों के बीच बीट काउंट को संरेखित करता है।"
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr "<em>माउस सिंक</em> ब्लॉक चूहों के बीच बीट काउंट को संरेखित करता है।"
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr "मक़ाम"
+#~ msgid "Maqam"
+#~ msgstr "मक़ाम"
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr "ऐओलियन"
+#~ msgid "Aeolian"
+#~ msgstr "ऐओलियन"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr "हार्मोनिक-माइनर"
+#~ msgid "harmonic-minor"
+#~ msgstr "हार्मोनिक-माइनर"
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr "उदाहरण के लिए, यदि आपके पास 5 के मूल्य के साथ एक डेक्रेसेंडो ब्लॉक में शामिल 7 सिरे में नोट हैं, तो अंतिम नोट प्रारंभ ध्वनि से 35% कम होगा।"
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr "उदाहरण के लिए, यदि आपके पास 5 के मूल्य के साथ एक डेक्रेसेंडो ब्लॉक में शामिल 7 सिरे में नोट हैं, तो अंतिम नोट प्रारंभ ध्वनि से 35% कम होगा।"
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr "<em>ग्रेटर-थैन</em> ब्लॉक लौटाता है <em>सत्य</em> अगर शीर्ष संख्या निचली संख्या से अधिक है।"
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr "<em>ग्रेटर-थैन</em> ब्लॉक लौटाता है <em>सत्य</em> अगर शीर्ष संख्या निचली संख्या से अधिक है।"
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr "<em>एड-टू</em> ब्लॉक का उपयोग बॉक्स में संग्रहित मूल्य में जोड़ने के लिए किया जाता है। इसे <em>कलर</em>, <em>पेन-साइज</em> आदि के साथ भी उपयोग किया जा सकता है।"
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr "<em>एड-टू</em> ब्लॉक का उपयोग बॉक्स में संग्रहित मूल्य में जोड़ने के लिए किया जाता है। इसे <em>कलर</em>, <em>पेन-साइज</em> आदि के साथ भी उपयोग किया जा सकता है।"
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr "रिवर्सहीप ब्लॉक हीप के क्रम को उलटा देता है।"
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr "रिवर्सहीप ब्लॉक हीप के क्रम को उलटा देता है।"
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr "<em>वन ऑफ</em> ब्लॉक दो विकल्पों में से एक लौटाता है।"
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr "<em>वन ऑफ</em> ब्लॉक दो विकल्पों में से एक लौटाता है।"
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr "लोक्रियन"
+#~ msgid "Locrian"
+#~ msgstr "लोक्रियन"
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr "<em>सेट ह्यू</em> ब्लॉक पेन के रंग को बदलता है।"
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr "<em>सेट ह्यू</em> ब्लॉक पेन के रंग को बदलता है।"
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr "<em>स्टोर इन</em> ब्लॉक एक बॉक्स में मूल्य संग्रहित करेगा।"
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr "<em>स्टोर इन</em> ब्लॉक एक बॉक्स में मूल्य संग्रहित करेगा।"
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ".svg के रूप में सहेजें"
+#~ msgid "Save as .svg"
+#~ msgstr ".svg के रूप में सहेजें"
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr "ब्लूज़"
+#~ msgid "Blues"
+#~ msgstr "ब्लूज़"
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr "आप टाइप कर सकते हैं \"d\" और \"do\" ब्लॉक बनाने के लिए, \"r\" और \"re\" ब्लॉक बनाने के लिए, आदि।"
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr "आप टाइप कर सकते हैं \"d\" और \"do\" ब्लॉक बनाने के लिए, \"r\" और \"re\" ब्लॉक बनाने के लिए, आदि।"
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr "इम्पैक्ट डेटा को पार्स नहीं किया जा सकता।"
+#~ msgid "Cannot parse Impact data."
+#~ msgstr "इम्पैक्ट डेटा को पार्स नहीं किया जा सकता।"
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr "उदाहरण के लिए, गिटार, वायलिन, स्नेयर ड्रम, आदि।"
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr "उदाहरण के लिए, गिटार, वायलिन, स्नेयर ड्रम, आदि।"
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr "<em>टेम्पो</em> ब्लॉक एक मेट्रोनोम को खोलता है ताकत को दृष्टिगत करने के लिए।"
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr "<em>टेम्पो</em> ब्लॉक एक मेट्रोनोम को खोलता है ताकत को दृष्टिगत करने के लिए।"
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr "<em>इनवर्ट</em> ब्लॉक किसी भी शामिल नोट्स को एक लक्ष्य नोट के चारों ओर घुमाता है।"
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr "<em>इनवर्ट</em> ब्लॉक किसी भी शामिल नोट्स को एक लक्ष्य नोट के चारों ओर घुमाता है।"
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr "क्षेत्र"
+#~ msgid "field"
+#~ msgstr "क्षेत्र"
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr "मी"
+#~ msgid "m"
+#~ msgstr "मी"
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr "<em>ऑन-एवरी-बीट</em> ब्लॉक आपको प्रत्येक बीट पर करने के लिए क्रियाएं निर्दिष्ट करने की अनुमति देता है।"
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr "<em>ऑन-एवरी-बीट</em> ब्लॉक आपको प्रत्येक बीट पर करने के लिए क्रियाएं निर्दिष्ट करने की अनुमति देता है।"
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr "और अधिक जानकारी के लिए, कृपया <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks गाइड</a> की सलाह लें।"
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr "और अधिक जानकारी के लिए, कृपया <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks गाइड</a> की सलाह लें।"
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr "रे"
+#~ msgid "rs"
+#~ msgstr "रे"
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr "<em>क्लिक</em> ब्लॉक एक माउस क्लिक किया गया है तो <em>सत्य</em> लौटाता है।"
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr "<em>क्लिक</em> ब्लॉक एक माउस क्लिक किया गया है तो <em>सत्य</em> लौटाता है।"
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr "इम्पैक्ट फील्ड नहीं मिला।"
+#~ msgid "Impact field not found."
+#~ msgstr "इम्पैक्ट फील्ड नहीं मिला।"
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr "जी"
+#~ msgid "gs"
+#~ msgstr "जी"
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr "माइनर"
+#~ msgid "Minor"
+#~ msgstr "माइनर"
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr " "
+#~ msgid " "
+#~ msgstr " "
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr "बिजंटाइन"
+#~ msgid "Byzantine"
+#~ msgstr "बिजंटाइन"
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr "जैज़ माइनर"
+#~ msgid "Jazz Minor"
+#~ msgstr "जैज़ माइनर"
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr "<em>डू</em> ब्लॉक का उपयोग क्रिया की शुरुआत के लिए किया जाता है। उदाहरण में, इसका उपयोग <em>वन ऑफ</em> ब्लॉक के साथ एक यादृच्छिक चरण का चयन करने के लिए किया जाता है।"
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr "<em>डू</em> ब्लॉक का उपयोग क्रिया की शुरुआत के लिए किया जाता है। उदाहरण में, इसका उपयोग <em>वन ऑफ</em> ब्लॉक के साथ एक यादृच्छिक चरण का चयन करने के लिए किया जाता है।"
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr "HTML के रूप में सहेजें"
+#~ msgid "Save as HTML"
+#~ msgstr "HTML के रूप में सहेजें"
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr "बीट पर"
+#~ msgid "on beat"
+#~ msgstr "बीट पर"
 
 #: js/activity.js:3857
 
@@ -11172,196 +11172,196 @@ msgstr "सरकाय"
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr "फ़ाइल से परियोजना लोड करें"
+#~ msgid "Load project from files"
+#~ msgstr "फ़ाइल से परियोजना लोड करें"
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr "<em>सेट टेम्परामेंट</em> ब्लॉक का उपयोग म्यूजिक ब्लॉक्स द्वारा उपयोग किए जाने वाले ट्यूनिंग सिस्टम को चुनने के लिए किया जाता है।"
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr "<em>सेट टेम्परामेंट</em> ब्लॉक का उपयोग म्यूजिक ब्लॉक्स द्वारा उपयोग किए जाने वाले ट्यूनिंग सिस्टम को चुनने के लिए किया जाता है।"
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr "<em>डिस्पैच</em> ब्लॉक का उपयोग किसी घटना को ट्रिगर करने के लिए किया जाता है।"
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr "<em>डिस्पैच</em> ब्लॉक का उपयोग किसी घटना को ट्रिगर करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "ब्लॉक पैलेट दिखाएँ / छिपाएं"
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "ब्लॉक पैलेट दिखाएँ / छिपाएं"
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr "तेज़ चलाएं / धीरे चलाने के लिए लंबा दबाएं"
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr "तेज़ चलाएं / धीरे चलाने के लिए लंबा दबाएं"
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr "ग्रिड छिपाएं"
+#~ msgid "hide grid"
+#~ msgstr "ग्रिड छिपाएं"
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr "स्नेर-ड्रम"
+#~ msgid "snare-drum"
+#~ msgstr "स्नेर-ड्रम"
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr "<em>मेजर काउंट</em> ब्लॉक वर्तमान माप को लौटाता है।"
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr "<em>मेजर काउंट</em> ब्लॉक वर्तमान माप को लौटाता है।"
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr "<em>फाउंड माउस</em> ब्लॉक सही लौटाएगा यदि निर्दिष्ट माउस पाया जा सकता है।"
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr "<em>फाउंड माउस</em> ब्लॉक सही लौटाएगा यदि निर्दिष्ट माउस पाया जा सकता है।"
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr "डिस्पैच ब्लॉक का उपयोग किसी घटना को ट्रिगर करने के लिए किया जाता है।"
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr "डिस्पैच ब्लॉक का उपयोग किसी घटना को ट्रिगर करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr "खोजें"
+#~ msgid "Search"
+#~ msgstr "खोजें"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr "सफेद शोर"
+#~ msgid "white-noise"
+#~ msgstr "सफेद शोर"
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr "ऑक्टाटोनिक"
+#~ msgid "Octatonic"
+#~ msgstr "ऑक्टाटोनिक"
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr "पिच-टाइम मैट्रिक्स ब्लॉक एक उपकरण खोलता है जो संगीतात्मक वाक्यांश बनाने के लिए होता है।"
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr "पिच-टाइम मैट्रिक्स ब्लॉक एक उपकरण खोलता है जो संगीतात्मक वाक्यांश बनाने के लिए होता है।"
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr "<em>टॉप</em> ब्लॉक कैनवास के शीर्ष की स्थिति लौटाता है।"
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr "<em>टॉप</em> ब्लॉक कैनवास के शीर्ष की स्थिति लौटाता है।"
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr "<em>लिसन</em> ब्लॉक का उपयोग किसी घटना जैसे माउस क्लिक के लिए सुनने के लिए किया जाता है। जब घटना होती है, तो एक <em>क्रिया</em> ली जाती है।"
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr "<em>लिसन</em> ब्लॉक का उपयोग किसी घटना जैसे माउस क्लिक के लिए सुनने के लिए किया जाता है। जब घटना होती है, तो एक <em>क्रिया</em> ली जाती है।"
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr "बाएं महसूस करें"
+#~ msgid "sense left"
+#~ msgstr "बाएं महसूस करें"
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr "<em>म्यूजिक कीबोर्ड</em> ब्लॉक एक पियानो कीबोर्ड खोलता है जिसका उपयोग नोट्स बनाने के लिए किया जा सकता है।"
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr "<em>म्यूजिक कीबोर्ड</em> ब्लॉक एक पियानो कीबोर्ड खोलता है जिसका उपयोग नोट्स बनाने के लिए किया जा सकता है।"
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr "<em>सेटहीपएंट्री</em> ब्लॉक निर्दिष्ट स्थान पर हीप में एक मान सेट करता है।"
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr "<em>सेटहीपएंट्री</em> ब्लॉक निर्दिष्ट स्थान पर हीप में एक मान सेट करता है।"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr "जैज़-माइनर"
+#~ msgid "jazz-minor"
+#~ msgstr "जैज़-माइनर"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr "माइनर-ब्लूज़"
+#~ msgid "minor-blues"
+#~ msgstr "माइनर-ब्लूज़"
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr "पिछला पृष्ठ"
+#~ msgid "previous page"
+#~ msgstr "पिछला पृष्ठ"
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr "<em>पेन-डाउन</em> ब्लॉक पेन को नीचे करता है ताकि वह खींचे।"
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr "<em>पेन-डाउन</em> ब्लॉक पेन को नीचे करता है ताकि वह खींचे।"
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr "<em>सेमी-टोन ट्रांसपोज़िशन</em> ब्लॉक <em>नोट</em> ब्लॉकों के अंदर निहित पिचों को आधे चरणों से ऊपर (या नीचे) स्थानांतरित करेगा। ऊपर दिखाए गए उदाहरण में, <em>सोल</em> को <em>सोल#</em> तक स्थानांतरित किया गया है।"
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr "<em>सेमी-टोन ट्रांसपोज़िशन</em> ब्लॉक <em>नोट</em> ब्लॉकों के अंदर निहित पिचों को आधे चरणों से ऊपर (या नीचे) स्थानांतरित करेगा। ऊपर दिखाए गए उदाहरण में, <em>सोल</em> को <em>सोल#</em> तक स्थानांतरित किया गया है।"
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr "आप नाम से ब्लॉकों की खोज कर सकते हैं।"
+#~ msgid "You can search for blocks by name."
+#~ msgstr "आप नाम से ब्लॉकों की खोज कर सकते हैं।"
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr "काउ-बेल"
+#~ msgid "cow-bell"
+#~ msgstr "काउ-बेल"
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr "दूसरा"
+#~ msgid "2nd"
+#~ msgstr "दूसरा"
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr "<em>मीडिया</em> ब्लॉक का उपयोग एक छवि आयात करने के लिए किया जाता है।"
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr "<em>मीडिया</em> ब्लॉक का उपयोग एक छवि आयात करने के लिए किया जाता है।"
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr "ऑफ़लाइन। साझाकरण अनुपलब्ध है।"
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr "ऑफ़लाइन। साझाकरण अनुपलब्ध है।"
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr "f#"
+#~ msgid "fs"
+#~ msgstr "f#"
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr "स्टॉपप्लेबैक ब्लॉक"
+#~ msgid "The Stopplayback block"
+#~ msgstr "स्टॉपप्लेबैक ब्लॉक"
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr "कंडीशनल आपके प्रोग्राम को <em>शर्त</em> के आधार पर विभिन्न क्रियाएँ लेने देता है। इस उदाहरण में, <em>यदि</em> माउस बटन दबाया जाता है, तो स्नेर ड्रम बजेगा। अन्यथा (<em>अन्यथा</em>) एक किक ड्रम बजेगा।"
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr "कंडीशनल आपके प्रोग्राम को <em>शर्त</em> के आधार पर विभिन्न क्रियाएँ लेने देता है। इस उदाहरण में, <em>यदि</em> माउस बटन दबाया जाता है, तो स्नेर ड्रम बजेगा। अन्यथा (<em>अन्यथा</em>) एक किक ड्रम बजेगा।"
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr "<em>लाउडनेस</em> ब्लॉक माइक्रोफ़ोन द्वारा पता लगाए गए वॉल्यूम को लौटाता है।"
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr "<em>लाउडनेस</em> ब्लॉक माइक्रोफ़ोन द्वारा पता लगाए गए वॉल्यूम को लौटाता है।"
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr "<em>शो ब्लॉक्स</em> ब्लॉक ब्लॉकों को दिखाता है।"
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr "<em>शो ब्लॉक्स</em> ब्लॉक ब्लॉकों को दिखाता है।"
 
-#~msgid "food"
-#~msgstr "खाना"
+#~ msgid "food"
+#~ msgstr "खाना"
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr "ऑस्कटाइम"
+#~ msgid "osctime"
+#~ msgstr "ऑस्कटाइम"
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr "बीट मूल्य विभाजित करें"
+#~ msgid "divide beat value"
+#~ msgstr "बीट मूल्य विभाजित करें"
 
 #: js/turtledefs.js:187
 
@@ -11369,150 +11369,150 @@ msgstr "सरकाय"
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr "PNG के रूप में सहेजें"
+#~ msgid "Save as PNG"
+#~ msgstr "PNG के रूप में सहेजें"
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr "<em>कॉमेंट</em> ब्लॉक एक टिप्पणी को स्क्रीन के शीर्ष पर प्रिंट करता है जब प्रोग्राम धीमी गति में चल रहा होता है।"
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr "<em>कॉमेंट</em> ब्लॉक एक टिप्पणी को स्क्रीन के शीर्ष पर प्रिंट करता है जब प्रोग्राम धीमी गति में चल रहा होता है।"
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr "<em>स्टॉप मीडिया</em> ब्लॉक ऑडियो या वीडियो प्लेबैक को रोकता है।"
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr "<em>स्टॉप मीडिया</em> ब्लॉक ऑडियो या वीडियो प्लेबैक को रोकता है।"
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr "<em>माउस-बटन</em> ब्लॉक <em>सत्य</em> लौटाता है यदि माउस बटन दबाया जाता है।"
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr "<em>माउस-बटन</em> ब्लॉक <em>सत्य</em> लौटाता है यदि माउस बटन दबाया जाता है।"
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr "ब्लूज़"
+#~ msgid "blues"
+#~ msgstr "ब्लूज़"
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr "अधिक"
+#~ msgid "More"
+#~ msgstr "अधिक"
 
-#~msgid "maths"
-#~msgstr "गणित"
+#~ msgid "maths"
+#~ msgstr "गणित"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr "अन्यथा (else) एक किक ड्रम बजेगा।"
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr "अन्यथा (else) एक किक ड्रम बजेगा।"
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr "फाइल से प्रोजेक्ट खोलें\","
+#~ msgid "Open project from file\","
+#~ msgstr "फाइल से प्रोजेक्ट खोलें\","
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr "त्रितोन"
+#~ msgid "tritone"
+#~ msgstr "त्रितोन"
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr "डोरियन"
+#~ msgid "Dorian"
+#~ msgstr "डोरियन"
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr "यह टूलबार पैलेट बटन मैट्रिक्स नोट्स टोन टर्टल और अधिक शामिल करता है।"
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr "यह टूलबार पैलेट बटन मैट्रिक्स नोट्स टोन टर्टल और अधिक शामिल करता है।"
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr "किक-ड्रम"
+#~ msgid "kick-drum"
+#~ msgstr "किक-ड्रम"
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr "पाँचवाँ"
+#~ msgid "5th"
+#~ msgstr "पाँचवाँ"
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr "<em>माउस इलैप्स नोट्स</em> ब्लॉक निर्दिष्ट माउस द्वारा बजाए गए नोट्स की संख्या लौटाता है।"
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr "<em>माउस इलैप्स नोट्स</em> ब्लॉक निर्दिष्ट माउस द्वारा बजाए गए नोट्स की संख्या लौटाता है।"
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr "<em>माउस पिच</em> ब्लॉक निर्दिष्ट माउस द्वारा बजाई जा रही वर्तमान पिच संख्या को लौटाता है।"
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr "<em>माउस पिच</em> ब्लॉक निर्दिष्ट माउस द्वारा बजाई जा रही वर्तमान पिच संख्या को लौटाता है।"
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr "यह टूलबार पैलेट बटन, जिसमें रिदम पिच टोन एक्शन और अधिक शामिल हैं।"
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr "यह टूलबार पैलेट बटन, जिसमें रिदम पिच टोन एक्शन और अधिक शामिल हैं।"
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr "अगला पृष्ठ"
+#~ msgid "next page"
+#~ msgstr "अगला पृष्ठ"
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr "<em>रिपीट</em> ब्लॉक निहित ब्लॉकों को दोहराएगा। इस उदाहरण में, नोट 4 बार चलाया जाएगा।"
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr "<em>रिपीट</em> ब्लॉक निहित ब्लॉकों को दोहराएगा। इस उदाहरण में, नोट 4 बार चलाया जाएगा।"
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr "सेव-स्टैक बटन एक स्टैक को एक कस्टम पैलेट पर सहेजता है। यह एक स्टैक पर \"लंबे दबाव\" के बाद दिखाई देता है।"
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr "सेव-स्टैक बटन एक स्टैक को एक कस्टम पैलेट पर सहेजता है। यह एक स्टैक पर \"लंबे दबाव\" के बाद दिखाई देता है।"
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr "रिदम"
+#~ msgid "Rhythm"
+#~ msgstr "रिदम"
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr "<em>नंबर टू ऑक्टेव</em> ब्लॉक एक पिच संख्या को एक ऑक्टेव में परिवर्तित करेगा।"
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr "<em>नंबर टू ऑक्टेव</em> ब्लॉक एक पिच संख्या को एक ऑक्टेव में परिवर्तित करेगा।"
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr "क्लिपबोर्ड पर स्टैक को कॉपी करने के लिए, स्टैक पर \"लंबे दबाव\" करें। पेस्ट बटन हाइलाइट होगा।"
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr "क्लिपबोर्ड पर स्टैक को कॉपी करने के लिए, स्टैक पर \"लंबे दबाव\" करें। पेस्ट बटन हाइलाइट होगा।"
 
-#~msgid "hspace"
-#~msgstr "एचस्पेस"
+#~ msgid "hspace"
+#~ msgstr "एचस्पेस"
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr "ब्लॉक(ओं) को कॉपी करने के लिए लंबे समय तक दबाएं। पेस्ट करने के लिए यहां क्लिक करें।"
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr "ब्लॉक(ओं) को कॉपी करने के लिए लंबे समय तक दबाएं। पेस्ट करने के लिए यहां क्लिक करें।"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr "मेलोडिक-माइनर"
+#~ msgid "melodic-minor"
+#~ msgstr "मेलोडिक-माइनर"
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is empty."
-#~msgstr "हीप खाली है? ब्लॉक सत्य लौटाता है यदि हीप खाली है।"
+#~ msgid "The Heap empty? block returns true if the heap is empty."
+#~ msgstr "हीप खाली है? ब्लॉक सत्य लौटाता है यदि हीप खाली है।"
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr "प्लेबैक ब्लॉक"
+#~ msgid "The Playback block"
+#~ msgstr "प्लेबैक ब्लॉक"
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr "<em>नोट मूल्य</em> ब्लॉक वर्तमान में बजाए जा रहे नोट की अवधि का मूल्य है।"
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr "<em>नोट मूल्य</em> ब्लॉक वर्तमान में बजाए जा रहे नोट की अवधि का मूल्य है।"
 
 #: js/turtledefs.js:187
 
@@ -11520,257 +11520,257 @@ msgstr "सरकाय"
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr "WAV के रूप में सहेजें"
+#~ msgid "Save as WAV"
+#~ msgstr "WAV के रूप में सहेजें"
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr "<em>ट्रेमोलो</em> ब्लॉक एक डगमगाने वाला प्रभाव जोड़ता है।"
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr "<em>ट्रेमोलो</em> ब्लॉक एक डगमगाने वाला प्रभाव जोड़ता है।"
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr "<em>सेट ग्रे</em> ब्लॉक पेन के रंग की जीवंतता को बदलता है।"
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr "<em>सेट ग्रे</em> ब्लॉक पेन के रंग की जीवंतता को बदलता है।"
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr "<em>टेक्स्ट</em> ब्लॉक एक टेक्स्ट स्ट्रिंग रखता है।"
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr "<em>टेक्स्ट</em> ब्लॉक एक टेक्स्ट स्ट्रिंग रखता है।"
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr "क्रियाएँ"
+#~ msgid "actions"
+#~ msgstr "क्रियाएँ"
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr "<em>रजिस्टर</em> ब्लॉक उन नोट्स के रजिस्टर (ऑक्टेव) को संशोधित करने का एक आसान तरीका प्रदान करता है जो इसके बाद आते हैं।"
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr "<em>रजिस्टर</em> ब्लॉक उन नोट्स के रजिस्टर (ऑक्टेव) को संशोधित करने का एक आसान तरीका प्रदान करता है जो इसके बाद आते हैं।"
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr "नोट मूल्य 0 से अधिक होना चाहिए"
+#~ msgid "Note value must be greater than 0"
+#~ msgstr "नोट मूल्य 0 से अधिक होना चाहिए"
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr "<em>टुपलेट्स</em> विशिष्ट अवधि के लिए मापित होने वाले नोट का संग्रह हैं। टुपलेट्स का उपयोग करके 2 की शक्ति पर आधारित नहीं होने वाले नोटों के समूह बनाना आसान होता है।"
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr "<em>टुपलेट्स</em> विशिष्ट अवधि के लिए मापित होने वाले नोट का संग्रह हैं। टुपलेट्स का उपयोग करके 2 की शक्ति पर आधारित नहीं होने वाले नोटों के समूह बनाना आसान होता है।"
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr "पिच-टाइम मैट्रिक्स"
+#~ msgid "pitch-time matrix"
+#~ msgstr "पिच-टाइम मैट्रिक्स"
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr "उदा., गिटार, वायलिन, स्नेयर ड्रम, आदि."
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr "उदा., गिटार, वायलिन, स्नेयर ड्रम, आदि."
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr "<em>स्कैलर इंटरवल</em> ब्लॉक दो नोट्स के बीच की दूरी को सेमी-टोन में मापता है।"
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr "<em>स्कैलर इंटरवल</em> ब्लॉक दो नोट्स के बीच की दूरी को सेमी-टोन में मापता है।"
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr "प्रोजेक्ट को धीमे मोड में चलाने के लिए रन बटन को लंबे समय तक दबाएं।"
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr "प्रोजेक्ट को धीमे मोड में चलाने के लिए रन बटन को लंबे समय तक दबाएं।"
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr "<em>पिच नंबर ऑफसेट सेट करें</em> ब्लॉक का उपयोग पिच और ऑक्टेव को मैप करने के लिए ऑफसेट सेट करने के लिए किया जाता है।"
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr "<em>पिच नंबर ऑफसेट सेट करें</em> ब्लॉक का उपयोग पिच और ऑक्टेव को मैप करने के लिए ऑफसेट सेट करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "एक पोलर-संयोजन ग्रिड दिखाएं या छिपाएं।"
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "एक पोलर-संयोजन ग्रिड दिखाएं या छिपाएं।"
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr "इसे कलर, पेन-साइज आदि के साथ भी उपयोग किया जा सकता है।"
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr "इसे कलर, पेन-साइज आदि के साथ भी उपयोग किया जा सकता है।"
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr "अपनी परियोजना साझा करने के लिए इस लिंक को कॉपी करें।"
+#~ msgid "Copy this link to share your project."
+#~ msgstr "अपनी परियोजना साझा करने के लिए इस लिंक को कॉपी करें।"
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "स्क्रीन को साफ करें और कछुओं को उनके प्रारंभिक स्थानों पर लौटाएं।"
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "स्क्रीन को साफ करें और कछुओं को उनके प्रारंभिक स्थानों पर लौटाएं।"
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr "<em>बॉक्स1</em> वह मूल्य लौटाता है जो <em>बॉक्स1</em> पर संग्रहित है।"
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr "<em>बॉक्स1</em> वह मूल्य लौटाता है जो <em>बॉक्स1</em> पर संग्रहित है।"
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr "स्टेप पिच ब्लॉक का उपयोग नोट ब्लॉक के अंदर करना चाहिए।"
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr "स्टेप पिच ब्लॉक का उपयोग नोट ब्लॉक के अंदर करना चाहिए।"
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr "ब्लिंक (मि.से.)"
+#~ msgid "blink (ms)"
+#~ msgstr "ब्लिंक (मि.से.)"
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr "<em>ड्यूओ सिंथ</em> ब्लॉक एक ड्यूओ-फ्रीक्वेंसी मॉड्युलेटर है जिसका उपयोग एक टिम्बर को परिभाषित करने के लिए किया जाता है।"
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr "<em>ड्यूओ सिंथ</em> ब्लॉक एक ड्यूओ-फ्रीक्वेंसी मॉड्युलेटर है जिसका उपयोग एक टिम्बर को परिभाषित करने के लिए किया जाता है।"
 
-#~msgid "begin hollow line"
-#~msgstr "शुरू करें होलो रेखा"
+#~ msgid "begin hollow line"
+#~ msgstr "शुरू करें होलो रेखा"
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr "गीज"
+#~ msgid "Geez"
+#~ msgstr "गीज"
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr "रिदम ब्लॉक: क्या आपने एक नोट ब्लॉक का उपयोग करने का इरादा किया है?"
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr "रिदम ब्लॉक: क्या आपने एक नोट ब्लॉक का उपयोग करने का इरादा किया है?"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr "इस उदाहरण में, अगर माउस बटन दबाया जाता है, तो एक स्नेयर ड्रम बजेगा।"
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr "इस उदाहरण में, अगर माउस बटन दबाया जाता है, तो एक स्नेयर ड्रम बजेगा।"
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr "इस टूलबार में मैट्रिक्स, नोट्स, टोन, टर्टल, और अन्य के पैलेट बटन होते हैं। ब्लॉक के पैलेट दिखाने के लिए क्लिक करें और कैनवास पर ब्लॉक खींचें ताकि आप उन्हें उपयोग कर सकें।"
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr "इस टूलबार में मैट्रिक्स, नोट्स, टोन, टर्टल, और अन्य के पैलेट बटन होते हैं। ब्लॉक के पैलेट दिखाने के लिए क्लिक करें और कैनवास पर ब्लॉक खींचें ताकि आप उन्हें उपयोग कर सकें।"
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr "<em>डॉक ब्लॉक</em> ब्लॉक दो ब्लॉक्स कनेक्ट करता है।"
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr "<em>डॉक ब्लॉक</em> ब्लॉक दो ब्लॉक्स कनेक्ट करता है।"
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr "<em>स्टेप पिच</em> ब्लॉक (एक <em>नंबर</em> ब्लॉक के साथ संयोजन करके) एक स्केल में अगले पिच को बजाएगा, उदाहरण के लिए, यदि आखिरी नोट जो बजाई गई थी <em>सोल</em> थी, तो <em>स्टेप पिच 1</em> <em>ला</em> बजाएगा।"
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr "<em>स्टेप पिच</em> ब्लॉक (एक <em>नंबर</em> ब्लॉक के साथ संयोजन करके) एक स्केल में अगले पिच को बजाएगा, उदाहरण के लिए, यदि आखिरी नोट जो बजाई गई थी <em>सोल</em> थी, तो <em>स्टेप पिच 1</em> <em>ला</em> बजाएगा।"
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr "<em>बैकवर्ड</em> ब्लॉक कोड को उल्टी क्रम में चलाता है (संगीत रेट्रोग्रेड)।"
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr "<em>बैकवर्ड</em> ब्लॉक कोड को उल्टी क्रम में चलाता है (संगीत रेट्रोग्रेड)।"
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr "पुराना नोट मूल्य"
+#~ msgid "deprecated note value"
+#~ msgstr "पुराना नोट मूल्य"
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr "अरबी"
+#~ msgid "Arabic"
+#~ msgstr "अरबी"
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr "इस उदाहरण में, एक साधारित ड्रम मशीन, एक किक ड्रम हमेशा के लिए 1/4 नोट बजाएगी।"
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr "इस उदाहरण में, एक साधारित ड्रम मशीन, एक किक ड्रम हमेशा के लिए 1/4 नोट बजाएगी।"
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr "हर्ट्ज ब्लॉक: क्या आपने एक नोट ब्लॉक का उपयोग करने का इरादा किया है?"
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr "हर्ट्ज ब्लॉक: क्या आपने एक नोट ब्लॉक का उपयोग करने का इरादा किया है?"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr "मेजर-ब्लूज़"
+#~ msgid "major-blues"
+#~ msgstr "मेजर-ब्लूज़"
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr "<em>मोड</em> ब्लॉक विभाजन से शेषफल लौटाता है।"
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr "<em>मोड</em> ब्लॉक विभाजन से शेषफल लौटाता है।"
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr "पिच को <em>C D E F G A B</em> के रूप में निर्दिष्ट किया जा सकता है।"
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr "पिच को <em>C D E F G A B</em> के रूप में निर्दिष्ट किया जा सकता है।"
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr "हिंदू"
+#~ msgid "Hindu"
+#~ msgstr "हिंदू"
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr "<em>मिलीसेकंड</em> ब्लॉक एक <em>नोट</em> ब्लॉक के समान होता है, सिवाय इसके कि यह नोट की अवधि निर्दिष्ट करने के लिए समय (एमएस में) का उपयोग करता है।"
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr "<em>मिलीसेकंड</em> ब्लॉक एक <em>नोट</em> ब्लॉक के समान होता है, सिवाय इसके कि यह नोट की अवधि निर्दिष्ट करने के लिए समय (एमएस में) का उपयोग करता है।"
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr "<em>नॉट</em> ब्लॉक तार्किक नॉट ऑपरेटर है।"
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr "<em>नॉट</em> ब्लॉक तार्किक नॉट ऑपरेटर है।"
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr "नया प्रोजेक्ट\","
+#~ msgid "New project\","
+#~ msgstr "नया प्रोजेक्ट\","
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr "स्टेप पिच"
+#~ msgid "step pitch"
+#~ msgstr "स्टेप पिच"
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr "<em>बॉक्स2 में स्टोर करें</em> ब्लॉक का उपयोग <em>बॉक्स2</em> में एक मान संग्रहीत करने के लिए किया जाता है।"
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr "<em>बॉक्स2 में स्टोर करें</em> ब्लॉक का उपयोग <em>बॉक्स2</em> में एक मान संग्रहीत करने के लिए किया जाता है।"
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr "PNG के रूप में सहेजें"
+#~ msgid "Save as png"
+#~ msgstr "PNG के रूप में सहेजें"
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr "<em>नोट्स छोड़ें</em> ब्लॉक नोट्स को छोड़ने का कारण बनेगा।"
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr "<em>नोट्स छोड़ें</em> ब्लॉक नोट्स को छोड़ने का कारण बनेगा।"
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr "<em>स्केलर अंतराल</em> ब्लॉक वर्तमान मोड के आधार पर एक सापेक्ष अंतराल की गणना करता है, मोड के बाहर के सभी नोट्स को छोड़ देता है। चित्र में, हम <em>सोल</em> में <em>ला</em> जोड़ते हैं।"
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr "<em>स्केलर अंतराल</em> ब्लॉक वर्तमान मोड के आधार पर एक सापेक्ष अंतराल की गणना करता है, मोड के बाहर के सभी नोट्स को छोड़ देता है। चित्र में, हम <em>सोल</em> में <em>ला</em> जोड़ते हैं।"
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr "पीछे की ओर चलाएं"
+#~ msgid "play backward"
+#~ msgstr "पीछे की ओर चलाएं"
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr "<em>पिच में बदलाव</em> ब्लॉक वर्तमान पिच और पिछले पिच के बीच का अंतर (आधे चरणों में) है।"
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr "<em>पिच में बदलाव</em> ब्लॉक वर्तमान पिच और पिछले पिच के बीच का अंतर (आधे चरणों में) है।"
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr "<em>कंट्रोल-पॉइंट 1</em> ब्लॉक बेज़ियर वक्र के लिए पहला नियंत्रण बिंदु सेट करता है।"
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr "<em>कंट्रोल-पॉइंट 1</em> ब्लॉक बेज़ियर वक्र के लिए पहला नियंत्रण बिंदु सेट करता है।"
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr "bk"
+#~ msgid "bk"
+#~ msgstr "bk"
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr "bt"
+#~ msgid "bt"
+#~ msgstr "bt"
 
 #: js/logo.js:2175
 
@@ -11784,223 +11784,223 @@ msgstr "सरकाय"
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr "माउस नहीं मिला"
+#~ msgid "Could not find mouse"
+#~ msgstr "माउस नहीं मिला"
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr "<em>ग्रीन प्राप्त करें</em> ब्लॉक माउस के नीचे पिक्सेल के हरे घटक को लौटाता है।"
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr "<em>ग्रीन प्राप्त करें</em> ब्लॉक माउस के नीचे पिक्सेल के हरे घटक को लौटाता है।"
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr "<em>रिदम</em> ब्लॉक का उपयोग ताल पैटर्न उत्पन्न करने के लिए किया जाता है।"
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr "<em>रिदम</em> ब्लॉक का उपयोग ताल पैटर्न उत्पन्न करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr "???"
+#~ msgid "???"
+#~ msgstr "???"
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr "<em>कर्सर एक्स</em> ब्लॉक माउस की क्षैतिज स्थिति लौटाता है।"
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr "<em>कर्सर एक्स</em> ब्लॉक माउस की क्षैतिज स्थिति लौटाता है।"
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr "प्रोजेक्ट सहेजें"
+#~ msgid "Save Project"
+#~ msgstr "प्रोजेक्ट सहेजें"
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr "<em>सेट फ़ॉन्ट</em> ब्लॉक <em>शो</em> ब्लॉक द्वारा उपयोग किए गए फ़ॉन्ट को सेट करता है।"
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr "<em>सेट फ़ॉन्ट</em> ब्लॉक <em>शो</em> ब्लॉक द्वारा उपयोग किए गए फ़ॉन्ट को सेट करता है।"
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr "डो रे मी फा सोल ला टी"
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr "डो रे मी फा सोल ला टी"
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr "<em>अनिल</em> ब्लॉक तब तक दोहराएगा जब तक शर्त सही नहीं हो जाती।"
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr "<em>अनिल</em> ब्लॉक तब तक दोहराएगा जब तक शर्त सही नहीं हो जाती।"
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr "<em>ऑर</em> ब्लॉक तार्किक या ऑपरेटर है।"
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr "<em>ऑर</em> ब्लॉक तार्किक या ऑपरेटर है।"
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr "विपरीत दिशा में घुमाएं"
+#~ msgid "rotate counter clockwise"
+#~ msgstr "विपरीत दिशा में घुमाएं"
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr "आदि"
+#~ msgid "etc."
+#~ msgstr "आदि"
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr "सॉर्ट करें"
+#~ msgid "sort"
+#~ msgstr "सॉर्ट करें"
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr "पिच ब्लॉक: क्या आपका मतलब नोट ब्लॉक2 का उपयोग करना था?"
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr "पिच ब्लॉक: क्या आपका मतलब नोट ब्लॉक2 का उपयोग करना था?"
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr "विकृति सीमा में नहीं है"
+#~ msgid "Distortion not in range"
+#~ msgstr "विकृति सीमा में नहीं है"
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr "<em>पेन आकार</em> ब्लॉक वर्तमान पेन आकार मान लौटाता है।"
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr "<em>पेन आकार</em> ब्लॉक वर्तमान पेन आकार मान लौटाता है।"
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr "<em>ऐप पर हीप सहेजें</em> ब्लॉक हीप को एक वेब पेज पर सहेजता है।"
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr "<em>ऐप पर हीप सहेजें</em> ब्लॉक हीप को एक वेब पेज पर सहेजता है।"
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr "<em>रैंडम</em> ब्लॉक एक यादृच्छिक संख्या लौटाता है।"
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr "<em>रैंडम</em> ब्लॉक एक यादृच्छिक संख्या लौटाता है।"
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr "ध्रुवीय"
+#~ msgid "Polar"
+#~ msgstr "ध्रुवीय"
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr "वर्तमान पिच नाम"
+#~ msgid "current pitch name"
+#~ msgstr "वर्तमान पिच नाम"
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "एक कार्टेशियन-निर्देशांक ग्रिड दिखाएँ या छिपाएँ"
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "एक कार्टेशियन-निर्देशांक ग्रिड दिखाएँ या छिपाएँ"
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr "<em>शो हीप</em> ब्लॉक स्क्रीन के शीर्ष पर हीप की सामग्री प्रदर्शित करता है।"
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr "<em>शो हीप</em> ब्लॉक स्क्रीन के शीर्ष पर हीप की सामग्री प्रदर्शित करता है।"
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr "gp"
+#~ msgid "gp"
+#~ msgstr "gp"
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr "<em>माउस-नाम</em> ब्लॉक एक माउस का नाम लौटाता है।"
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr "<em>माउस-नाम</em> ब्लॉक एक माउस का नाम लौटाता है।"
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ".png के रूप में सहेजें"
+#~ msgid "Save as .png"
+#~ msgstr ".png के रूप में सहेजें"
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr "मिक्सोलिडियन"
+#~ msgid "Mixolydian"
+#~ msgstr "मिक्सोलिडियन"
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr "mकीबोर्ड"
+#~ msgid "mKeyboard"
+#~ msgstr "mकीबोर्ड"
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr "<em>स्टॉप</em> ब्लॉक एक लूप को रोक देगा (जैसे, फॉरएवर, रिपीट, व्हाइल, या अनिल)।"
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr "<em>स्टॉप</em> ब्लॉक एक लूप को रोक देगा (जैसे, फॉरएवर, रिपीट, व्हाइल, या अनिल)।"
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr "<em>पिच संख्या</em> ब्लॉक वर्तमान में बजाए जा रहे नोट की पिच का मूल्य है।"
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr "<em>पिच संख्या</em> ब्लॉक वर्तमान में बजाए जा रहे नोट की पिच का मूल्य है।"
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr "<em>शेल</em> ब्लॉक का उपयोग माउस की उपस्थिति को बदलने के लिए किया जाता है।"
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr "<em>शेल</em> ब्लॉक का उपयोग माउस की उपस्थिति को बदलने के लिए किया जाता है।"
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr "<em>बराबर</em> ब्लॉक <em>सत्य</em> लौटाता है यदि दोनों संख्याएँ समान हैं।"
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr "<em>बराबर</em> ब्लॉक <em>सत्य</em> लौटाता है यदि दोनों संख्याएँ समान हैं।"
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr "प्लैनेट पर अपलोड करें"
+#~ msgid "Upload to Planet"
+#~ msgstr "प्लैनेट पर अपलोड करें"
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr "<em>स्केलर स्टेप डाउन</em> ब्लॉक वर्तमान कुंजी और मोड में पिछले नोट तक अर्ध-स्वरों की संख्या लौटाता है।"
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr "<em>स्केलर स्टेप डाउन</em> ब्लॉक वर्तमान कुंजी और मोड में पिछले नोट तक अर्ध-स्वरों की संख्या लौटाता है।"
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr "<em>पिक्सेल प्राप्त करें</em> ब्लॉक माउस के नीचे पिक्सेल का रंग लौटाता है।"
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr "<em>पिक्सेल प्राप्त करें</em> ब्लॉक माउस के नीचे पिक्सेल का रंग लौटाता है।"
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr "फाइल से प्लगइन लोड करें"
+#~ msgid "Load plugin from file"
+#~ msgstr "फाइल से प्लगइन लोड करें"
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr "<em>प्लेबैक</em> ब्लॉक"
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr "<em>प्लेबैक</em> ब्लॉक"
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ".abc के रूप में सहेजें"
+#~ msgid "Save as .abc"
+#~ msgstr ".abc के रूप में सहेजें"
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr "लिलीपॉन्ड आंशिक को संसाधित नहीं कर सकता"
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr "लिलीपॉन्ड आंशिक को संसाधित नहीं कर सकता"
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr "<em>हर्ट्ज़ में पिच</em> ब्लॉक वर्तमान में बजाए जा रहे नोट की पिच का हर्ट्ज़ में मान है।"
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr "<em>हर्ट्ज़ में पिच</em> ब्लॉक वर्तमान में बजाए जा रहे नोट की पिच का हर्ट्ज़ में मान है।"
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr "डिग्री"
+#~ msgid "degree"
+#~ msgstr "डिग्री"
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr "गाओ"
+#~ msgid "sing"
+#~ msgstr "गाओ"
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr "<em>कंट्रोल-पॉइंट 2</em> ब्लॉक बेज़ियर वक्र के लिए दूसरा नियंत्रण बिंदु सेट करता है।"
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr "<em>कंट्रोल-पॉइंट 2</em> ब्लॉक बेज़ियर वक्र के लिए दूसरा नियंत्रण बिंदु सेट करता है।"
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr "चीनी"
+#~ msgid "Chinese"
+#~ msgstr "चीनी"
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr "संगीत बजाएं"
+#~ msgid "Play music"
+#~ msgstr "संगीत बजाएं"
 
 #: js/samplesviewer.js:91
 
@@ -12010,144 +12010,144 @@ msgstr "सरकाय"
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr "डाउनलोड"
+#~ msgid "Download"
+#~ msgstr "डाउनलोड"
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr "दरबूका ड्रम"
+#~ msgid "darbuka-drum"
+#~ msgstr "दरबूका ड्रम"
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr "<em>सेमी-टोन अंतराल</em> ब्लॉक आधे चरणों पर आधारित एक सापेक्ष अंतराल की गणना करता है। चित्र में, हम <em>सोल#</em> में <em>सोल</em> जोड़ते हैं।"
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr "<em>सेमी-टोन अंतराल</em> ब्लॉक आधे चरणों पर आधारित एक सापेक्ष अंतराल की गणना करता है। चित्र में, हम <em>सोल#</em> में <em>सोल</em> जोड़ते हैं।"
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr "<em>प्लस</em> ब्लॉक जोड़ने के लिए उपयोग होता है।"
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr "<em>प्लस</em> ब्लॉक जोड़ने के लिए उपयोग होता है।"
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr "उदा. 1, 2, 3, या 4।"
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr "उदा. 1, 2, 3, या 4।"
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr "<em>लोडहीप</em> ब्लॉक एक फाइल से हीप लोड करता है।"
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr "<em>लोडहीप</em> ब्लॉक एक फाइल से हीप लोड करता है।"
 
-#~msgid "cloud"
-#~msgstr "बादल"
+#~ msgid "cloud"
+#~ msgstr "बादल"
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr "<em>बॉटम</em> ब्लॉक कैनवास के निचले हिस्से की स्थिति लौटाता है।"
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr "<em>बॉटम</em> ब्लॉक कैनवास के निचले हिस्से की स्थिति लौटाता है।"
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr "SVG के रूप में सहेजें"
+#~ msgid "Save as svg"
+#~ msgstr "SVG के रूप में सहेजें"
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr "प्रभाव यूआईडी नहीं मिला।"
+#~ msgid "Impact UID not found."
+#~ msgstr "प्रभाव यूआईडी नहीं मिला।"
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr "सोल्फा"
+#~ msgid "Solfa"
+#~ msgstr "सोल्फा"
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr "फ़िल्टर जोड़ें"
+#~ msgid "add filter"
+#~ msgstr "फ़िल्टर जोड़ें"
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr "turtleHeaps में एक मान्य हीप नहीं है"
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr "turtleHeaps में एक मान्य हीप नहीं है"
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr "आप ब्लॉकों के स्टैक को कॉपी करने के लिए Alt+C का भी उपयोग कर सकते हैं।"
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr "आप ब्लॉकों के स्टैक को कॉपी करने के लिए Alt+C का भी उपयोग कर सकते हैं।"
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr "पैलेट दिखाएँ / छुपाएँ"
+#~ msgid "Show/hide palettes"
+#~ msgstr "पैलेट दिखाएँ / छुपाएँ"
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr "होम' + ' [होम]"
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr "होम' + ' [होम]"
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr "<em>स्टार्ट माउस</em> ब्लॉक निर्दिष्ट माउस को शुरू करता है।"
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr "<em>स्टार्ट माउस</em> ब्लॉक निर्दिष्ट माउस को शुरू करता है।"
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr "लाना"
+#~ msgid "fetch"
+#~ msgstr "लाना"
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr "<em>बॉक्स</em> ब्लॉक बॉक्स में संग्रहित मान लौटाता है।"
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr "<em>बॉक्स</em> ब्लॉक बॉक्स में संग्रहित मान लौटाता है।"
 
-#~msgid "rodi"
-#~msgstr "रोडी"
+#~ msgid "rodi"
+#~ msgstr "रोडी"
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr "<em>सेट माउस</em> ब्लॉक निर्दिष्ट माउस द्वारा चलाए जाने वाले ब्लॉकों का एक स्टैक भेजता है।"
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr "<em>सेट माउस</em> ब्लॉक निर्दिष्ट माउस द्वारा चलाए जाने वाले ब्लॉकों का एक स्टैक भेजता है।"
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr "<em>बॉक्स1</em> ब्लॉक <em>बॉक्स1</em> में संग्रहित मान लौटाता है।"
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr "<em>बॉक्स1</em> ब्लॉक <em>बॉक्स1</em> में संग्रहित मान लौटाता है।"
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr "आप ब्लॉकों के स्टैक को पेस्ट करने के लिए Alt+P का भी उपयोग कर सकते हैं।"
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr "आप ब्लॉकों के स्टैक को पेस्ट करने के लिए Alt+P का भी उपयोग कर सकते हैं।"
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr "पेंटाटोनिक"
+#~ msgid "pentatonic"
+#~ msgstr "पेंटाटोनिक"
 
-#~msgid "blocks"
-#~msgstr "ब्लॉक्स"
+#~ msgid "blocks"
+#~ msgstr "ब्लॉक्स"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr "<em>पिच-टाइम मैट्रिक्स</em> ब्लॉक संगीत वाक्यांश बनाने के लिए एक उपकरण खोलता है।"
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr "<em>पिच-टाइम मैट्रिक्स</em> ब्लॉक संगीत वाक्यांश बनाने के लिए एक उपकरण खोलता है।"
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr "<em>हेडिंग</em> ब्लॉक माउस की अभिविन्यास को लौटाता है।"
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr "<em>हेडिंग</em> ब्लॉक माउस की अभिविन्यास को लौटाता है।"
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr "<em>एबस</em> ब्लॉक परिशुद्ध मान लौटाता है।"
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr "<em>एबस</em> ब्लॉक परिशुद्ध मान लौटाता है।"
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr "उदाहरण के लिए, यदि आपके पास एक क्रेसेंडो ब्लॉक में 5 के मान के साथ 7 नोट्स अनुक्रम में हैं, तो अंतिम नोट प्रारंभिक मात्रा से 35% अधिक होगा।"
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr "उदाहरण के लिए, यदि आपके पास एक क्रेसेंडो ब्लॉक में 5 के मान के साथ 7 नोट्स अनुक्रम में हैं, तो अंतिम नोट प्रारंभिक मात्रा से 35% अधिक होगा।"
 
 #: js/block.js:962
 
@@ -12155,57 +12155,57 @@ msgstr "सरकाय"
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr "ताल शासक"
+#~ msgid "rhythm ruler"
+#~ msgstr "ताल शासक"
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr "दर्ज की गई गहराई सीमा से बाहर है"
+#~ msgid "Depth entered is out of range"
+#~ msgstr "दर्ज की गई गहराई सीमा से बाहर है"
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr "<em>स्केलर अंतराल</em> ब्लॉक वर्तमान कुंजी और मोड में दो नोट्स के बीच की दूरी को मापता है।"
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr "<em>स्केलर अंतराल</em> ब्लॉक वर्तमान कुंजी और मोड में दो नोट्स के बीच की दूरी को मापता है।"
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr "<em>फॉरवर्ड</em> ब्लॉक माउस को आगे बढ़ाता है।"
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr "<em>फॉरवर्ड</em> ब्लॉक माउस को आगे बढ़ाता है।"
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr "पेंटाटोनिक"
+#~ msgid "Pentatonic"
+#~ msgstr "पेंटाटोनिक"
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr "<em>टेम्परामेंट</em> उपकरण का उपयोग कस्टम ट्यूनिंग को परिभाषित करने के लिए किया जाता है।"
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr "<em>टेम्परामेंट</em> उपकरण का उपयोग कस्टम ट्यूनिंग को परिभाषित करने के लिए किया जाता है।"
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr "मेजर ब्लॉक के लिए इनपुट 2, 3, 6, या 7 होना चाहिए"
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr "मेजर ब्लॉक के लिए इनपुट 2, 3, 6, या 7 होना चाहिए"
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr "<em>प्रिंट</em> ब्लॉक स्क्रीन के शीर्ष पर पाठ प्रदर्शित करता है।"
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr "<em>प्रिंट</em> ब्लॉक स्क्रीन के शीर्ष पर पाठ प्रदर्शित करता है।"
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr "<em>वेटेड पार्शियल्स</em> ब्लॉक एक टिम्बर से जुड़े पार्शियल्स को निर्दिष्ट करने के लिए उपयोग होता है।"
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr "<em>वेटेड पार्शियल्स</em> ब्लॉक एक टिम्बर से जुड़े पार्शियल्स को निर्दिष्ट करने के लिए उपयोग होता है।"
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr "संवाद"
+#~ msgid "articulation"
+#~ msgstr "संवाद"
 
 #: js/turtledefs.js:387
 
@@ -12215,30 +12215,30 @@ msgstr "सरकाय"
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr "<em>कैलकुलेट</em> ब्लॉक एक क्रिया द्वारा गणित किए गए मूल्य को लौटाता है।"
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr "<em>कैलकुलेट</em> ब्लॉक एक क्रिया द्वारा गणित किए गए मूल्य को लौटाता है।"
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr "उन्नत विकल्प"
+#~ msgid "Advanced options"
+#~ msgstr "उन्नत विकल्प"
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr "<em>रिटर्न</em> ब्लॉक एक क्रिया से मूल्य लौटाएगा।"
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr "<em>रिटर्न</em> ब्लॉक एक क्रिया से मूल्य लौटाएगा।"
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr "<em>एक्शन</em> ब्लॉक ब्लॉक्स को एक साथ समृद्ध करने के लिए उपयोग होता है ताकि इसे एक से अधिक बार उपयोग किया जा सके। यह अक्सर उस संगीत वाक्य को संग्रहित करने के लिए उपयोग होता है जो बार-बार होता है।"
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr "<em>एक्शन</em> ब्लॉक ब्लॉक्स को एक साथ समृद्ध करने के लिए उपयोग होता है ताकि इसे एक से अधिक बार उपयोग किया जा सके। यह अक्सर उस संगीत वाक्य को संग्रहित करने के लिए उपयोग होता है जो बार-बार होता है।"
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr "<em>गेट ब्लू</em> ब्लॉक माउस के नीचे पिक्सेल का नीला घटक लौटाता है।"
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr "<em>गेट ब्लू</em> ब्लॉक माउस के नीचे पिक्सेल का नीला घटक लौटाता है।"
 
 #: js/turtledefs.js:187
 
@@ -12246,107 +12246,107 @@ msgstr "सरकाय"
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr "शीट संगीत सहेजें"
+#~ msgid "Save sheet music"
+#~ msgstr "शीट संगीत सहेजें"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr "रोमानियाई माइनर"
+#~ msgid "romanian-minor"
+#~ msgstr "रोमानियाई माइनर"
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr "चौथा"
+#~ msgid "4th"
+#~ msgstr "चौथा"
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr "<em>सेट रिलेटिव वॉल्यूम</em> ब्लॉक संग्रहित नोट्स की वॉल्यूम को बदलता है।"
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr "<em>सेट रिलेटिव वॉल्यूम</em> ब्लॉक संग्रहित नोट्स की वॉल्यूम को बदलता है।"
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matching <em>Case</em>."
-#~msgstr "<em>स्विच</em> ब्लॉक समान <em>केस</em> में कोड चलाएगा।"
+#~ msgid "The <em>Switch</em> block will run the code in the matching <em>Case</em>."
+#~ msgstr "<em>स्विच</em> ब्लॉक समान <em>केस</em> में कोड चलाएगा।"
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr "स्थानांतरण समायोजित करें"
+#~ msgid "adjust transposition"
+#~ msgstr "स्थानांतरण समायोजित करें"
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "तेज़ी से प्रोजेक्ट चलाने के लिए क्लिक करें।"
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "तेज़ी से प्रोजेक्ट चलाने के लिए क्लिक करें।"
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr "नोट द्वारा नोट चलाएं"
+#~ msgid "Run note by note"
+#~ msgstr "नोट द्वारा नोट चलाएं"
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr "हीप लेंथ ब्लॉक हीप की लंबाई लौटाता है।"
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr "हीप लेंथ ब्लॉक हीप की लंबाई लौटाता है।"
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr "शैल"
+#~ msgid "shell"
+#~ msgstr "शैल"
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr "प्लैनेट बंद करें\","
+#~ msgid "Close Planet\","
+#~ msgstr "प्लैनेट बंद करें\","
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr "अगला पृष्ठ"
+#~ msgid "Next page"
+#~ msgstr "अगला पृष्ठ"
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr "ब्लॉक पर लंबे समय तक दबाएं कॉपी के लिए।"
+#~ msgid "Long press on blocks to copy."
+#~ msgstr "ब्लॉक पर लंबे समय तक दबाएं कॉपी के लिए।"
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr "<em>कोरस</em> ब्लॉक एक कोरस प्रभाव जोड़ता है।"
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr "<em>कोरस</em> ब्लॉक एक कोरस प्रभाव जोड़ता है।"
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr "<em>कस्टम मोड</em> ब्लॉक संगीत मोड (स्केल में नोट्स की जगह) का अन्वेषण करने के लिए एक टूल खोलता है।"
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr "<em>कस्टम मोड</em> ब्लॉक संगीत मोड (स्केल में नोट्स की जगह) का अन्वेषण करने के लिए एक टूल खोलता है।"
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr "कृपया नए एक को खोलने से पहले वर्तमान मैट्रिक्स को बंद करें।"
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr "कृपया नए एक को खोलने से पहले वर्तमान मैट्रिक्स को बंद करें।"
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr "<em>वेट</em> ब्लॉक प्रोग्राम को निर्दिष्ट समय के लिए रोकता है।"
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr "<em>वेट</em> ब्लॉक प्रोग्राम को निर्दिष्ट समय के लिए रोकता है।"
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr "<em>सेट ड्रम</em> ब्लॉक किसी भी संग्रहित नोट्स के पिच को बदलने के लिए एक ड्रम साउंड का चयन करेगा। उपर्युक्त उदाहरण में, <em>किक ड्रम</em> साउंड <em>सोल</em> की जगह बजाया जाएगा।"
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr "<em>सेट ड्रम</em> ब्लॉक किसी भी संग्रहित नोट्स के पिच को बदलने के लिए एक ड्रम साउंड का चयन करेगा। उपर्युक्त उदाहरण में, <em>किक ड्रम</em> साउंड <em>सोल</em> की जगह बजाया जाएगा।"
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr "<em>हीप लेंथ</em> ब्लॉक हीप की लंबाई लौटाता है।"
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr "<em>हीप लेंथ</em> ब्लॉक हीप की लंबाई लौटाता है।"
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr "ऑन ऑफबीट करें"
+#~ msgid "on offbeat do"
+#~ msgstr "ऑन ऑफबीट करें"
 
 #: js/StringHelper.js:17
 
@@ -12354,287 +12354,287 @@ msgstr "सरकाय"
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr "डेटा-टूलटिप"
+#~ msgid "data-tooltip"
+#~ msgstr "डेटा-टूलटिप"
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr "रोकें"
+#~ msgid "pause"
+#~ msgstr "रोकें"
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr "निर्दिष्ट नोट मूल्य अवधि का एक विराम <em>साइलेंस</em> ब्लॉक का उपयोग करके बनाया जा सकता है।"
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr "निर्दिष्ट नोट मूल्य अवधि का एक विराम <em>साइलेंस</em> ब्लॉक का उपयोग करके बनाया जा सकता है।"
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr "उदा., गिटार, पियानो, वायलिन, या सेलो।"
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr "उदा., गिटार, पियानो, वायलिन, या सेलो।"
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr "कठिन रोक"
+#~ msgid "Hard stop"
+#~ msgstr "कठिन रोक"
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr "<em>गेट रेड</em> ब्लॉक माउस के नीचे पिक्सेल का लाल घटक लौटाता है।"
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr "<em>गेट रेड</em> ब्लॉक माउस के नीचे पिक्सेल का लाल घटक लौटाता है।"
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr "मुक्त समय"
+#~ msgid "free time"
+#~ msgstr "मुक्त समय"
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr "उदा., यदि अंतिम नोट सोल था, तो स्केलर स्टेप 1 ला बजेगा।"
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr "उदा., यदि अंतिम नोट सोल था, तो स्केलर स्टेप 1 ला बजेगा।"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr "पूर्ण-स्वर"
+#~ msgid "whole-tone"
+#~ msgstr "पूर्ण-स्वर"
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr "आप ब्लॉकों के स्टैक को कॉपी करने के लिए Alt+C का भी उपयोग कर सकते हैं।"
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr "आप ब्लॉकों के स्टैक को कॉपी करने के लिए Alt+C का भी उपयोग कर सकते हैं।"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr "प्राकृतिक-माइनर"
+#~ msgid "natural-minor"
+#~ msgstr "प्राकृतिक-माइनर"
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr "यहां पेस्ट करने के लिए क्लिक करें"
+#~ msgid "Click here to paste"
+#~ msgstr "यहां पेस्ट करने के लिए क्लिक करें"
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr "यह बटन मुख्य उपकरण पट्टी को खोलता एवं  बंद करता है"
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr "यह बटन मुख्य उपकरण पट्टी को खोलता एवं  बंद करता है"
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr "संगीत को कदम दर कदम चलाएँ"
+#~ msgid "Run music step by step"
+#~ msgstr "संगीत को कदम दर कदम चलाएँ"
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr "<em>सेवहीप</em> ब्लॉक हीप को एक फाइल में सहेजता है।"
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr "<em>सेवहीप</em> ब्लॉक हीप को एक फाइल में सहेजता है।"
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr "इथियोपियन"
+#~ msgid "Ethiopian"
+#~ msgstr "इथियोपियन"
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr "यह एक स्टैक पर एक लम्बी दबाई के बाद प्रकट होता है।"
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr "यह एक स्टैक पर एक लम्बी दबाई के बाद प्रकट होता है।"
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr "परफेक्ट ब्लॉक के लिए इनपुट 1, 4, 5, या 8 होना चाहिए"
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr "परफेक्ट ब्लॉक के लिए इनपुट 1, 4, 5, या 8 होना चाहिए"
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr "टेबल"
+#~ msgid "table"
+#~ msgstr "टेबल"
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ".tb के रूप में सहेजें"
+#~ msgid "Save as .tb"
+#~ msgstr ".tb के रूप में सहेजें"
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr "सीपी"
+#~ msgid "cp"
+#~ msgstr "सीपी"
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr "<em>ऑन-वीक-बीट</em> ब्लॉक आपको कमजोर (ऑफ) बीट्स पर क्रियाएँ निर्दिष्ट करने की अनुमति देता है।"
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr "<em>ऑन-वीक-बीट</em> ब्लॉक आपको कमजोर (ऑफ) बीट्स पर क्रियाएँ निर्दिष्ट करने की अनुमति देता है।"
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr "दाहिने की अनुभूति"
+#~ msgid "sense right"
+#~ msgstr "दाहिने की अनुभूति"
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr "<em>एप से हीप लोड करें</em> ब्लॉक हीप को एक वेब पेज से लोड करता है।"
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr "<em>एप से हीप लोड करें</em> ब्लॉक हीप को एक वेब पेज से लोड करता है।"
 
-#~msgid "vspace"
-#~msgstr "व्यास"
+#~ msgid "vspace"
+#~ msgstr "व्यास"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr "स्पैनिश-जिप्सी"
+#~ msgid "spanish-gypsy"
+#~ msgstr "स्पैनिश-जिप्सी"
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr "<em>रंग</em> ब्लॉक वर्तमान पेन का रंग लौटाता है।"
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr "<em>रंग</em> ब्लॉक वर्तमान पेन का रंग लौटाता है।"
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr "बेबॉप"
+#~ msgid "Bebop"
+#~ msgstr "बेबॉप"
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr "पेस्ट बटन हाइलाइट करेगा।"
+#~ msgid "The Paste Button will highlight."
+#~ msgstr "पेस्ट बटन हाइलाइट करेगा।"
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr "एप से हीप लोड करें ब्लॉक हीप को एक वेब पेज से लोड करता है।"
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr "एप से हीप लोड करें ब्लॉक हीप को एक वेब पेज से लोड करता है।"
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr "स्टेप पिच ब्लॉक को नोट ब्लॉक के अंदर उपयोग करना चाहिए।"
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr "स्टेप पिच ब्लॉक को नोट ब्लॉक के अंदर उपयोग करना चाहिए।"
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "कैनवास पर सभी सामग्री को हटाएं, ब्लॉक्स सहित"
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "कैनवास पर सभी सामग्री को हटाएं, ब्लॉक्स सहित"
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr "SVG सहेजें"
+#~ msgid "save svg"
+#~ msgstr "SVG सहेजें"
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr "मेरे यन्त्र पे"
+#~ msgid "On my device"
+#~ msgstr "मेरे यन्त्र पे"
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr "<em>कोई पृष्ठभूमि नहीं</em> ब्लॉक सहेजे गए SVG आउटपुट से पृष्ठभूमि को हटा देता है।"
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr "<em>कोई पृष्ठभूमि नहीं</em> ब्लॉक सहेजे गए SVG आउटपुट से पृष्ठभूमि को हटा देता है।"
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr "मेरा संगीत ब्लॉक्स निर्माण"
+#~ msgid "My Music Blocks Creation"
+#~ msgstr "मेरा संगीत ब्लॉक्स निर्माण"
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr "<em>पैलेट खोलें</em> ब्लॉक एक पैलेट खोलता है।"
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr "<em>पैलेट खोलें</em> ब्लॉक एक पैलेट खोलता है।"
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr "<em>फॉरएवर</em> ब्लॉक निर्धारित ब्लॉक्स को हमेशा के लिए दोहराएगा। इस उदाहरण में, एक साधारित ड्रम मशीन, एक किक ड्रम हमेशा 1/4 नोट्स बजाएगा।"
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr "<em>फॉरएवर</em> ब्लॉक निर्धारित ब्लॉक्स को हमेशा के लिए दोहराएगा। इस उदाहरण में, एक साधारित ड्रम मशीन, एक किक ड्रम हमेशा 1/4 नोट्स बजाएगा।"
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "डिमिनिश ब्लॉक के लिए इनपुट 1, 2, 3, 4, 5, 6, 7, या 8 होना चाहिए"
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "डिमिनिश ब्लॉक के लिए इनपुट 1, 2, 3, 4, 5, 6, 7, या 8 होना चाहिए"
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr "संगीत को धीमी गति से चलाएँ"
+#~ msgid "Run music slow"
+#~ msgstr "संगीत को धीमी गति से चलाएँ"
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr "स्टैक को क्लिपबोर्ड पर कॉपी करने के लिए, स्टैक पर लंबे समय तक दबाएं।"
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr "स्टैक को क्लिपबोर्ड पर कॉपी करने के लिए, स्टैक पर लंबे समय तक दबाएं।"
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr "उदा. गिटार, पियानो, वायलिन, या सेलो।"
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr "उदा. गिटार, पियानो, वायलिन, या सेलो।"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr "माइनर-पेंटाटोनिक"
+#~ msgid "minor-pentatonic"
+#~ msgstr "माइनर-पेंटाटोनिक"
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr "<em>एएम सिंथ</em> ब्लॉक एक आयाम मॉड्यूलेटर है जिसका उपयोग एक स्वर को परिभाषित करने के लिए किया जाता है।"
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr "<em>एएम सिंथ</em> ब्लॉक एक आयाम मॉड्यूलेटर है जिसका उपयोग एक स्वर को परिभाषित करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr "<em>राइट</em> ब्लॉक माउस को दाईं ओर घुमाता है।"
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr "<em>राइट</em> ब्लॉक माउस को दाईं ओर घुमाता है।"
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr "<em>हार्मोनिक</em> ब्लॉक संग्रहित नोट्स में हार्मोनिक्स जोड़ देगा।"
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr "<em>हार्मोनिक</em> ब्लॉक संग्रहित नोट्स में हार्मोनिक्स जोड़ देगा।"
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr "<em>स्टेकाटो</em> ब्लॉक वास्तविक नोट की लंबाई को कम करता है जबकि नोट्स के निर्दिष्ट ताल मूल्य को बनाए रखता है।"
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr "<em>स्टेकाटो</em> ब्लॉक वास्तविक नोट की लंबाई को कम करता है जबकि नोट्स के निर्दिष्ट ताल मूल्य को बनाए रखता है।"
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr "निर्यात"
+#~ msgid "export"
+#~ msgstr "निर्यात"
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr " <em>पॉवर</em> ब्लॉक एक पॉवर फ़ंक्शन की गणना करता है।"
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr " <em>पॉवर</em> ब्लॉक एक पॉवर फ़ंक्शन की गणना करता है।"
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr "<em>सेट हेडिंग</em> ब्लॉक माउस की हेडिंग सेट करता है।"
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr "<em>सेट हेडिंग</em> ब्लॉक माउस की हेडिंग सेट करता है।"
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr "<em>नोट</em> ब्लॉक एक या एक से अधिक <em>पिच</em> ब्लॉक्स के लिए एक संग्रहक है। <em>नोट</em> ब्लॉक इसके सामग्री की अवधि (नोट मूल्य) को निर्दिष्ट करता है।"
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr "<em>नोट</em> ब्लॉक एक या एक से अधिक <em>पिच</em> ब्लॉक्स के लिए एक संग्रहक है। <em>नोट</em> ब्लॉक इसके सामग्री की अवधि (नोट मूल्य) को निर्दिष्ट करता है।"
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr "<em>लेस थैन</em> ब्लॉक टॉप नंबर बॉटम नंबर से कम है तो <em>ट्रू</em> लौटाता है।"
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr "<em>लेस थैन</em> ब्लॉक टॉप नंबर बॉटम नंबर से कम है तो <em>ट्रू</em> लौटाता है।"
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr "<em>बीट काउंट</em> ब्लॉक वर्तमान बीट की संख्या है, जैसे 1, 2, 3, या 4।\n चित्र में, इसका उपयोग प्रत्येक माप के पहले बीट पर क्रिया करने के लिए किया जाता है।"
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr "<em>बीट काउंट</em> ब्लॉक वर्तमान बीट की संख्या है, जैसे 1, 2, 3, या 4।\n चित्र में, इसका उपयोग प्रत्येक माप के पहले बीट पर क्रिया करने के लिए किया जाता है।"
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr "<em>माउस रंग</em> ब्लॉक निर्दिष्ट माउस का पेन रंग लौटाता है।"
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr "<em>माउस रंग</em> ब्लॉक निर्दिष्ट माउस का पेन रंग लौटाता है।"
 
 #: js/turtledefs.js:187
 
@@ -12642,13 +12642,13 @@ msgstr "सरकाय"
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr "ABC के रूप में सहेजें"
+#~ msgid "Save as ABC"
+#~ msgstr "ABC के रूप में सहेजें"
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr "सिंथेसाइज़र"
+#~ msgid "synthesizer"
+#~ msgstr "सिंथेसाइज़र"
 
 #: js/logo.js:630
 
@@ -12656,86 +12656,86 @@ msgstr "सरकाय"
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr "मेजर"
+#~ msgid "Major"
+#~ msgstr "मेजर"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr "सेवहीप ब्लॉक हीप को एक फ़ाइल में सहेजता है।"
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr "सेवहीप ब्लॉक हीप को एक फ़ाइल में सहेजता है।"
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr "<em>सेट मास्टर वॉल्यूम</em> ब्लॉक सभी सिंथेसाइज़र्स के लिए वॉल्यूम सेट करता है।"
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr "<em>सेट मास्टर वॉल्यूम</em> ब्लॉक सभी सिंथेसाइज़र्स के लिए वॉल्यूम सेट करता है।"
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr "डुप्लीकेट नोट्स"
+#~ msgid "duplicate notes"
+#~ msgstr "डुप्लीकेट नोट्स"
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in the heap at the specified location."
-#~msgstr "<em>सेटहीपएंट्री</em> ब्लॉक निर्दिष्ट स्थान पर हीप में एक मूल्य सेट करता है।"
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
+#~ msgstr "<em>सेटहीपएंट्री</em> ब्लॉक निर्दिष्ट स्थान पर हीप में एक मूल्य सेट करता है।"
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr "स्क्रोलिंग अक्षम करें"
+#~ msgid "Disable scrolling"
+#~ msgstr "स्क्रोलिंग अक्षम करें"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr "स्केलर इंटरवल ब्लॉक दो नोट्स के बीच की दूरी को सेमी-टोन में मापता है।"
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr "स्केलर इंटरवल ब्लॉक दो नोट्स के बीच की दूरी को सेमी-टोन में मापता है।"
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr "रिदम ब्लॉक: क्या आपने मैट्रिक्स ब्लॉक का उपयोग करने का इरादा किया है?"
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr "रिदम ब्लॉक: क्या आपने मैट्रिक्स ब्लॉक का उपयोग करने का इरादा किया है?"
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr "<em>नोट्स प्लेड</em> ब्लॉक उन नोट्स की संख्या है जो बजाए गए हैं। (डिफ़ॉल्ट रूप से, यह क्वार्टर नोट्स की गिनती करता है।)"
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr "<em>नोट्स प्लेड</em> ब्लॉक उन नोट्स की संख्या है जो बजाए गए हैं। (डिफ़ॉल्ट रूप से, यह क्वार्टर नोट्स की गिनती करता है।)"
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr "डिफ़ॉल्ट वॉल्यूम 50 है; सीमा 0 (शांति) से 100 (पूर्ण वॉल्यूम) तक है।"
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr "डिफ़ॉल्ट वॉल्यूम 50 है; सीमा 0 (शांति) से 100 (पूर्ण वॉल्यूम) तक है।"
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr "प्रत्येक <em>स्टार्ट</em> ब्लॉक एक अलग आवाज़ है। <em>प्ले</em> बटन दबाया जाता है तो सभी <em>स्टार्ट</em> ब्लॉक्स एक साथ चलते हैं।"
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr "प्रत्येक <em>स्टार्ट</em> ब्लॉक एक अलग आवाज़ है। <em>प्ले</em> बटन दबाया जाता है तो सभी <em>स्टार्ट</em> ब्लॉक्स एक साथ चलते हैं।"
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "जैसे, \"डो\" हमेशा \"सी-नैचुरल\" होता है); जब Movable do सच है, तो सोलफेज़ नोट नामों को स्केल के डिग्री में सौंपा जाता है (\"डो\" हमेशा मेजर स्केल के पहले डिग्री होता है)।"
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "जैसे, \"डो\" हमेशा \"सी-नैचुरल\" होता है); जब Movable do सच है, तो सोलफेज़ नोट नामों को स्केल के डिग्री में सौंपा जाता है (\"डो\" हमेशा मेजर स्केल के पहले डिग्री होता है)।"
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr "वर्तमान पिच ऑक्टेव"
+#~ msgid "current pitch octave"
+#~ msgstr "वर्तमान पिच ऑक्टेव"
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr "<em>रिवर्सहीप</em> ब्लॉक हीप के क्रम को उल्टा करता है।"
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr "<em>रिवर्सहीप</em> ब्लॉक हीप के क्रम को उल्टा करता है।"
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr "हिराजोशी"
+#~ msgid "Hirajoshi"
+#~ msgstr "हिराजोशी"
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr "<em>मेक ब्लॉक</em> ब्लॉक एक नया ब्लॉक बनाता है।"
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr "<em>मेक ब्लॉक</em> ब्लॉक एक नया ब्लॉक बनाता है।"
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr "स्पैनिश"
+#~ msgid "Spanish"
+#~ msgstr "स्पैनिश"
 

--- a/po/ht.po
+++ b/po/ht.po
@@ -2215,7 +2215,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2296,33 +2296,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2422,7 +2422,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2651,8 +2651,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2821,14 +2821,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2859,7 +2859,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2884,7 +2884,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2893,7 +2893,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2914,7 +2914,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2932,8 +2932,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3035,7 +3035,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3169,14 +3169,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3251,7 +3251,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3287,7 +3287,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3296,7 +3296,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3787,7 +3787,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3799,8 +3799,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3810,7 +3810,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3822,8 +3822,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3833,15 +3833,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3850,14 +3850,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3866,14 +3866,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3923,7 +3923,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3940,7 +3940,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4009,8 +4009,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4032,7 +4032,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4318,7 +4318,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4649,21 +4649,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4672,12 +4672,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4690,62 +4690,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4758,7 +4758,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4767,7 +4767,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4780,7 +4780,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4789,17 +4789,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4808,12 +4808,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4835,17 +4835,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4862,56 +4862,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4927,7 +4927,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4936,7 +4936,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4944,7 +4944,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4953,8 +4953,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4962,7 +4962,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4976,116 +4976,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5104,19 +5104,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5124,61 +5124,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5188,149 +5188,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5339,7 +5339,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5418,22 +5418,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5590,7 +5590,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5612,7 +5612,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5623,7 +5623,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5652,7 +5652,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5661,7 +5661,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5694,7 +5694,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5704,7 +5704,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5713,7 +5713,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5722,7 +5722,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5745,13 +5745,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5760,7 +5760,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5769,7 +5769,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5789,7 +5789,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5814,7 +5814,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5828,7 +5828,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5838,7 +5838,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5876,7 +5876,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5885,7 +5885,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5898,18 +5898,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6030,7 +6030,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6049,7 +6049,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6058,7 +6058,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6075,7 +6075,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6088,7 +6088,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6117,7 +6117,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6140,7 +6140,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6157,7 +6157,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6166,7 +6166,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6183,7 +6183,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6192,7 +6192,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6226,7 +6226,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6235,7 +6235,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6252,7 +6252,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6267,7 +6267,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6301,12 +6301,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6315,12 +6315,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6329,13 +6329,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6353,7 +6353,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6385,8 +6385,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6442,7 +6442,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6599,12 +6599,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6614,8 +6614,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6623,12 +6623,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6637,7 +6637,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6654,7 +6654,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6664,12 +6664,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6679,7 +6679,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6688,7 +6688,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6738,7 +6738,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6771,7 +6771,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6780,12 +6780,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6794,7 +6794,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6803,7 +6803,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6812,7 +6812,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6823,8 +6823,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6834,7 +6834,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6860,7 +6860,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6898,12 +6898,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6915,12 +6915,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6929,7 +6929,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6975,22 +6975,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7012,7 +7012,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7021,47 +7021,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7074,7 +7074,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7083,7 +7083,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7091,7 +7091,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7105,8 +7105,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7135,7 +7135,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7160,14 +7160,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7177,7 +7177,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7196,7 +7196,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7206,7 +7206,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7223,17 +7223,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7242,7 +7242,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7252,7 +7252,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7262,7 +7262,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7274,7 +7274,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7292,7 +7292,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7313,7 +7313,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7328,7 +7328,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7352,7 +7352,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7408,7 +7408,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7586,7 +7586,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7595,7 +7595,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7604,7 +7604,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7613,7 +7613,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7623,13 +7623,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7642,7 +7642,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7651,7 +7651,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7660,7 +7660,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7669,7 +7669,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7678,7 +7678,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7687,7 +7687,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7696,7 +7696,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7705,7 +7705,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7715,17 +7715,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7734,7 +7734,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8161,7 +8161,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8171,7 +8171,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8215,12 +8215,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8229,7 +8229,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8286,7 +8286,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8304,7 +8304,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8317,7 +8317,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8382,7 +8382,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8447,7 +8447,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8456,12 +8456,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8470,7 +8470,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8479,7 +8479,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8488,7 +8488,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8513,7 +8513,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8648,27 +8648,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8694,18 +8694,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8720,7 +8720,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8741,7 +8741,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8758,7 +8758,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8771,7 +8771,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8781,7 +8781,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8795,7 +8795,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8816,7 +8816,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8830,7 +8830,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9017,7 +9017,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9026,7 +9026,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9148,7 +9148,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9231,7 +9231,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9281,7 +9281,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9398,7 +9398,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9477,48 +9477,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9951,38 +9951,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9990,8 +9990,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10001,8 +10001,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10014,35 +10014,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10056,69 +10056,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10138,13 +10138,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10152,58 +10152,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10219,25 +10219,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10247,43 +10247,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10293,190 +10293,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10486,305 +10486,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10794,97 +10794,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10894,144 +10894,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11041,15 +11041,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11059,23 +11059,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11085,8 +11085,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11094,224 +11094,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11327,37 +11327,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11365,28 +11365,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11400,8 +11400,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11411,65 +11411,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11477,8 +11477,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11488,127 +11488,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11616,608 +11616,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12227,165 +12227,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12399,28 +12399,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12428,133 +12428,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12562,136 +12562,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12701,127 +12701,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12829,397 +12829,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13231,196 +13231,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13428,155 +13428,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13584,257 +13584,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13848,223 +13848,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14074,144 +14074,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14219,57 +14219,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14279,30 +14279,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14310,112 +14310,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14423,287 +14423,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14711,13 +14711,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14725,86 +14725,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -2215,7 +2215,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2296,33 +2296,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2422,7 +2422,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2651,8 +2651,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2821,14 +2821,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2859,7 +2859,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2884,7 +2884,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2893,7 +2893,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2914,7 +2914,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2932,8 +2932,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3035,7 +3035,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3169,14 +3169,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3251,7 +3251,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3287,7 +3287,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3296,7 +3296,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3787,7 +3787,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3799,8 +3799,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3810,7 +3810,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3822,8 +3822,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3833,15 +3833,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3850,14 +3850,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3866,14 +3866,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3923,7 +3923,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3940,7 +3940,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4009,8 +4009,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4032,7 +4032,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4318,7 +4318,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4649,21 +4649,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4672,12 +4672,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4690,62 +4690,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4758,7 +4758,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4767,7 +4767,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4780,7 +4780,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4789,17 +4789,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4808,12 +4808,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4835,17 +4835,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4862,56 +4862,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4927,7 +4927,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4936,7 +4936,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4944,7 +4944,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4953,8 +4953,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4962,7 +4962,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4976,116 +4976,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5104,19 +5104,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5124,61 +5124,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5188,149 +5188,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5339,7 +5339,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5418,22 +5418,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5590,7 +5590,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5612,7 +5612,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5623,7 +5623,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5652,7 +5652,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5661,7 +5661,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5694,7 +5694,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5704,7 +5704,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5713,7 +5713,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5722,7 +5722,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5745,13 +5745,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5760,7 +5760,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5769,7 +5769,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5789,7 +5789,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5814,7 +5814,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5828,7 +5828,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5838,7 +5838,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5876,7 +5876,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5885,7 +5885,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5898,18 +5898,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6030,7 +6030,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6049,7 +6049,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6058,7 +6058,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6075,7 +6075,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6088,7 +6088,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6117,7 +6117,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6140,7 +6140,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6157,7 +6157,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6166,7 +6166,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6183,7 +6183,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6192,7 +6192,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6226,7 +6226,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6235,7 +6235,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6252,7 +6252,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6267,7 +6267,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6301,12 +6301,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6315,12 +6315,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6329,13 +6329,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6353,7 +6353,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6385,8 +6385,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6442,7 +6442,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6599,12 +6599,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6614,8 +6614,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6623,12 +6623,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6637,7 +6637,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6654,7 +6654,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6664,12 +6664,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6679,7 +6679,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6688,7 +6688,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6738,7 +6738,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6771,7 +6771,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6780,12 +6780,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6794,7 +6794,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6803,7 +6803,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6812,7 +6812,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6823,8 +6823,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6834,7 +6834,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6860,7 +6860,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6898,12 +6898,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6915,12 +6915,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6929,7 +6929,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6975,22 +6975,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7012,7 +7012,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7021,47 +7021,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7074,7 +7074,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7083,7 +7083,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7091,7 +7091,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7105,8 +7105,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7135,7 +7135,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7160,14 +7160,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7177,7 +7177,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7196,7 +7196,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7206,7 +7206,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7223,17 +7223,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7242,7 +7242,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7252,7 +7252,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7262,7 +7262,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7274,7 +7274,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7292,7 +7292,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7313,7 +7313,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7328,7 +7328,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7352,7 +7352,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7408,7 +7408,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7586,7 +7586,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7595,7 +7595,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7604,7 +7604,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7613,7 +7613,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7623,13 +7623,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7642,7 +7642,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7651,7 +7651,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7660,7 +7660,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7669,7 +7669,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7678,7 +7678,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7687,7 +7687,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7696,7 +7696,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7705,7 +7705,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7715,17 +7715,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7734,7 +7734,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8161,7 +8161,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8171,7 +8171,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8215,12 +8215,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8229,7 +8229,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8286,7 +8286,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8304,7 +8304,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8317,7 +8317,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8382,7 +8382,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8447,7 +8447,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8456,12 +8456,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8470,7 +8470,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8479,7 +8479,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8488,7 +8488,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8513,7 +8513,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8648,27 +8648,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8694,18 +8694,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8720,7 +8720,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8741,7 +8741,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8758,7 +8758,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8771,7 +8771,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8781,7 +8781,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8795,7 +8795,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8816,7 +8816,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8830,7 +8830,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9017,7 +9017,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9026,7 +9026,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9148,7 +9148,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9231,7 +9231,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9281,7 +9281,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9398,7 +9398,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9477,48 +9477,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9951,38 +9951,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9990,8 +9990,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10001,8 +10001,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10014,35 +10014,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10056,69 +10056,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10138,13 +10138,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10152,58 +10152,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10219,25 +10219,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10247,43 +10247,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10293,190 +10293,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10486,305 +10486,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10794,97 +10794,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10894,144 +10894,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11041,15 +11041,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11059,23 +11059,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11085,8 +11085,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11094,224 +11094,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11327,37 +11327,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11365,28 +11365,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11400,8 +11400,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11411,65 +11411,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11477,8 +11477,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11488,127 +11488,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11616,608 +11616,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12227,165 +12227,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12399,28 +12399,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12428,133 +12428,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12562,136 +12562,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12701,127 +12701,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12829,397 +12829,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13231,196 +13231,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13428,155 +13428,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13584,257 +13584,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13848,223 +13848,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14074,144 +14074,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14219,57 +14219,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14279,30 +14279,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14310,112 +14310,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14423,287 +14423,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14711,13 +14711,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14725,86 +14725,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/hus.po
+++ b/po/hus.po
@@ -2216,7 +2216,7 @@ msgstr "pakdha' t'ojláb"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "ka jolk'ow an t'i'nél"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "kaldha'"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "nixa'"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "chuchbixtaláb y"
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "chuchbixtaláb x"
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr "ka t'uchiy an mukuxtalab"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "ka k'adhba' i kits'oxtaláb"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "ka pa'ba' a kits'oxtal"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "ka ts'atba' in puwel"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "tejwa'méjdha'"
+#~ msgid "show"
+#~ msgstr "tejwa'méjdha'"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "T'oka'"
+#~ msgid "Clean"
+#~ msgstr "T'oka'"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "tsina' an kwene' t'ojláb"
+#~ msgid "hide blocks"
+#~ msgstr "tsina' an kwene' t'ojláb"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "kuba'"
+#~ msgid "stop"
+#~ msgstr "kuba'"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "owát"
+#~ msgid "duration"
+#~ msgstr "owát"
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "ne'nek"
+#~ msgid "hello"
+#~ msgstr "ne'nek"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "pet"
+#~ msgid "turtle"
+#~ msgstr "pet"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Japiy"
+#~ msgid "Open"
+#~ msgstr "Japiy"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/hy.po
+++ b/po/hy.po
@@ -2213,7 +2213,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2280,7 +2280,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2294,33 +2294,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2342,7 +2342,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2420,7 +2420,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2649,8 +2649,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2809,7 +2809,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2819,14 +2819,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2857,7 +2857,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2882,7 +2882,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2912,7 +2912,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2930,8 +2930,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3033,7 +3033,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3167,14 +3167,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3249,7 +3249,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3285,7 +3285,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3294,7 +3294,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3785,7 +3785,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3797,8 +3797,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3820,8 +3820,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3831,15 +3831,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3848,14 +3848,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3864,14 +3864,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3912,7 +3912,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3921,7 +3921,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3938,7 +3938,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4007,8 +4007,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4030,7 +4030,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4316,7 +4316,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4647,21 +4647,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4670,12 +4670,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4688,62 +4688,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4778,7 +4778,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4787,17 +4787,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4806,12 +4806,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4824,7 +4824,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4833,17 +4833,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4860,56 +4860,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4917,7 +4917,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4925,7 +4925,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4934,7 +4934,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4942,7 +4942,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4951,8 +4951,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4960,7 +4960,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4974,116 +4974,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5102,19 +5102,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5122,61 +5122,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5186,149 +5186,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5337,7 +5337,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5416,22 +5416,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5588,7 +5588,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5610,7 +5610,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5621,7 +5621,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5650,7 +5650,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5659,7 +5659,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5702,7 +5702,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5711,7 +5711,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5720,7 +5720,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5743,13 +5743,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5758,7 +5758,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5767,7 +5767,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5787,7 +5787,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5812,7 +5812,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5826,7 +5826,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5836,7 +5836,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5874,7 +5874,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5883,7 +5883,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5896,18 +5896,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6028,7 +6028,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6047,7 +6047,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6056,7 +6056,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6073,7 +6073,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6086,7 +6086,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6115,7 +6115,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6138,7 +6138,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6155,7 +6155,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6164,7 +6164,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6181,7 +6181,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6190,7 +6190,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6224,7 +6224,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6233,7 +6233,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6265,7 +6265,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6299,12 +6299,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6313,12 +6313,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6327,13 +6327,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6351,7 +6351,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6383,8 +6383,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6440,7 +6440,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6597,12 +6597,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6612,8 +6612,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6621,12 +6621,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6635,7 +6635,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6652,7 +6652,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6662,12 +6662,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6677,7 +6677,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6686,7 +6686,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6736,7 +6736,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6769,7 +6769,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6778,12 +6778,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6792,7 +6792,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6801,7 +6801,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6810,7 +6810,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6821,8 +6821,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6832,7 +6832,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6858,7 +6858,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6896,12 +6896,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6913,12 +6913,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6927,7 +6927,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6973,22 +6973,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6997,7 +6997,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7010,7 +7010,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7019,47 +7019,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7072,7 +7072,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7081,7 +7081,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7089,7 +7089,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7103,8 +7103,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7133,7 +7133,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7158,14 +7158,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7175,7 +7175,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7194,7 +7194,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7204,7 +7204,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7221,17 +7221,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7240,7 +7240,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7250,7 +7250,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7260,7 +7260,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7272,7 +7272,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7280,7 +7280,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7290,7 +7290,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7311,7 +7311,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7326,7 +7326,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7336,7 +7336,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7350,7 +7350,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7406,7 +7406,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7584,7 +7584,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7593,7 +7593,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7602,7 +7602,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7611,7 +7611,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7621,13 +7621,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7640,7 +7640,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7649,7 +7649,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7658,7 +7658,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7667,7 +7667,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7676,7 +7676,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7685,7 +7685,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7694,7 +7694,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7703,7 +7703,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7713,17 +7713,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7732,7 +7732,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8159,7 +8159,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8169,7 +8169,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8213,12 +8213,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8227,7 +8227,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8284,7 +8284,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8302,7 +8302,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8315,7 +8315,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8380,7 +8380,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8445,7 +8445,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8454,12 +8454,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8468,7 +8468,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8477,7 +8477,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8486,7 +8486,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8511,7 +8511,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8646,27 +8646,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8692,18 +8692,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8718,7 +8718,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8739,7 +8739,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8756,7 +8756,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8769,7 +8769,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8779,7 +8779,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8793,7 +8793,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8814,7 +8814,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8828,7 +8828,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9015,7 +9015,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9024,7 +9024,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9146,7 +9146,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9229,7 +9229,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9279,7 +9279,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9396,7 +9396,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9475,48 +9475,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9949,38 +9949,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9988,8 +9988,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -9999,8 +9999,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10012,35 +10012,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10054,69 +10054,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10136,13 +10136,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10150,58 +10150,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10217,25 +10217,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10245,43 +10245,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10291,190 +10291,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10484,305 +10484,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10792,97 +10792,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10892,144 +10892,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11039,15 +11039,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11057,23 +11057,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11083,8 +11083,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11092,224 +11092,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11325,37 +11325,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11363,28 +11363,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11398,8 +11398,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11409,65 +11409,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11475,8 +11475,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11486,127 +11486,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11614,608 +11614,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12225,165 +12225,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12397,28 +12397,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12426,133 +12426,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12560,136 +12560,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12699,127 +12699,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12827,397 +12827,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13229,196 +13229,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13426,155 +13426,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13582,257 +13582,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13846,223 +13846,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14072,144 +14072,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14217,57 +14217,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14277,30 +14277,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14308,112 +14308,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14421,287 +14421,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14709,13 +14709,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14723,86 +14723,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/ibo.po
+++ b/po/ibo.po
@@ -15,10 +15,10 @@ msgstr ""
 "X-POOTLE-MTIME: 1423841876.000000\n"
 "Language-Team: \n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -104,7 +104,7 @@ msgstr "edinam"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -171,7 +171,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -185,33 +185,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -233,7 +233,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -311,7 +311,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -540,8 +540,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -710,14 +710,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -748,7 +748,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "dee uru"
 
@@ -782,7 +782,7 @@ msgstr "dee uru"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -803,7 +803,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -821,8 +821,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "pitch"
 
@@ -924,7 +924,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -1058,14 +1058,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -1140,7 +1140,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr "igba"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -1185,7 +1185,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -1688,8 +1688,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "nkọ"
 
@@ -1699,7 +1699,7 @@ msgstr "nkọ"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -1711,8 +1711,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "flaati"
 
@@ -1722,15 +1722,15 @@ msgstr "flaati"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -1739,14 +1739,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -1755,14 +1755,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -1803,7 +1803,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -1812,7 +1812,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "mita"
 
@@ -1898,8 +1898,8 @@ msgstr "yana mgbakwunye"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgstr "mgbagha"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -2207,7 +2207,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -2538,21 +2538,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -2561,12 +2561,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -2579,62 +2579,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -2647,7 +2647,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -2656,7 +2656,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -2669,7 +2669,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -2678,17 +2678,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -2697,12 +2697,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -2715,7 +2715,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -2724,17 +2724,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -2751,56 +2751,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -2808,7 +2808,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "sine"
 
@@ -2816,7 +2816,7 @@ msgstr "sine"
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "square"
 
@@ -2825,7 +2825,7 @@ msgstr "square"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "triangul"
 
@@ -2833,7 +2833,7 @@ msgstr "triangul"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "sawtooth"
 
@@ -2842,8 +2842,8 @@ msgstr "sawtooth"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -2851,7 +2851,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -2865,116 +2865,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -2993,19 +2993,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -3013,61 +3013,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -3077,149 +3077,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -3228,7 +3228,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3307,22 +3307,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -3479,7 +3479,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -3501,7 +3501,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "ntughe"
 
@@ -3512,7 +3512,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -3541,7 +3541,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "ekpokwasị efu?"
 
@@ -3593,7 +3593,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "efu kpokọtara"
 
@@ -3602,7 +3602,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -3611,7 +3611,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "ndeksi obo"
 
@@ -3634,13 +3634,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "setịpụụrụ obo"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "ndeksi"
 
@@ -3649,7 +3649,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "pop"
 
@@ -3658,7 +3658,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "kwaa"
 
@@ -3678,7 +3678,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "octave"
 
@@ -3703,7 +3703,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -3717,7 +3717,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -3727,7 +3727,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -3765,7 +3765,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -3774,7 +3774,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -3787,18 +3787,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "setịpụụrụ ntughe "
 
@@ -3919,7 +3919,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -3938,7 +3938,7 @@ msgstr "slur"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "staccato"
 
@@ -3947,7 +3947,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -3964,7 +3964,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "ibu kpokọtara"
 
@@ -4006,7 +4006,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -4029,7 +4029,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -4046,7 +4046,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "ịzọpụta kpokọtara"
 
@@ -4055,7 +4055,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -4072,7 +4072,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -4081,7 +4081,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -4115,7 +4115,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -4124,7 +4124,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -4141,7 +4141,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -4156,7 +4156,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "dee"
 
@@ -4190,12 +4190,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "siwing"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -4204,12 +4204,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "ọtụtụ ụda"
 
@@ -4218,13 +4218,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "ntụpọ"
 
@@ -4242,7 +4242,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -4274,8 +4274,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -4331,7 +4331,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "tuplet"
 
@@ -4488,12 +4488,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "ụda ihe na-akpata"
 
@@ -4503,8 +4503,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -4512,12 +4512,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "gbagwojuru kwa nkeji"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -4526,7 +4526,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -4543,7 +4543,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -4553,12 +4553,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -4568,7 +4568,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -4577,7 +4577,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "aka ekpe"
 
@@ -4627,7 +4627,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -4660,7 +4660,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -4669,12 +4669,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "transposition"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -4683,7 +4683,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -4692,7 +4692,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -4701,7 +4701,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -4712,8 +4712,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -4723,7 +4723,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -4749,7 +4749,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -4787,12 +4787,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -4804,12 +4804,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -4818,7 +4818,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -4864,22 +4864,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -4888,7 +4888,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -4901,7 +4901,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -4910,47 +4910,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -4972,7 +4972,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -4980,7 +4980,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -4994,8 +4994,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -5024,7 +5024,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -5049,14 +5049,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -5066,7 +5066,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -5085,7 +5085,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -5095,7 +5095,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -5112,17 +5112,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -5131,7 +5131,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -5141,7 +5141,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -5151,7 +5151,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -5163,7 +5163,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -5171,7 +5171,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -5181,7 +5181,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -5202,7 +5202,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -5217,7 +5217,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -5227,7 +5227,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -5241,7 +5241,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -5297,7 +5297,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -5475,7 +5475,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -5484,7 +5484,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -5493,7 +5493,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -5502,7 +5502,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -5512,13 +5512,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -5531,7 +5531,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "oke y"
 
@@ -5540,7 +5540,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "mbe y"
 
@@ -5549,7 +5549,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "oke x"
 
@@ -5558,7 +5558,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "mbe x"
 
@@ -5567,7 +5567,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -5576,7 +5576,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -5585,7 +5585,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -5594,7 +5594,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -5604,17 +5604,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -5623,7 +5623,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -6060,7 +6060,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -6104,12 +6104,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "kwụsị play"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "egwu azụ"
 
@@ -6175,7 +6175,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "mara na ugboro ole"
 
@@ -6193,7 +6193,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "size"
 
@@ -6206,7 +6206,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -6271,7 +6271,7 @@ msgstr "ọgwụgwụ erijueala"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "ndabere"
 
@@ -6336,7 +6336,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "oghere ogbara"
 
@@ -6345,12 +6345,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "imeju "
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "pen elu"
 
@@ -6359,7 +6359,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "pen ala"
 
@@ -6368,7 +6368,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "set pen size"
 
@@ -6377,7 +6377,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -6402,7 +6402,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "set isi awọ"
 
@@ -6537,27 +6537,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -6583,18 +6583,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -6609,7 +6609,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -6630,7 +6630,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -6647,7 +6647,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -6660,7 +6660,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -6670,7 +6670,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -6684,7 +6684,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -6705,7 +6705,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -6719,7 +6719,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -6906,7 +6906,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -6915,7 +6915,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -7037,7 +7037,7 @@ msgid "Undo"
 msgstr "Wepu"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -7120,7 +7120,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -7287,7 +7287,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -7366,48 +7366,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -7840,38 +7840,38 @@ msgstr "ije"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "Azọpụta gị oru ngo ka a faịlụ Lilypond."
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "Azọpụta gị oru ngo ka a faịlụ Lilypond."
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "Gosi ndị a ozi"
+#~ msgid "Show these messages."
+#~ msgstr "Gosi ndị a ozi"
 
 #: js/rubrics.js:531
 
@@ -7879,8 +7879,8 @@ msgstr "ije"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "sensọ"
+#~ msgid "sensors"
+#~ msgstr "sensọ"
 
 #: js/rubrics.js:532
 
@@ -7890,8 +7890,8 @@ msgstr "ije"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "media"
+#~ msgid "media"
+#~ msgstr "media"
 
 #: js/block-verbose.js:3837
 
@@ -7903,35 +7903,35 @@ msgstr "ije"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "zie"
+#~ msgid "show"
+#~ msgstr "zie"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -7945,69 +7945,69 @@ msgstr "ije"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "ọcha"
+#~ msgid "Clean"
+#~ msgstr "ọcha"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "Gbaa Obere Obere"
+#~ msgid "Run slow"
+#~ msgstr "Gbaa Obere Obere"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "hide blocks"
+#~ msgid "hide blocks"
+#~ msgstr "hide blocks"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr "oyiri ndetu"
+#~ msgid "duplicate"
+#~ msgstr "oyiri ndetu"
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8027,13 +8027,13 @@ msgstr "ije"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "kwụsị"
+#~ msgid "stop"
+#~ msgstr "kwụsị"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "Na oge (ms)"
+#~ msgid "duration (ms)"
+#~ msgstr "Na oge (ms)"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8041,58 +8041,58 @@ msgstr "ije"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "doro anya"
+#~ msgid "clear"
+#~ msgstr "doro anya"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "invert"
+#~ msgid "invert"
+#~ msgstr "invert"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -8108,25 +8108,25 @@ msgstr "ije"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "oge"
+#~ msgid "duration"
+#~ msgstr "oge"
 
 #: js/widgets/temperament.js:454
 
@@ -8136,46 +8136,46 @@ msgstr "ije"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr "igwu egwu"
+#~ msgid "play"
+#~ msgstr "igwu egwu"
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
-#~msgid ""Toggle Fullscreen"
-#~msgstr ""Gbanwee ihuenyo zuru oke"
+#~ msgid "Toggle Fullscreen"
+#~ msgstr "Gbanwee ihuenyo zuru oke"
 
 #: js/toolbar.js:70
 
@@ -8185,190 +8185,190 @@ msgstr "ije"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -8378,305 +8378,305 @@ msgstr "ije"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "Gbaa ngwa ngwa"
+#~ msgid "Run fast"
+#~ msgstr "Gbaa ngwa ngwa"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "Ịmụbawanye / daa collapsible blocks"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "Ịmụbawanye / daa collapsible blocks"
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -8686,97 +8686,97 @@ msgstr "ije"
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "ego"
+#~ msgid "currency"
+#~ msgstr "ego"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "site"
+#~ msgid "from"
+#~ msgstr "site"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "ngwaahịa price"
+#~ msgid "stock price"
+#~ msgstr "ngwaahịa price"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "ịsụgharị"
+#~ msgid "translate"
+#~ msgstr "ịsụgharị"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "hallo"
+#~ msgid "hello"
+#~ msgstr "hallo"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "chọpụta naanị"
+#~ msgid "detect lang"
+#~ msgstr "chọpụta naanị"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "dị nnọọ ka"
+#~ msgid "set lang"
+#~ msgstr "dị nnọọ ka"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "obodo ohere"
+#~ msgid "city latitude"
+#~ msgstr "obodo ohere"
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "obodo lonjituudu"
+#~ msgid "city longitude"
+#~ msgstr "obodo lonjituudu"
 
 #: plugins/gmap.rtp:71
 
@@ -8786,144 +8786,144 @@ msgstr "ije"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "Ahazi data adịghị."
+#~ msgid "Coordinate data not available."
+#~ msgstr "Ahazi data adịghị."
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "Google map"
+#~ msgid "Google map"
+#~ msgstr "Google map"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "na-achịkọta"
+#~ msgid "coordinates"
+#~ msgstr "na-achịkọta"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "mbugharị na-akpata"
+#~ msgid "zoom factor"
+#~ msgstr "mbugharị na-akpata"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "mbugharị"
+#~ msgid "zoom"
+#~ msgstr "mbugharị"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "ohere"
+#~ msgid "latitude"
+#~ msgstr "ohere"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "lonjituudu"
+#~ msgid "longitude"
+#~ msgstr "lonjituudu"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "degrees"
+#~ msgid "degrees"
+#~ msgstr "degrees"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "radians"
+#~ msgid "radians"
+#~ msgstr "radians"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "kọwaa"
+#~ msgid "define"
+#~ msgstr "kọwaa"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "Bitcoin"
+#~ msgid "bitcoin"
+#~ msgstr "Bitcoin"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -8933,15 +8933,15 @@ msgstr "ije"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr "zie"
+#~ msgid "hide"
+#~ msgstr "zie"
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -8951,23 +8951,23 @@ msgstr "ije"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr "gbapụta si"
+#~ msgid "popout"
+#~ msgstr "gbapụta si"
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -8977,8 +8977,8 @@ msgstr "ije"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -8986,224 +8986,224 @@ msgstr "ije"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr "eval"
+#~ msgid "eval"
+#~ msgstr "eval"
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -9219,37 +9219,37 @@ msgstr "ije"
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -9257,28 +9257,28 @@ msgstr "ije"
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -9292,8 +9292,8 @@ msgstr "ije"
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -9303,62 +9303,62 @@ msgstr "ije"
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -9366,8 +9366,8 @@ msgstr "ije"
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -9377,127 +9377,127 @@ msgstr "ije"
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr "setịpụrụ uda"
+#~ msgid "set volume"
+#~ msgstr "setịpụrụ uda"
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr "awa gara aga"
+#~ msgid "hours ago"
+#~ msgstr "awa gara aga"
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr "Nke a ogwè e dere ihe palette buttons matriks, Note, ụda, Turtle, na ndị ọzọ. Pịa egosi na palettes nke blocks na ikpuru blocks si palettes na na kwaaji na-eji ha."
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr "Nke a ogwè e dere ihe palette buttons matriks, Note, ụda, Turtle, na ndị ọzọ. Pịa egosi na palettes nke blocks na ikpuru blocks si palettes na na kwaaji na-eji ha."
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -9505,606 +9505,606 @@ msgstr "ije"
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr "rea-mu"
+#~ msgid "eatme"
+#~ msgstr "rea-mu"
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr "Mr. Òké bụ anyị Egwú nkanka eduzi. Mr. Òké na i kwesịrị inyocha Egwú nkanka. Ka anyị na-amalite anyị njegharị!"
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr "Mr. Òké bụ anyị Egwú nkanka eduzi. Mr. Òké na i kwesịrị inyocha Egwú nkanka. Ka anyị na-amalite anyị njegharị!"
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "Mepee a panel maka configuring mbe nkanka ."
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "Mepee a panel maka configuring mbe nkanka ."
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr "The tapawa button na-nyeere e nwere blocks depụtaghachiri n'elu clipboard"
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr "The tapawa button na-nyeere e nwere blocks depụtaghachiri n'elu clipboard"
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr "denominator"
+#~ msgid "denominator"
+#~ msgstr "denominator"
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr "ọdịdị"
+#~ msgid "mashape"
+#~ msgstr "ọdịdị"
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "I nwere ike mara ọhụrụ blocks si faịlụ usoro"
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "I nwere ike mara ọhụrụ blocks si faịlụ usoro"
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr "Ntọala"
+#~ msgid "Settings"
+#~ msgstr "Ntọala"
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr "dee olu"
+#~ msgid "note volume"
+#~ msgstr "dee olu"
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr "setịpụụrụ gafere kwa nkeji"
+#~ msgid "set beats per minute"
+#~ msgstr "setịpụụrụ gafere kwa nkeji"
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr "hichapụ niile"
+#~ msgid "Delete all"
+#~ msgstr "hichapụ niile"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr "UID"
+#~ msgid "UID"
+#~ msgstr "UID"
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr "numerator"
+#~ msgid "numerator"
+#~ msgstr "numerator"
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -10114,165 +10114,165 @@ msgstr "ije"
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr "Egwú nkanka bụ a collection of aghụghọ ngwá ọrụ maka ịgagharị isi musical banye n'eluigwe na-integrative na fun ụzọ."
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr "Egwú nkanka bụ a collection of aghụghọ ngwá ọrụ maka ịgagharị isi musical banye n'eluigwe na-integrative na fun ụzọ."
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr "Kwụsị egwu (na mbe)."
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr "Kwụsị egwu (na mbe)."
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -10286,28 +10286,28 @@ msgstr "ije"
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10315,128 +10315,128 @@ msgstr "ije"
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr "Zọpụta ndị gị oru ngo na-a nkesa"
+#~ msgid "Save your project to a server."
+#~ msgstr "Zọpụta ndị gị oru ngo na-a nkesa"
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr "Pịa agba ọsọ dị nnọọ ka music na onye na-adịghị mode."
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr "Pịa agba ọsọ dị nnọọ ka music na onye na-adịghị mode."
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr "azọpụta dị ka lilypond"
+#~ msgid "save as lilypond"
+#~ msgstr "azọpụta dị ka lilypond"
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr "Ịmụbawanye / ida toolbar"
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr "Ịmụbawanye / ida toolbar"
 
 #: js/turtledefs.js:187
 
@@ -10444,136 +10444,136 @@ msgstr "ije"
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "mbe"
+#~ msgid "turtle"
+#~ msgstr "mbe"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -10583,127 +10583,127 @@ msgstr "ije"
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr "asuanetop"
+#~ msgid "Publish"
+#~ msgstr "asuanetop"
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -10711,397 +10711,397 @@ msgstr "ije"
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr "Uwa-obosara"
+#~ msgid "Worldwide"
+#~ msgstr "Uwa-obosara"
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr "akwụsị oghere ogbara"
+#~ msgid "end hollow line"
+#~ msgstr "akwụsị oghere ogbara"
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Mekpe"
+#~ msgid "Open"
+#~ msgstr "Mekpe"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr "Pịa agba ọsọ ahụ music dee site na ndetu."
+#~ msgid "Click to run the music note by note."
+#~ msgstr "Pịa agba ọsọ ahụ music dee site na ndetu."
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr "gosi"
+#~ msgid "confirm"
+#~ msgstr "gosi"
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr "fiilidi"
+#~ msgid "field"
+#~ msgstr "fiilidi"
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -11113,194 +11113,194 @@ msgstr "ije"
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "Zoo ma ọ bụ na-egosi na ngọngọ palettes"
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "Zoo ma ọ bụ na-egosi na ngọngọ palettes"
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
-#~msgid "1/32 note 𝅘𝅥𝅰"
-#~msgstr "1/32 note 𝅘𝅥𝅰"
+#~ msgid "1/32 note 𝅘𝅥𝅰"
+#~ msgstr "1/32 note 𝅘𝅥𝅰"
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr "nri"
+#~ msgid "food"
+#~ msgstr "nri"
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr "osctime"
+#~ msgid "osctime"
+#~ msgstr "osctime"
 
 #: js/turtledefs.js:187
 
@@ -11308,145 +11308,145 @@ msgstr "ije"
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr "maths"
+#~ msgid "maths"
+#~ msgstr "maths"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr "Nke a ogwè e dere ihe palette buttons matriks, Note, ụda, Turtle, na ndị ọzọ. "
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr "Nke a ogwè e dere ihe palette buttons matriks, Note, ụda, Turtle, na ndị ọzọ. "
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr "hspace"
+#~ msgid "hspace"
+#~ msgstr "hspace"
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11454,252 +11454,252 @@ msgstr "ije"
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr "Cheta uru ga-adị ukwuu karịa 0"
+#~ msgid "Note value must be greater than 0"
+#~ msgstr "Cheta uru ga-adị ukwuu karịa 0"
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "Egosi ma ọ bụ zoo a polar-ahazi okporo"
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "Egosi ma ọ bụ zoo a polar-ahazi okporo"
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "Kọwaa ihuenyo ma laghachi na turtles ha mbụ ọnọdụ"
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "Kọwaa ihuenyo ma laghachi na turtles ha mbụ ọnọdụ"
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr "amalite oghere akara"
+#~ msgid "begin hollow line"
+#~ msgstr "amalite oghere akara"
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr "egwu backward"
+#~ msgid "play backward"
+#~ msgstr "egwu backward"
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -11713,228 +11713,228 @@ msgstr "ije"
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr "pola"
+#~ msgid "Polar"
+#~ msgstr "pola"
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr "aha pitch ugbu a"
+#~ msgid "current pitch name"
+#~ msgstr "aha pitch ugbu a"
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "Egosi ma ọ bụ zoo a Cartesian-ahazi okporo"
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "Egosi ma ọ bụ zoo a Cartesian-ahazi okporo"
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr "Ibu Ibu plugin si faịlụ"
+#~ msgid "Load plugin from file"
+#~ msgstr "Ibu Ibu plugin si faịlụ"
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor."
-#~msgstr "Mr. Òké bụ anyị Egwú nkanka eduzi."
+#~ msgid "Mr. Mouse is our Music Blocks conductor."
+#~ msgstr "Mr. Òké bụ anyị Egwú nkanka eduzi."
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr "na-abụ abụ"
+#~ msgid "sing"
+#~ msgstr "na-abụ abụ"
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -11944,144 +11944,144 @@ msgstr "ije"
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr "ala-ibu"
+#~ msgid "Download"
+#~ msgstr "ala-ibu"
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr "urupuru"
+#~ msgid "cloud"
+#~ msgstr "urupuru"
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr "Gosi / hide palettes"
+#~ msgid "Show/hide palettes"
+#~ msgstr "Gosi / hide palettes"
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr "ozi kpọtara"
+#~ msgid "fetch"
+#~ msgstr "ozi kpọtara"
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr "Rhodes"
+#~ msgid "rodi"
+#~ msgstr "Rhodes"
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr "blocks"
+#~ msgid "blocks"
+#~ msgstr "blocks"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -12089,57 +12089,57 @@ msgstr "ije"
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -12149,30 +12149,30 @@ msgstr "ije"
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12180,112 +12180,112 @@ msgstr "ije"
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr "Zọpụta mpempe akwụkwọ egwu"
+#~ msgid "Save sheet music"
+#~ msgstr "Zọpụta mpempe akwụkwọ egwu"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "Pịa-agba ọsọ ahụ oru ngo na ngwa ngwa mode"
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "Pịa-agba ọsọ ahụ oru ngo na ngwa ngwa mode"
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr "Agba ọsọ dee site na ndetu"
+#~ msgid "Run note by note"
+#~ msgstr "Agba ọsọ dee site na ndetu"
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr "shei"
+#~ msgid "shell"
+#~ msgstr "shei"
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -12293,287 +12293,287 @@ msgstr "ije"
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr "Nke a button emepekwa na-emechi isi toolbar."
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr "Nke a button emepekwa na-emechi isi toolbar."
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr "v ohere"
+#~ msgid "vspace"
+#~ msgstr "v ohere"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse encourages you to explore Music Blocks"
-#~msgstr "Mr. Òké na i kwesịrị inyocha Egwú nkanka."
+#~ msgid "Mr. Mouse encourages you to explore Music Blocks"
+#~ msgstr "Mr. Òké na i kwesịrị inyocha Egwú nkanka."
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "Wepụ niile ọdịnaya na kwaaji, gụnyere blocks"
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "Wepụ niile ọdịnaya na kwaaji, gụnyere blocks"
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr "save svg"
+#~ msgid "save svg"
+#~ msgstr "save svg"
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr "On m ngwaọrụ"
+#~ msgid "On my device"
+#~ msgstr "On m ngwaọrụ"
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr "Agba ọsọ egwu ngwa ngwa"
+#~ msgid "Run music slow"
+#~ msgstr "Agba ọsọ egwu ngwa ngwa"
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12581,13 +12581,13 @@ msgstr "ije"
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -12595,81 +12595,81 @@ msgstr "ije"
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr "pitch octave ugbu a"
+#~ msgid "current pitch octave"
+#~ msgstr "pitch octave ugbu a"
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -2216,7 +2216,7 @@ msgstr "aksi"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr "akhir memenuhi"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "pena mati"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "pena nyala"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "atur ukuran pena"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "bersihkan"
+#~ msgid "Clean"
+#~ msgstr "bersihkan"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/is.po
+++ b/po/is.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -2216,7 +2216,7 @@ msgstr "azione"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr "Nascondi"
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "Mio Progetto"
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr "La registrazione è in corso"
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "Nome del file"
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "Titolo del progetto"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "Autore del progetto"
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "Salva come Lilypond"
 
@@ -2345,7 +2345,7 @@ msgstr "Salva come Lilypond"
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "Mr. Mouse"
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "si la sol fa mi re do"
 
@@ -2812,7 +2812,7 @@ msgstr "righello"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "timbro"
 
@@ -2822,14 +2822,14 @@ msgstr "scala"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "tempo"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "modo"
 
@@ -2860,7 +2860,7 @@ msgstr "batteria"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr "Silenzio"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "giu"
 
@@ -2933,8 +2933,8 @@ msgstr "su"
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr "tenore"
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "basso"
 
@@ -3170,14 +3170,14 @@ msgstr "Nessun blocco selezionato"
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "Campione"
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "ritmo"
 
@@ -3288,7 +3288,7 @@ msgstr "flusso"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "doppio diesis"
 
@@ -3800,8 +3800,8 @@ msgstr "doppio diesis"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "diesis"
 
@@ -3811,7 +3811,7 @@ msgstr "diesis"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "naturale"
 
@@ -3823,8 +3823,8 @@ msgstr "naturale"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "bemolle"
 
@@ -3834,15 +3834,15 @@ msgstr "bemolle"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "doppio bemolle"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "maggiore"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr "ionica"
 
@@ -3867,14 +3867,14 @@ msgstr "ionica"
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "minore"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr "eolica"
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr "il synth non può suonare accordi"
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr "Cerca"
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr "extras"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "programma"
 
@@ -4033,7 +4033,7 @@ msgstr "logica"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr "passa alto"
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "vuotare pila"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "pop"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "spingire"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "ottava"
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr "Nella figura, aggiungiamo sol# al sol"
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "aprire pila"
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "carica dizionario"
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr "imposta dizionario"
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "Salvare pila"
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "nota"
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr "nota intera"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr "tipo"
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr "Impossibile trovare il blocco iniziale"
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "mouse y"
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "mouse x"
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr "destra (schermo)"
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "sinistra (schermo)"
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "interrompere riproduzione"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "dimensione"
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr "terminare riempimento"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "caricare penna"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "scendere penna"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "selezionare dimensione della penna"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "selezionare grigio"
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "campionatore"
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr "disfare"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr "muovere"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr "Salva l'audio del tuo progetto come file WAV."
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr "Salva l'audio del tuo progetto come file WAV."
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr "Salva il tuo progetto come file ABC."
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr "Salva il tuo progetto come file ABC."
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "Salva il tuo progetto come file Lilypond."
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "Salva il tuo progetto come file Lilypond."
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr "Mostra o nascondi la griglia di coordinate"
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr "Mostra o nascondi la griglia di coordinate"
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "Mostrare questi messagi."
+#~ msgid "Show these messages."
+#~ msgstr "Mostrare questi messagi."
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr "muovere"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "sensori"
+#~ msgid "sensors"
+#~ msgstr "sensori"
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr "muovere"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "mezzi"
+#~ msgid "media"
+#~ msgstr "mezzi"
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr "muovere"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "mostrare"
+#~ msgid "show"
+#~ msgstr "mostrare"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr "Mostra/nascondi blocco"
+#~ msgid "Show/hide block"
+#~ msgstr "Mostra/nascondi blocco"
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "Griglia"
+#~ msgid "grid"
+#~ msgstr "Griglia"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr "muovere"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr "Schermo Intero"
+#~ msgid "Full Screen"
+#~ msgstr "Schermo Intero"
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr "Nuovo Progetto"
+#~ msgid "New Project"
+#~ msgstr "Nuovo Progetto"
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr "musica"
+#~ msgid "music"
+#~ msgstr "musica"
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr "salva"
+#~ msgid "save"
+#~ msgstr "salva"
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Pulire"
+#~ msgid "Clean"
+#~ msgstr "Pulire"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "Correre lento"
+#~ msgid "Run slow"
+#~ msgstr "Correre lento"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "nascondi blocchi"
+#~ msgid "hide blocks"
+#~ msgstr "nascondi blocchi"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr "muovere"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "fermare"
+#~ msgid "stop"
+#~ msgstr "fermare"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "durata (ms)"
+#~ msgid "duration (ms)"
+#~ msgstr "durata (ms)"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr "muovere"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "pulire"
+#~ msgid "clear"
+#~ msgstr "pulire"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr "filter"
+#~ msgid "filter"
+#~ msgstr "filter"
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr "muovere"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "durata"
+#~ msgid "duration"
+#~ msgstr "durata"
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr "muovere"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr "Aggiorna il tuo browser per passare alla modalità avanzata."
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr "Aggiorna il tuo browser per passare alla modalità avanzata."
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr "Aggiorna il tuo browser per passare alla modalità principiante."
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr "Aggiorna il tuo browser per passare alla modalità principiante."
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr "muovere"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr "Abilita/disabilita Javascript Editor"
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr "Abilita/disabilita Javascript Editor"
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr "Schermo intero"
+#~ msgid "FullScreen"
+#~ msgstr "Schermo intero"
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr "muovere"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr "Più dettagli"
+#~ msgid "More Details"
+#~ msgstr "Più dettagli"
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr "Condividi progetto"
+#~ msgid "Share project"
+#~ msgstr "Condividi progetto"
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr "Copia il link negli appunti"
+#~ msgid "Copy link to clipboard"
+#~ msgstr "Copia il link negli appunti"
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr "Opzioni Avanzate"
+#~ msgid "Advanced Options"
+#~ msgstr "Opzioni Avanzate"
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "Correre veloce"
+#~ msgid "Run fast"
+#~ msgstr "Correre veloce"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "Espandire/collassare blocchi collassabili"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "Espandire/collassare blocchi collassabili"
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr "muovere"
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr "Menu ausiliario"
+#~ msgid "Auxilary menu"
+#~ msgstr "Menu ausiliario"
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr "Per eseguire questo progetto, apri Music Blocks in un browser web e trascina e rilascia questo file nella finestra del browser."
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr "Per eseguire questo progetto, apri Music Blocks in un browser web e trascina e rilascia questo file nella finestra del browser."
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr "Devi sempre avere almeno un blocco di inizio."
+#~ msgid "You must always have at least one start block."
+#~ msgstr "Devi sempre avere almeno un blocco di inizio."
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr "ottava su"
+#~ msgid "octave up"
+#~ msgstr "ottava su"
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr "ottava giú"
+#~ msgid "octave down"
+#~ msgstr "ottava giú"
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "moneta"
+#~ msgid "currency"
+#~ msgstr "moneta"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "da"
+#~ msgid "from"
+#~ msgstr "da"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "prezzo di stock"
+#~ msgid "stock price"
+#~ msgstr "prezzo di stock"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "tradurre"
+#~ msgid "translate"
+#~ msgstr "tradurre"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "ciao"
+#~ msgid "hello"
+#~ msgstr "ciao"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "riconoscere lingua"
+#~ msgid "detect lang"
+#~ msgstr "riconoscere lingua"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "selezionare lingua"
+#~ msgid "set lang"
+#~ msgstr "selezionare lingua"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr "muovere"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "Coordinate non disponibili"
+#~ msgid "Coordinate data not available."
+#~ msgstr "Coordinate non disponibili"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "Carte geografiche di Google"
+#~ msgid "Google map"
+#~ msgstr "Carte geografiche di Google"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "coordinati"
+#~ msgid "coordinates"
+#~ msgstr "coordinati"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "fattore di zoom"
+#~ msgid "zoom factor"
+#~ msgstr "fattore di zoom"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "zoom"
+#~ msgid "zoom"
+#~ msgstr "zoom"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "latitudine"
+#~ msgid "latitude"
+#~ msgstr "latitudine"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "longitudine"
+#~ msgid "longitude"
+#~ msgstr "longitudine"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "gradi"
+#~ msgid "degrees"
+#~ msgstr "gradi"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "radianti"
+#~ msgid "radians"
+#~ msgstr "radianti"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "definere"
+#~ msgid "define"
+#~ msgstr "definere"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "bitcoin"
+#~ msgid "bitcoin"
+#~ msgstr "bitcoin"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr "Devi selezionare un file."
+#~ msgid "You need to select a file."
+#~ msgstr "Devi selezionare un file."
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr "mostra basso"
+#~ msgid "show bass"
+#~ msgstr "mostra basso"
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr "mostra tenote"
+#~ msgid "show tenor"
+#~ msgstr "mostra tenote"
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr "nascondi basso"
+#~ msgid "hide bass"
+#~ msgstr "nascondi basso"
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr "nascondi Cartesiano"
+#~ msgid "hide Cartesian"
+#~ msgstr "nascondi Cartesiano"
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr "muovere"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr "muovere"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr "muovere"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr "muovere"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr "Nascondi blocchi."
+#~ msgid "Hide blocks."
+#~ msgstr "Nascondi blocchi."
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr "Clicca su questo pulsante per espandere o comprimere la barra degli strumenti ausiliari."
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr "Clicca su questo pulsante per espandere o comprimere la barra degli strumenti ausiliari."
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr "valutare"
+#~ msgid "eval"
+#~ msgstr "valutare"
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr "100"
+#~ msgid "100"
+#~ msgstr "100"
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr "muovere"
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr "Trascina"
+#~ msgid "Drag"
+#~ msgstr "Trascina"
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr "muovere"
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr "muovere"
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr "espandi"
+#~ msgid "expand"
+#~ msgstr "espandi"
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr "muovere"
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr "Inizializza un nuovo progetto"
+#~ msgid "Initialise a new project."
+#~ msgstr "Inizializza un nuovo progetto"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr "muovere"
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr "muovere"
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr "annulla"
+#~ msgid "undo"
+#~ msgstr "annulla"
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr "imposta volume"
+#~ msgid "set volume"
+#~ msgstr "imposta volume"
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr "quinte"
+#~ msgid "fifths"
+#~ msgstr "quinte"
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr "mi"
+#~ msgid "mi"
+#~ msgstr "mi"
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr "muovere"
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr "mangiami"
+#~ msgid "eatme"
+#~ msgstr "mangiami"
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr "mobile"
+#~ msgid "movable"
+#~ msgstr "mobile"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr "Giapponese"
+#~ msgid "Japanese"
+#~ msgstr "Giapponese"
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr "Nascondi griglia"
+#~ msgid "Hide grid"
+#~ msgstr "Nascondi griglia"
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr "Pagina Precedente"
+#~ msgid "Previous page"
+#~ msgstr "Pagina Precedente"
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr "effetti"
+#~ msgid "effects"
+#~ msgstr "effetti"
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr "Condividi su Facebook"
+#~ msgid "Share on Facebook"
+#~ msgstr "Condividi su Facebook"
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr "Il Signor Mouse è il nostro direttore di Music Blocks. Il Signor Mouse ti incoraggia ad esplorare Music Blocks. Iniziamo il nostro tour!"
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr "Il Signor Mouse è il nostro direttore di Music Blocks. Il Signor Mouse ti incoraggia ad esplorare Music Blocks. Iniziamo il nostro tour!"
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr "per esempio, C Maggiore"
+#~ msgid "e.g., C Major"
+#~ msgstr "per esempio, C Maggiore"
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr "Tieni premuto per eseguire la musica lentamente."
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr "Tieni premuto per eseguire la musica lentamente."
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr "Per copiare una pila negli appunti, fai clic destro sulla pila."
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr "Per copiare una pila negli appunti, fai clic destro sulla pila."
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr "Salva come abc"
+#~ msgid "Save as abc"
+#~ msgstr "Salva come abc"
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "Apri un pannello per configurare Music Blocks"
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "Apri un pannello per configurare Music Blocks"
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr "Salva come .wav"
+#~ msgid "Save as .wav"
+#~ msgstr "Salva come .wav"
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr "Egiziano"
+#~ msgid "Egyptian"
+#~ msgstr "Egiziano"
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr "Il pulsante di incolla è abilitato quando ci sono blocchi copiati negli appunti."
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr "Il pulsante di incolla è abilitato quando ci sono blocchi copiati negli appunti."
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr "denominatore"
+#~ msgid "denominator"
+#~ msgstr "denominatore"
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr "mashape"
+#~ msgid "mashape"
+#~ msgstr "mashape"
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "Tu puoi aprire nuovi blocchi dal filesystem."
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "Tu puoi aprire nuovi blocchi dal filesystem."
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr "Impostazioni"
+#~ msgid "Settings"
+#~ msgstr "Impostazioni"
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr "muovi giú"
+#~ msgid "move down"
+#~ msgstr "muovi giú"
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr "Fibonacci"
+#~ msgid "Fibonacci"
+#~ msgstr "Fibonacci"
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr "Suona musica lentamente"
+#~ msgid "Run music slowly"
+#~ msgstr "Suona musica lentamente"
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr "muovere"
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr "La tonalità può essere specificata in termini di <em>do re mi fa sol la si</em>."
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr "La tonalità può essere specificata in termini di <em>do re mi fa sol la si</em>."
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr "muovere"
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr "Suona accordo"
+#~ msgid "play chord"
+#~ msgstr "Suona accordo"
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr "muovere"
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr "Music Blocks è una raccolta di strumenti open source per esplorare concetti musicali. Un elenco completo dei contributori è disponibile nel repository di Music Blocks su GitHub. Music Blocks è distribuito con licenza AGPL. La versione attuale è:"
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr "Music Blocks è una raccolta di strumenti open source per esplorare concetti musicali. Un elenco completo dei contributori è disponibile nel repository di Music Blocks su GitHub. Music Blocks è distribuito con licenza AGPL. La versione attuale è:"
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr "Salvare tuo progetto nel server."
+#~ msgid "Save your project to a server."
+#~ msgstr "Salvare tuo progetto nel server."
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr "Espandere/collassare la barra degli strumenti"
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr "Espandere/collassare la barra degli strumenti"
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr "muovere"
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "tartaruga"
+#~ msgid "turtle"
+#~ msgstr "tartaruga"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr "muovere"
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr "muovere"
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr "Music Blocks è una raccolta di strumenti open source per esplorare concetti musicali. Un elenco completo dei contributori è disponibile nel repository di Music Blocks su GitHub. Music Blocks è distribuito con licenza AGPL. La versione attuale è:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr "Music Blocks è una raccolta di strumenti open source per esplorare concetti musicali. Un elenco completo dei contributori è disponibile nel repository di Music Blocks su GitHub. Music Blocks è distribuito con licenza AGPL. La versione attuale è:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr "muovere"
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "Nascondire o mostrare i tavolozzi di blocchi."
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "Nascondire o mostrare i tavolozzi di blocchi."
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr "cibo"
+#~ msgid "food"
+#~ msgstr "cibo"
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr "muovere"
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr "matematica"
+#~ msgid "maths"
+#~ msgstr "matematica"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr "muovere"
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "Mostrare o nascondire una grigia di coordinate polari."
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "Mostrare o nascondire una grigia di coordinate polari."
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "Pulire lo schermo e retornare le tartaruge per i suoi posizioni iniziali."
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "Pulire lo schermo e retornare le tartaruge per i suoi posizioni iniziali."
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr "muovere"
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr "Polare"
+#~ msgid "Polar"
+#~ msgstr "Polare"
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "Mostrare o nascondire una griglia di coordinate Cartesiane."
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "Mostrare o nascondire una griglia di coordinate Cartesiane."
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr "Aprire plugin da un file"
+#~ msgid "Load plugin from file"
+#~ msgstr "Aprire plugin da un file"
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr "Salva come .abc"
+#~ msgid "Save as .abc"
+#~ msgstr "Salva come .abc"
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr "cantare"
+#~ msgid "sing"
+#~ msgstr "cantare"
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr "Cinese"
+#~ msgid "Chinese"
+#~ msgstr "Cinese"
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr "muovere"
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr "Scarica"
+#~ msgid "Download"
+#~ msgstr "Scarica"
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr "Salva come svg"
+#~ msgid "Save as svg"
+#~ msgstr "Salva come svg"
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr "aggiungi filtro"
+#~ msgid "add filter"
+#~ msgstr "aggiungi filtro"
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr "Puoi anche utilizzare Alt+C per copiare una pila di blocchi."
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr "Puoi anche utilizzare Alt+C per copiare una pila di blocchi."
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr "Mostrare/nascondere tavolozze"
+#~ msgid "Show/hide palettes"
+#~ msgstr "Mostrare/nascondere tavolozze"
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr "rodi"
+#~ msgid "rodi"
+#~ msgstr "rodi"
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr "Puoi anche usare Alt+P per incollare una pila di blocchi."
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr "Puoi anche usare Alt+P per incollare una pila di blocchi."
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr "blocchi"
+#~ msgid "blocks"
+#~ msgstr "blocchi"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr "muovere"
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr "Pentatonica"
+#~ msgid "Pentatonic"
+#~ msgstr "Pentatonica"
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr "muovere"
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr "Opzioni avanzate"
+#~ msgid "Advanced options"
+#~ msgstr "Opzioni avanzate"
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr "muovere"
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr "Salva la partitura."
+#~ msgid "Save sheet music"
+#~ msgstr "Salva la partitura."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "Click per correre il progetto in modalità veloce."
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "Click per correre il progetto in modalità veloce."
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr "console"
+#~ msgid "shell"
+#~ msgstr "console"
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr "Pagina successiva"
+#~ msgid "Next page"
+#~ msgstr "Pagina successiva"
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr "Tieni premuto sui blocchi per copiarli."
+#~ msgid "Long press on blocks to copy."
+#~ msgstr "Tieni premuto sui blocchi per copiarli."
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr "muovere"
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr "Puoi anche utilizzare Alt+C per copiare una pila di blocchi."
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr "Puoi anche utilizzare Alt+C per copiare una pila di blocchi."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr "minore naturale"
+#~ msgid "natural-minor"
+#~ msgstr "minore naturale"
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr "Clicca qui per incollare"
+#~ msgid "Click here to paste"
+#~ msgstr "Clicca qui per incollare"
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr "Questo pulsante apre e chiude la barra di strumenti principali."
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr "Questo pulsante apre e chiude la barra di strumenti principali."
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr "tabella"
+#~ msgid "table"
+#~ msgstr "tabella"
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr "Salva come .tb"
+#~ msgid "Save as .tb"
+#~ msgstr "Salva come .tb"
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "Rimuovere tutti il contenuto del canovaccio, compreso i blocchi."
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "Rimuovere tutti il contenuto del canovaccio, compreso i blocchi."
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr "salvare svg"
+#~ msgid "save svg"
+#~ msgstr "salvare svg"
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr "Sul mio dispositivo"
+#~ msgid "On my device"
+#~ msgstr "Sul mio dispositivo"
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr "per esempio chitarra, piano, violino o violoncello"
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr "per esempio chitarra, piano, violino o violoncello"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr "esporta"
+#~ msgid "export"
+#~ msgstr "esporta"
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr "muovere"
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr "Salva come ABC"
+#~ msgid "Save as ABC"
+#~ msgstr "Salva come ABC"
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr "sintetizzatore"
+#~ msgid "synthesizer"
+#~ msgstr "sintetizzatore"
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr "muovere"
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr "Maggiore"
+#~ msgid "Major"
+#~ msgstr "Maggiore"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr "Disabilita lo scrolling"
+#~ msgid "Disable scrolling"
+#~ msgstr "Disabilita lo scrolling"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr "Spagnolo"
+#~ msgid "Spanish"
+#~ msgstr "Spagnolo"
 

--- a/po/ja-kana.po
+++ b/po/ja-kana.po
@@ -101,7 +101,7 @@ msgstr "アクション"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr "あひる"
 
@@ -168,7 +168,7 @@ msgstr "プロジェクトの コードを ひひょうじに する"
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "じぶんの プロジェクト"
 
@@ -182,33 +182,33 @@ msgid "Your recording is in progress."
 msgstr "ろくおんちゅう"
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "ファイルめい"
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "きょくめい"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "さっきょくか"
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "MIDIのアウトプット がくふにも まとめましょうか？"
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "ギターの TABも がくふに まとめましょうか？"
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "Lilypondがくふの フォーマットで ほぞん"
 
@@ -230,7 +230,7 @@ msgstr "Lilypondがくふの フォーマットで ほぞん"
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "ミスター・マウス"
 
@@ -308,7 +308,7 @@ msgstr "ほうがん（ざひょう）を ひょうじ"
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr "おんど"
 
@@ -537,8 +537,8 @@ msgstr "ブロックの ヘルプを ほぞん"
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "シ ラ ソ ファ ミ レ ド"
 
@@ -697,7 +697,7 @@ msgstr "リズムメーカー"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "ねいろ"
 
@@ -707,14 +707,14 @@ msgstr "かいだん"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "メトロノーム"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "おんかい"
 
@@ -745,7 +745,7 @@ msgstr "ドラム"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "リズムメーカー"
 
@@ -770,7 +770,7 @@ msgstr "リズムメーカー"
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "おとの ながさ"
 
@@ -779,7 +779,7 @@ msgstr "おとの ながさ"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "おんかいの じょうげ"
 
@@ -800,7 +800,7 @@ msgid "silence"
 msgstr "きゅうふ"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "した"
 
@@ -818,8 +818,8 @@ msgstr "うえ"
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "おとの たかさ"
 
@@ -921,7 +921,7 @@ msgstr "テノールきごう"
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "コントラバス"
 
@@ -1055,14 +1055,14 @@ msgstr "ブロックが えらばれて いません。"
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "ネズミへんこう"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "ねいろ サンプル"
 
@@ -1137,7 +1137,7 @@ msgstr "ドラム・スタート"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "おんぷ"
 
@@ -1173,7 +1173,7 @@ msgstr "じっこうてじゅん"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr "センサー"
 
@@ -1182,7 +1182,7 @@ msgstr "センサー"
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr "メディア"
 
@@ -1673,7 +1673,7 @@ msgstr "コンパイル かんりょう"
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "ダブルシャープ"
 
@@ -1685,8 +1685,8 @@ msgstr "ダブルシャープ"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "シャープ"
 
@@ -1696,7 +1696,7 @@ msgstr "シャープ"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "ナチュラル"
 
@@ -1708,8 +1708,8 @@ msgstr "ナチュラル"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "フラット"
 
@@ -1719,15 +1719,15 @@ msgstr "フラット"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "ダブルフラット"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr "ユニゾン（同度）"
 
@@ -1736,14 +1736,14 @@ msgstr "ユニゾン（同度）"
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "メジャー"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr "アイオニアン おんかい"
 
@@ -1752,14 +1752,14 @@ msgstr "アイオニアン おんかい"
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "マイナー（短）"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr "エオリアンおんかい"
 
@@ -1800,7 +1800,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "「ばいおん ウェート」ブロックの なかに ひとつ いじょうの ばいおん ブロックが はいっている ひつようが あります。"
 
@@ -1809,7 +1809,7 @@ msgid "synth cannot play chords."
 msgstr "この シンセでは わおんが できません。"
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr "https://github.com/sugarlabs/musicblocks/tree/master/guide-ja/music_blocks_operation_manual.pdf"
 
@@ -1826,7 +1826,7 @@ msgstr "けんさく"
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "ひょうし"
 
@@ -1895,8 +1895,8 @@ msgstr "そのた"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "プログラム"
 
@@ -1918,7 +1918,7 @@ msgstr "ろんり"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr "おんがく"
 
@@ -2204,7 +2204,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr "しょうきょ"
 
@@ -2535,21 +2535,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr "げん１４ど"
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "１ど 2ど 3ど 4ど 5ど 6ど 7ど 8ど 9ど 10ど 11ど 12ど"
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "オーギュメント（ぞう）"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "ディミニッシュ（げん）"
 
@@ -2558,12 +2558,12 @@ msgstr "ディミニッシュ（げん）"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "パーフェクト（かんぜん）"
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "クロマティック おんかい"
 
@@ -2576,62 +2576,62 @@ msgid "spanish"
 msgstr "スペイン おんかい"
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr "オクタトニック・スケール"
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "ハーモニック・メジャー（和声長おんかい）"
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "しぜんたん おんかい"
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "わせいたん おんかい"
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "せんりつたん おんかい"
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr "ドリアン おんかい"
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr "フリジアン おんかい"
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr "リディアン おんかい"
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "ミクソリディアン おんかい"
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr "ロクリアン おんかい"
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "オルタード おんかい"
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr "ビバップ おんかい"
 
@@ -2644,7 +2644,7 @@ msgid "byzantine"
 msgstr "ビザンティン"
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "ヴェルディのおんかい"
 
@@ -2653,7 +2653,7 @@ msgid "ethiopian"
 msgstr "エチオピアおんかい"
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "ゲエズ おんかい"
 
@@ -2666,7 +2666,7 @@ msgid "hungarian"
 msgstr "ハンガリー おんかい"
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "ルーマニア・マイナー おんかい"
 
@@ -2675,17 +2675,17 @@ msgid "spanish gypsy"
 msgstr "スパニッシュ・ジプシー おんかい"
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "マカーム おんかい"
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "マイナー・ブルース おんかい"
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr "メジャー・ブルース おんかい"
 
@@ -2694,12 +2694,12 @@ msgid "whole tone"
 msgstr "ホールトーン おんかい"
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "マイナー・ペンタトニック おんかい"
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "メジャー・ペンタトニックおんかい"
 
@@ -2712,7 +2712,7 @@ msgid "egyptian"
 msgstr "エジプト おんかい"
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "ひらじょうし"
 
@@ -2721,17 +2721,17 @@ msgid "Japan"
 msgstr "にほん"
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "いんおんかい"
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "みんよ おんかい"
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "フィボナッチ おんかい"
 
@@ -2748,56 +2748,56 @@ msgstr "フィボナッチ おんかい"
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr "オリジナル"
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr "ハイパス・フィルター"
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr "ローパス・フィルター"
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr "バンドパス・フィルター"
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr "ハイシェルフ・フィルター"
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr "ローシェルフ・フィルター"
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr "ノッチ・フィルター"
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr "オールパスフィルター"
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr "ピーク・フィルタ"
 
@@ -2805,7 +2805,7 @@ msgstr "ピーク・フィルタ"
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "サインは"
 
@@ -2813,7 +2813,7 @@ msgstr "サインは"
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "しかくの なみ"
 
@@ -2822,7 +2822,7 @@ msgstr "しかくの なみ"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "さんかくの なみ"
 
@@ -2830,7 +2830,7 @@ msgstr "さんかくの なみ"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "ぎざぎざの なみ"
 
@@ -2839,8 +2839,8 @@ msgstr "ぎざぎざの なみ"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr "ぐうすう"
 
@@ -2848,7 +2848,7 @@ msgstr "ぐうすう"
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr "きすう"
 
@@ -2862,116 +2862,116 @@ msgstr "おんかいてき"
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr "ピアノ"
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr "バイオリン"
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr "ビオラ"
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "もっきん"
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "てっきん"
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr "チェロ"
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr "ダブルベース"
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr "ギター"
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr "アコースティック"
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr "フルート"
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr "クラリネット"
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr "サクソフォン"
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr "チューバ"
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr "トランペット"
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr "オーボエ"
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr "トロンボーン"
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr "シンセサイザー"
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "シンプル１"
 
@@ -2990,19 +2990,19 @@ msgstr "シンプル４"
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr "ホワイト ノイズ"
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "ブラウンノイズ"
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "ピンクノイズ"
 
@@ -3010,61 +3010,61 @@ msgstr "ピンクノイズ"
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr "スネアドラム"
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr "キックドラム"
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr "タムタム"
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr "フロアタム"
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr "バスドラム"
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "カップドラム"
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr "ダブカドラム"
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr "ハイハット"
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr "ライドベル"
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr "カウベル"
 
@@ -3074,149 +3074,149 @@ msgstr "たいこ"
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr "しょう"
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr "トライアングル"
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr "フィンガー シンバル"
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "チャイム"
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr "ドラ"
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr "カチャカチャ"
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr "クラッシュ"
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr "あきびん"
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr "てびょうし"
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr "ピシャリ"
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr "しぶき"
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr "あわ"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr "あめのしずく"
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr "ねこ"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr "こおろぎ"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr "いぬ"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr "バンジョー"
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr "こと"
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr "ダルシマー"
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr "エレクトリック"
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr "バスーン"
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr "セレスタ"
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr "へいきん おんりつ"
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "ピタゴラス おんりつ "
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr "じゅんせいりつ"
 
@@ -3225,7 +3225,7 @@ msgstr "じゅんせいりつ"
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3304,22 +3304,22 @@ msgid "previous"
 msgstr "このまえの"
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "シンプル・シンセ２"
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "シンプル・シンセ３"
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "シンプル・シンセ４"
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr "たいこ"
 
@@ -3476,7 +3476,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "あたいを あらわす"
 
@@ -3498,7 +3498,7 @@ msgstr "キーワード"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "ちょう"
 
@@ -3509,7 +3509,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr "あたいを せってい"
 
@@ -3538,7 +3538,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "ドラムを おんぷに かえる"
 
@@ -3547,7 +3547,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "例の画像に<em>ソル</em>の代わりに<em>キックドラム</em>が鳴らします。"
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "ドラムを せってい"
 
@@ -3580,7 +3580,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "ヒープは から ですか？"
 
@@ -3590,7 +3590,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "からの ヒープ"
 
@@ -3599,7 +3599,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr "ヒープを ぎゃくに する"
 
@@ -3608,7 +3608,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "ヒープに ばんごうを ふる"
 
@@ -3631,13 +3631,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "ヒープを せってい する"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "インデックス"
 
@@ -3646,7 +3646,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "ポップ"
 
@@ -3655,7 +3655,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "プッシュ"
 
@@ -3675,7 +3675,7 @@ msgstr "おんりつを せってい"
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "オクターヴの たかさ"
 
@@ -3700,7 +3700,7 @@ msgid "current interval"
 msgstr "げんざいの おんかい"
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr "半おんかい的音程で計る"
 
@@ -3714,7 +3714,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr "全おんかい的音程で計る"
 
@@ -3724,7 +3724,7 @@ msgstr "例の画像には<em>ソル</em>が<em>ソル#</em>になります。"
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr "半おんかい的音程"
 
@@ -3762,7 +3762,7 @@ msgid "In the figure, we add la to sol."
 msgstr "<br><br>うえのず では、 ソの 「おんぷブロック」 を きじゅんに して、 「おんかいの じょうげブロック」の すうちを ２に せっていしている ので、 ソと、 ソから ２おん あがった シの おとが どうじに えんそうされる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr "ちょうを ていぎ する"
 
@@ -3771,7 +3771,7 @@ msgid "movable Do"
 msgstr "いどう ド"
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "おんかいの おんすう"
 
@@ -3784,18 +3784,18 @@ msgid "Most Western scales have 7 notes."
 msgstr "<br>せいようの ほとんどの おんかいは、 7つの おとを もつ。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。<br><br>たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "げんだいの おんかい"
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr "げんだいの ちょう"
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "ちょうをせってい"
 
@@ -3916,7 +3916,7 @@ msgstr "スラーの ながさ ファクター"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr "おとを くわえる"
 
@@ -3935,7 +3935,7 @@ msgstr "スラー"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "スタッカート"
 
@@ -3944,7 +3944,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr "アプリから ヒープを ロード"
 
@@ -3961,7 +3961,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr "アプリに ヒープを ほぞん"
 
@@ -3974,7 +3974,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "ヒープを ロード する"
 
@@ -4003,7 +4003,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "じしょを ロードする"
 
@@ -4026,7 +4026,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr "じしょを せってい"
 
@@ -4043,7 +4043,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "ヒープを ほぞん する"
 
@@ -4052,7 +4052,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr "じしょを せってい"
 
@@ -4069,7 +4069,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr "ブロックを けす"
 
@@ -4078,7 +4078,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr "ブロックを うごかす"
 
@@ -4112,7 +4112,7 @@ msgid "y"
 msgstr "yざひょう（たて）"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr "ブロックを じっこう"
 
@@ -4121,7 +4121,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr "ブロックを つなぐ"
 
@@ -4138,7 +4138,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr "ブロックを つくる"
 
@@ -4153,7 +4153,7 @@ msgstr "ブロックを つくる"
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "おんぷ"
 
@@ -4187,12 +4187,12 @@ msgstr "おとの ながさは、 0より おおきい あたいを せってい
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "スイング"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "スイングの すうち"
 
@@ -4201,12 +4201,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "おんぷの省略"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "おんかを ～ばいにする ファクター"
 
@@ -4215,13 +4215,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr "<h2>タイブロック</h2><br>２つの おとを つなげて １つの おとに する。 「おとのたかさブロック」 を いれて つかう。 おなじ たかさの おとだけ、 つなぐことが できる。"
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "タイ"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "ふてんおんぷ"
 
@@ -4239,7 +4239,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr "おんぷ（ドラム）"
 
@@ -4271,8 +4271,8 @@ msgstr "オクターヴ・スペース"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "れんぷ（かけ算）"
 
@@ -4328,7 +4328,7 @@ msgstr "ぜんおんぷ"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "～れんぷ（タプル）"
 
@@ -4485,12 +4485,12 @@ msgid "duplicate factor"
 msgstr "複製ファクター"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr "げんだいの びょうし"
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "はくを ～ばいにする ファクター"
 
@@ -4500,8 +4500,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "１ぷんあたりの はくのかず"
 
@@ -4509,12 +4509,12 @@ msgstr "１ぷんあたりの はくのかず"
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "スピードを きめる"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr "しょうせつの かず"
 
@@ -4523,7 +4523,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr "はくの いち"
 
@@ -4540,7 +4540,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr " たとえば、 かくしょうせつの ３はくめに なにか アクション・イベントを おこしたいときなどに つかう。"
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr "おとの ながさを たす"
 
@@ -4550,12 +4550,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr "おんぷの ごうけい すう"
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr "さいせい された ぜんおんぷの かず"
 
@@ -4565,7 +4565,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr "ぜんたいの はくの かず"
 
@@ -4574,7 +4574,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr "<em>クロックなし</em>ブロックはそれぞれの動作の順番をリズムより優先します。"
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "クロックなし"
 
@@ -4624,7 +4624,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr "ぜんたいの スピードを きめる"
 
@@ -4657,7 +4657,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr "<h2>スピードを きめるブロック</h2><br>１ぷんあたりの はくの かずを せってい することで、 きょくの スピードを きめる。 ひょうじゅんは ４ぶおんぷ ９０こ。<br><br>★はくとは<br>くりかえされる リズムのこと。"
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr "ピックアップ"
 
@@ -4666,12 +4666,12 @@ msgid "number of beats"
 msgstr "はくの かず"
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "いちょう"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr "おんかい内で~度下がる:"
 
@@ -4680,7 +4680,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr "おんかい内で~度上がる:"
 
@@ -4689,7 +4689,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr "おんていの ちがい"
 
@@ -4698,7 +4698,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr "<em>音程の違い</em>ブロックは現在に鳴らされている音高と現在のちょうど前に鳴らされている音高（半おとの値で）の違いです。"
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr "おんかいに よって おんていの ちがい"
 
@@ -4709,8 +4709,8 @@ msgstr "おんかいに よって おんていの ちがい"
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr "おとのたかさを かずでひょうじ"
 
@@ -4720,7 +4720,7 @@ msgstr "<h2>おとのたかさを かずでひょうじ ブロック</h2><br>お
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr "おとのたかさを ヘルツで ひょうじ"
 
@@ -4746,7 +4746,7 @@ msgid "alphabet"
 msgstr "アルファベット"
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr "アルファベット・クラス"
 
@@ -4784,12 +4784,12 @@ msgstr "おとのたかさをいろに"
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr "MIDI"
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr "音高の数字を初期化"
 
@@ -4801,12 +4801,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "なまえ"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "すうじを おんめいへ"
 
@@ -4815,7 +4815,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "すうちをオクターヴ表記へ"
 
@@ -4861,22 +4861,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "てんかいを (きすう)"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "てんかいを (ぐうすう)"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr "登録"
 
@@ -4885,7 +4885,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -4898,7 +4898,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr "例の画像に<em>ソル</em>が<em>ソル#</em>に上に移動されています。"
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr "はんおんで いちょう"
 
@@ -4907,47 +4907,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr "「ひで いどう」ブロックは おんぷの なかの ピッチを ひで いどうさせる。"
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr "ひで いどう"
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr "おんかいで6ど した"
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr "おんかいで3ど した"
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr "7どの おと"
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr "6どの おと"
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr "5どの おと"
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr "４どの おと"
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr "3どの おと"
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr "2どの おと"
 
@@ -4960,7 +4960,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr "<br><br>ずのれいでは、 ソがラに、 ラがシに、 シがドに… と おきかえられている。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。<br>★ちょうとは<br>ちゅうしんてきな やくわりを はたすおとと、 おんかいの しゅるいによって きまる、 きょくの かんじ。 ちゅうしんてきな やくわりを はたすおと だけを  さすこともある。"
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr "ちょうを かえる"
 
@@ -4969,7 +4969,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr "<em>変化記号</em>ブロックは <em>シャープ(嬰)</em>と<em>フラット(変)</em>を決めるきのうです。"
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr "へんかきごう　むし"
 
@@ -4977,7 +4977,7 @@ msgstr "へんかきごう　むし"
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr "ヘルツ"
 
@@ -4991,8 +4991,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr "ピッチど"
 
@@ -5021,7 +5021,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr "おんかいないを のぼる／おりる"
 
@@ -5046,14 +5046,14 @@ msgstr "オシレータ―"
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr "しゅるい"
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr "ばいおん"
 
@@ -5063,7 +5063,7 @@ msgstr "ふくすうの オシレーター ブロックを ついか してい�
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr "シーケンサーこみ シンセ"
 
@@ -5082,7 +5082,7 @@ msgstr "ビブラート エフェクタの きょうど"
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr "AM シンセ"
 
@@ -5092,7 +5092,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr "FM シンセ"
 
@@ -5109,17 +5109,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr "ばいおんの ウェートは ０と １の あいだ である ひつようが あります。"
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr "ばいおん ブロック が「ばいおん ウェート ブロック」の なかに ある ひつようが あります。"
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr "ウェートばいおん"
 
@@ -5128,7 +5128,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr "ハーモニックス"
 
@@ -5138,7 +5138,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr "ディストーション"
 
@@ -5148,7 +5148,7 @@ msgstr "<h2>トレモロ ブロック</h2><br>ゆれるような おとの ひ�
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr "トレモロ"
 
@@ -5160,7 +5160,7 @@ msgstr "トレモロ"
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr "はやさ"
 
@@ -5168,7 +5168,7 @@ msgstr "はやさ"
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr "おおきさ"
 
@@ -5178,7 +5178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr "フェーザー"
 
@@ -5199,7 +5199,7 @@ msgstr "<h2>コーラス ブロック</h2><br>ひろがりの ある おとの �
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr "コーラス"
 
@@ -5214,7 +5214,7 @@ msgstr "<h2>ビブラートブロック</h2><br>おとの たかさに こきざ
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr "ビブラート"
 
@@ -5224,7 +5224,7 @@ msgid "intensity"
 msgstr "おおきさ"
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr "シンセを せってい"
 
@@ -5238,7 +5238,7 @@ msgstr "ねいろひょうじゅんを せってい"
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr "ねいろを せってい"
 
@@ -5294,7 +5294,7 @@ msgstr "けいさん する"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr "<h2>アクションブロック（してい）</h2><br>していした アクションブロックを じっこうする。"
 
@@ -5472,7 +5472,7 @@ msgid "Cannot find start block"
 msgstr "「スタート」ブロックが みつかりません。"
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "ネズミの いろ"
 
@@ -5481,7 +5481,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -5490,7 +5490,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "ネズミの すすむ かくど"
 
@@ -5499,7 +5499,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -5509,13 +5509,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr "ネズミを せってい"
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "ネズミの yざひょう"
 
@@ -5537,7 +5537,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "ネズミののy座標"
 
@@ -5546,7 +5546,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "ネズミの xざひょう"
 
@@ -5555,7 +5555,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "ネズミのx座標"
 
@@ -5564,7 +5564,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "ネズミの えんそうした おんぷの かず"
 
@@ -5573,7 +5573,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -5582,7 +5582,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "ネズミの音高数字"
 
@@ -5591,7 +5591,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -5601,17 +5601,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr "ネズミの おんか"
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "ネズミを どうき させる"
 
@@ -5620,7 +5620,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -6047,7 +6047,7 @@ msgid "wrap"
 msgstr "まきつける"
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr "ざひょうち（みぎ）"
 
@@ -6057,7 +6057,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの みぎはし の ｘざひょうち。 プラスの すうち。カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "ざひょうち （ひだり）"
 
@@ -6101,12 +6101,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの たてはば の すうちを あらわす。 カンバスの じょうほうを もつ すうちブロックは、 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "ていし"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr "メディアを けす"
 
@@ -6115,7 +6115,7 @@ msgid "The Erase Media block erases text and images."
 msgstr "「メディアを けす」ブロックは もじと がぞうを けします。"
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "プレーバック"
 
@@ -6172,7 +6172,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "おんぷの たかさを しゅうはすう ひょうじへ"
 
@@ -6190,7 +6190,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "おおきさ"
 
@@ -6203,7 +6203,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr "<h2>ひょうじブロック（スタンプ）</h2><br>スタンプは、 じっこうすると ネズミの いちに してい した もじ または がぞう を ひょうじする。 ネズミの からだの したに あらわれるので、 ちいさいもじ や がぞう だと ネズミがいどうしないと みえない ばあいがある。"
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "スタンプ"
 
@@ -6268,7 +6268,7 @@ msgstr "きにゅうを おわらせる"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "はいけい"
 
@@ -6333,7 +6333,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "（ちゅうくうの）せん"
 
@@ -6342,12 +6342,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr "<h2>ペンブロック</h2><br>ネズミが えがいた ずけいの うちがわを ぬりつぶす。"
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "ぬりつぶす"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "ペンを あげる"
 
@@ -6356,7 +6356,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "<h2>ペンブロック</h2><br>ネズミの うごきに あわせて せんを えがくことを やめる。"
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "ペンを おろす"
 
@@ -6365,7 +6365,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "<h2>ペンブロック</h2><br>ネズミの うごきに あわせて せんを えがく。"
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "ふとさを せってい"
 
@@ -6374,7 +6374,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr "<h2>ペンブロック</h2><br>ネズミが えがく せんの ふとさを かえる。 ふとさには、 0より おおきい あたいを つかう。"
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "透明度をせってい"
 
@@ -6399,7 +6399,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr "<h2>ペンブロック</h2><br>ネズミが えがく せんの いろの こさを せっていする。"
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "はいいろを せってい"
 
@@ -6534,27 +6534,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr "エンベロープ"
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "アタック"
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "ディケイ"
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "サステイン"
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "リリース"
 
@@ -6580,18 +6580,18 @@ msgstr "封筒ブロックを複数追加しています。"
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr "フィルター"
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr "ロールオフ"
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr "ロールオフ あたいは -12, -24, -48, -98 デシベル / オクターヴ である ひつようが あります。"
 
@@ -6606,7 +6606,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr "ねいろサンプルを アップロードして、 おとの たかさを あわせる"
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "サンプラー"
 
@@ -6627,7 +6627,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr "<h2>モード（おんかい）ブロック</h2><br>いろいろな ちょうを さがす ツールを ひょうじする。おんかいは、 おとと おとの かんかくを きめながら さがすことが できる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "おんかい"
 
@@ -6644,7 +6644,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "音高-ドラム・マッパー"
 
@@ -6657,7 +6657,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr "<h2>ヘルツスライダーブロック</h2><br>スライダーを じょうげに うごかすことで、 ちがう しゅうはすう（ヘルツのすうち） の おとを きくことが できる。 つくった おとを データに することが できる。また、 ヘルツの しょきせっていち は じゆうに かえられる。<br>★ヘルツとは<br>おとの たかさを あらわす しゅうはすう。<br>★しゅうはすうとは<br>おとが １びょうかん に なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。"
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "ヘルツスライダー"
 
@@ -6667,7 +6667,7 @@ msgstr "クロマティック キーボード"
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr "キーボード"
 
@@ -6681,7 +6681,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "音高の数列を作る"
 
@@ -6702,7 +6702,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr "<h2>フレーズメーカーブロック</h2><br>フレーズを つくるための テーブルを  ひょうじする。 つくった フレーズを データに することが できる。<br><br>"
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "フレーズメーカー"
 
@@ -6716,7 +6716,7 @@ msgstr "<h2>じっこうじょうきょうブロック</h2><br>ブロックの�
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr "AIおんがく"
 
@@ -6903,7 +6903,7 @@ msgstr "ビブラートの はやさは、 0より おおきい あたいを せ
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr "（エフェクタの）ふかさの すうじが へんいきがい です。"
 
@@ -6912,7 +6912,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr "ディストーションは、 0から 100までの はんいで せってい して ください。"
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr "ばいおんが ０いじょう である ひつようが あります。"
 
@@ -7034,7 +7034,7 @@ msgid "Undo"
 msgstr "１つもどす"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr "クリックでおとのたかさを選んでちょうをせっていできます。"
 
@@ -7117,7 +7117,7 @@ msgid "Save drum machine"
 msgstr "ドラム として ほぞん"
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr "リズムをタップする"
 
@@ -7167,7 +7167,7 @@ msgid "Playback"
 msgstr "さいせい"
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr "さんしょうピッチ"
 
@@ -7284,7 +7284,7 @@ msgstr "シンセサイザー"
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr "こうかおん"
 
@@ -7363,48 +7363,48 @@ msgid "Cannot connect to server"
 msgstr "サーバに せつぞく できません"
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr "すべての プロジェクト"
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr "じぶんの プロジェクト"
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr "プロジェクトの みほん"
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr "アート"
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr "さんすう"
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr "インタラクティブ"
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr "デザイン"
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr "ゲーム"
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr "みじかいコード"
 
@@ -7837,38 +7837,38 @@ msgstr "動き出し"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr "プロジェクトの おとを WAVで ほぞん"
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr "プロジェクトの おとを WAVで ほぞん"
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr "プロジェクトを ABCがくふで ほぞん"
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr "プロジェクトを ABCがくふで ほぞん"
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "さくせいした おんがくを、 コンピューターじょうで がくふ をえがく ファイル（Lilypondファイル）に かえて ほぞんする。"
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "さくせいした おんがくを、 コンピューターじょうで がくふ をえがく ファイル（Lilypondファイル）に かえて ほぞんする。"
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr "カンバスじょうに ほうがん（ざひょう）や ちゅうしんの かくどを ひょうじしたり、かくしたりできる。"
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr "カンバスじょうに ほうがん（ざひょう）や ちゅうしんの かくどを ひょうじしたり、かくしたりできる。"
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr "ブロックをひろげる/おりたたむ"
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr "ブロックをひろげる/おりたたむ"
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "ミスター・マウスによる、 ミュージック・ブロックスの せつめいを ひょうじする。"
+#~ msgid "Show these messages."
+#~ msgstr "ミスター・マウスによる、 ミュージック・ブロックスの せつめいを ひょうじする。"
 
 #: js/rubrics.js:531
 
@@ -7876,8 +7876,8 @@ msgstr "動き出し"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "センサー"
+#~ msgid "sensors"
+#~ msgstr "センサー"
 
 #: js/rubrics.js:532
 
@@ -7887,8 +7887,8 @@ msgstr "動き出し"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "ほかのメディア"
+#~ msgid "media"
+#~ msgstr "ほかのメディア"
 
 #: js/block-verbose.js:3837
 
@@ -7900,35 +7900,35 @@ msgstr "動き出し"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr "うがんざひょうと きょくざひょうを ひょうじ"
+#~ msgid "Cartesian+polar"
+#~ msgstr "うがんざひょうと きょくざひょうを ひょうじ"
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "ひょうじする"
+#~ msgid "show"
+#~ msgstr "ひょうじする"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr "ブロックを ひょうじする/かくす"
+#~ msgid "Show/hide block"
+#~ msgstr "ブロックを ひょうじする/かくす"
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "グリッド"
+#~ msgid "grid"
+#~ msgstr "グリッド"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr "へんかきごうは"
+#~ msgid "You have chosen key "
+#~ msgstr "へんかきごうは"
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr "のおんかいによってしています。"
+#~ msgid " for your pitch preview."
+#~ msgstr "のおんかいによってしています。"
 
 #: js/toolbar.js:113
 
@@ -7942,69 +7942,69 @@ msgstr "動き出し"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr "フルスクリーン"
+#~ msgid "Full Screen"
+#~ msgstr "フルスクリーン"
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr "しんき さくせい"
+#~ msgid "New Project"
+#~ msgstr "しんき さくせい"
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr "おんがく"
+#~ msgid "music"
+#~ msgstr "おんがく"
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr "ほぞん する"
+#~ msgid "save"
+#~ msgstr "ほぞん する"
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "ネズミと ペンを もどす"
+#~ msgid "Clean"
+#~ msgstr "ネズミと ペンを もどす"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "ゆっくりじっこうする"
+#~ msgid "Run slow"
+#~ msgstr "ゆっくりじっこうする"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr "ちゅうぜん おんりつ"
+#~ msgid "meantone"
+#~ msgstr "ちゅうぜん おんりつ"
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr "オリジナル"
+#~ msgid "Custom"
+#~ msgstr "オリジナル"
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "ブロックを ひひょうじ"
+#~ msgid "hide blocks"
+#~ msgstr "ブロックを ひひょうじ"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr "複製する"
+#~ msgid "duplicate"
+#~ msgstr "複製する"
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8024,13 +8024,13 @@ msgstr "動き出し"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "止める"
+#~ msgid "stop"
+#~ msgstr "止める"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "ながさ（ミリびょう）"
+#~ msgid "duration (ms)"
+#~ msgstr "ながさ（ミリびょう）"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8038,58 +8038,58 @@ msgstr "動き出し"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "１つもどす"
+#~ msgid "clear"
+#~ msgstr "１つもどす"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "両ほうこうにずれる"
+#~ msgid "invert"
+#~ msgstr "両ほうこうにずれる"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr "オシレータ―"
+#~ msgid "oscillator"
+#~ msgstr "オシレータ―"
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr "ずれ"
+#~ msgid "delay"
+#~ msgstr "ずれ"
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr "エンベロープ"
+#~ msgid "envelope"
+#~ msgstr "エンベロープ"
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr "フィルター"
+#~ msgid "filter"
+#~ msgstr "フィルター"
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr "AIおんがく"
+#~ msgid "aimusic"
+#~ msgstr "AIおんがく"
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -8105,25 +8105,25 @@ msgstr "動き出し"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr "あたらしいアクションを つくりました！"
+#~ msgid "New action block generated!"
+#~ msgstr "あたらしいアクションを つくりました！"
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr "ろくおんちゅう"
+#~ msgid "Recording started..."
+#~ msgstr "ろくおんちゅう"
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr "ろくおんかんりょう"
+#~ msgid "Recording complete..."
+#~ msgstr "ろくおんかんりょう"
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "きかんのせってい"
+#~ msgid "duration"
+#~ msgstr "きかんのせってい"
 
 #: js/widgets/temperament.js:454
 
@@ -8133,1094 +8133,1095 @@ msgstr "動き出し"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr "しゅうりょう"
+#~ msgid "close"
+#~ msgstr "しゅうりょう"
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr "プロジェクトを こうかい する"
+#~ msgid "Publish Project"
+#~ msgstr "プロジェクトを こうかい する"
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr "じっこう"
+#~ msgid "play"
+#~ msgstr "じっこう"
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr "Lilypondでは この ピックアップを たいおう できません："
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr "Lilypondでは この ピックアップを たいおう できません："
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr "はってんモードに するには、 ブラウザを こうしん して下さい。"
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr "はってんモードに するには、 ブラウザを こうしん して下さい。"
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr "かんたんモードに するには、 ブラウザを こうしん してください"
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr "かんたんモードに するには、 ブラウザを こうしん してください"
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr "JavaScriptへんしゅうをオン／オフ"
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr "JavaScriptへんしゅうをオン／オフ"
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr "おんかいうちを あがる／おりるブロックは、 おんぷブロックの なかに いれて つかって ください。"
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr "おんかいうちを あがる／おりるブロックは、 おんぷブロックの なかに いれて つかって ください。"
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr "おんかいうちを あがる／おりるブロックは、 おとの たかさ ブロックの あとに つかってください。"
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr "おんかいうちを あがる／おりるブロックは、 おとの たかさ ブロックの あとに つかってください。"
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr "<br><br>３連符（れんぷ）や５連符（れんぷ）など、２の倍数ではない音符（おんぷ）の数でグループを作りやすくなる。"
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr "<br><br>３連符（れんぷ）や５連符（れんぷ）など、２の倍数ではない音符（おんぷ）の数でグループを作りやすくなる。"
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr "<h2>おんりつを せってい ブロック</h2><br>ミュージックブロックスで もちいる おんかいの ちょうりつのしかた を せっていする。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。<br>★ちょうりつとは<br>がっきの おとのたかさを、 おんりつに したがって ととのえること。<br>★おんりつとは<br>おんてい （おとどうしの へだたり） の きめかた。 おなじ おんかい でも、 おんりつに よって おとの たかさが かわる。<br>★オクターヴの たかさとは<br>おなじ なまえでも たかさがちがう おとを あらわす すうち。"
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr "<h2>おんりつを せってい ブロック</h2><br>ミュージックブロックスで もちいる おんかいの ちょうりつのしかた を せっていする。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。<br>★ちょうりつとは<br>がっきの おとのたかさを、 おんりつに したがって ととのえること。<br>★おんりつとは<br>おんてい （おとどうしの へだたり） の きめかた。 おなじ おんかい でも、 おんりつに よって おとの たかさが かわる。<br>★オクターヴの たかさとは<br>おなじ なまえでも たかさがちがう おとを あらわす すうち。"
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr "「おんていを かずで ひょうじ」ブロックは おんかいの かずを けいさんして ひょうじする"
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr "「おんていを かずで ひょうじ」ブロックは おんかいの かずを けいさんして ひょうじする"
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr "<em>半おんかい的音程</em>ブロックはちょうを無視、半音であたらしい音高をけいさんして鳴らします。"
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr "<em>半おんかい的音程</em>ブロックはちょうを無視、半音であたらしい音高をけいさんして鳴らします。"
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr "「アルペジオ」ブロックは 「おんぷ」ブロックを かいすう さいせいして、コードによって へんかします。"
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr "「アルペジオ」ブロックは 「おんぷ」ブロックを かいすう さいせいして、コードによって へんかします。"
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr "<h2>おんかいの じょうげ ブロック</h2><br>なかに くみいれる 「おんぷブロック」の おとを きじゅんにして、 べつの おとを つけくわえる。"
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr "<h2>おんかいの じょうげ ブロック</h2><br>なかに くみいれる 「おんぷブロック」の おとを きじゅんにして、 べつの おとを つけくわえる。"
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree o The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr "<h2>アクションブロック</h2><br>ふくすうの ブロックを １つの グループとして まとめ、 じっこうする。グループと なった プログラムは、 １つの「アクション」として じゆうに なまえを つけることが できる。"
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree o The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr "<h2>アクションブロック</h2><br>ふくすうの ブロックを １つの グループとして まとめ、 じっこうする。グループと なった プログラムは、 １つの「アクション」として じゆうに なまえを つけることが できる。"
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr "<h2>しんぎブロック（だい なり）</h2><br>２つの すうちをくらべて、 すうちの だいしょうを はんてい する。「＞」は うえの すうちが したの すうちよりも おおきければ 「しん（しん）」、 したの すうちと おなじか ちいさければ 「にせ（ぎ）」という けっかになる。<br><br>★しんぎブロックとは<br>「もし～ならば」などの じょうけんブロックを うごかすために ひつような ブロック。<br>「もし～ならば」は、 せいかくに ひょうげんすると、 「もし～という じょうけんが ただしい ならば、 つぎの ブロックを じっこうする」という いみ である。 しんぎブロックは ふとうしき などによる ひかくが 「ただしい（しん）」か、 「ただしくない（にせ）」かの けっかを あらわし、 「もし～ならば」に つづく ブロックを じっこうするか どうか きめる。"
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr "<h2>しんぎブロック（だい なり）</h2><br>２つの すうちをくらべて、 すうちの だいしょうを はんてい する。「＞」は うえの すうちが したの すうちよりも おおきければ 「しん（しん）」、 したの すうちと おなじか ちいさければ 「にせ（ぎ）」という けっかになる。<br><br>★しんぎブロックとは<br>「もし～ならば」などの じょうけんブロックを うごかすために ひつような ブロック。<br>「もし～ならば」は、 せいかくに ひょうげんすると、 「もし～という じょうけんが ただしい ならば、 つぎの ブロックを じっこうする」という いみ である。 しんぎブロックは ふとうしき などによる ひかくが 「ただしい（しん）」か、 「ただしくない（にせ）」かの けっかを あらわし、 「もし～ならば」に つづく ブロックを じっこうするか どうか きめる。"
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr "<h2>しんぎブロック（しょう なり）</h2><br>２つの すうちをくらべて、 すうちの だいしょうを はんてい する。 「＜」は うえの すうちが したの すうちよりも ちいさければ 「しん（しん）」、 したの すうちと おなじか おおきければ 「にせ（ぎ）」という けっかになる。<br><br>★しんぎブロックとは<br>「もし～ならば」などの じょうけんブロックを うごかすために ひつような ブロック。<br>「もし～ならば」は、 せいかくに ひょうげんすると、 「もし～という じょうけんが ただしい ならば、 つぎの ブロックを じっこうする」という いみ である。 しんぎブロックは ふとうしき などによる ひかくが 「ただしい（しん）」か、 「ただしくない（にせ）」かの けっかを あらわし、 「もし～ならば」に つづく ブロックを じっこうするか どうか きめる。"
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr "<h2>しんぎブロック（しょう なり）</h2><br>２つの すうちをくらべて、 すうちの だいしょうを はんてい する。 「＜」は うえの すうちが したの すうちよりも ちいさければ 「しん（しん）」、 したの すうちと おなじか おおきければ 「にせ（ぎ）」という けっかになる。<br><br>★しんぎブロックとは<br>「もし～ならば」などの じょうけんブロックを うごかすために ひつような ブロック。<br>「もし～ならば」は、 せいかくに ひょうげんすると、 「もし～という じょうけんが ただしい ならば、 つぎの ブロックを じっこうする」という いみ である。 しんぎブロックは ふとうしき などによる ひかくが 「ただしい（しん）」か、 「ただしくない（にせ）」かの けっかを あらわし、 「もし～ならば」に つづく ブロックを じっこうするか どうか きめる。"
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "<br>ずのれいでは、 みぎむきに すすみ つづける ネズミが カンバスの うたん から はみでると、 カンバスの ひだりはし から でてくる。"
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "<br>ずのれいでは、 みぎむきに すすみ つづける ネズミが カンバスの うたん から はみでると、 カンバスの ひだりはし から でてくる。"
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "<br>ずのれいでは、 うわむきに すすみ つづける ネズミが カンバスの じょうたん から はみでると、 カンバスの かたん から でてくる。"
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "<br>ずのれいでは、 うわむきに すすみ つづける ネズミが カンバスの じょうたん から はみでると、 カンバスの かたん から でてくる。"
 
-#~msgid "video material"
-#~msgstr "がぞうそざい"
+#~ msgid "video material"
+#~ msgstr "がぞうそざい"
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr "<h2>ドラムを せってい ブロック</h2><br>「おんぷブロック」 ないの おとを、 ドラムの おとに おきかえる。<br>ずのれいでは、 ソの おとの かわりに、 キックドラムの おとが えんそうされる。"
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr "<h2>ドラムを せってい ブロック</h2><br>「おんぷブロック」 ないの おとを、 ドラムの おとに おきかえる。<br>ずのれいでは、 ソの おとの かわりに、 キックドラムの おとが えんそうされる。"
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr "<h2>おとのながさ ブロック</h2><br>おとの ながさを ひょうじする。<br>"
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr "<h2>おとのながさ ブロック</h2><br>おとの ながさを ひょうじする。<br>"
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr "<h2>きゅうふブロック</h2><br>おとがない ぶぶんに つかわれる。<br>★きゅうふとは<br>やすみのながさ。"
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr "<h2>きゅうふブロック</h2><br>おとがない ぶぶんに つかわれる。<br>★きゅうふとは<br>やすみのながさ。"
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr "<h2>じょうけんブロック</h2><br>じょうけんブロックを つかうと、 じょうけんによって ちがう はたらきをする プログラムを つくることが できる。 "
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr "<h2>じょうけんブロック</h2><br>じょうけんブロックを つかうと、 じょうけんによって ちがう はたらきをする プログラムを つくることが できる。 "
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr "<br><br>ずのれい では、 もし、 パソコンのマウスを ながおし していれば 「スネアドラム」ブロックを えんそうする。ながおし していなければ（そうでなければ）「キックドラム」ブロック をえんそう する。"
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr "<br><br>ずのれい では、 もし、 パソコンのマウスを ながおし していれば 「スネアドラム」ブロックを えんそうする。ながおし していなければ（そうでなければ）「キックドラム」ブロック をえんそう する。"
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr "<br><br>ずのれいは 「アクション」の じっこうを くりかえす。"
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr "<br><br>ずのれいは 「アクション」の じっこうを くりかえす。"
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr "<h2>いどう ブロック</h2><br>ネズミの いちを、 してい した おおきさ と かくど の えん をえがいて いどう させる。 かくどの すうちは、 プラスだと みぎまわり、 マイナスだと ひだりまわり になる。"
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr "<h2>いどう ブロック</h2><br>ネズミの いちを、 してい した おおきさ と かくど の えん をえがいて いどう させる。 かくどの すうちは、 プラスだと みぎまわり、 マイナスだと ひだりまわり になる。"
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr "<h2>いどうブロック</h2><br>ネズミの むきを、 してい した すうち の かくどに かえる。"
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr "<h2>いどうブロック</h2><br>ネズミの むきを、 してい した すうち の かくどに かえる。"
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr "<h2>スラーブロック</h2><br>おとと つぎのおとを、 なめらかに つなげる。 ただし、 「おんぷブロック」 で せっていした おとの ながさは かわらない。"
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr "<h2>スラーブロック</h2><br>おとと つぎのおとを、 なめらかに つなげる。 ただし、 「おんぷブロック」 で せっていした おとの ながさは かわらない。"
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr "<h2>スタッカート ブロック</h2><br>おとを みじかく きる。 ただし、 「おんぷブロック」 で せっていした おとの ながさは かわらない。"
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr "<h2>スタッカート ブロック</h2><br>おとを みじかく きる。 ただし、 「おんぷブロック」 で せっていした おとの ながさは かわらない。"
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr "<h2>デクレシェンドブロック</h2><br>おんりょうを だんだん ちいさくする。"
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "<h2>デクレシェンドブロック</h2><br>おんりょうを だんだん ちいさくする。"
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr "<br>たとえば、 ７つの おとに、 すうちが ５の  「デクレシェンドブロック」 を つかうと、 １おんごとに さいしょの おとの おんりょうの ５パーセントずつ おんりょうが へり、 さいごの おとは さいしょの おとよりも ３５パーセント おんりょうが ちいさくなる。"
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr "<br>たとえば、 ７つの おとに、 すうちが ５の  「デクレシェンドブロック」 を つかうと、 １おんごとに さいしょの おとの おんりょうの ５パーセントずつ おんりょうが へり、 さいごの おとは さいしょの おとよりも ３５パーセント おんりょうが ちいさくなる。"
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr "<h2>クレシェンド ブロック</h2><br>おんりょうを だんだん おおきくする。"
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "<h2>クレシェンド ブロック</h2><br>おんりょうを だんだん おおきくする。"
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr "<br>たとえば、 ７つの おとに、 すうちが ５の 「クレシェンドブロック」 を つかうと、 １おんごとに さいしょの おとの おんりょうの ５パーセントずつ おんりょうが ふえ、 さいごの おとは さいしょの おとよりも ３５パーセント おんりょうが おおきくなる。"
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr "<br>たとえば、 ７つの おとに、 すうちが ５の 「クレシェンドブロック」 を つかうと、 １おんごとに さいしょの おとの おんりょうの ５パーセントずつ おんりょうが ふえ、 さいごの おとは さいしょの おとよりも ３５パーセント おんりょうが おおきくなる。"
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr "「ねいろひょうじゅんを せってい」ブロックは ねいろの デフォルトを 「シンセサイザー」から おこのみの がっきに せっていします。"
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr "「ねいろひょうじゅんを せってい」ブロックは ねいろの デフォルトを 「シンセサイザー」から おこのみの がっきに せっていします。"
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr "<br>ずのれいでは、 それぞれの しょうせつの１ぱくめに、 とくていの アクション・イベントを おこしている。<br><br>★はくとは<br>くりかえされる リズムのこと。<br>★しょうせつとは<br>がくふの、 たての せんで くぎられた ぶぶん。 しょうせつの なかの はくは、 ひょうしと おなじかずに なる。"
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr "<br>ずのれいでは、 それぞれの しょうせつの１ぱくめに、 とくていの アクション・イベントを おこしている。<br><br>★はくとは<br>くりかえされる リズムのこと。<br>★しょうせつとは<br>がくふの、 たての せんで くぎられた ぶぶん。 しょうせつの なかの はくは、 ひょうしと おなじかずに なる。"
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr "<br><br>★はくとは<br>くりかえされる リズムのこと。"
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr "<br><br>★はくとは<br>くりかえされる リズムのこと。"
 
-#~msgid "More Details"
-#~msgstr "しょうさい"
+#~ msgid "More Details"
+#~ msgstr "しょうさい"
 
-#~msgid "Share project"
-#~msgstr "プロジェクトを シェア する"
+#~ msgid "Share project"
+#~ msgstr "プロジェクトを シェア する"
 
-#~msgid "Copy link to clipboard"
-#~msgstr "リンクを クリップボードに コピー する"
+#~ msgid "Copy link to clipboard"
+#~ msgstr "リンクを クリップボードに コピー する"
 
-#~msgid "Run project on startup."
-#~msgstr "スタートしたら プロジェクトを さいせい する"
+#~ msgid "Run project on startup."
+#~ msgstr "スタートしたら プロジェクトを さいせい する"
 
-#~msgid "Show code blocks on startup."
-#~msgstr "スタート したら、コード ブロックを ひょうじ する"
+#~ msgid "Show code blocks on startup."
+#~ msgstr "スタート したら、コード ブロックを ひょうじ する"
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr "スタートしたら、コードブロックをけす"
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr "スタートしたら、コードブロックをけす"
 
-#~msgid "Advanced Options"
-#~msgstr "じょうきゅう オプション"
+#~ msgid "Advanced Options"
+#~ msgstr "じょうきゅう オプション"
 
-#~msgid "Warning: Sound is only coming out from one side."
-#~msgstr "おとは みぎか ひだりの ひとつだけの スピーカから いま なっています。"
+#~ msgid "Warning: Sound is only coming out from one side."
+#~ msgstr "おとは みぎか ひだりの ひとつだけの スピーカから いま なっています。"
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr "ヘルツ・ブロック：おんぷ ブロックを つかいますか？"
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr "ヘルツ・ブロック：おんぷ ブロックを つかいますか？"
 
-#~msgid "triad (root position)"
-#~msgstr "さんわおん (きほんけい)"
+#~ msgid "triad (root position)"
+#~ msgstr "さんわおん (きほんけい)"
 
-#~msgid "triad (1st inversion)"
-#~msgstr "さんわおん (だい1てんかいけい)"
+#~ msgid "triad (1st inversion)"
+#~ msgstr "さんわおん (だい1てんかいけい)"
 
-#~msgid "triad (2nd inversion)"
-#~msgstr "さんわおん (だい2てんかいけい)"
+#~ msgid "triad (2nd inversion)"
+#~ msgstr "さんわおん (だい2てんかいけい)"
 
-#~msgid "seventh (root position)"
-#~msgstr "しちのわおん (きほんけい)"
+#~ msgid "seventh (root position)"
+#~ msgstr "しちのわおん (きほんけい)"
 
-#~msgid "seventh (1st inversion)"
-#~msgstr "しちのわおん (だい1てんかいけい)"
+#~ msgid "seventh (1st inversion)"
+#~ msgstr "しちのわおん (だい1てんかいけい)"
 
-#~msgid "seventh (2nd inversion)"
-#~msgstr "しちのわおん (だい2てんかいけい)"
+#~ msgid "seventh (2nd inversion)"
+#~ msgstr "しちのわおん (だい2てんかいけい)"
 
-#~msgid "seventh (3rd inversion)"
-#~msgstr "しちのわおん (だい3てんかいけい)"
+#~ msgid "seventh (3rd inversion)"
+#~ msgstr "しちのわおん (だい3てんかいけい)"
 
-#~msgid "ninth (root position)"
-#~msgstr "きゅうのわおん (きほんけい)"
+#~ msgid "ninth (root position)"
+#~ msgstr "きゅうのわおん (きほんけい)"
 
-#~msgid "thirteenth (root position)"
-#~msgstr "じゅうさんのわおん (きほんけい)"
+#~ msgid "thirteenth (root position)"
+#~ msgstr "じゅうさんのわおん (きほんけい)"
 
-#~msgid "Like project"
-#~msgstr "プロジェクトに 「いいね」を する"
+#~ msgid "Like project"
+#~ msgstr "プロジェクトに 「いいね」を する"
 
-#~msgid "Republish Project"
-#~msgstr "プロジェクトを さいど こうかい する"
+#~ msgid "Republish Project"
+#~ msgstr "プロジェクトを さいど こうかい する"
 
-#~msgid "dominant seventh"
-#~msgstr "セブンス"
+#~ msgid "dominant seventh"
+#~ msgstr "セブンス"
 
-#~msgid "minor seventh"
-#~msgstr "マイナー・セブンス"
+#~ msgid "minor seventh"
+#~ msgstr "マイナー・セブンス"
 
-#~msgid "major seventh"
-#~msgstr "メジャー・セブンス"
+#~ msgid "major seventh"
+#~ msgstr "メジャー・セブンス"
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr "ちゅうい：おとのながさは ２より おおきいです"
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr "ちゅうい：おとのながさは ２より おおきいです"
 
-#~msgid "chord5"
-#~msgstr "5どの わおん"
+#~ msgid "chord5"
+#~ msgstr "5どの わおん"
 
-#~msgid "chord4"
-#~msgstr "4どの わおん"
+#~ msgid "chord4"
+#~ msgstr "4どの わおん"
 
-#~msgid "chord1"
-#~msgstr "1どの わおん"
+#~ msgid "chord1"
+#~ msgstr "1どの わおん"
 
-#~msgid "Run fast"
-#~msgstr "じっこう"
+#~ msgid "Run fast"
+#~ msgstr "じっこう"
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "チャンクを ひょうじ/ひひょうじ"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "チャンクを ひょうじ/ひひょうじ"
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr "「なんひきめ のネズミの なまえ」のブロックは すうちによって ネズミの なまえを あらわす。"
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr "「なんひきめ のネズミの なまえ」のブロックは すうちによって ネズミの なまえを あらわす。"
 
-#~msgid "search for blocks"
-#~msgstr "ブロックをさがす"
+#~ msgid "search for blocks"
+#~ msgstr "ブロックをさがす"
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr "ブラウザの ひょうじを 100パーセントに して ください。"
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr "ブラウザの ひょうじを 100パーセントに して ください。"
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr "このプロジェクトを ひらくには、 ミュージック・ブロックスに アクセスし、 このファイルを アプリケーションの ウィンドウに ドラッグ するか、"
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr "このプロジェクトを ひらくには、 ミュージック・ブロックスに アクセスし、 このファイルを アプリケーションの ウィンドウに ドラッグ するか、"
 
-#~msgid "You must always have at least one start block."
-#~msgstr "スタート ブロックは、 １つ いじょう  のこして おいて ください。"
+#~ msgid "You must always have at least one start block."
+#~ msgstr "スタート ブロックは、 １つ いじょう  のこして おいて ください。"
 
-#~msgid "pitch up"
-#~msgstr "おとの たかさを あげる"
+#~ msgid "pitch up"
+#~ msgstr "おとの たかさを あげる"
 
-#~msgid "pitch down"
-#~msgstr "おとの たかさを さげる"
+#~ msgid "pitch down"
+#~ msgstr "おとの たかさを さげる"
 
-#~msgid "currency"
-#~msgstr "つうか"
+#~ msgid "currency"
+#~ msgstr "つうか"
 
-#~msgid "from"
-#~msgstr "から"
+#~ msgid "from"
+#~ msgstr "から"
 
-#~msgid "stock price"
-#~msgstr "かぶか"
+#~ msgid "stock price"
+#~ msgstr "かぶか"
 
-#~msgid "translate"
-#~msgstr "ほんやく"
+#~ msgid "translate"
+#~ msgstr "ほんやく"
 
-#~msgid "hello"
-#~msgstr "こんにちは"
+#~ msgid "hello"
+#~ msgstr "こんにちは"
 
-#~msgid "detect lang"
-#~msgstr "げんごを けんしゅつ"
+#~ msgid "detect lang"
+#~ msgstr "げんごを けんしゅつ"
 
-#~msgid "set lang"
-#~msgstr "げんごを せってい"
+#~ msgid "set lang"
+#~ msgstr "げんごを せってい"
 
-#~msgid "city latitude"
-#~msgstr "しの いど"
+#~ msgid "city latitude"
+#~ msgstr "しの いど"
 
-#~msgid "city longitude"
-#~msgstr "しの けいど"
+#~ msgid "city longitude"
+#~ msgstr "しの けいど"
 
-#~msgid "Coordinate data not available."
-#~msgstr "ざひょう データが みつかりません"
+#~ msgid "Coordinate data not available."
+#~ msgstr "ざひょう データが みつかりません"
 
-#~msgid "Google map"
-#~msgstr "グーグル マップ"
+#~ msgid "Google map"
+#~ msgstr "グーグル マップ"
 
-#~msgid "coordinates"
-#~msgstr "ざひょう"
+#~ msgid "coordinates"
+#~ msgstr "ざひょう"
 
-#~msgid "zoom factor"
-#~msgstr "ズーム ファクター"
+#~ msgid "zoom factor"
+#~ msgstr "ズーム ファクター"
 
-#~msgid "zoom"
-#~msgstr "ズーム"
+#~ msgid "zoom"
+#~ msgstr "ズーム"
 
-#~msgid "latitude"
-#~msgstr "いど"
+#~ msgid "latitude"
+#~ msgstr "いど"
 
-#~msgid "longitude"
-#~msgstr "けいど"
+#~ msgid "longitude"
+#~ msgstr "けいど"
 
-#~msgid "degrees"
-#~msgstr "おんど"
+#~ msgid "degrees"
+#~ msgstr "おんど"
 
-#~msgid "radians"
-#~msgstr "ラジアン"
+#~ msgid "radians"
+#~ msgstr "ラジアン"
 
-#~msgid "define"
-#~msgstr "ていぎ"
+#~ msgid "define"
+#~ msgstr "ていぎ"
 
-#~msgid "bitcoin"
-#~msgstr "ビットコイン" #Maybe no need, but this did seem to come up in dictionary"
+#~ msgid "bitcoin"
+# Maybe no need, but this did seem to come up in dictionary
+#~ msgstr "ビットコイン"
 
-#~msgid "You need to select a file."
-#~msgstr "ファイルをえらぶひつようがあります"
+#~ msgid "You need to select a file."
+#~ msgstr "ファイルをえらぶひつようがあります"
 
-#~msgid "accdental-override"
-#~msgstr "へんかきごうを むこう"
+#~ msgid "accdental-override"
+#~ msgstr "へんかきごうを むこう"
 
-#~msgid "show treble"
-#~msgstr "トレブルきごう を ひょうじ"
+#~ msgid "show treble"
+#~ msgstr "トレブルきごう を ひょうじ"
 
-#~msgid "hide Polar"
-#~msgstr "ちゅうしんの かくどを かくす"
+#~ msgid "hide Polar"
+#~ msgstr "ちゅうしんの かくどを かくす"
 
-#~msgid "show bass"
-#~msgstr "バスきごうを ひょうじ"
+#~ msgid "show bass"
+#~ msgstr "バスきごうを ひょうじ"
 
-#~msgid "show mezzo-soprano"
-#~msgstr "メゾソプラノきごうを ひょうじ"
+#~ msgid "show mezzo-soprano"
+#~ msgstr "メゾソプラノきごうを ひょうじ"
 
-#~msgid "show alto"
-#~msgstr "アルトきごうを ひょうじ"
+#~ msgid "show alto"
+#~ msgstr "アルトきごうを ひょうじ"
 
-#~msgid "show tenor"
-#~msgstr "テノールを ひょうじ"
+#~ msgid "show tenor"
+#~ msgstr "テノールを ひょうじ"
 
-#~msgid "hide bass"
-#~msgstr "バスを かくす"
+#~ msgid "hide bass"
+#~ msgstr "バスを かくす"
 
-#~msgid "show Polar"
-#~msgstr "ほうがんと かくどの ひょうじ"
+#~ msgid "show Polar"
+#~ msgstr "ほうがんと かくどの ひょうじ"
 
-#~msgid "hide Cartesian"
-#~msgstr "ほうがん（ざひょう）を かくす"
+#~ msgid "hide Cartesian"
+#~ msgstr "ほうがん（ざひょう）を かくす"
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr "Lilypondでは この テンポを たいおう できません："
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr "Lilypondでは この テンポを たいおう できません："
 
-#~msgid "Save as PDF"
-#~msgstr "PDFで ほぞん"
+#~ msgid "Save as PDF"
+#~ msgstr "PDFで ほぞん"
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr "Lilypondは このちょうを むし します"
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr "Lilypondは このちょうを むし します"
 
-#~msgid "Do you want to save your project?"
-#~msgstr "プロジェクトを ほぞん しますか"
+#~ msgid "Do you want to save your project?"
+#~ msgstr "プロジェクトを ほぞん しますか"
 
-#~msgid "Click to select a block."
-#~msgstr "クリックして ブロックを えらんで ください"
+#~ msgid "Click to select a block."
+#~ msgstr "クリックして ブロックを えらんで ください"
 
-#~msgid "hide"
-#~msgstr "隠す"
+#~ msgid "hide"
+#~ msgstr "隠す"
 
-#~msgid "show2"
-#~msgstr "ひょうじする"
+#~ msgid "show2"
+#~ msgstr "ひょうじする"
 
-#~msgid "popout"
-#~msgstr "ポップアップ"
+#~ msgid "popout"
+#~ msgstr "ポップアップ"
 
-#~msgid "myblocks"
-#~msgstr "マイ・ブロックス"
+#~ msgid "myblocks"
+#~ msgstr "マイ・ブロックス"
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr "ドラム ブロック：おんぷ ブロックと いっしょに つかいますか？"
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr "ドラム ブロック：おんぷ ブロックと いっしょに つかいますか？"
 
-#~msgid "save rhythms"
-#~msgstr "リズムを ほぞん"
+#~ msgid "save rhythms"
+#~ msgstr "リズムを ほぞん"
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr "おとの たかさブロック： おんぷブロックを つかいますか?"
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr "おとの たかさブロック： おんぷブロックを つかいますか?"
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr "<h2>しんぎブロック（クリック）</h2><br>マウスが クリックされたかどうか はんてい する。 クリックとは おされた マウスボタンが、 はなされたときのことを しめす。 クリックされていれば「しん（しん）」、 されていなければ「にせ（ぎ）」という あたいになる。"
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr "<h2>しんぎブロック（クリック）</h2><br>マウスが クリックされたかどうか はんてい する。 クリックとは おされた マウスボタンが、 はなされたときのことを しめす。 クリックされていれば「しん（しん）」、 されていなければ「にせ（ぎ）」という あたいになる。"
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr "<h2>すうちブロック</h2><br>すうちブロック として、 はこ２の すうちを つかう。"
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr "<h2>すうちブロック</h2><br>すうちブロック として、 はこ２の すうちを つかう。"
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr "<h2>すうちブロック</h2><br>すうちブロック として、 はこ１の すうちを つかう。"
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr "<h2>すうちブロック</h2><br>すうちブロック として、 はこ１の すうちを つかう。"
 
-#~msgid "Cannot be further decreased"
-#~msgstr "これより ちいさくできない"
+#~ msgid "Cannot be further decreased"
+#~ msgstr "これより ちいさくできない"
 
-#~msgid "Cannot be further increased"
-#~msgstr "これより おおきくできない"
+#~ msgid "Cannot be further increased"
+#~ msgstr "これより おおきくできない"
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr "ネズミの てんめつを オフに され、FPSを １０に されている"
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr "ネズミの てんめつを オフに され、FPSを １０に されている"
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr "ネズミの てんめつを オンに され、FPSを ３０に されている；"
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr "ネズミの てんめつを オンに され、FPSを ３０に されている；"
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr "タイブロックは、 おなじ たかさの おと しか つなげません。 スラーブロックを つかいますか？"
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr "タイブロックは、 おなじ たかさの おと しか つなげません。 スラーブロックを つかいますか？"
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr "おんめいは 「A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯, A♭」のなか から ひつようが あります。"
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr "おんめいは 「A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯, A♭」のなか から ひつようが あります。"
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr "インターネットの 「プラネット（わくせい）」 という ページから、 ほかのひとが つくった プロジェクトを  えらんで、 よみこむことが できる。"
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr "インターネットの 「プラネット（わくせい）」 という ページから、 ほかのひとが つくった プロジェクトを  えらんで、 よみこむことが できる。"
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr "このボタンをクリックするとオプションツールバーをひょうじ/ひひょうじ"
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr "このボタンをクリックするとオプションツールバーをひょうじ/ひひょうじ"
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr "<h2>びょうし ブロック</h2><br>ひょうしを せっていする。 ひょうじゅんは ４ぶんの ４びょうし。<br><br>★ひょうしとは<br>はくが いくつか まとまったもの。<br>★４ぶんの４びょうしとは<br>４ぶおんぷが ４つでひとまとまりになった ひょうし。<br>★はくとは<br>くりかえされる リズムのこと。"
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr "<h2>びょうし ブロック</h2><br>ひょうしを せっていする。 ひょうじゅんは ４ぶんの ４びょうし。<br><br>★ひょうしとは<br>はくが いくつか まとまったもの。<br>★４ぶんの４びょうしとは<br>４ぶおんぷが ４つでひとまとまりになった ひょうし。<br>★はくとは<br>くりかえされる リズムのこと。"
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr "<h2>ぜんたいの スピードを きめるブロック</h2><br>１ぷんあたりの はくの かずを せってい することで、 きょくぜんたいの スピードを  きめる。 ひょうじゅんは ４ぶおんぷ ９０こ。<br><br>★はくとは<br>くりかえされる リズムのこと。"
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr "<h2>ぜんたいの スピードを きめるブロック</h2><br>１ぷんあたりの はくの かずを せってい することで、 きょくぜんたいの スピードを  きめる。 ひょうじゅんは ４ぶおんぷ ９０こ。<br><br>★はくとは<br>くりかえされる リズムのこと。"
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr "<h2>ぜんぶの おんぷに アクション じっこう</h2><br>すべてのおんぷに せっていするときに つかう。"
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr "<h2>ぜんぶの おんぷに アクション じっこう</h2><br>すべてのおんぷに せっていするときに つかう。"
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr "<h2>ぜんたいの はくの かずブロック</h2><br>ぜんたいの はくの かずを ひょうじする。 ひょうじゅんは はくは ４ぶおんぷを いみするため、 げんそくは、 きょくぜんたいの ４ぶおんぷの かずを あらわす。"
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr "<h2>ぜんたいの はくの かずブロック</h2><br>ぜんたいの はくの かずを ひょうじする。 ひょうじゅんは はくは ４ぶおんぷを いみするため、 げんそくは、 きょくぜんたいの ４ぶおんぷの かずを あらわす。"
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr "<h2>おとの たかさを かずで ひょうじ ブロック</h2><br>おとの たかさを かずで ひょうじする。 たとえば、 オクターヴ４の 「ド」 の おとは ０、 オクターヴ４の 「ソ」 の おとは ７、 オクターヴ３の 「シ」 の おとは -１ と ひょうじされる。"
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr "<h2>おとの たかさを かずで ひょうじ ブロック</h2><br>おとの たかさを かずで ひょうじする。 たとえば、 オクターヴ４の 「ド」 の おとは ０、 オクターヴ４の 「ソ」 の おとは ７、 オクターヴ３の 「シ」 の おとは -１ と ひょうじされる。"
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr "<h2>ヘルツスライダーブロック</h2><br>スライダーを じょうげに うごかすことで、 ちがう しゅうはすう（ヘルツのすうち） の おとを きくことが できる。 つくった おとを データに することが できる。ヘルツの しょきせっていち は じゆうに かえられる。 <br><br>★ヘルツとは<br>おとの たかさを あらわす しゅうはすう。<br>★しゅうはすうとは<br>おとが １びょうかん に なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。"
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr "<h2>ヘルツスライダーブロック</h2><br>スライダーを じょうげに うごかすことで、 ちがう しゅうはすう（ヘルツのすうち） の おとを きくことが できる。 つくった おとを データに することが できる。ヘルツの しょきせっていち は じゆうに かえられる。 <br><br>★ヘルツとは<br>おとの たかさを あらわす しゅうはすう。<br>★しゅうはすうとは<br>おとが １びょうかん に なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。"
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr " プログラムには、 すくなくとも １つの スタートブロックが おかれていないと じっこうできない。 ふくすうの スタートブロックが あるときは、 じっこうボタンが おされると、 ふくすうの スタートブロックが どうじに じっこうされる。 １つ１つの スタートブロックは べつべつの えんそうしゃと かんがえることが できる。"
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr " プログラムには、 すくなくとも １つの スタートブロックが おかれていないと じっこうできない。 ふくすうの スタートブロックが あるときは、 じっこうボタンが おされると、 ふくすうの スタートブロックが どうじに じっこうされる。 １つ１つの スタートブロックは べつべつの えんそうしゃと かんがえることが できる。"
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr "<h2>かずのはこ（あたいをいれる）</h2><br>はこ１に してい した すうちを いれる。"
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr "<h2>かずのはこ（あたいをいれる）</h2><br>はこ１に してい した すうちを いれる。"
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr "<h2>かずのはこ（あたいをいれる）</h2><br>はこ２に してい した すうちを いれる。"
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr "<h2>かずのはこ（あたいをいれる）</h2><br>はこ２に してい した すうちを いれる。"
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr "<h2>ひょうじブロック（ネズミ）</h2><br>ネズミの みため を、 してい した がぞうに かえる。"
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr "<h2>ひょうじブロック（ネズミ）</h2><br>ネズミの みため を、 してい した がぞうに かえる。"
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr "<em>強拍に</em>ブロックは決められているびょうしに対する強拍だけに特定されているアクションをします。"
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr "<em>強拍に</em>ブロックは決められているびょうしに対する強拍だけに特定されているアクションをします。"
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr "<em>弱拍</em>ブロックは決められているびょうしに対する弱拍だけに特定されているアクションをします。"
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr "<em>弱拍</em>ブロックは決められているびょうしに対する弱拍だけに特定されているアクションをします。"
 
-#~msgid "down minor"
-#~msgstr "たん３ど した"
+#~ msgid "down minor"
+#~ msgstr "たん３ど した"
 
-#~msgid "down major"
-#~msgstr "ちょう３ど した"
+#~ msgid "down major"
+#~ msgstr "ちょう３ど した"
 
-#~msgid "eval"
-#~msgstr "ひょうか"
+#~ msgid "eval"
+#~ msgstr "ひょうか"
 
-#~msgid "100"
-#~msgstr "ひゃく"
+#~ msgid "100"
+#~ msgstr "ひゃく"
 
-#~msgid "Drag"
-#~msgstr "ドラッグ"
+#~ msgid "Drag"
+#~ msgstr "ドラッグ"
 
-#~msgid "playback music"
-#~msgstr "コンパイル された おんがく"
+#~ msgid "playback music"
+#~ msgstr "コンパイル された おんがく"
 
-#~msgid "pause playback"
-#~msgstr "コンパイル された おんがくを ていし"
+#~ msgid "pause playback"
+#~ msgstr "コンパイル された おんがくを ていし"
 
-#~msgid "restart playback"
-#~msgstr "コンパイル された おんがくを さいせい"
+#~ msgid "restart playback"
+#~ msgstr "コンパイル された おんがくを さいせい"
 
-#~msgid "prepare music for playback"
-#~msgstr "プレイバックようの おんがくを じゅんび（コンパイル）します"
+#~ msgid "prepare music for playback"
+#~ msgstr "プレイバックようの おんがくを じゅんび（コンパイル）します"
 
-#~msgid "decimal to fraction"
-#~msgstr "しょうすうをぶんすうになおす"
+#~ msgid "decimal to fraction"
+#~ msgstr "しょうすうをぶんすうになおす"
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr "<h2>ねいろをせってい ブロック</h2>なかに はいっている 「おんぷブロック」 の ねいろを せっていする。"
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr "<h2>ねいろをせってい ブロック</h2>なかに はいっている 「おんぷブロック」 の ねいろを せっていする。"
 
-#~msgid "set timbre"
-#~msgstr "ねいろを せってい"
+#~ msgid "set timbre"
+#~ msgstr "ねいろを せってい"
 
-#~msgid "right2"
-#~msgstr "ざひょうち（みぎ）"
+#~ msgid "right2"
+#~ msgstr "ざひょうち（みぎ）"
 
-#~msgid "left2"
-#~msgstr "ざひょうち（ひだり）"
+#~ msgid "left2"
+#~ msgstr "ざひょうち（ひだり）"
 
-#~msgid "expand"
-#~msgstr "テーブルをひろげる"
+#~ msgid "expand"
+#~ msgstr "テーブルをひろげる"
 
-#~msgid "collapse"
-#~msgstr "テーブルをちぢめる"
+#~ msgid "collapse"
+#~ msgstr "テーブルをちぢめる"
 
-#~msgid "Stop the current project."
-#~msgstr "プロジェクトを止めます"
+#~ msgid "Stop the current project."
+#~ msgstr "プロジェクトを止めます"
 
-#~msgid "japanese"
-#~msgstr "日本おんかい"
+#~ msgid "japanese"
+#~ msgstr "日本おんかい"
 
-#~msgid "undo"
-#~msgstr "もとに もどす"
+#~ msgid "undo"
+#~ msgstr "もとに もどす"
 
-#~msgid "set volume"
-#~msgstr "音量をせってい"
+#~ msgid "set volume"
+#~ msgstr "音量をせってい"
 
-#~msgid "hours ago"
-#~msgstr "時間前"
+#~ msgid "hours ago"
+#~ msgstr "時間前"
 
-#~msgid "play scale"
-#~msgstr "ちょうを さいせい する"
+#~ msgid "play scale"
+#~ msgstr "ちょうを さいせい する"
 
-#~msgid "ml"
-#~msgstr "モ"
+#~ msgid "ml"
+#~ msgstr "モ"
 
-#~msgid "play backward"
-#~msgstr "逆に再生"
+#~ msgid "play backward"
+#~ msgstr "逆に再生"
 
-#~msgid "Merge project from file"
-#~msgstr "ファイルからプロジェクトをマージする"
+#~ msgid "Merge project from file"
+#~ msgstr "ファイルからプロジェクトをマージする"
 
-#~msgid "eatme"
-#~msgstr "わたしを食べろ"
+#~ msgid "eatme"
+#~ msgstr "わたしを食べろ"
 
-#~msgid "movable"
-#~msgstr "いどうド"
+#~ msgid "movable"
+#~ msgstr "いどうド"
 
-#~msgid "triangle-bell"
-#~msgstr "トライアングル"
+#~ msgid "triangle-bell"
+#~ msgstr "トライアングル"
 
-#~msgid "Hide grid"
-#~msgstr "ざひょうを ひひょうじ"
+#~ msgid "Hide grid"
+#~ msgstr "ざひょうを ひひょうじ"
 
-#~msgid "Previous page"
-#~msgstr "まえの ページ"
+#~ msgid "Previous page"
+#~ msgstr "まえの ページ"
 
-#~msgid "effects"
-#~msgstr "こうかおん"
+#~ msgid "effects"
+#~ msgstr "こうかおん"
 
-#~msgid "Share on Facebook"
-#~msgstr "フェースブックでシェア"
+#~ msgid "Share on Facebook"
+#~ msgstr "フェースブックでシェア"
 
-#~msgid "rs"
-#~msgstr "赤"
+#~ msgid "rs"
+#~ msgstr "赤"
 
-#~msgid "divide note value"
-#~msgstr "音価を割る"
+#~ msgid "divide note value"
+#~ msgstr "音価を割る"
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr "もっと ながおしで おんがくを ゆっくり さいせい"
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr "もっと ながおしで おんがくを ゆっくり さいせい"
 
-#~msgid "save drum machine"
-#~msgstr "ドラム マシーンを ほぞん"
+#~ msgid "save drum machine"
+#~ msgstr "ドラム マシーンを ほぞん"
 
-#~msgid "whole note 𝅝"
-#~msgstr "全音符　𝅝"
+#~ msgid "whole note 𝅝"
+#~ msgstr "全音符　𝅝"
 
-#~msgid "note volume"
-#~msgstr "おんぷのおんりょう"
+#~ msgid "note volume"
+#~ msgstr "おんぷのおんりょう"
 
-#~msgid "Save as .abc"
-#~msgstr "ABCでほぞん"
+#~ msgid "Save as .abc"
+#~ msgstr "ABCでほぞん"
 
-#~msgid "top"
-#~msgstr "ざひょうち（うえ）"
+#~ msgid "top"
+#~ msgstr "ざひょうち（うえ）"
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "ミュージック・ブロックスの せっていメニューを ひらく。"
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "ミュージック・ブロックスの せっていメニューを ひらく。"
 
-#~msgid "Save as .wav"
-#~msgstr "WAVでほぞん"
+#~ msgid "Save as .wav"
+#~ msgstr "WAVでほぞん"
 
-#~msgid "The Planet is unavailable."
-#~msgstr "「プラネット」サーバは今つかえません"
+#~ msgid "The Planet is unavailable."
+#~ msgstr "「プラネット」サーバは今つかえません"
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr "<em>ドラム</em>ブロックは ひとつ いじょう <em>おんぷ</em> ブロックに いれる ことが できます。"
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr "<em>ドラム</em>ブロックは ひとつ いじょう <em>おんぷ</em> ブロックに いれる ことが できます。"
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr "Alt+Vでブロックスを はりつけることも できます。"
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr "Alt+Vでブロックスを はりつけることも できます。"
 
-#~msgid "left2 (screen)"
-#~msgstr "ざひょうち（ひだり）"
+#~ msgid "left2 (screen)"
+#~ msgstr "ざひょうち（ひだり）"
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr "スタックほぞんボタンを押すと、スタックはカスタムパレットのしたにほぞんされます。"
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr "スタックほぞんボタンを押すと、スタックはカスタムパレットのしたにほぞんされます。"
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr "ブロックスが クリップボードに コピーされると、ペーストボタンが つかえるように なります。"
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr "ブロックスが クリップボードに コピーされると、ペーストボタンが つかえるように なります。"
 
-#~msgid "denominator"
-#~msgstr "分母"
+#~ msgid "denominator"
+#~ msgstr "分母"
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr "より ながおしすると、より スローさいせいと なります。"
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr "より ながおしすると、より スローさいせいと なります。"
 
-#~msgid "Run"
-#~msgstr "再生"
+#~ msgid "Run"
+#~ msgstr "再生"
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "あたらしいブロックを ファイルシステムから ロードできます。"
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "あたらしいブロックを ファイルシステムから ロードできます。"
 
-#~msgid "Settings"
-#~msgstr "せってい"
+#~ msgid "Settings"
+#~ msgstr "せってい"
 
-#~msgid "move down"
-#~msgstr "したに うごく"
+#~ msgid "move down"
+#~ msgstr "したに うごく"
 
-#~msgid "consonant step up"
-#~msgstr "コンソナントステップアップ"
+#~ msgid "consonant step up"
+#~ msgstr "コンソナントステップアップ"
 
-#~msgid "View More"
-#~msgstr "もっと みる"
+#~ msgid "View More"
+#~ msgstr "もっと みる"
 
-#~msgid "Run music slowly"
-#~msgstr "音楽をゆっくりに演奏する"
+#~ msgid "Run music slowly"
+#~ msgstr "音楽をゆっくりに演奏する"
 
-#~msgid "You can search for blocks by name."
-#~msgstr "ブロックスをなまえでけんさくできます"
+#~ msgid "You can search for blocks by name."
+#~ msgstr "ブロックスをなまえでけんさくできます"
 
-#~msgid "finger-cymbals"
-#~msgstr "指のシンバル"
+#~ msgid "finger-cymbals"
+#~ msgstr "指のシンバル"
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr "タプル・ブロック：音高・時刻ぎょうれつブロックを使うつもりですか？"
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr "タプル・ブロック：音高・時刻ぎょうれつブロックを使うつもりですか？"
 
-#~msgid "set beats per minute"
-#~msgstr "BPM(一分あたりの拍数)をせってい"
+#~ msgid "set beats per minute"
+#~ msgstr "BPM(一分あたりの拍数)をせってい"
 
-#~msgid "Delete all"
-#~msgstr "ブロックを全部捨てる"
+#~ msgid "Delete all"
+#~ msgstr "ブロックを全部捨てる"
 
-#~msgid "UID"
-#~msgstr "ユーザのなまえ"
+#~ msgid "UID"
+#~ msgstr "ユーザのなまえ"
 
-#~msgid "rotate clockwise"
-#~msgstr "とけい まわり"
+#~ msgid "rotate clockwise"
+#~ msgstr "とけい まわり"
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr "「短（マイナー）」ブロックには 2, 3, 6, 7いずれかの数をいれてください。"
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr "「短（マイナー）」ブロックには 2, 3, 6, 7いずれかの数をいれてください。"
 
-#~msgid "bottom"
-#~msgstr "ざひょうち（した）"
+#~ msgid "bottom"
+#~ msgstr "ざひょうち（した）"
 
-#~msgid "numerator"
-#~msgstr "分子"
+#~ msgid "numerator"
+#~ msgstr "分子"
 
-#~msgid "eighth note ♪"
-#~msgstr "８分音符　♪"
+#~ msgid "eighth note ♪"
+#~ msgstr "８分音符　♪"
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "オーギュメントブロックには 1, 2, 3, 4, 5, 6, 7, 8 のいずれかのかずをいれてください。"
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "オーギュメントブロックには 1, 2, 3, 4, 5, 6, 7, 8 のいずれかのかずをいれてください。"
 
-#~msgid "cup-drum"
-#~msgstr "カップ ドラム"
+#~ msgid "cup-drum"
+#~ msgstr "カップ ドラム"
 
-#~msgid "hi-hat"
-#~msgstr "ハイハット"
+#~ msgid "hi-hat"
+#~ msgstr "ハイハット"
 
-#~msgid "untitled"
-#~msgstr "無題"
+#~ msgid "untitled"
+#~ msgstr "無題"
 
-#~msgid "Click here to paste."
-#~msgstr "はりつけるにはここをクリック"
+#~ msgid "Click here to paste."
+#~ msgstr "はりつけるにはここをクリック"
 
-#~msgid "relative interval"
-#~msgstr "相対的な音とおとの間の間隔"
+#~ msgid "relative interval"
+#~ msgstr "相対的な音とおとの間の間隔"
 
-#~msgid "on beat"
-#~msgstr "強拍にて"
+#~ msgid "on beat"
+#~ msgstr "強拍にて"
 
-#~msgid "floor-tom-tom"
-#~msgstr "フロアタムタム"
+#~ msgid "floor-tom-tom"
+#~ msgstr "フロアタムタム"
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr "ソルフェージュの名前が<em>「ド、レ、ミ、ファ、ソ、ラ、シ」</em>からえらぶことができます。"
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr "ソルフェージュの名前が<em>「ド、レ、ミ、ファ、ソ、ラ、シ」</em>からえらぶことができます。"
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr "このツールバーには、リズム、ピッチ、ねいろ、タートル、その他のパレットボタンがあります。"
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr "このツールバーには、リズム、ピッチ、ねいろ、タートル、その他のパレットボタンがあります。"
 
-#~msgid "block artwork"
-#~msgstr "ブロックのアート"
+#~ msgid "block artwork"
+#~ msgstr "ブロックのアート"
 
-#~msgid "1st"
-#~msgstr "１度"
+#~ msgid "1st"
+#~ msgstr "１度"
 
-#~msgid "Could not find turtle"
-#~msgstr "タートルがみつかりませんでした。"
+#~ msgid "Could not find turtle"
+#~ msgstr "タートルがみつかりませんでした。"
 
-#~msgid "play chord"
-#~msgstr "わおんを さいせい する"
+#~ msgid "play chord"
+#~ msgstr "わおんを さいせい する"
 
-#~msgid "Optimize feedback"
-#~msgstr "フィードバックを さいだいげんに する"
+#~ msgid "Optimize feedback"
+#~ msgstr "フィードバックを さいだいげんに する"
 
-#~msgid "free time"
-#~msgstr "クロックなし"
+#~ msgid "free time"
+#~ msgstr "クロックなし"
 
-#~msgid "Save your project to a server."
-#~msgstr "サーバーにプロジェクトをほぞん"
+#~ msgid "Save your project to a server."
+#~ msgstr "サーバーにプロジェクトをほぞん"
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr "おんがくをゆっくりさいせいしたい時は、ここをクリック。"
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr "おんがくをゆっくりさいせいしたい時は、ここをクリック。"
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr "はやいスピードでさいせいします／ながおしでスローさいせい／よりながおしでさらにスローさいせい"
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr "はやいスピードでさいせいします／ながおしでスローさいせい／よりながおしでさらにスローさいせい"
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr "もしくは、エンターキー、リターンキーの どちらかを おしてください。"
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr "もしくは、エンターキー、リターンキーの どちらかを おしてください。"
 
-#~msgid "turtle"
-#~msgstr "タートル"
+#~ msgid "turtle"
+#~ msgstr "タートル"
 
-#~msgid "3rd"
-#~msgstr "３度"
+#~ msgid "3rd"
+#~ msgstr "３度"
 
-#~msgid "Optimize performance"
-#~msgstr "パーフォマンスを最大限にする"
+#~ msgid "Optimize performance"
+#~ msgstr "パーフォマンスを最大限にする"
 
-#~msgid "simple-1"
-#~msgstr "シンプル・シンセ１"
+#~ msgid "simple-1"
+#~ msgstr "シンプル・シンセ１"
 
-#~msgid "consonant step down"
-#~msgstr "コンソナントステップダウン"
+#~ msgid "consonant step down"
+#~ msgstr "コンソナントステップダウン"
 
-#~msgid "ride-bell"
-#~msgstr "ライド"
+#~ msgid "ride-bell"
+#~ msgstr "ライド"
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr "ミュージック・ブロックス：音楽と算数とコーディングの関係を発見するツール"
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr "ミュージック・ブロックス：音楽と算数とコーディングの関係を発見するツール"
 
-#~msgid "Cannot read pixel color"
-#~msgstr "ピクセルの色が読めません"
+#~ msgid "Cannot read pixel color"
+#~ msgstr "ピクセルの色が読めません"
 
-#~msgid "Publish"
-#~msgstr "サーバにアップロードして発表する"
+#~ msgid "Publish"
+#~ msgstr "サーバにアップロードして発表する"
 
-#~msgid "Worldwide"
-#~msgstr "世界中のプロジェクト"
+#~ msgid "Worldwide"
+#~ msgstr "世界中のプロジェクト"
 
-#~msgid "long press to run slowly"
-#~msgstr "長押しでスロー再生"
+#~ msgid "long press to run slowly"
+#~ msgstr "長押しでスロー再生"
 
-#~msgid "1/64 note 𝅘𝅥𝅱"
-#~msgstr "６４分おんぷ　𝅘𝅥𝅱"
+#~ msgid "1/64 note 𝅘𝅥𝅱"
+#~ msgstr "６４分おんぷ　𝅘𝅥𝅱"
 
-#~msgid "end hollow line"
-#~msgstr "（中空の）線を終わらせる"
+#~ msgid "end hollow line"
+#~ msgstr "（中空の）線を終わらせる"
 
-#~msgid "Open"
-#~msgstr "ひらく"
+#~ msgid "Open"
+#~ msgstr "ひらく"
 
-#~msgid "tom-tom"
-#~msgstr "タムタム"
+#~ msgid "tom-tom"
+#~ msgstr "タムタム"
 
-#~msgid "ch"
-#~msgstr "リ"
+#~ msgid "ch"
+#~ msgstr "リ"
 
-#~msgid "add pitches"
-#~msgstr "音高を足す"
+#~ msgid "add pitches"
+#~ msgstr "音高を足す"
 
-#~msgid "cb"
-#~msgstr "カ"
+#~ msgid "cb"
+#~ msgstr "カ"
 
-#~msgid "Click to run the music note by note."
-#~msgstr "おんぷを ひとつずつ さいせいするには ここを クリック。"
+#~ msgid "Click to run the music note by note."
+#~ msgstr "おんぷを ひとつずつ さいせいするには ここを クリック。"
 
-#~msgid "poly"
-#~msgstr "ポリリズム"
+#~ msgid "poly"
+#~ msgstr "ポリリズム"
 
-#~msgid "move up"
-#~msgstr "うえに うごく"
+#~ msgid "move up"
+#~ msgstr "うえに うごく"
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "直交座標をひょうじする/隠す"
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "直交座標をひょうじする/隠す"
 
-#~msgid "Save as .svg"
-#~msgstr "SVGでほぞん"
+#~ msgid "Save as .svg"
+#~ msgstr "SVGでほぞん"
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr "「d」を うつと「ド」の ブロックが つくられ、「r」を うつと「レ」の ブロックが つくられます"
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr "「d」を うつと「ド」の ブロックが つくられ、「r」を うつと「レ」の ブロックが つくられます"
 
-#~msgid "field"
-#~msgstr "場"
+#~ msgid "field"
+#~ msgstr "場"
 
-#~msgid "m"
-#~msgstr "鼠"
+#~ msgid "m"
+#~ msgstr "鼠"
 
-#~msgid "gs"
-#~msgstr "灰"
+#~ msgid "gs"
+#~ msgstr "灰"
 
-#~msgid "graphical notation matrix"
-#~msgstr "簡単なビジュアル・マトリックス"
+#~ msgid "graphical notation matrix"
+#~ msgstr "簡単なビジュアル・マトリックス"
 
-#~msgid "Save as HTML"
-#~msgstr "HTMLをほぞん"
+#~ msgid "Save as HTML"
+#~ msgstr "HTMLをほぞん"
 
-#~msgid "Load project from files"
-#~msgstr "ファイルからロードする"
+#~ msgid "Load project from files"
+#~ msgstr "ファイルからロードする"
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "ブロックのパレットをひょうじする / 隠す"
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "ブロックのパレットをひょうじする / 隠す"
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr "はやいスピードでさいせいします・ながおしでスローさいせい"
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr "はやいスピードでさいせいします・ながおしでスローさいせい"
 
-#~msgid "snare-drum"
-#~msgstr "スネアドラム"
+#~ msgid "snare-drum"
+#~ msgstr "スネアドラム"
 
-#~msgid "1/32 note 𝅘𝅥𝅰"
-#~msgstr "32ぶんおんぷ　𝅘𝅥𝅰"
+#~ msgid "1/32 note 𝅘𝅥𝅰"
+#~ msgstr "32ぶんおんぷ　𝅘𝅥𝅰"
 
-#~msgid "Search"
-#~msgstr "検索"
+#~ msgid "Search"
+#~ msgstr "検索"
 
-#~msgid "previous page"
-#~msgstr "まえの ページ"
+#~ msgid "previous page"
+#~ msgstr "まえの ページ"
 
-#~msgid "cow-bell"
-#~msgstr "カウベル"
+#~ msgid "cow-bell"
+#~ msgstr "カウベル"
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr "オフライン。シェアきのうがつかえません"
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr "オフライン。シェアきのうがつかえません"
 
-#~msgid "fs"
-#~msgstr "鼯"
+#~ msgid "fs"
+#~ msgstr "鼯"
 
-#~msgid "1/16 note ♬"
-#~msgstr "16分おんぷ　♬"
+#~ msgid "1/16 note ♬"
+#~ msgstr "16分おんぷ　♬"
 
-#~msgid "food"
-#~msgstr "食べ物"
+#~ msgid "food"
+#~ msgstr "食べ物"
 
-#~msgid "osctime"
-#~msgstr "オシレータータイム"
+#~ msgid "osctime"
+#~ msgstr "オシレータータイム"
 
-#~msgid "blues"
-#~msgstr "ブルース"
+#~ msgid "blues"
+#~ msgstr "ブルース"
 
-#~msgid "More"
-#~msgstr "その他"
+#~ msgid "More"
+#~ msgstr "その他"
 
-#~msgid "maths"
-#~msgstr "数学"
+#~ msgid "maths"
+#~ msgstr "数学"
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr "このツールバーには、パレットボタンやリズム、ピッチなどがふくまれています。"
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr "このツールバーには、パレットボタンやリズム、ピッチなどがふくまれています。"
 
-#~msgid "kick-drum"
-#~msgstr "キック ドラム"
+#~ msgid "kick-drum"
+#~ msgstr "キック ドラム"
 
-#~msgid "Rhythm"
-#~msgstr "おんぷ"
+#~ msgid "Rhythm"
+#~ msgstr "おんぷ"
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr "ブロックを長押しするとコピーできます。はりつけるにはここをクリック。"
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr "ブロックを長押しするとコピーできます。はりつけるにはここをクリック。"
 
-#~msgid "This toolbar contains the palette buttons Matrix, Chunk, Perform, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr "このツールバーには、音高・時刻ぎょうれつ、チャンク、演奏、ねいろ、タートル、その他を含むパレットボタンがあります。ここをクリックすると、ブロックスのパレットがひょうじされます。パレットからブロックスをキャンバスへドラッグすると、ブロックスを使うことができます。"
+#~ msgid "This toolbar contains the palette buttons Matrix, Chunk, Perform, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr "このツールバーには、音高・時刻ぎょうれつ、チャンク、演奏、ねいろ、タートル、その他を含むパレットボタンがあります。ここをクリックすると、ブロックスのパレットがひょうじされます。パレットからブロックスをキャンバスへドラッグすると、ブロックスを使うことができます。"
 
-#~msgid "Click this button to expand or collapse the auxilary toolbar."
-#~msgstr "ここをクリックして、オプションツールバーをひょうじ"
+#~ msgid "Click this button to expand or collapse the auxilary toolbar."
+#~ msgstr "ここをクリックして、オプションツールバーをひょうじ"
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr "ツールバーを開く/隠す"
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr "ツールバーを開く/隠す"
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr "ながおしで スローさいせい になります。"
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr "ながおしで スローさいせい になります。"
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "カンバスじょうに ほうがん（ざひょう）や ちゅうしんの かくどを ひょうじしたり、かくしたりできる。"
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "カンバスじょうに ほうがん（ざひょう）や ちゅうしんの かくどを ひょうじしたり、かくしたりできる。"
 
-#~msgid "Copy this link to share your project."
-#~msgstr "あなたのプロジェクトをシェアしたい時は、このリンクをコピーしてください。"
+#~ msgid "Copy this link to share your project."
+#~ msgstr "あなたのプロジェクトをシェアしたい時は、このリンクをコピーしてください。"
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "画面にあるものを全部消して、初期状態に戻します。"
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "画面にあるものを全部消して、初期状態に戻します。"
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr "ステップ音高ブロックは音符ブロックの中にあるひつようがあります。"
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr "ステップ音高ブロックは音符ブロックの中にあるひつようがあります。"
 
-#~msgid "begin hollow line"
-#~msgstr "（中空の）線を始める"
+#~ msgid "begin hollow line"
+#~ msgstr "（中空の）線を始める"
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr "ピッチ・アルファベットの名前が<em>「C D E F G A B」</em>からえらぶことができます。"
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr "ピッチ・アルファベットの名前が<em>「C D E F G A B」</em>からえらぶことができます。"
 
-#~msgid "step pitch"
-#~msgstr "ステップ音高"
+#~ msgid "step pitch"
+#~ msgstr "ステップ音高"
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr "音楽とネズミの動きを止めます。"
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr "音楽とネズミの動きを止めます。"
 
-#~msgid "bk"
-#~msgstr "黒"
+#~ msgid "bk"
+#~ msgstr "黒"
 
-#~msgid "bt"
-#~msgstr "蝙"
+#~ msgid "bt"
+#~ msgstr "蝙"
 
-#~msgid "Could not find mouse"
-#~msgstr "ネズミがみつかりません"
+#~ msgid "Could not find mouse"
+#~ msgstr "ネズミがみつかりません"
 
-#~msgid "br"
-#~msgstr "茶"
+#~ msgid "br"
+#~ msgstr "茶"
 
-#~msgid "multiply beat"
-#~msgstr "はくをばいに"
+#~ msgid "multiply beat"
+#~ msgstr "はくをばいに"
 
-#~msgid "save as lilypond"
-#~msgstr "Lilypondの ファイルフォーマットで ほぞん"
+#~ msgid "save as lilypond"
+#~ msgstr "Lilypondの ファイルフォーマットで ほぞん"
 
-#~msgid "Save Project"
-#~msgstr "プロジェクトを ほぞん"
+#~ msgid "Save Project"
+#~ msgstr "プロジェクトを ほぞん"
 
-#~msgid "rotate counter clockwise"
-#~msgstr "はんとけい まわり"
+#~ msgid "rotate counter clockwise"
+#~ msgstr "はんとけい まわり"
 
-#~msgid "etc."
-#~msgstr "<br>"
+#~ msgid "etc."
+#~ msgstr "<br>"
 
-#~msgid "sort"
-#~msgstr "せいり する"
+#~ msgid "sort"
+#~ msgstr "せいり する"
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr "ピッチ・ブロック：音符ブロックと一緒に使いますか？"
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr "ピッチ・ブロック：音符ブロックと一緒に使いますか？"
 
-#~msgid "Polar"
-#~msgstr "ちゅうしんのかくどとほうがん（ざひょう）をひょうじ"
+#~ msgid "Polar"
+#~ msgstr "ちゅうしんのかくどとほうがん（ざひょう）をひょうじ"
 
-#~msgid "current pitch name"
-#~msgstr "現在の音高の名前"
+#~ msgid "current pitch name"
+#~ msgstr "現在の音高の名前"
 
-#~msgid "confirm"
-#~msgstr "かくにん する"
+#~ msgid "confirm"
+#~ msgstr "かくにん する"
 
-#~msgid "gp"
-#~msgstr "ギ"
+#~ msgid "gp"
+#~ msgstr "ギ"
 
-#~msgid "Save as .png"
-#~msgstr "PNGでほぞん"
+#~ msgid "Save as .png"
+#~ msgstr "PNGでほぞん"
 
-#~msgid "Upload to Planet"
-#~msgstr "プラネットにアップロード"
+#~ msgid "Upload to Planet"
+#~ msgstr "プラネットにアップロード"
 
-#~msgid "Load plugin from file"
-#~msgstr "プラグインを よみこむ"
+#~ msgid "Load plugin from file"
+#~ msgstr "プラグインを よみこむ"
 
-#~msgid "degree"
-#~msgstr "温度記号"
+#~ msgid "degree"
+#~ msgstr "温度記号"
 
-#~msgid "sing"
-#~msgstr "歌う"
+#~ msgid "sing"
+#~ msgstr "歌う"
 
-#~msgid "Play music"
-#~msgstr "おんがくを さいせい"
+#~ msgid "Play music"
+#~ msgstr "おんがくを さいせい"
 
-#~msgid "Download"
-#~msgstr "ダウンロード"
+#~ msgid "Download"
+#~ msgstr "ダウンロード"
 
-#~msgid "darbuka-drum"
-#~msgstr "ダラブッカ"
+#~ msgid "darbuka-drum"
+#~ msgstr "ダラブッカ"
 
-#~msgid "cloud"
-#~msgstr "クラウド"
+#~ msgid "cloud"
+#~ msgstr "クラウド"
 
-#~msgid "quarter note ♩"
-#~msgstr "4ぶんおんぷ　♩"
+#~ msgid "quarter note ♩"
+#~ msgstr "4ぶんおんぷ　♩"
 
-#~msgid "add filter"
-#~msgstr "フィルターを くわえる"
+#~ msgid "add filter"
+#~ msgstr "フィルターを くわえる"
 
-#~msgid "Show/hide palettes"
-#~msgstr "パレットをひょうじする / 隠す"
+#~ msgid "Show/hide palettes"
+#~ msgstr "パレットをひょうじする / 隠す"
 
-#~msgid "fetch"
-#~msgstr "フェッチ"
+#~ msgid "fetch"
+#~ msgstr "フェッチ"
 
-#~msgid "rodi"
-#~msgstr "ロデイ"
+#~ msgid "rodi"
+#~ msgstr "ロデイ"
 
-#~msgid "pentatonic"
-#~msgstr "五音おんかい（ペンタトニック）"
+#~ msgid "pentatonic"
+#~ msgstr "五音おんかい（ペンタトニック）"
 
-#~msgid "blocks"
-#~msgstr "ブロックス"
+#~ msgid "blocks"
+#~ msgstr "ブロックス"
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr "メジャーブロックには 2, 3, 6, 7いずれかの数をいれてください。"
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr "メジャーブロックには 2, 3, 6, 7いずれかの数をいれてください。"
 
-#~msgid "Advanced options"
-#~msgstr "上級オプション"
+#~ msgid "Advanced options"
+#~ msgstr "上級オプション"
 
-#~msgid "adjust transposition"
-#~msgstr "移調を変える"
+#~ msgid "adjust transposition"
+#~ msgstr "移調を変える"
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "はやいスピードでさいせいするためにはここをクリック。"
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "はやいスピードでさいせいするためにはここをクリック。"
 
-#~msgid "Run note by note"
-#~msgstr "おんぷを ひとつずつ さいせい"
+#~ msgid "Run note by note"
+#~ msgstr "おんぷを ひとつずつ さいせい"
 
-#~msgid "Next page"
-#~msgstr "つぎの ページ"
+#~ msgid "Next page"
+#~ msgstr "つぎの ページ"
 
-#~msgid "Long press on blocks to copy."
-#~msgstr "ブロック ながおしで コピー"
+#~ msgid "Long press on blocks to copy."
+#~ msgstr "ブロック ながおしで コピー"
 
-#~msgid "on offbeat do"
-#~msgstr "じゃくはくにて～する"
+#~ msgid "on offbeat do"
+#~ msgstr "じゃくはくにて～する"
 
-#~msgid "Hard stop"
-#~msgstr "すぐストップ"
+#~ msgid "Hard stop"
+#~ msgstr "すぐストップ"
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore the Musical Blocks, the Matrix, and the Performance/Notation possibilities of Music Blocks. \"Let\'s start our tour!\"
-#~msgstr "ミスター・マウスはわたしたちのミュージック・ブロックスのしきしゃです。ミスター・マウスは、あなたのミュージック・ブロックスにおけるさまざまなたんきゅうに力を貸してくれます。さぁ、わたしたちのミュージックブロックスツアーをはじめましょう！ "
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore the Musical Blocks, the Matrix, and the Performance/Notation possibilities of Music Blocks. \"Let\'s start our tour!\"
+#~ msgstr "ミスター・マウスはわたしたちのミュージック・ブロックスのしきしゃです。ミスター・マウスは、あなたのミュージック・ブロックスにおけるさまざまなたんきゅうに力を貸してくれます。さぁ、わたしたちのミュージックブロックスツアーをはじめましょう！ "
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr "Alt+Cでブロックスを コピーすることも できます。"
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr "Alt+Cでブロックスを コピーすることも できます。"
 
-#~msgid "Click here to paste"
-#~msgstr "はりつけるため、ここでクリック"
+#~ msgid "Click here to paste"
+#~ msgstr "はりつけるため、ここでクリック"
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr "ツールバーを開いたり閉じたりするにはこのボタンをクリックしてください"
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr "ツールバーを開いたり閉じたりするにはこのボタンをクリックしてください"
 
-#~msgid "Run music step by step"
-#~msgstr "音楽を音符ずつ演奏する"
+#~ msgid "Run music step by step"
+#~ msgstr "音楽を音符ずつ演奏する"
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr "スタックを長押しすると現れます。"
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr "スタックを長押しすると現れます。"
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr "完全ブロックには 1, 4, 5, 8 いずれかの数をいれてください"
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr "完全ブロックには 1, 4, 5, 8 いずれかの数をいれてください"
 
-#~msgid "table"
-#~msgstr "グラフ"
+#~ msgid "table"
+#~ msgstr "グラフ"
 
-#~msgid "cp"
-#~msgstr "ヌ"
+#~ msgid "cp"
+#~ msgstr "ヌ"
 
-#~msgid "vspace"
-#~msgstr "たてのスペース"
+#~ msgid "vspace"
+#~ msgstr "たてのスペース"
 
-#~msgid "The Paste Button will highlight."
-#~msgstr "ペーストボタンが ひかります。"
+#~ msgid "The Paste Button will highlight."
+#~ msgstr "ペーストボタンが ひかります。"
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "画面上にひょうじされているもの（ブロックスを含む）を全て消します。"
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "画面上にひょうじされているもの（ブロックスを含む）を全て消します。"
 
-#~msgid "next page"
-#~msgstr "つぎの ページ"
+#~ msgid "next page"
+#~ msgstr "つぎの ページ"
 
-#~msgid "On my device"
-#~msgstr "自分のPCにあるファイル"
+#~ msgid "On my device"
+#~ msgstr "自分のPCにあるファイル"
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "ディミニッシュブロックには 1, 2, 3, 4, 5, 6, 7, 8 いずれかのかずをいれてください"
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "ディミニッシュブロックには 1, 2, 3, 4, 5, 6, 7, 8 いずれかのかずをいれてください"
 
-#~msgid "Run music slow"
-#~msgstr "おんがくを スロー さいせい"
+#~ msgid "Run music slow"
+#~ msgstr "おんがくを スロー さいせい"
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr "スタックうえで ながおしすると、スタックを クリップボードに コピー できます。"
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr "スタックうえで ながおしすると、スタックを クリップボードに コピー できます。"
 
-#~msgid "export"
-#~msgstr "エクスポート"
+#~ msgid "export"
+#~ msgstr "エクスポート"
 
-#~msgid "synthesizer"
-#~msgstr "シンセサイザー"
+#~ msgid "synthesizer"
+#~ msgstr "シンセサイザー"
 
-#~msgid "Disable scrolling"
-#~msgstr "スクロールを無効にする"
+#~ msgid "Disable scrolling"
+#~ msgstr "スクロールを無効にする"
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr "リズムブロックと：音高・時刻ぎょうれつと一緒に使いますか？"
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr "リズムブロックと：音高・時刻ぎょうれつと一緒に使いますか？"
 
-#~msgid "My Music Blocks Creation"
-#~msgstr "わたしのミュージック・ブロックスさくひん"
+#~ msgid "My Music Blocks Creation"
+#~ msgstr "わたしのミュージック・ブロックスさくひん"
 
-#~msgid "current pitch octave"
-#~msgstr "今の音が属するオクターヴ"
+#~ msgid "current pitch octave"
+#~ msgstr "今の音が属するオクターヴ"
 
-#~msgid "half note 𝅗𝅥"
-#~msgstr "半おんぷ 𝅗𝅥"
+#~ msgid "half note 𝅗𝅥"
+#~ msgstr "半おんぷ 𝅗𝅥"
 
-#~msgid "Solfege pitch preview"
-#~msgstr "ソルフェージュで おとの たかさの プレビュー"
+#~ msgid "Solfege pitch preview"
+#~ msgstr "ソルフェージュで おとの たかさの プレビュー"
 
-#~msgid "Moveable Do"
-#~msgstr "いどうド"
+#~ msgid "Moveable Do"
+#~ msgstr "いどうド"
 
-#~msgid "Fixed Do"
-#~msgstr "こていド"
+#~ msgid "Fixed Do"
+#~ msgstr "こていド"
 
-#~msgid "Fullscreen"
-#~msgstr "フルスクリーン"
+#~ msgid "Fullscreen"
+#~ msgstr "フルスクリーン"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -14,10 +14,10 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Pootle 2.0.1\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -103,7 +103,7 @@ msgstr "アクション"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr "あひる"
 
@@ -170,7 +170,7 @@ msgstr "プロジェクトのコードを非表示にする"
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "自分のプロジェクト"
 
@@ -184,33 +184,33 @@ msgid "Your recording is in progress."
 msgstr "録音中"
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "ファイル名"
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "曲名"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "作曲家"
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "MIDIのアウトプットがくふにもまとめましょうか？"
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "ギターのTABもがくふにまとめましょうか？"
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "Lilypondがくふのフォーマットでほぞん"
 
@@ -232,7 +232,7 @@ msgstr "Lilypondがくふのフォーマットでほぞん"
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "ミスター・マウス"
 
@@ -310,7 +310,7 @@ msgstr "ほうがん（ざひょう）を表示"
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr "音度"
 
@@ -539,8 +539,8 @@ msgstr "ブロックの ヘルプを 保存"
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "シ ラ ソ ファ ミ レ ド"
 
@@ -699,7 +699,7 @@ msgstr "リズムメーカー"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "音色"
 
@@ -709,14 +709,14 @@ msgstr "階段"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "メトロノーム"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "モード（音階）"
 
@@ -747,7 +747,7 @@ msgstr "ドラム"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "リズムメーカー"
 
@@ -772,7 +772,7 @@ msgstr "リズムメーカー"
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "音の長さ"
 
@@ -781,7 +781,7 @@ msgstr "音の長さ"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "音階の上下"
 
@@ -802,7 +802,7 @@ msgid "silence"
 msgstr "休符"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "下"
 
@@ -820,8 +820,8 @@ msgstr "上"
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "音の高さ"
 
@@ -923,7 +923,7 @@ msgstr "テノール記号"
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "コントラバス"
 
@@ -1057,14 +1057,14 @@ msgstr "ブロックが選ばれていません"
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "ネズミへんこう"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "音色サンプル"
 
@@ -1139,7 +1139,7 @@ msgstr "ドラム・スタート"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "音符"
 
@@ -1175,7 +1175,7 @@ msgstr "実行手順"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr "センサー"
 
@@ -1184,7 +1184,7 @@ msgstr "センサー"
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr "メディア"
 
@@ -1675,7 +1675,7 @@ msgstr "コンパイル完了"
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "ダブルシャープ"
 
@@ -1687,8 +1687,8 @@ msgstr "ダブルシャープ"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "シャープ"
 
@@ -1698,7 +1698,7 @@ msgstr "シャープ"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "ナチュラル"
 
@@ -1710,8 +1710,8 @@ msgstr "ナチュラル"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "フラット"
 
@@ -1721,15 +1721,15 @@ msgstr "フラット"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "ダブルフラット"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr "ユニゾン（同度）"
 
@@ -1738,14 +1738,14 @@ msgstr "ユニゾン（同度）"
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "メジャー"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr "アイオニアン音階"
 
@@ -1754,14 +1754,14 @@ msgstr "アイオニアン音階"
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "マイナー（短）"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr "エオリアン音階"
 
@@ -1802,7 +1802,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "「倍音ウェート」ブロックの中に一つ以上の倍音ブロックが入っている必要があります。"
 
@@ -1811,7 +1811,7 @@ msgid "synth cannot play chords."
 msgstr "このシンセでは和音ができません"
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr "https://github.com/sugarlabs/musicblocks/tree/master/guide-ja/music_blocks_operation_manual.pdf"
 
@@ -1828,7 +1828,7 @@ msgstr "検索"
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "拍子"
 
@@ -1897,8 +1897,8 @@ msgstr "その他"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "プログラム"
 
@@ -1920,7 +1920,7 @@ msgstr "論理"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr "音楽"
 
@@ -2206,7 +2206,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr "もとにもどす"
 
@@ -2537,21 +2537,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr "減14度"
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "１度 2度 3度 4度 5度 6度 7度 8度 9度 10度 11度 12度"
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "オーギュメント（増）"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "ディミニッシュ（減）"
 
@@ -2560,12 +2560,12 @@ msgstr "ディミニッシュ（減）"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "パーフェクト（完全）"
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "クロマティック音階"
 
@@ -2578,62 +2578,62 @@ msgid "spanish"
 msgstr "スペイン音階"
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr "オクタトニック・スケール"
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "ハーモニック・メジャー（和声長音階）"
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "自然短音階"
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "和声短音階"
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "旋律短音階"
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr "ドリアン音階"
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr "フリジアン音階"
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr "リディアン音階"
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "ミクソリディアン音階"
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr "ロクリアン音階"
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "オルタード音階"
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr "ビバップ音階"
 
@@ -2646,7 +2646,7 @@ msgid "byzantine"
 msgstr "ビザンティン"
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "ヴェルディの音階"
 
@@ -2655,7 +2655,7 @@ msgid "ethiopian"
 msgstr "エチオピア音階"
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "ゲエズ音階"
 
@@ -2668,7 +2668,7 @@ msgid "hungarian"
 msgstr "ハンガリー音階"
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "ルーマニア・マイナー音階"
 
@@ -2677,17 +2677,17 @@ msgid "spanish gypsy"
 msgstr "スパニッシュ・ジプシー音階"
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "マカーム音階"
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "マイナー・ブルース音階"
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr "メジャー・ブルース音階"
 
@@ -2696,12 +2696,12 @@ msgid "whole tone"
 msgstr "ホールトーン音階"
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "マイナー・ペンタトニック音階"
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "メジャー・ペンタトニック音階"
 
@@ -2714,7 +2714,7 @@ msgid "egyptian"
 msgstr "エジプト音階"
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "平調子"
 
@@ -2723,17 +2723,17 @@ msgid "Japan"
 msgstr "日本"
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "陰音階"
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "民謡音階"
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "フィボナッチ音階"
 
@@ -2750,56 +2750,56 @@ msgstr "フィボナッチ音階"
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr "オリジナル"
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr "ハイパス・フィルター"
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr "ローパス・フィルター"
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr "バンドパス・フィルター"
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr "ハイシェルフ・フィルター"
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr "ローシェルフ・フィルター"
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr "ノッチ・フィルター"
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr "オールパスフィルター"
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr "ピーク・フィルタ"
 
@@ -2807,7 +2807,7 @@ msgstr "ピーク・フィルタ"
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "サイン波"
 
@@ -2815,7 +2815,7 @@ msgstr "サイン波"
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "四角の波"
 
@@ -2824,7 +2824,7 @@ msgstr "四角の波"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "三角の波"
 
@@ -2832,7 +2832,7 @@ msgstr "三角の波"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "ぎざぎざの波"
 
@@ -2841,8 +2841,8 @@ msgstr "ぎざぎざの波"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr "偶数"
 
@@ -2850,7 +2850,7 @@ msgstr "偶数"
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr "奇数"
 
@@ -2864,116 +2864,116 @@ msgstr "音階的"
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr "ピアノ"
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr "バイオリン"
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr "ビオラ"
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "木琴"
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "鉄琴"
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr "チェロ"
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr "ダブルベース"
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr "ギター"
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr "アコースティック"
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr "フルート"
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr "クラリネット"
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr "サクソフォン"
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr "チューバ"
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr "トランペット"
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr "オーボエ"
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr "トロンボーン"
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr "シンセサイザー"
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "シンプル１"
 
@@ -2992,19 +2992,19 @@ msgstr "シンプル４"
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr "ホワイトノイズ"
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "ブラウンノイズ"
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "ピンクノイズ"
 
@@ -3012,61 +3012,61 @@ msgstr "ピンクノイズ"
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr "スネアドラム"
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr "キックドラム"
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr "タムタム"
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr "フロアタム"
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr "バスドラム"
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "カップドラム"
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr "ダブカドラム"
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr "ハイハット"
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr "ライドベル"
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr "カウベル"
 
@@ -3076,149 +3076,149 @@ msgstr "太鼓"
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr "鉦"
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr "トライアングル"
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr "フィンガーシンバル"
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "チャイム"
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr "ドラ"
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr "カチャカチャ"
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr "クラッシュ"
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr "空きびん"
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr "てびょうし"
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr "ピシャリ"
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr "しぶき"
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr "あわ"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr "雨のしずく"
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr "ねこ"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr "こおろぎ"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr "いぬ"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr "バンジョー"
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr "こと"
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr "ダルシマー"
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr "エレキギター"
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr "バスーン"
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr "セレスタ"
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr "平均律"
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "ピタゴラス音律 "
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr "純正律"
 
@@ -3227,7 +3227,7 @@ msgstr "純正律"
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr "中全音律"
 
@@ -3306,22 +3306,22 @@ msgid "previous"
 msgstr "この前の"
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "シンプル・シンセ２"
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "シンプル・シンセ３"
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "シンプル・シンセ４"
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr "太鼓"
 
@@ -3478,7 +3478,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "数価を表す"
 
@@ -3500,7 +3500,7 @@ msgstr "キーワード"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "調"
 
@@ -3511,7 +3511,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr "値を設定"
 
@@ -3540,7 +3540,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "音符をドラムに変える"
 
@@ -3549,7 +3549,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "例の画像に<em>ソル</em>の代わりに<em>キックドラム</em>が鳴らします。"
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "ドラムをせってい"
 
@@ -3582,7 +3582,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "ヒープは空ですか？"
 
@@ -3592,7 +3592,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "空のヒープ"
 
@@ -3601,7 +3601,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr "ヒープを逆にする"
 
@@ -3610,7 +3610,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "ヒープに番号をふる"
 
@@ -3633,13 +3633,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "ヒープを設定する"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "インデックス"
 
@@ -3648,7 +3648,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "ポップ"
 
@@ -3657,7 +3657,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "プッシュ"
 
@@ -3677,7 +3677,7 @@ msgstr "音律をせってい"
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "オクターヴの高さ"
 
@@ -3702,7 +3702,7 @@ msgid "current interval"
 msgstr "現在の音階"
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr "半音階的音程で計る"
 
@@ -3716,7 +3716,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr "全音階的音程で計る"
 
@@ -3726,7 +3726,7 @@ msgstr "例の画像には<em>ソル</em>が<em>ソル#</em>になります。"
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr "半音階的音程"
 
@@ -3764,7 +3764,7 @@ msgid "In the figure, we add la to sol."
 msgstr "<br><br>上の図では、ソの「音符（おんぷ）ブロック」をきじゅんにして、「音階の上下ブロック」のすうちを２にせっていしているので、ソと、ソから２音あがったシの音が同時にえんそうされる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。"
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr "モードを定義する"
 
@@ -3773,7 +3773,7 @@ msgid "movable Do"
 msgstr "移動ド"
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "音階の音数"
 
@@ -3786,18 +3786,18 @@ msgid "Most Western scales have 7 notes."
 msgstr "西洋のほとんどの音階は、7つの音をもつ。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。"
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "現代の音階"
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr "現代の調"
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "調をせってい"
 
@@ -3918,7 +3918,7 @@ msgstr "スラーの長さファクター"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr "音を加える"
 
@@ -3937,7 +3937,7 @@ msgstr "スラー"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "スタッカート"
 
@@ -3946,7 +3946,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr "アプリからヒープをロード"
 
@@ -3963,7 +3963,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr "アプリにヒープを保存"
 
@@ -3976,7 +3976,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "ヒープをロードする"
 
@@ -4005,7 +4005,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "辞書をロード"
 
@@ -4028,7 +4028,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr "辞書を設定"
 
@@ -4045,7 +4045,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "ヒープを保存する"
 
@@ -4054,7 +4054,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr "辞書を保存"
 
@@ -4071,7 +4071,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr "ブロックを消す"
 
@@ -4080,7 +4080,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr "ブロックを動かす"
 
@@ -4114,7 +4114,7 @@ msgid "y"
 msgstr "yざひょう（たて）"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr "ブロックを再生"
 
@@ -4123,7 +4123,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr "ブロックを繋ぐ"
 
@@ -4140,7 +4140,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr "ブロックを作る"
 
@@ -4155,7 +4155,7 @@ msgstr "ブロックを作る"
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "音符"
 
@@ -4189,12 +4189,12 @@ msgstr "音の長さは、0より大きいあたいをせっていしてくだ�
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "スイング"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "スイングの数値"
 
@@ -4203,12 +4203,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "音符の省略"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "音価を～倍にするファクター"
 
@@ -4217,13 +4217,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr "<h2>タイブロック</h2><br>２つの音をつなげて１つの音にする。「音の高さブロック」を入れて使う。同じ高さの音だけ、つなぐことができる。"
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "タイ"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "付点音符"
 
@@ -4241,7 +4241,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr "音符（ドラム）"
 
@@ -4273,8 +4273,8 @@ msgstr "オクターヴ・スペース"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "連符（かけ算）"
 
@@ -4330,7 +4330,7 @@ msgstr "全音符"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "～連符（タプル）"
 
@@ -4487,12 +4487,12 @@ msgid "duplicate factor"
 msgstr "複製ファクター"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr "現代の拍子"
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "拍を～倍にするファクター"
 
@@ -4502,8 +4502,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "１分当たりの拍の数"
 
@@ -4511,12 +4511,12 @@ msgstr "１分当たりの拍の数"
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "スピードを決める"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr "小節の数"
 
@@ -4525,7 +4525,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr "拍の位置"
 
@@ -4542,7 +4542,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr "<br>図の例では、それぞれの小節の１拍（ぱく）目に、特定のアクション・イベントを起こしている。"
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr "音の長さを足す"
 
@@ -4552,12 +4552,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr "音符の合計数"
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr "さいせいされた全音符の数"
 
@@ -4567,7 +4567,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr "全体の拍の数"
 
@@ -4576,7 +4576,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr "<em>クロックなし</em>ブロックはそれぞれの動作の順番をリズムより優先します。"
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "クロックなし"
 
@@ -4626,7 +4626,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr "全体のスピードを決める"
 
@@ -4659,7 +4659,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr "<h2>スピードを決めるブロック</h2><br>１分あたりの拍（はく）の数をせっていすることで、曲のスピードを決める。ひょうじゅんは４分音符（おんぷ）９０こ。<br><br>★拍（はく）とは<br>くり返されるリズムのこと。"
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr "ピックアップ"
 
@@ -4668,12 +4668,12 @@ msgid "number of beats"
 msgstr "拍の数"
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "移調"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr "音階内で~度下がる:"
 
@@ -4682,7 +4682,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr "音階内で~度上がる:"
 
@@ -4691,7 +4691,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr "音程の違い"
 
@@ -4700,7 +4700,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr "<em>音程の違い</em>ブロックは現在に鳴らされている音高と現在のちょうど前に鳴らされている音高（半音の値で）の違いです。"
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr "音階のよって音程の違い"
 
@@ -4711,8 +4711,8 @@ msgstr "音階のよって音程の違い"
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr "音の高さを数で表示"
 
@@ -4722,7 +4722,7 @@ msgstr "<h2>音の高さを数で表示ブロック</h2><br>音の高さを数�
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr "音の高さをヘルツで表示"
 
@@ -4748,7 +4748,7 @@ msgid "alphabet"
 msgstr "アルファベット"
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr "アルファベット・クラス"
 
@@ -4786,12 +4786,12 @@ msgstr "音の高さを色に"
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr "音高の数字を初期化"
 
@@ -4803,12 +4803,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "名前"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "数字を音名へ"
 
@@ -4817,7 +4817,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "数値をオクターヴ表記へ"
 
@@ -4863,22 +4863,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr "転回を"
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "転回を （奇数）"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "転回を （偶数）"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr "登録"
 
@@ -4887,7 +4887,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -4900,7 +4900,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr "例の画像に<em>ソル</em>が<em>ソル#</em>に上に移動されています。"
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr "半音で移調"
 
@@ -4909,47 +4909,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr "「比で移動」ブロックは 音符の中のピッチを比で移動させる。"
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr "比で移動"
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr "音階で6度下"
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr "音階で3度下"
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr "7度の音"
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr "6度の音"
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr "5度の音"
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr "４度の音"
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr "3度の音"
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr "2度の音"
 
@@ -4962,7 +4962,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr "<br><br>図の例では、ソがラに、ラがシに、シがドに…と置きかえられている。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。<br>★調とは<br>中心的な役わりをはたす音と、音階の種類によって決まる、曲の感じ。中心的な役わりをはたす音だけを指すこともある。"
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr "調を変える"
 
@@ -4971,7 +4971,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr "<em>変化記号</em>ブロックは <em>シャープ(嬰)</em>と<em>フラット(変)</em>を決める機能です。"
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr "変化記号無視"
 
@@ -4979,7 +4979,7 @@ msgstr "変化記号無視"
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr "ヘルツ"
 
@@ -4993,8 +4993,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr "ピッチ度"
 
@@ -5023,7 +5023,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr "音階内を上る／下りる"
 
@@ -5048,14 +5048,14 @@ msgstr "オシレータ―"
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr "種類"
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr "倍音"
 
@@ -5065,7 +5065,7 @@ msgstr "複数のオシレーターブロックを追加しています。"
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr "シーケンサー込みシンセ"
 
@@ -5084,7 +5084,7 @@ msgstr "ビブラートエフェクタの強度"
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr "AM シンセ"
 
@@ -5094,7 +5094,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr "FM シンセ"
 
@@ -5111,17 +5111,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr "倍音のウェートは０と１の間である必要があります。"
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr "倍音ブロックが「倍音ウェートブロック」の中にある必要があります。"
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr "ウェート倍音"
 
@@ -5130,7 +5130,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr "ハーモニックス"
 
@@ -5140,7 +5140,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr "ディストーション"
 
@@ -5150,7 +5150,7 @@ msgstr "<h2>トレモロブロック</h2><br>ゆれるような音のひびき�
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr "トレモロ"
 
@@ -5162,7 +5162,7 @@ msgstr "トレモロ"
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr "はやさ"
 
@@ -5170,7 +5170,7 @@ msgstr "はやさ"
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr "大きさ"
 
@@ -5180,7 +5180,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr "フェーザー"
 
@@ -5201,7 +5201,7 @@ msgstr "<h2>コーラスブロック</h2><br>広がりのある音のひびき�
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr "コーラス"
 
@@ -5216,7 +5216,7 @@ msgstr "<h2>ビブラートブロック</h2><br>音の高さに小きざみな�
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr "ビブラート"
 
@@ -5226,7 +5226,7 @@ msgid "intensity"
 msgstr "大きさ"
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr "シンセを設定"
 
@@ -5240,7 +5240,7 @@ msgstr "音色標準を設定"
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr "音色をせってい"
 
@@ -5296,7 +5296,7 @@ msgstr "計算する"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr "<h2>アクションブロック（指定）</h2><br>指定したアクションブロックを実行する。"
 
@@ -5474,7 +5474,7 @@ msgid "Cannot find start block"
 msgstr "「スタート」ブロックが見つかりません。"
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "ネズミの色"
 
@@ -5483,7 +5483,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "タートルの色"
 
@@ -5492,7 +5492,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "ネズミの進む角度"
 
@@ -5501,7 +5501,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "タートルの進む角度"
 
@@ -5511,13 +5511,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr "ネズミを設定"
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr "タートルを設定"
 
@@ -5530,7 +5530,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "ネズミのy座標"
 
@@ -5539,7 +5539,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "タートルのy座標"
 
@@ -5548,7 +5548,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "ネズミのx座標"
 
@@ -5557,7 +5557,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "タートルのx座標"
 
@@ -5566,7 +5566,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "ネズミの演奏した音符の数"
 
@@ -5575,7 +5575,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "タートルの演奏した音符の数"
 
@@ -5584,7 +5584,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "ネズミの音高数字"
 
@@ -5593,7 +5593,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "タートルの音高数字"
 
@@ -5603,17 +5603,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr "ネズミの音価"
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "タートルの音価"
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "ネズミを同期させる"
 
@@ -5622,7 +5622,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "タートルを同期させる"
 
@@ -6049,7 +6049,7 @@ msgid "wrap"
 msgstr "巻きつける"
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr "ざひょうち（右）"
 
@@ -6059,7 +6059,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの右のｘざひょうち。プラスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "ざひょうち（左）"
 
@@ -6103,12 +6103,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスのたてはばのすうちを表す。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "再生を停止"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr "メディアを消す"
 
@@ -6117,7 +6117,7 @@ msgid "The Erase Media block erases text and images."
 msgstr "「メディアを消す」のブロックは文字と画像を消します。"
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "プレーバック"
 
@@ -6174,7 +6174,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "音符の高さを周波数表示へ"
 
@@ -6192,7 +6192,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "大きさ"
 
@@ -6205,7 +6205,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr "<h2>表示ブロック（スタンプ）</h2><br>スタンプは、実行するとネズミの位置に指定した文字またはがぞうを表示する。ネズミの体の下に表れるので、小さい文字やがぞうだとネズミが移動しないと見えない場合がある。"
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "スタンプ"
 
@@ -6270,7 +6270,7 @@ msgstr "記入を終わらせる"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "背景"
 
@@ -6335,7 +6335,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "（中空の）線"
 
@@ -6344,12 +6344,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがいた図形の内がわをぬりつぶす。"
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "ぬりつぶす"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "ペンを上げる"
 
@@ -6358,7 +6358,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "<h2>ペンブロック</h2><br>ネズミの動きに合わせて線をえがくことをやめる。"
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "ペンを下ろす"
 
@@ -6367,7 +6367,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "<h2>ペンブロック</h2><br>ネズミの動きに合わせて線をえがく。"
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "太さをせってい"
 
@@ -6376,7 +6376,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがく線の太さをせっていする。太さには、0より大きいあたいを使う。"
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "透明度を設定"
 
@@ -6401,7 +6401,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがく線の色のこさをせっていする。"
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "灰色を設定"
 
@@ -6536,27 +6536,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr "エンベロープ"
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "アタック"
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "ディケイ"
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "サステイン"
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "リリース"
 
@@ -6582,18 +6582,18 @@ msgstr "封筒ブロックを複数追加しています。"
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr "フィルター"
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr "ロールオフ"
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr "ロールオフ値は -12, -24, -48, -98 デシベル / オクターヴである必要があります。"
 
@@ -6608,7 +6608,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "サンプラー"
 
@@ -6629,7 +6629,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr "<h2>モード（音階）ブロック</h2><br>いろいろな音階をさがすツールを表示する。音階は、音と音のかんかくを決めながらさがすことができる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。"
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "音階"
 
@@ -6646,7 +6646,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "音高-ドラム・マッパー"
 
@@ -6659,7 +6659,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr "<h2>ヘルツスライダーブロック</h2><br>スライダーを上下にうごかすことで、違う周波数（ヘルツのすうち）の音を聞くことができる。作った音をデータ化することができる。また、ヘルツの初期せっていちは、自由に変えられる。<br><br>★ヘルツとは音の高さを表す周波数。<br>★周波数とは音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。"
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "ヘルツスライダー"
 
@@ -6669,7 +6669,7 @@ msgstr "クロマティック・キーボード"
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr "キーボード"
 
@@ -6683,7 +6683,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "音高の数列を作る"
 
@@ -6704,7 +6704,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr "<h2>フレーズメーカーブロック</h2><br>フレーズを作るためのテーブルを表示する。作ったフレーズをデータ化することができる。<br><br>★フレーズとは<br>ひとまとまりの音楽。<br><br>"
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "フレーズメーカー"
 
@@ -6718,7 +6718,7 @@ msgstr "<h2>実行じょうきょうブロック</h2><br>ブロックの実行�
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr "AI音楽"
 
@@ -6905,7 +6905,7 @@ msgstr "ビブラートのはやさは、0より大きいあたいをせって�
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr "（エフェクタの）深さの数字が変域外です。"
 
@@ -6914,7 +6914,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr "ディストーションは、0から100までのはんいでせっていしてください。"
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr "倍音が０以上である必要があります。"
 
@@ -7036,7 +7036,7 @@ msgid "Undo"
 msgstr "１つもどす"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr "クリックで音の高さを選んで音階を設定できます。"
 
@@ -7119,7 +7119,7 @@ msgid "Save drum machine"
 msgstr "ドラムとしてほぞん"
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr "リズムをタップする"
 
@@ -7169,7 +7169,7 @@ msgid "Playback"
 msgstr "再生"
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr "参照ピッチ"
 
@@ -7286,7 +7286,7 @@ msgstr "シンセサイザー"
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr "音響効果"
 
@@ -7365,48 +7365,48 @@ msgid "Cannot connect to server"
 msgstr "サーバに接続できません"
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr "全てのプロジェクト"
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr "自分のプロジェクト"
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr "プロジェクトの見本"
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr "アート"
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr "算数"
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr "インタラクティブ"
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr "デザイン"
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr "ゲーム"
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr "短いコード"
 
@@ -7839,38 +7839,38 @@ msgstr "動き出し"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr "プロジェクトの音をWAVで保存"
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr "プロジェクトの音をWAVで保存"
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr "プロジェクトをABCで保存"
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr "プロジェクトをABCで保存"
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "作成した音楽を、コンピューター上でがくふをえがくファイル（Lilypondファイル）に変えてほぞんする。"
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "作成した音楽を、コンピューター上でがくふをえがくファイル（Lilypondファイル）に変えてほぞんする。"
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr "カンバス上にほうがん（ざひょう）や中心の角度を表示したり、かくしたりできる。"
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr "カンバス上にほうがん（ざひょう）や中心の角度を表示したり、かくしたりできる。"
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr "ブロックを広げる/折りたたむ"
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr "ブロックを広げる/折りたたむ"
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "ミスター・マウスによる、ミュージック・ブロックスの説明を表示する。"
+#~ msgid "Show these messages."
+#~ msgstr "ミスター・マウスによる、ミュージック・ブロックスの説明を表示する。"
 
 #: js/rubrics.js:531
 
@@ -7878,8 +7878,8 @@ msgstr "動き出し"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "センサー"
+#~ msgid "sensors"
+#~ msgstr "センサー"
 
 #: js/rubrics.js:532
 
@@ -7889,8 +7889,8 @@ msgstr "動き出し"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "他のメディア"
+#~ msgid "media"
+#~ msgstr "他のメディア"
 
 #: js/block-verbose.js:3837
 
@@ -7902,35 +7902,35 @@ msgstr "動き出し"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr "右岸座標と極座標を表示"
+#~ msgid "Cartesian+polar"
+#~ msgstr "右岸座標と極座標を表示"
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "表示する"
+#~ msgid "show"
+#~ msgstr "表示する"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr "ブロックを表示する/かくす"
+#~ msgid "Show/hide block"
+#~ msgstr "ブロックを表示する/かくす"
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "グリッド"
+#~ msgid "grid"
+#~ msgstr "グリッド"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr "変化記号は"
+#~ msgid "You have chosen key "
+#~ msgstr "変化記号は"
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr "の音階によって設定しています。"
+#~ msgid " for your pitch preview."
+#~ msgstr "の音階によって設定しています。"
 
 #: js/toolbar.js:113
 
@@ -7944,69 +7944,69 @@ msgstr "動き出し"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr "フルスクリーン"
+#~ msgid "Full Screen"
+#~ msgstr "フルスクリーン"
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr "新しいプロジェクト"
+#~ msgid "New Project"
+#~ msgstr "新しいプロジェクト"
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr "音楽"
+#~ msgid "music"
+#~ msgstr "音楽"
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr "保存する"
+#~ msgid "save"
+#~ msgstr "保存する"
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "ネズミとペンをもどす"
+#~ msgid "Clean"
+#~ msgstr "ネズミとペンをもどす"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "ゆっくり実行する"
+#~ msgid "Run slow"
+#~ msgstr "ゆっくり実行する"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr "中全音律"
+#~ msgid "meantone"
+#~ msgstr "中全音律"
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr "オリジナル"
+#~ msgid "Custom"
+#~ msgstr "オリジナル"
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "ブロックを非表示"
+#~ msgid "hide blocks"
+#~ msgstr "ブロックを非表示"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr "複製する"
+#~ msgid "duplicate"
+#~ msgstr "複製する"
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8026,13 +8026,13 @@ msgstr "動き出し"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "止める"
+#~ msgid "stop"
+#~ msgstr "止める"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "長さ（ミリ秒）"
+#~ msgid "duration (ms)"
+#~ msgstr "長さ（ミリ秒）"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8040,58 +8040,58 @@ msgstr "動き出し"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "もとにもどす"
+#~ msgid "clear"
+#~ msgstr "もとにもどす"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "両方向にずれる"
+#~ msgid "invert"
+#~ msgstr "両方向にずれる"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr "オシレータ―"
+#~ msgid "oscillator"
+#~ msgstr "オシレータ―"
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr "ずれ"
+#~ msgid "delay"
+#~ msgstr "ずれ"
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr "エンベロープ"
+#~ msgid "envelope"
+#~ msgstr "エンベロープ"
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr "フィルター"
+#~ msgid "filter"
+#~ msgstr "フィルター"
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr "AI音楽"
+#~ msgid "aimusic"
+#~ msgstr "AI音楽"
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr "下"
+#~ msgid " below"
+#~ msgstr "下"
 
 #: js/widgets/modewidget.js:1017
 
@@ -8107,25 +8107,25 @@ msgstr "動き出し"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr "新しいアクションを作りました！"
+#~ msgid "New action block generated!"
+#~ msgstr "新しいアクションを作りました！"
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr "録音中"
+#~ msgid "Recording started..."
+#~ msgstr "録音中"
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr "録音完了"
+#~ msgid "Recording complete..."
+#~ msgstr "録音完了"
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "期間の設定"
+#~ msgid "duration"
+#~ msgstr "期間の設定"
 
 #: js/widgets/temperament.js:454
 
@@ -8135,1118 +8135,1118 @@ msgstr "動き出し"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr "とじる"
+#~ msgid "close"
+#~ msgstr "とじる"
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr "プロジェクトを公開する"
+#~ msgid "Publish Project"
+#~ msgstr "プロジェクトを公開する"
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr "実行"
+#~ msgid "play"
+#~ msgstr "実行"
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr "Lilypondではこのピックアップを対応できません："
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr "Lilypondではこのピックアップを対応できません："
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr "高度モードにするには、ブラウザをこうしんして下さい。"
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr "高度モードにするには、ブラウザをこうしんして下さい。"
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr "はってんモードにするには、ブラウザをこうしんしてください。"
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr "はってんモードにするには、ブラウザをこうしんしてください。"
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr "新しいアクションを作りました"
+#~ msgid "New action blocks generated"
+#~ msgstr "新しいアクションを作りました"
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr "新しいアクションを作りました"
+#~ msgid "New action block generated"
+#~ msgstr "新しいアクションを作りました"
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr "JavaScript編集をオン／オフ"
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr "JavaScript編集をオン／オフ"
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr "音階内を上る／下りるブロックは、音符ブロックの中に入れて使ってください。"
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr "音階内を上る／下りるブロックは、音符ブロックの中に入れて使ってください。"
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr "音階内を上る／下りるブロックは、音の高さブロックの後に使ってください。"
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr "音階内を上る／下りるブロックは、音の高さブロックの後に使ってください。"
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr "<br><br>３連符（れんぷ）や５連符（れんぷ）など、２の倍数ではない音符（おんぷ）の数でグループを作りやすくなる。"
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr "<br><br>３連符（れんぷ）や５連符（れんぷ）など、２の倍数ではない音符（おんぷ）の数でグループを作りやすくなる。"
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr "<h2>音律（おんりつ）をせっていブロック</h2><br>ミュージック・ブロックスで用いる音階の調律（ちょうりつ）のしかたをせっていする。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。<br>★調律（ちょうりつ）とは<br>楽器の音の高さを、音律（おんりつ）にしたがって整えること。<br>★音律（おんりつ）とは<br>音程（おんてい）（音どうしのへだたり）の決め方。同じ音階でも、音律（おんりつ）によって音の高さが変わる。<br>★オクターヴの高さとは<br>同じ名前でも高さがちがう音を表すすうち。<br>"
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr "<h2>音律（おんりつ）をせっていブロック</h2><br>ミュージック・ブロックスで用いる音階の調律（ちょうりつ）のしかたをせっていする。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。<br>★調律（ちょうりつ）とは<br>楽器の音の高さを、音律（おんりつ）にしたがって整えること。<br>★音律（おんりつ）とは<br>音程（おんてい）（音どうしのへだたり）の決め方。同じ音階でも、音律（おんりつ）によって音の高さが変わる。<br>★オクターヴの高さとは<br>同じ名前でも高さがちがう音を表すすうち。<br>"
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr "「音程を数で表示」ブロックは音階の数を経産して表示する"
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr "「音程を数で表示」ブロックは音階の数を経産して表示する"
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr "<em>半音階的音程</em>ブロックは音階を無視、半音で新しい音高を計算して鳴らします。"
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr "<em>半音階的音程</em>ブロックは音階を無視、半音で新しい音高を計算して鳴らします。"
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr "「アルペジオ」ブロックは 「音符」ブロックを回数 再生して、コードによって 変更します。"
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr "「アルペジオ」ブロックは 「音符」ブロックを回数 再生して、コードによって 変更します。"
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr "<h2>音階の上下ブロック</h2><br>中に組み入れる「音符（おんぷ）ブロック」の音をきじゅんにして、別の音をつけ加える。"
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr "<h2>音階の上下ブロック</h2><br>中に組み入れる「音符（おんぷ）ブロック」の音をきじゅんにして、別の音をつけ加える。"
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr "<h2>アクションブロック</h2><br>ふくすうのブロックを１つのグループとしてまとめ、実行する。グループとなったプログラムは、１つの「アクション」として自由に名前をつけることができる。"
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr "<h2>アクションブロック</h2><br>ふくすうのブロックを１つのグループとしてまとめ、実行する。グループとなったプログラムは、１つの「アクション」として自由に名前をつけることができる。"
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr "<h2>しんぎブロック（大なり）</h2><br>２つのすうちをくらべて、すうちの大小をはんていする。「＞」は上のすうちが下のすうちよりも大きければ「真（しん）」、下のすうちと同じか小さければ「偽（ぎ）」という結果になる。<br><br>★しんぎブロックとは<br>「もし～ならば」などのじょうけんブロックを動かすために必要なブロック。<br>「もし～ならば」は、せいかくに表現すると、「もし～というじょうけんが正しいならば、次のブロックを実行する」という意味である。しんぎブロックは不等式などによるひかくが「正しい（真）」か、「正しくない（偽）」かの結果を表し、「もし～ならば」に続くブロックを実行するかどうか決める。"
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr "<h2>しんぎブロック（大なり）</h2><br>２つのすうちをくらべて、すうちの大小をはんていする。「＞」は上のすうちが下のすうちよりも大きければ「真（しん）」、下のすうちと同じか小さければ「偽（ぎ）」という結果になる。<br><br>★しんぎブロックとは<br>「もし～ならば」などのじょうけんブロックを動かすために必要なブロック。<br>「もし～ならば」は、せいかくに表現すると、「もし～というじょうけんが正しいならば、次のブロックを実行する」という意味である。しんぎブロックは不等式などによるひかくが「正しい（真）」か、「正しくない（偽）」かの結果を表し、「もし～ならば」に続くブロックを実行するかどうか決める。"
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr "<h2>しんぎブロック（小なり）</h2><br>２つのすうちをくらべて、すうちの大小をはんていする。「＜」は上のすうちが下のすうちよりも小さければ「真（しん）」、下のすうちと同じか大きければ「偽（ぎ）」という結果になる。<br><br>★しんぎブロックとは<br>「もし～ならば」などのじょうけんブロックを動かすために必要なブロック。<br>「もし～ならば」は、せいかくに表現すると、「もし～というじょうけんが正しいならば、次のブロックを実行する」という意味である。しんぎブロックは不等式などによるひかくが「正しい（真）」か、「正しくない（偽）」かの結果を表し、「もし～ならば」に続くブロックを実行するかどうか決める。"
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr "<h2>しんぎブロック（小なり）</h2><br>２つのすうちをくらべて、すうちの大小をはんていする。「＜」は上のすうちが下のすうちよりも小さければ「真（しん）」、下のすうちと同じか大きければ「偽（ぎ）」という結果になる。<br><br>★しんぎブロックとは<br>「もし～ならば」などのじょうけんブロックを動かすために必要なブロック。<br>「もし～ならば」は、せいかくに表現すると、「もし～というじょうけんが正しいならば、次のブロックを実行する」という意味である。しんぎブロックは不等式などによるひかくが「正しい（真）」か、「正しくない（偽）」かの結果を表し、「もし～ならば」に続くブロックを実行するかどうか決める。"
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "<br>図の例では、右向きに進み続けるネズミがカンバスの右からはみ出ると、カンバスの左から出てくる。"
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "<br>図の例では、右向きに進み続けるネズミがカンバスの右からはみ出ると、カンバスの左から出てくる。"
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "<br>図の例では、右向きに進み続けるタートルがカンバスの右からはみ出ると、カンバスの左から出てくる。"
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "<br>図の例では、右向きに進み続けるタートルがカンバスの右からはみ出ると、カンバスの左から出てくる。"
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "<br>図の例では、上向きに進み続けるネズミがカンバスの上からはみ出ると、カンバスの下から出てくる。"
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "<br>図の例では、上向きに進み続けるネズミがカンバスの上からはみ出ると、カンバスの下から出てくる。"
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "<br>図の例では、上向きに進み続けるタートルがカンバスの上からはみ出ると、カンバスの下から出てくる。"
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "<br>図の例では、上向きに進み続けるタートルがカンバスの上からはみ出ると、カンバスの下から出てくる。"
 
-#~msgid "video material"
-#~msgstr "がぞうそざい"
+#~ msgid "video material"
+#~ msgstr "がぞうそざい"
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr "<h2>ドラムをせっていブロック</h2><br>「音符（おんぷ）ブロック」内の音を、ドラムの音に置きかえる。<br>図の例では、ソの音のかわりに、キックドラムの音がえんそうされる。"
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr "<h2>ドラムをせっていブロック</h2><br>「音符（おんぷ）ブロック」内の音を、ドラムの音に置きかえる。<br>図の例では、ソの音のかわりに、キックドラムの音がえんそうされる。"
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr "<h2>音の長さブロック</h2><br>音の長さを表示する。<br>"
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr "<h2>音の長さブロック</h2><br>音の長さを表示する。<br>"
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr "<h2>休符（きゅうふ）ブロック</h2><br>音がない部分に使われる。<br><br>★休符（きゅうふ）とは<br>休みの長さ。"
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr "<h2>休符（きゅうふ）ブロック</h2><br>音がない部分に使われる。<br><br>★休符（きゅうふ）とは<br>休みの長さ。"
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr "<h2>じょうけんブロック</h2><br>じょうけんブロックを使うと、じょうけんによってちがうはたらきをするプログラムを作ることができる。"
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr "<h2>じょうけんブロック</h2><br>じょうけんブロックを使うと、じょうけんによってちがうはたらきをするプログラムを作ることができる。"
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr "<br><br>図の例では、もし、パソコンのマウスを長おししていれば「キックドラム」ブロックをえんそうする。長おししていなければ（そうでなければ）「キックドラム」ブロックをえんそうする。"
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr "<br><br>図の例では、もし、パソコンのマウスを長おししていれば「キックドラム」ブロックをえんそうする。長おししていなければ（そうでなければ）「キックドラム」ブロックをえんそうする。"
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr "<br><br>図の例は「アクション」の実行をくり返す。"
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr "<br><br>図の例は「アクション」の実行をくり返す。"
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr "<h2>いどうブロック</h2><br>ネズミの位置を、指定した大きさと角度の円をえがいていどうさせる。角度のすうちは、プラスだと右回り、マイナスだと左回りになる。"
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr "<h2>いどうブロック</h2><br>ネズミの位置を、指定した大きさと角度の円をえがいていどうさせる。角度のすうちは、プラスだと右回り、マイナスだと左回りになる。"
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr "<h2>いどうブロック</h2><br>タートルの位置を、指定した大きさと角度の円をえがいていどうさせる。角度のすうちは、プラスだと右回り、マイナスだと左回りになる。"
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr "<h2>いどうブロック</h2><br>タートルの位置を、指定した大きさと角度の円をえがいていどうさせる。角度のすうちは、プラスだと右回り、マイナスだと左回りになる。"
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr "<h2>いどうブロック</h2><br>ネズミの向きを、指定したすうちの角度に変える。"
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr "<h2>いどうブロック</h2><br>ネズミの向きを、指定したすうちの角度に変える。"
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr "<h2>スラーブロック</h2><br>音と次の音をなめらかにつなげる。ただし、「音符（おんぷ）ブロック」でせっていした音の長さは変わらない。<br><br>"
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr "<h2>スラーブロック</h2><br>音と次の音をなめらかにつなげる。ただし、「音符（おんぷ）ブロック」でせっていした音の長さは変わらない。<br><br>"
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr "<h2>スタッカートブロック</h2><br>音を短かく切る。ただし、「音符（おんぷ）ブロック」でせっていした音の長さは変わらない。<br><br>"
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr "<h2>スタッカートブロック</h2><br>音を短かく切る。ただし、「音符（おんぷ）ブロック」でせっていした音の長さは変わらない。<br><br>"
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr "<h2>デクレシェンドブロック</h2><br>音量をだんだん小さくする。"
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "<h2>デクレシェンドブロック</h2><br>音量をだんだん小さくする。"
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr "<br>たとえば、７つの音にすうちが５の「デクレシェンドブロック」を使うと、１音ごとにさいしょの音の音量の５パーセントずつ音量がへり、さいごの音はさいしょの音よりも３５パーセント音量が小さくなる。"
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr "<br>たとえば、７つの音にすうちが５の「デクレシェンドブロック」を使うと、１音ごとにさいしょの音の音量の５パーセントずつ音量がへり、さいごの音はさいしょの音よりも３５パーセント音量が小さくなる。"
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr "<h2>クレシェンドブロック</h2><br>音量をだんだん大きくする。"
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "<h2>クレシェンドブロック</h2><br>音量をだんだん大きくする。"
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr "<br>たとえば、７つの音に、すうちが５の「クレシェンドブロック」を使うと、１音ごとにさいしょの音の音量の５パーセントずつ音量がふえ、さいごの音はさいしょの音よりも３５パーセント音量が大きくなる。<br><br> "
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr "<br>たとえば、７つの音に、すうちが５の「クレシェンドブロック」を使うと、１音ごとにさいしょの音の音量の５パーセントずつ音量がふえ、さいごの音はさいしょの音よりも３５パーセント音量が大きくなる。<br><br> "
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr "「音色標準を設定」ブロックは音色のデフォルトを「シンセサイザー」からお好みの楽器に設定します。"
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr "「音色標準を設定」ブロックは音色のデフォルトを「シンセサイザー」からお好みの楽器に設定します。"
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr "<br><br>★拍（はく）とは<br>くり返されるリズムのこと。<br>★小節（しょうせつ）とは<br>楽譜（がくふ）の、たての線で区切られた部分。小節（しょうせつ）の中の拍（はく）は、拍子（ひょうし）と同じ数になる。"
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr "<br><br>★拍（はく）とは<br>くり返されるリズムのこと。<br>★小節（しょうせつ）とは<br>楽譜（がくふ）の、たての線で区切られた部分。小節（しょうせつ）の中の拍（はく）は、拍子（ひょうし）と同じ数になる。"
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr "<br><br>★拍（はく）とは<br>くり返されるリズムのこと。"
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr "<br><br>★拍（はく）とは<br>くり返されるリズムのこと。"
 
-#~msgid "More Details"
-#~msgstr "詳細"
+#~ msgid "More Details"
+#~ msgstr "詳細"
 
-#~msgid "Share project"
-#~msgstr "プロジェクトをシェアする"
+#~ msgid "Share project"
+#~ msgstr "プロジェクトをシェアする"
 
-#~msgid "Copy link to clipboard"
-#~msgstr "リンクをクリップボードにコピーする"
+#~ msgid "Copy link to clipboard"
+#~ msgstr "リンクをクリップボードにコピーする"
 
-#~msgid "Run project on startup."
-#~msgstr "スタートしたらプロジェクトを再生する"
+#~ msgid "Run project on startup."
+#~ msgstr "スタートしたらプロジェクトを再生する"
 
-#~msgid "Show code blocks on startup."
-#~msgstr "スタートしたら、コードブロックを表示する"
+#~ msgid "Show code blocks on startup."
+#~ msgstr "スタートしたら、コードブロックを表示する"
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr "スタートしたら、コードブロックを消す"
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr "スタートしたら、コードブロックを消す"
 
-#~msgid "Advanced Options"
-#~msgstr "上級オプション"
+#~ msgid "Advanced Options"
+#~ msgstr "上級オプション"
 
-#~msgid "Warning: Sound is only coming out from one side."
-#~msgstr "音は右か左の一つだけのスピーカから今なっています。"
+#~ msgid "Warning: Sound is only coming out from one side."
+#~ msgstr "音は右か左の一つだけのスピーカから今なっています。"
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr "ヘルツブロック：音符ブロックを使いますか？"
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr "ヘルツブロック：音符ブロックを使いますか？"
 
-#~msgid "triad (root position)"
-#~msgstr "三和音 (基本形)"
+#~ msgid "triad (root position)"
+#~ msgstr "三和音 (基本形)"
 
-#~msgid "triad (1st inversion)"
-#~msgstr "三和音 (第1転回形)"
+#~ msgid "triad (1st inversion)"
+#~ msgstr "三和音 (第1転回形)"
 
-#~msgid "triad (2nd inversion)"
-#~msgstr "三和音 (第2転回形)"
+#~ msgid "triad (2nd inversion)"
+#~ msgstr "三和音 (第2転回形)"
 
-#~msgid "seventh (root position)"
-#~msgstr "七の和音 (基本形)"
+#~ msgid "seventh (root position)"
+#~ msgstr "七の和音 (基本形)"
 
-#~msgid "seventh (1st inversion)"
-#~msgstr "七の和音 (第1転回形)"
+#~ msgid "seventh (1st inversion)"
+#~ msgstr "七の和音 (第1転回形)"
 
-#~msgid "seventh (2nd inversion)"
-#~msgstr "七の和音 (第2転回形)"
+#~ msgid "seventh (2nd inversion)"
+#~ msgstr "七の和音 (第2転回形)"
 
-#~msgid "seventh (3rd inversion)"
-#~msgstr "七の和音 (第3転回形)"
+#~ msgid "seventh (3rd inversion)"
+#~ msgstr "七の和音 (第3転回形)"
 
-#~msgid "ninth (root position)"
-#~msgstr "九の和音 (基本形)"
+#~ msgid "ninth (root position)"
+#~ msgstr "九の和音 (基本形)"
 
-#~msgid "thirteenth (root position)"
-#~msgstr "十三の和音 (基本形)"
+#~ msgid "thirteenth (root position)"
+#~ msgstr "十三の和音 (基本形)"
 
-#~msgid "Like project"
-#~msgstr "プロジェクトに「いいね」をする"
+#~ msgid "Like project"
+#~ msgstr "プロジェクトに「いいね」をする"
 
-#~msgid "Republish Project"
-#~msgstr "プロジェクトを再度公開する"
+#~ msgid "Republish Project"
+#~ msgstr "プロジェクトを再度公開する"
 
-#~msgid "dominant seventh"
-#~msgstr "セブンス"
+#~ msgid "dominant seventh"
+#~ msgstr "セブンス"
 
-#~msgid "minor seventh"
-#~msgstr "マイナー・セブンス"
+#~ msgid "minor seventh"
+#~ msgstr "マイナー・セブンス"
 
-#~msgid "major seventh"
-#~msgstr "メジャー・セブンス"
+#~ msgid "major seventh"
+#~ msgstr "メジャー・セブンス"
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr "注意：音の長さは2より大きいです。"
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr "注意：音の長さは2より大きいです。"
 
-#~msgid "chord5"
-#~msgstr "５度の和音"
+#~ msgid "chord5"
+#~ msgstr "５度の和音"
 
-#~msgid "chord4"
-#~msgstr "4度の和音"
+#~ msgid "chord4"
+#~ msgstr "4度の和音"
 
-#~msgid "chord1"
-#~msgstr "1度の和音"
+#~ msgid "chord1"
+#~ msgstr "1度の和音"
 
-#~msgid "Run fast"
-#~msgstr "実行"
+#~ msgid "Run fast"
+#~ msgstr "実行"
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "膨らむブロックを 表示/非表示"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "膨らむブロックを 表示/非表示"
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr "「何匹目のネズミの名前」のブロックは数字によってそのネズミの名前を表す。"
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr "「何匹目のネズミの名前」のブロックは数字によってそのネズミの名前を表す。"
 
-#~msgid "search for blocks"
-#~msgstr "ブロックをさがす"
+#~ msgid "search for blocks"
+#~ msgstr "ブロックをさがす"
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr "ブラウザ表示を100%に設定してください。"
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr "ブラウザ表示を100%に設定してください。"
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr "このプロジェクトをひらくには、ミュージック・ブロックスにアクセスし、このファイルをアプリケーションのウィンドウにドラッグするか、"
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr "このプロジェクトをひらくには、ミュージック・ブロックスにアクセスし、このファイルをアプリケーションのウィンドウにドラッグするか、"
 
-#~msgid "You must always have at least one start block."
-#~msgstr "スタートブロックは、１つ以上残しておいてください。"
+#~ msgid "You must always have at least one start block."
+#~ msgstr "スタートブロックは、１つ以上残しておいてください。"
 
-#~msgid "pitch up"
-#~msgstr "音の高さを上げる"
+#~ msgid "pitch up"
+#~ msgstr "音の高さを上げる"
 
-#~msgid "pitch down"
-#~msgstr "音の高さを下げる"
+#~ msgid "pitch down"
+#~ msgstr "音の高さを下げる"
 
-#~msgid "currency"
-#~msgstr "通貨"
+#~ msgid "currency"
+#~ msgstr "通貨"
 
-#~msgid "from"
-#~msgstr "から"
+#~ msgid "from"
+#~ msgstr "から"
 
-#~msgid "stock price"
-#~msgstr "株価"
+#~ msgid "stock price"
+#~ msgstr "株価"
 
-#~msgid "translate"
-#~msgstr "翻訳"
+#~ msgid "translate"
+#~ msgstr "翻訳"
 
-#~msgid "hello"
-#~msgstr "こんにちは"
+#~ msgid "hello"
+#~ msgstr "こんにちは"
 
-#~msgid "detect lang"
-#~msgstr "言語を検出"
+#~ msgid "detect lang"
+#~ msgstr "言語を検出"
 
-#~msgid "set lang"
-#~msgstr "言語を設定"
+#~ msgid "set lang"
+#~ msgstr "言語を設定"
 
-#~msgid "city latitude"
-#~msgstr "市の緯度"
+#~ msgid "city latitude"
+#~ msgstr "市の緯度"
 
-#~msgid "city longitude"
-#~msgstr "市の経度"
+#~ msgid "city longitude"
+#~ msgstr "市の経度"
 
-#~msgid "Coordinate data not available."
-#~msgstr "座標データが見つかりません"
+#~ msgid "Coordinate data not available."
+#~ msgstr "座標データが見つかりません"
 
-#~msgid "Google map"
-#~msgstr "グーグルマップ"
+#~ msgid "Google map"
+#~ msgstr "グーグルマップ"
 
-#~msgid "coordinates"
-#~msgstr "座標"
+#~ msgid "coordinates"
+#~ msgstr "座標"
 
-#~msgid "zoom factor"
-#~msgstr "ズームファクター"
+#~ msgid "zoom factor"
+#~ msgstr "ズームファクター"
 
-#~msgid "zoom"
-#~msgstr "ズーム"
+#~ msgid "zoom"
+#~ msgstr "ズーム"
 
-#~msgid "latitude"
-#~msgstr "緯度"
+#~ msgid "latitude"
+#~ msgstr "緯度"
 
-#~msgid "longitude"
-#~msgstr "経度"
+#~ msgid "longitude"
+#~ msgstr "経度"
 
-#~msgid "degrees"
-#~msgstr "温度"
+#~ msgid "degrees"
+#~ msgstr "温度"
 
-#~msgid "radians"
-#~msgstr "ラジアン"
+#~ msgid "radians"
+#~ msgstr "ラジアン"
 
-#~msgid "define"
-#~msgstr "定義"
+#~ msgid "define"
+#~ msgstr "定義"
 
-#~msgid "bitcoin"
-#~msgstr "ビットコイン"
+#~ msgid "bitcoin"
+#~ msgstr "ビットコイン"
 
-#~msgid "You need to select a file."
-#~msgstr "ファイルを選ぶ必要があります"
+#~ msgid "You need to select a file."
+#~ msgstr "ファイルを選ぶ必要があります"
 
-#~msgid "accidental-override"
-#~msgstr "変化記号を無効"
+#~ msgid "accidental-override"
+#~ msgstr "変化記号を無効"
 
-#~msgid "show treble"
-#~msgstr "トレブル記号を表示"
+#~ msgid "show treble"
+#~ msgstr "トレブル記号を表示"
 
-#~msgid "hide Polar"
-#~msgstr "中心の角度をかくす"
+#~ msgid "hide Polar"
+#~ msgstr "中心の角度をかくす"
 
-#~msgid "show bass"
-#~msgstr "バス記号を表示"
+#~ msgid "show bass"
+#~ msgstr "バス記号を表示"
 
-#~msgid "show mezzo-soprano"
-#~msgstr "メゾソプラノを表示"
+#~ msgid "show mezzo-soprano"
+#~ msgstr "メゾソプラノを表示"
 
-#~msgid "show alto"
-#~msgstr "アルト記号を表示"
+#~ msgid "show alto"
+#~ msgstr "アルト記号を表示"
 
-#~msgid "show tenor"
-#~msgstr "テノール記号を表示"
+#~ msgid "show tenor"
+#~ msgstr "テノール記号を表示"
 
-#~msgid "hide bass"
-#~msgstr "バス記号を隠す"
+#~ msgid "hide bass"
+#~ msgstr "バス記号を隠す"
 
-#~msgid "show Polar"
-#~msgstr "ほうがんと角度を表示"
+#~ msgid "show Polar"
+#~ msgstr "ほうがんと角度を表示"
 
-#~msgid "hide Cartesian"
-#~msgstr "ほうがん（ざひょう）をかくす"
+#~ msgid "hide Cartesian"
+#~ msgstr "ほうがん（ざひょう）をかくす"
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr "Lilypondではこのテンポを対応できません："
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr "Lilypondではこのテンポを対応できません："
 
-#~msgid "Save as PDF"
-#~msgstr "PDFでほぞん"
+#~ msgid "Save as PDF"
+#~ msgstr "PDFでほぞん"
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr "Lilypondはこの音階を無視します"
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr "Lilypondはこの音階を無視します"
 
-#~msgid "Do you want to save your project?"
-#~msgstr "プロジェクトをほぞんしますか"
+#~ msgid "Do you want to save your project?"
+#~ msgstr "プロジェクトをほぞんしますか"
 
-#~msgid "Click to select a block."
-#~msgstr "クリックしてブロックを選んで下さい"
+#~ msgid "Click to select a block."
+#~ msgstr "クリックしてブロックを選んで下さい"
 
-#~msgid "hide"
-#~msgstr "隠す"
+#~ msgid "hide"
+#~ msgstr "隠す"
 
-#~msgid "show2"
-#~msgstr "表示する"
+#~ msgid "show2"
+#~ msgstr "表示する"
 
-#~msgid "popout"
-#~msgstr "ポップアップ"
+#~ msgid "popout"
+#~ msgstr "ポップアップ"
 
-#~msgid "myblocks"
-#~msgstr "自分のブロック"
+#~ msgid "myblocks"
+#~ msgstr "自分のブロック"
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr "ドラムブロック：音符ブロックを使いますか？"
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr "ドラムブロック：音符ブロックを使いますか？"
 
-#~msgid "save rhythms"
-#~msgstr "リズムだけをほぞん"
+#~ msgid "save rhythms"
+#~ msgstr "リズムだけをほぞん"
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr "音高ブロック：音符ブロックと一緒に使いますか?"
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr "音高ブロック：音符ブロックと一緒に使いますか?"
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr "<h2>しんぎブロック（クリック）</h2><br>マウスがクリックされたかどうかはんていする。クリックとはおされたマウスボタンが、離されたときのことを示す。クリックされていれば「真（しん）」、されていなければ「偽（ぎ）」という値になる。"
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr "<h2>しんぎブロック（クリック）</h2><br>マウスがクリックされたかどうかはんていする。クリックとはおされたマウスボタンが、離されたときのことを示す。クリックされていれば「真（しん）」、されていなければ「偽（ぎ）」という値になる。"
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr "<h2>数値ブロック</h2><br>数値ブロックとして、箱２の数値を使う。"
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr "<h2>数値ブロック</h2><br>数値ブロックとして、箱２の数値を使う。"
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr "<h2>数値ブロック</h2><br>数値ブロックとして、箱１の数値を使う。"
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr "<h2>数値ブロック</h2><br>数値ブロックとして、箱１の数値を使う。"
 
-#~msgid "Cannot be further decreased"
-#~msgstr "これより小さくできない"
+#~ msgid "Cannot be further decreased"
+#~ msgstr "これより小さくできない"
 
-#~msgid "Cannot be further increased"
-#~msgstr "これより大きくできない"
+#~ msgid "Cannot be further increased"
+#~ msgstr "これより大きくできない"
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr "ネズミの点滅をオフにされ、FPSを１０にされている"
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr "ネズミの点滅をオフにされ、FPSを１０にされている"
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr "ネズミの点滅をオンにされ、FPSを３０にされている；"
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr "ネズミの点滅をオンにされ、FPSを３０にされている；"
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr "タイブロックは、同じ高さの音しかつなげません。スラーブロックを使いますか？"
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr "タイブロックは、同じ高さの音しかつなげません。スラーブロックを使いますか？"
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr "音名はA, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭の中から必要があります。"
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr "音名はA, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭の中から必要があります。"
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr "自分のブロックスを全て消しますか？"
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr "自分のブロックスを全て消しますか？"
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr "インターネットの「プラネット（わくせい）」というページから、ほかの人が作ったプロジェクトを選んで、読みこむことができる。"
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr "インターネットの「プラネット（わくせい）」というページから、ほかの人が作ったプロジェクトを選んで、読みこむことができる。"
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr "このボタンをクリックするとオプションツールバーを表示/非表示"
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr "このボタンをクリックするとオプションツールバーを表示/非表示"
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr "<h2>拍子（ひょうし）ブロック</h2><br>拍子（ひょうし）をせっていする。ひょうじゅんは４分の４拍子（びょうし）。<br><br>★拍子（ひょうし）とは<br>拍がいくつかまとまったもの。<br>★４分の４拍子（びょうし）とは<br>４分音符（おんぷ）が４つでひとまとまりになった拍子（ひょうし）。<br>★拍（はく）とは<br>くり返されるリズムのこと。"
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr "<h2>拍子（ひょうし）ブロック</h2><br>拍子（ひょうし）をせっていする。ひょうじゅんは４分の４拍子（びょうし）。<br><br>★拍子（ひょうし）とは<br>拍がいくつかまとまったもの。<br>★４分の４拍子（びょうし）とは<br>４分音符（おんぷ）が４つでひとまとまりになった拍子（ひょうし）。<br>★拍（はく）とは<br>くり返されるリズムのこと。"
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr "<h2>全体のスピードを決めるブロック</h2><br>１分あたりの拍（はく）の数をせっていすることで、曲全体のスピードを決める。ひょうじゅんは４分音符（おんぷ）９０こ。<br><br>★拍（はく）とはくり返されるリズムのこと。"
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr "<h2>全体のスピードを決めるブロック</h2><br>１分あたりの拍（はく）の数をせっていすることで、曲全体のスピードを決める。ひょうじゅんは４分音符（おんぷ）９０こ。<br><br>★拍（はく）とはくり返されるリズムのこと。"
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr "<h2>全ての音符（おんぷ）にアクション実行</h2><br>すべての音符（おんぷ）にせっていするときに使う。<br><br>"
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr "<h2>全ての音符（おんぷ）にアクション実行</h2><br>すべての音符（おんぷ）にせっていするときに使う。<br><br>"
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr "<h2>全体の拍（はく）の数ブロック</h2><br>全体の拍（はく）の数を表示する。ひょうじゅんは拍（はく）は４分音符（おんぷ）を意味するため、げんそくは、曲全体の４分音符（おんぷ）の数を表す。"
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr "<h2>全体の拍（はく）の数ブロック</h2><br>全体の拍（はく）の数を表示する。ひょうじゅんは拍（はく）は４分音符（おんぷ）を意味するため、げんそくは、曲全体の４分音符（おんぷ）の数を表す。"
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr "<h2>音の高さを数で表示ブロック</h2><br>音の高さを数で表示する。たとえば、オクターヴ４の「ド」の音は０、オクターヴ４の「ソ」の音は７、オクターヴ３の「シ」の音は-１と表示される。"
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr "<h2>音の高さを数で表示ブロック</h2><br>音の高さを数で表示する。たとえば、オクターヴ４の「ド」の音は０、オクターヴ４の「ソ」の音は７、オクターヴ３の「シ」の音は-１と表示される。"
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr "<h2>ヘルツスライダーブロック</h2><br>スライダーを上下にうごかすことで、違う周波数（ヘルツのすうち）の音を聞くことができる。作った音をデータ化することができる。ヘルツの初期せっていちは、自由に変えられる。<br><br>★ヘルツとは<br>音の高さを表す周波数。<br>★周波数とは<br>音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。"
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr "<h2>ヘルツスライダーブロック</h2><br>スライダーを上下にうごかすことで、違う周波数（ヘルツのすうち）の音を聞くことができる。作った音をデータ化することができる。ヘルツの初期せっていちは、自由に変えられる。<br><br>★ヘルツとは<br>音の高さを表す周波数。<br>★周波数とは<br>音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。"
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr "<br><br>プログラムには、少なくとも１つのスタートブロックが置かれていないと実行できない。ふくすうのスタートブロックがあるときは、実行ボタンがおされると、ふくすうのスタートブロックが同時に実行される。１つ１つのスタートブロックは別々のえんそう者と考えることができる。"
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr "<br><br>プログラムには、少なくとも１つのスタートブロックが置かれていないと実行できない。ふくすうのスタートブロックがあるときは、実行ボタンがおされると、ふくすうのスタートブロックが同時に実行される。１つ１つのスタートブロックは別々のえんそう者と考えることができる。"
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr "<h2>数の箱（あたいを入れる）</h2><br>箱１に指定したすうちを入れる。"
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr "<h2>数の箱（あたいを入れる）</h2><br>箱１に指定したすうちを入れる。"
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr "<h2>数の箱（あたいを入れる）</h2><br>箱２に指定したすうちを入れる。"
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr "<h2>数の箱（あたいを入れる）</h2><br>箱２に指定したすうちを入れる。"
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr "<h2>表示ブロック（ネズミ）</h2><br>ネズミの見た目を、指定したがぞうに変える。"
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr "<h2>表示ブロック（ネズミ）</h2><br>ネズミの見た目を、指定したがぞうに変える。"
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr "<em>強拍に</em>ブロックは決められている拍子に対する強拍だけに特定されているアクションをします。"
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr "<em>強拍に</em>ブロックは決められている拍子に対する強拍だけに特定されているアクションをします。"
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr "<em>弱拍</em>ブロックは決められている拍子に対する弱拍だけに特定されているアクションをします。"
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr "<em>弱拍</em>ブロックは決められている拍子に対する弱拍だけに特定されているアクションをします。"
 
-#~msgid "down minor"
-#~msgstr "短３度下"
+#~ msgid "down minor"
+#~ msgstr "短３度下"
 
-#~msgid "down major"
-#~msgstr "長３度下"
+#~ msgid "down major"
+#~ msgstr "長３度下"
 
-#~msgid "eval"
-#~msgstr "評価"
+#~ msgid "eval"
+#~ msgstr "評価"
 
-#~msgid "100"
-#~msgstr "百"
+#~ msgid "100"
+#~ msgstr "百"
 
-#~msgid "Drag"
-#~msgstr "ドラッグ"
+#~ msgid "Drag"
+#~ msgstr "ドラッグ"
 
-#~msgid "playback music"
-#~msgstr "コンパイルされた音楽"
+#~ msgid "playback music"
+#~ msgstr "コンパイルされた音楽"
 
-#~msgid "pause playback"
-#~msgstr "コンパイルされた音楽を停止"
+#~ msgid "pause playback"
+#~ msgstr "コンパイルされた音楽を停止"
 
-#~msgid "restart playback"
-#~msgstr "コンパイルされた音楽を再生"
+#~ msgid "restart playback"
+#~ msgstr "コンパイルされた音楽を再生"
 
-#~msgid "prepare music for playback"
-#~msgstr "プレイバック用の音楽を準備（コンパイル）します"
+#~ msgid "prepare music for playback"
+#~ msgstr "プレイバック用の音楽を準備（コンパイル）します"
 
-#~msgid "decimal to fraction"
-#~msgstr "小数を分数に直す"
+#~ msgid "decimal to fraction"
+#~ msgstr "小数を分数に直す"
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr "<h2>音色をせっていブロック</h2><br>中に入っている「音符（おんぷ）ブロック」の音色を設定する。音色は、ギターやピアノなどの中から選ぶことができる。<br><br> "
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr "<h2>音色をせっていブロック</h2><br>中に入っている「音符（おんぷ）ブロック」の音色を設定する。音色は、ギターやピアノなどの中から選ぶことができる。<br><br> "
 
-#~msgid "set timbre"
-#~msgstr "音色をせってい"
+#~ msgid "set timbre"
+#~ msgstr "音色をせってい"
 
-#~msgid "right2"
-#~msgstr "ざひょうち（右）"
+#~ msgid "right2"
+#~ msgstr "ざひょうち（右）"
 
-#~msgid "left2"
-#~msgstr "ざひょうち（左）"
+#~ msgid "left2"
+#~ msgstr "ざひょうち（左）"
 
-#~msgid "expand"
-#~msgstr "テーブルを広げる"
+#~ msgid "expand"
+#~ msgstr "テーブルを広げる"
 
-#~msgid "collapse"
-#~msgstr "テーブルをちぢめる"
+#~ msgid "collapse"
+#~ msgstr "テーブルをちぢめる"
 
-#~msgid "Stop the current project."
-#~msgstr "プロジェクトを止めます"
+#~ msgid "Stop the current project."
+#~ msgstr "プロジェクトを止めます"
 
-#~msgid "japanese"
-#~msgstr "日本音階"
+#~ msgid "japanese"
+#~ msgstr "日本音階"
 
-#~msgid "7th"
-#~msgstr "７度"
+#~ msgid "7th"
+#~ msgstr "７度"
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr "１度' + ' ' + 'の和音"
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr "１度' + ' ' + 'の和音"
 
-#~msgid "set volume"
-#~msgstr "音量を設定"
+#~ msgid "set volume"
+#~ msgstr "音量を設定"
 
-#~msgid "hours ago"
-#~msgstr "時間前"
+#~ msgid "hours ago"
+#~ msgstr "時間前"
 
-#~msgid "play scale"
-#~msgstr "音階を再生する"
+#~ msgid "play scale"
+#~ msgstr "音階を再生する"
 
-#~msgid "ml"
-#~msgstr "モ"
+#~ msgid "ml"
+#~ msgstr "モ"
 
-#~msgid "play backward"
-#~msgstr "逆に再生"
+#~ msgid "play backward"
+#~ msgstr "逆に再生"
 
-#~msgid "Merge project from file"
-#~msgstr "ファイルからプロジェクトをマージする"
+#~ msgid "Merge project from file"
+#~ msgstr "ファイルからプロジェクトをマージする"
 
-#~msgid "eatme"
-#~msgstr "私を食べろ"
+#~ msgid "eatme"
+#~ msgstr "私を食べろ"
 
-#~msgid "movable"
-#~msgstr "移動の「ド、レ、ミ」"
+#~ msgid "movable"
+#~ msgstr "移動の「ド、レ、ミ」"
 
-#~msgid "triangle-bell"
-#~msgstr "トライアングル"
+#~ msgid "triangle-bell"
+#~ msgstr "トライアングル"
 
-#~msgid "Hide grid"
-#~msgstr "中心の角度をかくす"
+#~ msgid "Hide grid"
+#~ msgstr "中心の角度をかくす"
 
-#~msgid "effects"
-#~msgstr "音響効果"
+#~ msgid "effects"
+#~ msgstr "音響効果"
 
-#~msgid "Share on Facebook"
-#~msgstr "フェースブックでシェア"
+#~ msgid "Share on Facebook"
+#~ msgstr "フェースブックでシェア"
 
-#~msgid "rs"
-#~msgstr "赤"
+#~ msgid "rs"
+#~ msgstr "赤"
 
-#~msgid "divide note value"
-#~msgstr "音価を割る"
+#~ msgid "divide note value"
+#~ msgstr "音価を割る"
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr "より長押しで、よりスロー再生になります"
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr "より長押しで、よりスロー再生になります"
 
-#~msgid "save drum machine"
-#~msgstr "ドラムとしてほぞん"
+#~ msgid "save drum machine"
+#~ msgstr "ドラムとしてほぞん"
 
-#~msgid "whole note 𝅝"
-#~msgstr "全音符 𝅝"
+#~ msgid "whole note 𝅝"
+#~ msgstr "全音符 𝅝"
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr "コードスタックをコピーするため、右クリック"
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr "コードスタックをコピーするため、右クリック"
 
-#~msgid "note volume"
-#~msgstr "音符の音量"
+#~ msgid "note volume"
+#~ msgstr "音符の音量"
 
-#~msgid "top"
-#~msgstr "ざひょうち（上）"
+#~ msgid "top"
+#~ msgstr "ざひょうち（上）"
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "ミュージック・ブロックスの設定メニューを開く。"
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "ミュージック・ブロックスの設定メニューを開く。"
 
-#~msgid "The Planet is unavailable."
-#~msgstr "「プラネット」サーバは今使えません"
+#~ msgid "The Planet is unavailable."
+#~ msgstr "「プラネット」サーバは今使えません"
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr "<h2>ドラムブロック</h2><br>「音符（おんぷ）ブロック」のなかに入れて使う。色々なドラムの音色を選ぶことができる。１つの「音符（おんぷ）ブロック」の中でふくすうの音色のドラムを組み合わせて使うことができる。<br><br> "
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr "<h2>ドラムブロック</h2><br>「音符（おんぷ）ブロック」のなかに入れて使う。色々なドラムの音色を選ぶことができる。１つの「音符（おんぷ）ブロック」の中でふくすうの音色のドラムを組み合わせて使うことができる。<br><br> "
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr "Alt+Vでブロックスを貼り付けることもできます。"
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr "Alt+Vでブロックスを貼り付けることもできます。"
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr "スタックほぞんボタンを押すと、スタックはカスタムパレットの下にほぞんされます。"
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr "スタックほぞんボタンを押すと、スタックはカスタムパレットの下にほぞんされます。"
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr "ブロックスがクリップボードにコピーされると、ペーストボタンが使えるようになります。"
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr "ブロックスがクリップボードにコピーされると、ペーストボタンが使えるようになります。"
 
-#~msgid "denominator"
-#~msgstr "分母"
+#~ msgid "denominator"
+#~ msgstr "分母"
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr "より長押しすると、よりスロー再生となります。"
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr "より長押しすると、よりスロー再生となります。"
 
-#~msgid "Run"
-#~msgstr "再生"
+#~ msgid "Run"
+#~ msgstr "再生"
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "新しいブロックをファイルシステムからロードできます。"
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "新しいブロックをファイルシステムからロードできます。"
 
-#~msgid "Settings"
-#~msgstr "せってい"
+#~ msgid "Settings"
+#~ msgstr "せってい"
 
-#~msgid "move down"
-#~msgstr "下げる"
+#~ msgid "move down"
+#~ msgstr "下げる"
 
-#~msgid "consonant step up"
-#~msgstr "コンソナントステップアップ"
+#~ msgid "consonant step up"
+#~ msgstr "コンソナントステップアップ"
 
-#~msgid "View More"
-#~msgstr "もっと見る"
+#~ msgid "View More"
+#~ msgstr "もっと見る"
 
-#~msgid "collpase"
-#~msgstr "縮む"
+#~ msgid "collpase"
+#~ msgstr "縮む"
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr "<em>ステップピッチ</em>ブロックはメロディーの音符を音階的に上/下に動かすことができます。(例えば、もし<em>ステップピッチ</em>の前のブロックは<em>ソル</em>だったら<em>ステップピッチ＝１</em>は<em>ラ</em>を鳴らします。"
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr "<em>ステップピッチ</em>ブロックはメロディーの音符を音階的に上/下に動かすことができます。(例えば、もし<em>ステップピッチ</em>の前のブロックは<em>ソル</em>だったら<em>ステップピッチ＝１</em>は<em>ラ</em>を鳴らします。"
 
-#~msgid "Run music slowly"
-#~msgstr "音楽をゆっくりに演奏する"
+#~ msgid "Run music slowly"
+#~ msgstr "音楽をゆっくりに演奏する"
 
-#~msgid "You can search for blocks by name."
-#~msgstr "ブロックスを名前で検索できます"
+#~ msgid "You can search for blocks by name."
+#~ msgstr "ブロックスを名前で検索できます"
 
-#~msgid "finger-cymbals"
-#~msgstr "指のシンバル"
+#~ msgid "finger-cymbals"
+#~ msgstr "指のシンバル"
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr "タプル・ブロック：音高・時刻行列ブロックを使うつもりですか？"
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr "タプル・ブロック：音高・時刻行列ブロックを使うつもりですか？"
 
-#~msgid "set beats per minute"
-#~msgstr "BPM(一分あたりの拍数)を設定"
+#~ msgid "set beats per minute"
+#~ msgstr "BPM(一分あたりの拍数)を設定"
 
-#~msgid "Delete all"
-#~msgstr "ブロックを全部捨てる"
+#~ msgid "Delete all"
+#~ msgstr "ブロックを全部捨てる"
 
-#~msgid "UID"
-#~msgstr "ユーザの名前"
+#~ msgid "UID"
+#~ msgstr "ユーザの名前"
 
-#~msgid "rotate clockwise"
-#~msgstr "右回りにずれる"
+#~ msgid "rotate clockwise"
+#~ msgstr "右回りにずれる"
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr "「短（マイナー）」ブロックには 2, 3, 6, 7いずれかの数をいれて下さい。"
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr "「短（マイナー）」ブロックには 2, 3, 6, 7いずれかの数をいれて下さい。"
 
-#~msgid "bottom"
-#~msgstr "ざひょうち（下）"
+#~ msgid "bottom"
+#~ msgstr "ざひょうち（下）"
 
-#~msgid "numerator"
-#~msgstr "分子"
+#~ msgid "numerator"
+#~ msgstr "分子"
 
-#~msgid "eighth note ♪"
-#~msgstr "８分音符 ♪"
+#~ msgid "eighth note ♪"
+#~ msgstr "８分音符 ♪"
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "オーギュメントブロックには 1, 2, 3, 4, 5, 6, 7, 8 のいずれかの数をいれて下さい。"
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "オーギュメントブロックには 1, 2, 3, 4, 5, 6, 7, 8 のいずれかの数をいれて下さい。"
 
-#~msgid "cup-drum"
-#~msgstr "カップドラム"
+#~ msgid "cup-drum"
+#~ msgstr "カップドラム"
 
-#~msgid "hi-hat"
-#~msgstr "ハイハット"
+#~ msgid "hi-hat"
+#~ msgstr "ハイハット"
 
-#~msgid "untitled"
-#~msgstr "無題"
+#~ msgid "untitled"
+#~ msgstr "無題"
 
-#~msgid "Click here to paste."
-#~msgstr "貼り付けるにはここをクリック"
+#~ msgid "Click here to paste."
+#~ msgstr "貼り付けるにはここをクリック"
 
-#~msgid "relative interval"
-#~msgstr "相対的な音と音の間の間隔"
+#~ msgid "relative interval"
+#~ msgstr "相対的な音と音の間の間隔"
 
-#~msgid "on beat"
-#~msgstr "強拍にて"
+#~ msgid "on beat"
+#~ msgstr "強拍にて"
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr "ソルフェージュの名前が<em>「ド、レ、ミ、ファ、ソ、ラ、シ」</em>から選ぶことができます。"
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr "ソルフェージュの名前が<em>「ド、レ、ミ、ファ、ソ、ラ、シ」</em>から選ぶことができます。"
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr "このツールバーには、リズム、ピッチ、音色、タートル、その他のパレットボタンがあります。"
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr "このツールバーには、リズム、ピッチ、音色、タートル、その他のパレットボタンがあります。"
 
-#~msgid "block artwork"
-#~msgstr "ブロックのアート"
+#~ msgid "block artwork"
+#~ msgstr "ブロックのアート"
 
-#~msgid "1st"
-#~msgstr "１度"
+#~ msgid "1st"
+#~ msgstr "１度"
 
-#~msgid "Could not find turtle"
-#~msgstr "タートルが見つかりませんでした。"
+#~ msgid "Could not find turtle"
+#~ msgstr "タートルが見つかりませんでした。"
 
-#~msgid "play chord"
-#~msgstr "和音を再生する"
+#~ msgid "play chord"
+#~ msgstr "和音を再生する"
 
-#~msgid "Optimize feedback"
-#~msgstr "フィードバックを最大限にする"
+#~ msgid "Optimize feedback"
+#~ msgstr "フィードバックを最大限にする"
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore the Musical Blocks, the Matrix, and the Performance/Notation possibilities of Music Blocks. \"Let\'s start our tour!\"
-#~msgstr "ミスター・マウスは私たちのミュージック・ブロックスの指揮者です。ミスター・マウスは、あなたのミュージック・ブロックスにおけるさまざまな探究に力を貸してくれます。さぁ、私達のミュージックブロックスツアーを始めましょう！ "
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore the Musical Blocks, the Matrix, and the Performance/Notation possibilities of Music Blocks. \"Let\'s start our tour!\"
+#~ msgstr "ミスター・マウスは私たちのミュージック・ブロックスの指揮者です。ミスター・マウスは、あなたのミュージック・ブロックスにおけるさまざまな探究に力を貸してくれます。さぁ、私達のミュージックブロックスツアーを始めましょう！ "
 
-#~msgid "Save your project to a server."
-#~msgstr "サーバーにプロジェクトをほぞん"
+#~ msgid "Save your project to a server."
+#~ msgstr "サーバーにプロジェクトをほぞん"
 
-#~msgid "4th"
-#~msgstr "４度"
+#~ msgid "4th"
+#~ msgstr "４度"
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr "音楽をゆっくり再生したい時は、ここをクリック。"
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr "音楽をゆっくり再生したい時は、ここをクリック。"
 
-#~msgid "6th"
-#~msgstr "６度"
+#~ msgid "6th"
+#~ msgstr "６度"
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr "速いスピードで再生します／長押しでスロー再生／より長押しでさらにスロー再生"
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr "速いスピードで再生します／長押しでスロー再生／より長押しでさらにスロー再生"
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr "ENTERまたRETURNでも可能です"
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr "ENTERまたRETURNでも可能です"
 
-#~msgid "turtle"
-#~msgstr "タートル"
+#~ msgid "turtle"
+#~ msgstr "タートル"
 
-#~msgid "3rd"
-#~msgstr "３度"
+#~ msgid "3rd"
+#~ msgstr "３度"
 
-#~msgid "Optimize performance"
-#~msgstr "パーフォマンスを最大限にする"
+#~ msgid "Optimize performance"
+#~ msgstr "パーフォマンスを最大限にする"
 
-#~msgid "simple-1"
-#~msgstr "シンプル・シンセ１"
+#~ msgid "simple-1"
+#~ msgstr "シンプル・シンセ１"
 
-#~msgid "consonant step down"
-#~msgstr "コンソナントステップダウン"
+#~ msgid "consonant step down"
+#~ msgstr "コンソナントステップダウン"
 
-#~msgid "ride-bell"
-#~msgstr "ライド"
+#~ msgid "ride-bell"
+#~ msgstr "ライド"
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr "ミュージック・ブロックス：音楽と算数とコーディングの関係を発見するツール"
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr "ミュージック・ブロックス：音楽と算数とコーディングの関係を発見するツール"
 
-#~msgid "Cannot read pixel color"
-#~msgstr "ピクセルの色が読めません"
+#~ msgid "Cannot read pixel color"
+#~ msgstr "ピクセルの色が読めません"
 
-#~msgid "floor-tom-tom"
-#~msgstr "フロアタムタム"
+#~ msgid "floor-tom-tom"
+#~ msgstr "フロアタムタム"
 
-#~msgid "Publish"
-#~msgstr "サーバにアップロードして発表する"
+#~ msgid "Publish"
+#~ msgstr "サーバにアップロードして発表する"
 
-#~msgid "Worldwide"
-#~msgstr "世界中のプロジェクト"
+#~ msgid "Worldwide"
+#~ msgstr "世界中のプロジェクト"
 
-#~msgid "long press to run slowly"
-#~msgstr "長押しでスロー再生"
+#~ msgid "long press to run slowly"
+#~ msgstr "長押しでスロー再生"
 
-#~msgid "1/64 note 𝅘𝅥𝅱"
-#~msgstr "６４分音符 𝅘𝅥𝅱"
+#~ msgid "1/64 note 𝅘𝅥𝅱"
+#~ msgstr "６４分音符 𝅘𝅥𝅱"
 
-#~msgid "Previous page"
-#~msgstr "前のページ"
+#~ msgid "Previous page"
+#~ msgstr "前のページ"
 
-#~msgid "end hollow line"
-#~msgstr "（中空の）線を終わらせる"
+#~ msgid "end hollow line"
+#~ msgstr "（中空の）線を終わらせる"
 
-#~msgid "Open"
-#~msgstr "開く"
+#~ msgid "Open"
+#~ msgstr "開く"
 
-#~msgid "tom-tom"
-#~msgstr "タムタム"
+#~ msgid "tom-tom"
+#~ msgstr "タムタム"
 
-#~msgid "ch"
-#~msgstr "リ"
+#~ msgid "ch"
+#~ msgstr "リ"
 
-#~msgid "add pitches"
-#~msgstr "音高を足す"
+#~ msgid "add pitches"
+#~ msgstr "音高を足す"
 
-#~msgid "cb"
-#~msgstr "カ"
+#~ msgid "cb"
+#~ msgstr "カ"
 
-#~msgid "reference pitch"
-#~msgstr "参考音高"
+#~ msgid "reference pitch"
+#~ msgstr "参考音高"
 
-#~msgid "Click to run the music note by note."
-#~msgstr "音符を一つずつ再生するにはここをクリック。"
+#~ msgid "Click to run the music note by note."
+#~ msgstr "音符を一つずつ再生するにはここをクリック。"
 
-#~msgid "poly"
-#~msgstr "ポリリズム"
+#~ msgid "poly"
+#~ msgstr "ポリリズム"
 
-#~msgid "move up"
-#~msgstr "上げる"
+#~ msgid "move up"
+#~ msgstr "上げる"
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "直交座標を表示する/隠す"
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "直交座標を表示する/隠す"
 
-#~msgid "field"
-#~msgstr "場"
+#~ msgid "field"
+#~ msgstr "場"
 
-#~msgid "m"
-#~msgstr "鼠"
+#~ msgid "m"
+#~ msgstr "鼠"
 
-#~msgid "gs"
-#~msgstr "灰"
+#~ msgid "gs"
+#~ msgstr "灰"
 
-#~msgid "graphical notation matrix"
-#~msgstr "簡単なビジュアル・マトリックス"
+#~ msgid "graphical notation matrix"
+#~ msgstr "簡単なビジュアル・マトリックス"
 
-#~msgid "Save as HTML"
-#~msgstr "HTMLをほぞん"
+#~ msgid "Save as HTML"
+#~ msgstr "HTMLをほぞん"
 
-#~msgid "Load project from files"
-#~msgstr "ファイルからロードする"
+#~ msgid "Load project from files"
+#~ msgstr "ファイルからロードする"
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "ブロックのパレットを表示する / 隠す"
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "ブロックのパレットを表示する / 隠す"
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr "速いスピードで再生します・長押しでスロー再生"
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr "速いスピードで再生します・長押しでスロー再生"
 
-#~msgid "snare-drum"
-#~msgstr "スネアドラム"
+#~ msgid "snare-drum"
+#~ msgstr "スネアドラム"
 
-#~msgid "1/32 note 𝅘𝅥𝅰"
-#~msgstr "32分音符 𝅘𝅥𝅰"
+#~ msgid "1/32 note 𝅘𝅥𝅰"
+#~ msgstr "32分音符 𝅘𝅥𝅰"
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr "<h2>イベントブロック（発生）</h2><br>指定した名前のイベントをすべてのネズミに送る。<br>イベントの発生は、各スクリプトが【イベントの時にアクション】で指定したアクションの引きがねとしてはたらく。"
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr "<h2>イベントブロック（発生）</h2><br>指定した名前のイベントをすべてのネズミに送る。<br>イベントの発生は、各スクリプトが【イベントの時にアクション】で指定したアクションの引きがねとしてはたらく。"
 
-#~msgid "Search"
-#~msgstr "検索"
+#~ msgid "Search"
+#~ msgstr "検索"
 
-#~msgid "previous page"
-#~msgstr "前のページ"
+#~ msgid "previous page"
+#~ msgstr "前のページ"
 
-#~msgid "cow-bell"
-#~msgstr "カウベル"
+#~ msgid "cow-bell"
+#~ msgstr "カウベル"
 
-#~msgid "2nd"
-#~msgstr "２度"
+#~ msgid "2nd"
+#~ msgstr "２度"
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr "オフライン。シェア機能が使えません"
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr "オフライン。シェア機能が使えません"
 
-#~msgid "fs"
-#~msgstr "鼯"
+#~ msgid "fs"
+#~ msgstr "鼯"
 
-#~msgid "1/16 note ♬"
-#~msgstr "16分音符 ♬"
+#~ msgid "1/16 note ♬"
+#~ msgstr "16分音符 ♬"
 
-#~msgid "food"
-#~msgstr "食べ物"
+#~ msgid "food"
+#~ msgstr "食べ物"
 
-#~msgid "osctime"
-#~msgstr "オシレータータイム"
+#~ msgid "osctime"
+#~ msgstr "オシレータータイム"
 
-#~msgid "blues"
-#~msgstr "ブルース"
+#~ msgid "blues"
+#~ msgstr "ブルース"
 
-#~msgid "More"
-#~msgstr "その他"
+#~ msgid "More"
+#~ msgstr "その他"
 
-#~msgid "maths"
-#~msgstr "数学"
+#~ msgid "maths"
+#~ msgstr "数学"
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr "このツールバーには、パレットボタンやリズム、ピッチなどが含まれています。"
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr "このツールバーには、パレットボタンやリズム、ピッチなどが含まれています。"
 
-#~msgid "kick-drum"
-#~msgstr "キックドラム"
+#~ msgid "kick-drum"
+#~ msgstr "キックドラム"
 
-#~msgid "5th"
-#~msgstr "５度"
+#~ msgid "5th"
+#~ msgstr "５度"
 
-#~msgid "Rhythm"
-#~msgstr "音符"
+#~ msgid "Rhythm"
+#~ msgstr "音符"
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr "ブロックを長押しするとコピーできます。貼り付けるにはここをクリック。"
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr "ブロックを長押しするとコピーできます。貼り付けるにはここをクリック。"
 
-#~msgid "This toolbar contains the palette buttons Matrix, Chunk, Perform, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr "このツールバーには、音高・時刻行列、チャンク、演奏、音色、タートル、その他を含むパレットボタンがあります。ここをクリックすると、ブロックスのパレットが表示されます。パレットからブロックスをキャンバスへドラッグすると、ブロックスを使うことができます。"
+#~ msgid "This toolbar contains the palette buttons Matrix, Chunk, Perform, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr "このツールバーには、音高・時刻行列、チャンク、演奏、音色、タートル、その他を含むパレットボタンがあります。ここをクリックすると、ブロックスのパレットが表示されます。パレットからブロックスをキャンバスへドラッグすると、ブロックスを使うことができます。"
 
-#~msgid "Click this button to expand or collapse the auxilary toolbar."
-#~msgstr "ここをクリックして、オプションツールバーを表示"
+#~ msgid "Click this button to expand or collapse the auxilary toolbar."
+#~ msgstr "ここをクリックして、オプションツールバーを表示"
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr "ツールバーを開く/隠す"
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr "ツールバーを開く/隠す"
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr "長押しでスロー再生になります。"
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr "長押しでスロー再生になります。"
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "カンバス上にほうがん（ざひょう）や中心の角度を表示したり、かくしたりできる。"
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "カンバス上にほうがん（ざひょう）や中心の角度を表示したり、かくしたりできる。"
 
-#~msgid "Copy this link to share your project."
-#~msgstr "あなたのプロジェクトをシェアしたい時は、このリンクをコピーしてください。"
+#~ msgid "Copy this link to share your project."
+#~ msgstr "あなたのプロジェクトをシェアしたい時は、このリンクをコピーしてください。"
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "画面にあるものを全部消して、初期状態に戻します。"
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "画面にあるものを全部消して、初期状態に戻します。"
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr "ステップ音高ブロックは音符ブロックの中にある必要があります。"
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr "ステップ音高ブロックは音符ブロックの中にある必要があります。"
 
-#~msgid "begin hollow line"
-#~msgstr "（中空の）線を始める"
+#~ msgid "begin hollow line"
+#~ msgstr "（中空の）線を始める"
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr "ピッチ・アルファベットの名前が<em>「C D E F G A B」</em>から選ぶことができます。"
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr "ピッチ・アルファベットの名前が<em>「C D E F G A B」</em>から選ぶことができます。"
 
-#~msgid "step pitch"
-#~msgstr "ステップ音高"
+#~ msgid "step pitch"
+#~ msgstr "ステップ音高"
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr "音楽とネズミの動きを止めます。"
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr "音楽とネズミの動きを止めます。"
 
-#~msgid "bk"
-#~msgstr "黒"
+#~ msgid "bk"
+#~ msgstr "黒"
 
-#~msgid "bt"
-#~msgstr "蝙"
+#~ msgid "bt"
+#~ msgstr "蝙"
 
-#~msgid "Could not find mouse"
-#~msgstr "ネズミが見つかりません"
+#~ msgid "Could not find mouse"
+#~ msgstr "ネズミが見つかりません"
 
-#~msgid "br"
-#~msgstr "茶"
+#~ msgid "br"
+#~ msgstr "茶"
 
-#~msgid "multiply beat"
-#~msgstr "拍を倍に"
+#~ msgid "multiply beat"
+#~ msgstr "拍を倍に"
 
-#~msgid "Save Project"
-#~msgstr "プロジェクトをほぞん"
+#~ msgid "Save Project"
+#~ msgstr "プロジェクトをほぞん"
 
-#~msgid "rotate counter clockwise"
-#~msgstr "左回りにずれる"
+#~ msgid "rotate counter clockwise"
+#~ msgstr "左回りにずれる"
 
-#~msgid "etc."
-#~msgstr "<br>"
+#~ msgid "etc."
+#~ msgstr "<br>"
 
-#~msgid "sort"
-#~msgstr "ならべなおす"
+#~ msgid "sort"
+#~ msgstr "ならべなおす"
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr "ピッチ・ブロック：音符ブロックと一緒に使いますか？"
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr "ピッチ・ブロック：音符ブロックと一緒に使いますか？"
 
-#~msgid "Polar"
-#~msgstr "中心の角度とほうがん（ざひょう）を表示"
+#~ msgid "Polar"
+#~ msgstr "中心の角度とほうがん（ざひょう）を表示"
 
-#~msgid "current pitch name"
-#~msgstr "現在の音高の名前"
+#~ msgid "current pitch name"
+#~ msgstr "現在の音高の名前"
 
-#~msgid "confirm"
-#~msgstr "確認する"
+#~ msgid "confirm"
+#~ msgstr "確認する"
 
-#~msgid "gp"
-#~msgstr "ギ"
+#~ msgid "gp"
+#~ msgstr "ギ"
 
-#~msgid "Upload to Planet"
-#~msgstr "プラネットにアップロード"
+#~ msgid "Upload to Planet"
+#~ msgstr "プラネットにアップロード"
 
-#~msgid "Load plugin from file"
-#~msgstr "プラグインを読みこむ"
+#~ msgid "Load plugin from file"
+#~ msgstr "プラグインを読みこむ"
 
-#~msgid "degree"
-#~msgstr "温度記号"
+#~ msgid "degree"
+#~ msgstr "温度記号"
 
-#~msgid "sing"
-#~msgstr "歌う"
+#~ msgid "sing"
+#~ msgstr "歌う"
 
-#~msgid "Play music"
-#~msgstr "音楽を再生"
+#~ msgid "Play music"
+#~ msgstr "音楽を再生"
 
-#~msgid "Download"
-#~msgstr "ダウンロード"
+#~ msgid "Download"
+#~ msgstr "ダウンロード"
 
-#~msgid "darbuka-drum"
-#~msgstr "ダラブッカ"
+#~ msgid "darbuka-drum"
+#~ msgstr "ダラブッカ"
 
-#~msgid "cloud"
-#~msgstr "クラウド"
+#~ msgid "cloud"
+#~ msgstr "クラウド"
 
-#~msgid "quarter note ♩"
-#~msgstr "4分音符 ♩"
+#~ msgid "quarter note ♩"
+#~ msgstr "4分音符 ♩"
 
-#~msgid "add filter"
-#~msgstr "フィルターを加える"
+#~ msgid "add filter"
+#~ msgstr "フィルターを加える"
 
-#~msgid "Show/hide palettes"
-#~msgstr "パレットを表示する / 隠す"
+#~ msgid "Show/hide palettes"
+#~ msgstr "パレットを表示する / 隠す"
 
-#~msgid "fetch"
-#~msgstr "フェッチ"
+#~ msgid "fetch"
+#~ msgstr "フェッチ"
 
-#~msgid "rodi"
-#~msgstr "ロデイ"
+#~ msgid "rodi"
+#~ msgstr "ロデイ"
 
-#~msgid "pentatonic"
-#~msgstr "五音音階（ペンタトニック）"
+#~ msgid "pentatonic"
+#~ msgstr "五音音階（ペンタトニック）"
 
-#~msgid "blocks"
-#~msgstr "ブロックス"
+#~ msgid "blocks"
+#~ msgstr "ブロックス"
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr "メジャーブロックには 2, 3, 6, 7いずれかの数をいれて下さい。"
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr "メジャーブロックには 2, 3, 6, 7いずれかの数をいれて下さい。"
 
-#~msgid "Advanced options"
-#~msgstr "上級オプション"
+#~ msgid "Advanced options"
+#~ msgstr "上級オプション"
 
-#~msgid "undo"
-#~msgstr "１つもどす"
+#~ msgid "undo"
+#~ msgstr "１つもどす"
 
-#~msgid "adjust transposition"
-#~msgstr "移調を変える"
+#~ msgid "adjust transposition"
+#~ msgstr "移調を変える"
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "速いスピードで再生するためにはここをクリック。"
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "速いスピードで再生するためにはここをクリック。"
 
-#~msgid "Run note by note"
-#~msgstr "音符を一つずつ再生"
+#~ msgid "Run note by note"
+#~ msgstr "音符を一つずつ再生"
 
-#~msgid "Next page"
-#~msgstr "次のページ"
+#~ msgid "Next page"
+#~ msgstr "次のページ"
 
-#~msgid "Long press on blocks to copy."
-#~msgstr "ブロック長押しでコピー"
+#~ msgid "Long press on blocks to copy."
+#~ msgstr "ブロック長押しでコピー"
 
-#~msgid "on offbeat do"
-#~msgstr "弱拍にて～する"
+#~ msgid "on offbeat do"
+#~ msgstr "弱拍にて～する"
 
-#~msgid "Hard stop"
-#~msgstr "すぐストップ"
+#~ msgid "Hard stop"
+#~ msgstr "すぐストップ"
 
-#~msgid "free time"
-#~msgstr "クロックなし"
+#~ msgid "free time"
+#~ msgstr "クロックなし"
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr "Alt+Cでブロックスをコピーすることもできます。"
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr "Alt+Cでブロックスをコピーすることもできます。"
 
-#~msgid "Click here to paste"
-#~msgstr "貼り付けるため、ここでクリック"
+#~ msgid "Click here to paste"
+#~ msgstr "貼り付けるため、ここでクリック"
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr "ツールバーを開いたり閉じたりするにはこのボタンをクリックしてください"
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr "ツールバーを開いたり閉じたりするにはこのボタンをクリックしてください"
 
-#~msgid "Run music step by step"
-#~msgstr "音楽を音符ずつ演奏する"
+#~ msgid "Run music step by step"
+#~ msgstr "音楽を音符ずつ演奏する"
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr "スタックを長押しすると現れます。"
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr "スタックを長押しすると現れます。"
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr "完全ブロックには 1, 4, 5, 8 いずれかの数をいれて下さい"
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr "完全ブロックには 1, 4, 5, 8 いずれかの数をいれて下さい"
 
-#~msgid "table"
-#~msgstr "グラフ"
+#~ msgid "table"
+#~ msgstr "グラフ"
 
-#~msgid "cp"
-#~msgstr "ヌ"
+#~ msgid "cp"
+#~ msgstr "ヌ"
 
-#~msgid "vspace"
-#~msgstr "縦のスペース"
+#~ msgid "vspace"
+#~ msgstr "縦のスペース"
 
-#~msgid "The Paste Button will highlight."
-#~msgstr "ペーストボタンが光ります。"
+#~ msgid "The Paste Button will highlight."
+#~ msgstr "ペーストボタンが光ります。"
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "画面上に表示されているもの（ブロックスを含む）を全て消します。"
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "画面上に表示されているもの（ブロックスを含む）を全て消します。"
 
-#~msgid "next page"
-#~msgstr "次のページ"
+#~ msgid "next page"
+#~ msgstr "次のページ"
 
-#~msgid "On my device"
-#~msgstr "自分のPCにあるファイル"
+#~ msgid "On my device"
+#~ msgstr "自分のPCにあるファイル"
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "ディミニッシュブロックには 1, 2, 3, 4, 5, 6, 7, 8 いずれかの数をいれて下さい"
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "ディミニッシュブロックには 1, 2, 3, 4, 5, 6, 7, 8 いずれかの数をいれて下さい"
 
-#~msgid "Run music slow"
-#~msgstr "音楽をスロー再生"
+#~ msgid "Run music slow"
+#~ msgstr "音楽をスロー再生"
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr "スタック上で長押しすると、スタックをクリップボードにコピーできます。"
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr "スタック上で長押しすると、スタックをクリップボードにコピーできます。"
 
-#~msgid "export"
-#~msgstr "テーブルをほぞん"
+#~ msgid "export"
+#~ msgstr "テーブルをほぞん"
 
-#~msgid "synthesizer"
-#~msgstr "シンセサイザー"
+#~ msgid "synthesizer"
+#~ msgstr "シンセサイザー"
 
-#~msgid "Disable scrolling"
-#~msgstr "スクロールを無効にする"
+#~ msgid "Disable scrolling"
+#~ msgstr "スクロールを無効にする"
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr "リズムブロックと：音高・時刻行列と一緒に使いますか？"
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr "リズムブロックと：音高・時刻行列と一緒に使いますか？"
 
-#~msgid "My Music Blocks Creation"
-#~msgstr "私のミュージック・ブロックス作品"
+#~ msgid "My Music Blocks Creation"
+#~ msgstr "私のミュージック・ブロックス作品"
 
-#~msgid "current pitch octave"
-#~msgstr "今の音が属するオクターヴ"
+#~ msgid "current pitch octave"
+#~ msgstr "今の音が属するオクターヴ"
 
-#~msgid "half note 𝅗𝅥"
-#~msgstr "半音符 𝅗𝅥"
+#~ msgid "half note 𝅗𝅥"
+#~ msgstr "半音符 𝅗𝅥"
 
-#~msgid "Solfege pitch preview"
-#~msgstr "ソルフェージュで音の高さのプレビュー"
+#~ msgid "Solfege pitch preview"
+#~ msgstr "ソルフェージュで音の高さのプレビュー"
 
-#~msgid "Moveable Do"
-#~msgstr "移動ド"
+#~ msgid "Moveable Do"
+#~ msgstr "移動ド"
 
-#~msgid "Fixed Do"
-#~msgstr "固定ド"
+#~ msgid "Fixed Do"
+#~ msgstr "固定ド"
 
-#~msgid "Fullscreen"
-#~msgstr "フルスクリーン"
+#~ msgid "Fullscreen"
+#~ msgstr "フルスクリーン"
 

--- a/po/km.po
+++ b/po/km.po
@@ -2216,7 +2216,7 @@ msgstr "សកម្មភាព"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "លេច​ឡើង"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "ចុច"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "បង្ហាញ"
+#~ msgid "show"
+#~ msgstr "បង្ហាញ"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "ស្អាត"
+#~ msgid "Clean"
+#~ msgstr "ស្អាត"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "បញ្ឈប់"
+#~ msgid "stop"
+#~ msgstr "បញ្ឈប់"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "អណ្ដើក"
+#~ msgid "turtle"
+#~ msgstr "អណ្ដើក"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "បើក"
+#~ msgid "Open"
+#~ msgstr "បើក"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/kn.po
+++ b/po/kn.po
@@ -2213,7 +2213,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2280,7 +2280,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2294,33 +2294,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2342,7 +2342,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2420,7 +2420,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2649,8 +2649,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2809,7 +2809,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2819,14 +2819,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2857,7 +2857,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2882,7 +2882,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2912,7 +2912,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2930,8 +2930,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3033,7 +3033,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3167,14 +3167,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3249,7 +3249,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3285,7 +3285,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3294,7 +3294,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3785,7 +3785,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3797,8 +3797,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3820,8 +3820,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3831,15 +3831,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3848,14 +3848,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3864,14 +3864,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3912,7 +3912,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3921,7 +3921,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3938,7 +3938,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4007,8 +4007,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4030,7 +4030,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4316,7 +4316,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4647,21 +4647,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4670,12 +4670,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4688,62 +4688,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4778,7 +4778,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4787,17 +4787,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4806,12 +4806,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4824,7 +4824,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4833,17 +4833,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4860,56 +4860,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4917,7 +4917,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4925,7 +4925,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4934,7 +4934,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4942,7 +4942,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4951,8 +4951,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4960,7 +4960,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4974,116 +4974,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5102,19 +5102,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5122,61 +5122,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5186,149 +5186,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5337,7 +5337,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5416,22 +5416,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5588,7 +5588,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5610,7 +5610,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5621,7 +5621,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5650,7 +5650,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5659,7 +5659,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5702,7 +5702,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5711,7 +5711,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5720,7 +5720,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5743,13 +5743,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5758,7 +5758,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5767,7 +5767,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5787,7 +5787,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5812,7 +5812,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5826,7 +5826,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5836,7 +5836,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5874,7 +5874,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5883,7 +5883,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5896,18 +5896,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6028,7 +6028,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6047,7 +6047,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6056,7 +6056,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6073,7 +6073,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6086,7 +6086,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6115,7 +6115,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6138,7 +6138,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6155,7 +6155,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6164,7 +6164,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6181,7 +6181,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6190,7 +6190,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6224,7 +6224,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6233,7 +6233,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6265,7 +6265,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6299,12 +6299,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6313,12 +6313,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6327,13 +6327,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6351,7 +6351,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6383,8 +6383,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6440,7 +6440,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6597,12 +6597,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6612,8 +6612,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6621,12 +6621,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6635,7 +6635,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6652,7 +6652,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6662,12 +6662,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6677,7 +6677,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6686,7 +6686,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6736,7 +6736,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6769,7 +6769,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6778,12 +6778,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6792,7 +6792,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6801,7 +6801,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6810,7 +6810,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6821,8 +6821,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6832,7 +6832,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6858,7 +6858,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6896,12 +6896,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6913,12 +6913,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6927,7 +6927,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6973,22 +6973,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6997,7 +6997,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7010,7 +7010,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7019,47 +7019,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7072,7 +7072,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7081,7 +7081,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7089,7 +7089,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7103,8 +7103,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7133,7 +7133,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7158,14 +7158,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7175,7 +7175,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7194,7 +7194,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7204,7 +7204,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7221,17 +7221,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7240,7 +7240,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7250,7 +7250,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7260,7 +7260,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7272,7 +7272,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7280,7 +7280,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7290,7 +7290,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7311,7 +7311,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7326,7 +7326,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7336,7 +7336,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7350,7 +7350,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7406,7 +7406,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7584,7 +7584,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7593,7 +7593,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7602,7 +7602,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7611,7 +7611,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7621,13 +7621,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7640,7 +7640,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7649,7 +7649,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7658,7 +7658,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7667,7 +7667,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7676,7 +7676,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7685,7 +7685,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7694,7 +7694,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7703,7 +7703,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7713,17 +7713,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7732,7 +7732,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8159,7 +8159,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8169,7 +8169,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8213,12 +8213,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8227,7 +8227,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8284,7 +8284,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8302,7 +8302,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8315,7 +8315,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8380,7 +8380,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8445,7 +8445,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8454,12 +8454,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8468,7 +8468,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8477,7 +8477,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8486,7 +8486,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8511,7 +8511,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8646,27 +8646,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8692,18 +8692,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8718,7 +8718,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8739,7 +8739,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8756,7 +8756,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8769,7 +8769,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8779,7 +8779,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8793,7 +8793,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8814,7 +8814,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8828,7 +8828,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9015,7 +9015,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9024,7 +9024,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9146,7 +9146,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9229,7 +9229,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9279,7 +9279,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9396,7 +9396,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9475,48 +9475,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9949,38 +9949,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9988,8 +9988,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -9999,8 +9999,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10012,35 +10012,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10054,69 +10054,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10136,13 +10136,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10150,58 +10150,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10217,25 +10217,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10245,43 +10245,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10291,190 +10291,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10484,305 +10484,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10792,97 +10792,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10892,144 +10892,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11039,15 +11039,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11057,23 +11057,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11083,8 +11083,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11092,224 +11092,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11325,37 +11325,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11363,28 +11363,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11398,8 +11398,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11409,65 +11409,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11475,8 +11475,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11486,127 +11486,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11614,608 +11614,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12225,165 +12225,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12397,28 +12397,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12426,133 +12426,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12560,136 +12560,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12699,127 +12699,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12827,397 +12827,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13229,196 +13229,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13426,155 +13426,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13582,257 +13582,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13846,223 +13846,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14072,144 +14072,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14217,57 +14217,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14277,30 +14277,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14308,112 +14308,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14421,287 +14421,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14709,13 +14709,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14723,86 +14723,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -13,10 +13,10 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Pootle 1.2.1\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -102,7 +102,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -169,7 +169,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -183,33 +183,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -231,7 +231,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -309,7 +309,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -538,8 +538,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -708,14 +708,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "빠르기."
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "음표 값"
 
@@ -780,7 +780,7 @@ msgstr "음표 값"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -801,7 +801,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -819,8 +819,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -922,7 +922,7 @@ msgstr "테너."
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "베이스."
 
@@ -1056,14 +1056,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "박자"
 
@@ -1174,7 +1174,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -1183,7 +1183,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -1674,7 +1674,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -1686,8 +1686,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -1697,7 +1697,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -1709,8 +1709,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -1720,15 +1720,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -1737,14 +1737,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -1753,14 +1753,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -1801,7 +1801,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -1810,7 +1810,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -1827,7 +1827,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -1896,8 +1896,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -1919,7 +1919,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -2205,7 +2205,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -2536,21 +2536,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -2559,12 +2559,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -2577,62 +2577,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -2645,7 +2645,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -2654,7 +2654,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -2667,7 +2667,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -2676,17 +2676,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -2695,12 +2695,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -2713,7 +2713,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -2722,17 +2722,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -2749,56 +2749,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -2806,7 +2806,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -2814,7 +2814,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -2823,7 +2823,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -2831,7 +2831,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -2840,8 +2840,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -2849,7 +2849,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -2863,116 +2863,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -2991,19 +2991,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr "백색 소음."
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -3011,61 +3011,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -3075,149 +3075,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -3226,7 +3226,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3305,22 +3305,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -3477,7 +3477,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -3499,7 +3499,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -3510,7 +3510,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -3539,7 +3539,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -3548,7 +3548,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "드럼 설정."
 
@@ -3581,7 +3581,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -3591,7 +3591,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -3609,7 +3609,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -3632,13 +3632,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -3647,7 +3647,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "빼기"
 
@@ -3656,7 +3656,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "넣기"
 
@@ -3676,7 +3676,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -3701,7 +3701,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -3715,7 +3715,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -3725,7 +3725,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -3763,7 +3763,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -3772,7 +3772,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -3785,18 +3785,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -3917,7 +3917,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -3936,7 +3936,7 @@ msgstr "이음줄."
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "스타카토."
 
@@ -3945,7 +3945,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -3962,7 +3962,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -3975,7 +3975,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -4004,7 +4004,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -4027,7 +4027,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -4044,7 +4044,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -4053,7 +4053,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -4070,7 +4070,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -4079,7 +4079,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -4122,7 +4122,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -4139,7 +4139,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -4154,7 +4154,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "음표"
 
@@ -4188,12 +4188,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "스윙"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "스윙 값"
 
@@ -4202,12 +4202,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr "음표 건너뛰기 블록은 음표들을 건너 뛰고 연주하지 않는다."
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "음표 건너뛰기"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -4216,13 +4216,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "붙임줄"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -4272,8 +4272,8 @@ msgstr "옥타브 공간"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "박자"
 
@@ -4329,7 +4329,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -4486,12 +4486,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -4501,8 +4501,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "분당 비트2"
 
@@ -4510,12 +4510,12 @@ msgstr "분당 비트2"
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "분당 비트."
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -4524,7 +4524,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -4541,7 +4541,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -4551,12 +4551,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -4566,7 +4566,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -4575,7 +4575,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -4625,7 +4625,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -4658,7 +4658,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -4667,12 +4667,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -4681,7 +4681,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -4690,7 +4690,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -4699,7 +4699,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -4710,8 +4710,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -4721,7 +4721,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -4747,7 +4747,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -4785,12 +4785,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -4802,12 +4802,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -4816,7 +4816,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -4862,22 +4862,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -4886,7 +4886,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -4899,7 +4899,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -4908,47 +4908,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -4961,7 +4961,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -4970,7 +4970,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -4978,7 +4978,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -4992,8 +4992,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -5022,7 +5022,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -5047,14 +5047,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -5064,7 +5064,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -5083,7 +5083,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -5093,7 +5093,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -5110,17 +5110,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -5129,7 +5129,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -5139,7 +5139,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -5149,7 +5149,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -5161,7 +5161,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -5169,7 +5169,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -5179,7 +5179,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -5200,7 +5200,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -5215,7 +5215,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -5225,7 +5225,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -5239,7 +5239,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -5295,7 +5295,7 @@ msgstr "계산하기."
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -5473,7 +5473,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -5482,7 +5482,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -5491,7 +5491,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -5500,7 +5500,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -5510,13 +5510,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -5529,7 +5529,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -5538,7 +5538,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -5547,7 +5547,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -5556,7 +5556,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -5565,7 +5565,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -5574,7 +5574,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -5583,7 +5583,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -5592,7 +5592,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -5602,17 +5602,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -5621,7 +5621,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -6048,7 +6048,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -6058,7 +6058,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -6102,12 +6102,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -6116,7 +6116,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -6173,7 +6173,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -6191,7 +6191,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -6204,7 +6204,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -6269,7 +6269,7 @@ msgstr "채우기 끝"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "배경"
 
@@ -6334,7 +6334,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "빈 선."
 
@@ -6343,12 +6343,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "채우기."
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "펜 그리지 않기."
 
@@ -6357,7 +6357,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "펜 그리지 않기 블록은 팬을 들어올려 더이상 그려지지 않게 한다."
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "펜 그리기"
 
@@ -6366,7 +6366,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "펜 그리기 블록은 펜을 내려 그릴 수 있게 한다."
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "펜 크기 지정"
 
@@ -6375,7 +6375,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "투명도 설정."
 
@@ -6400,7 +6400,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -6535,27 +6535,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -6581,18 +6581,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -6607,7 +6607,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -6628,7 +6628,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -6645,7 +6645,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -6658,7 +6658,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -6668,7 +6668,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -6682,7 +6682,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -6703,7 +6703,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -6717,7 +6717,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -6904,7 +6904,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -6913,7 +6913,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -7035,7 +7035,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -7118,7 +7118,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -7168,7 +7168,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -7285,7 +7285,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -7364,48 +7364,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -7838,38 +7838,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -7877,8 +7877,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -7888,8 +7888,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -7901,35 +7901,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -7943,69 +7943,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "지우기"
+#~ msgid "Clean"
+#~ msgstr "지우기"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "블록 숨기기"
+#~ msgid "hide blocks"
+#~ msgstr "블록 숨기기"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8025,13 +8025,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "단계 실행"
+#~ msgid "stop"
+#~ msgstr "단계 실행"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8039,58 +8039,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr "필터."
+#~ msgid "filter"
+#~ msgstr "필터."
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -8106,25 +8106,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -8134,46 +8134,46 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
-#~msgid ""Toggle Fullscreen"
-#~msgstr ""전체 화면 전환"
+#~ msgid "Toggle Fullscreen"
+#~ msgstr "전체 화면 전환"
 
 #: js/toolbar.js:70
 
@@ -8183,190 +8183,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -8376,305 +8376,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -8684,97 +8684,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -8784,144 +8784,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -8931,15 +8931,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -8949,23 +8949,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -8975,8 +8975,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -8984,224 +8984,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -9217,37 +9217,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -9255,28 +9255,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -9290,8 +9290,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -9301,65 +9301,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -9367,8 +9367,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -9378,127 +9378,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -9506,608 +9506,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -10117,165 +10117,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -10289,28 +10289,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10318,133 +10318,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10452,136 +10452,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "터틀"
+#~ msgid "turtle"
+#~ msgstr "터틀"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -10591,127 +10591,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -10719,397 +10719,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -11121,196 +11121,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11318,155 +11318,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11474,257 +11474,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -11738,223 +11738,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -11964,144 +11964,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -12109,57 +12109,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -12169,30 +12169,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12200,112 +12200,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -12313,287 +12313,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12601,13 +12601,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -12615,86 +12615,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/kos.po
+++ b/po/kos.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/mg.po
+++ b/po/mg.po
@@ -2216,7 +2216,7 @@ msgstr "hetsika"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "foana"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "atoseho"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "akaro ny penina"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "ahidino ny penina"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "amboary ny haben'ny penina"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "asehoy"
+#~ msgid "show"
+#~ msgstr "asehoy"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Diovy"
+#~ msgid "Clean"
+#~ msgstr "Diovy"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "afeno ireo bolongana"
+#~ msgid "hide blocks"
+#~ msgstr "afeno ireo bolongana"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "Ajanony"
+#~ msgid "stop"
+#~ msgstr "Ajanony"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "sokatra"
+#~ msgid "turtle"
+#~ msgstr "sokatra"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Sokafy"
+#~ msgid "Open"
+#~ msgstr "Sokafy"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/mi.po
+++ b/po/mi.po
@@ -2216,7 +2216,7 @@ msgstr "hohenga"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "putu tāpae"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "pahū"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "peia"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "kiore y"
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "kiore x"
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr "whakakī mutunga"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "pene ki runga"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "pene ki raro"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "tautuhi rahinga pene"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "whakaatu"
+#~ msgid "show"
+#~ msgstr "whakaatu"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "mātiti"
+#~ msgid "grid"
+#~ msgstr "mātiti"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Horoia"
+#~ msgid "Clean"
+#~ msgstr "Horoia"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "huna paraka"
+#~ msgid "hide blocks"
+#~ msgstr "huna paraka"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "tū"
+#~ msgid "stop"
+#~ msgstr "tū"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "roanga"
+#~ msgid "duration"
+#~ msgstr "roanga"
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "kia ora"
+#~ msgid "hello"
+#~ msgstr "kia ora"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "honu"
+#~ msgid "turtle"
+#~ msgstr "honu"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Whakatuwhera"
+#~ msgid "Open"
+#~ msgstr "Whakatuwhera"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/mk.po
+++ b/po/mk.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/ml.po
+++ b/po/ml.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/mn.po
+++ b/po/mn.po
@@ -2216,7 +2216,7 @@ msgstr "үйлдэл"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "ав"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "өг"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "бүү зур"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "зур"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "үзэгний хэмжээ өг"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "үзүүлэх"
+#~ msgid "show"
+#~ msgstr "үзүүлэх"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Арилга"
+#~ msgid "Clean"
+#~ msgstr "Арилга"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "Блок нуу"
+#~ msgid "hide blocks"
+#~ msgstr "Блок нуу"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "зогсоох"
+#~ msgid "stop"
+#~ msgstr "зогсоох"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "яст мэлхий"
+#~ msgid "turtle"
+#~ msgstr "яст мэлхий"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Нээх"
+#~ msgid "Open"
+#~ msgstr "Нээх"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -14,10 +14,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.0.1\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -103,7 +103,7 @@ msgstr "क्रिया"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr "बत्तख"
 
@@ -170,7 +170,7 @@ msgstr "लपवा"
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "माझा प्रोजेक्ट"
 
@@ -184,33 +184,33 @@ msgid "Your recording is in progress."
 msgstr "तुमची रेकॉर्डिंग सुरू आहे."
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "फाईलचे नाव"
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "प्रोजेक्ट शीर्षक"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "प्रोजेक्ट लेखक"
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "MIDI आउटपुट समाविष्ट करा?"
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "गिटार टॅब्लेचर आउटपुट समाविष्ट करा?"
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "लिलीपॉन्ड म्हणून जतन करा"
 
@@ -232,7 +232,7 @@ msgstr "लिलीपॉन्ड म्हणून जतन करा"
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "श्री. माउस"
 
@@ -310,7 +310,7 @@ msgstr "कार्टेशियन दाखवा"
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr "पैमाने की डिग्री"
 
@@ -539,8 +539,8 @@ msgstr "ब्लॉक सहायता सहेजें"
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "ती ला सोल फा मी रे दो"
 
@@ -699,7 +699,7 @@ msgstr "रूलर"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "स्वर"
 
@@ -709,14 +709,14 @@ msgstr "सीढ़ी"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "ताल"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "मोड"
 
@@ -747,7 +747,7 @@ msgstr "ड्रम"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "रिदम मेकर"
 
@@ -772,7 +772,7 @@ msgstr "रिदम मेकर"
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "नोट मूल्य"
 
@@ -781,7 +781,7 @@ msgstr "नोट मूल्य"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "स्केलर अंतराल"
 
@@ -802,7 +802,7 @@ msgid "silence"
 msgstr "मौन"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "नीचे"
 
@@ -820,8 +820,8 @@ msgstr "ऊपर"
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "स्वर"
 
@@ -923,7 +923,7 @@ msgstr "टेनर"
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "बास"
 
@@ -1057,14 +1057,14 @@ msgstr "कोई ब्लॉक चयनित नहीं है।"
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "अवतार"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "नमूना"
 
@@ -1139,7 +1139,7 @@ msgstr "ड्रम सुरू करा"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "ताल"
 
@@ -1175,7 +1175,7 @@ msgstr "प्रवाह"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr "संवेदी"
 
@@ -1184,7 +1184,7 @@ msgstr "संवेदी"
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr "मीडिया"
 
@@ -1675,7 +1675,7 @@ msgstr "प्लेबॅक तयार आहे."
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "दोगुना तेज़"
 
@@ -1687,8 +1687,8 @@ msgstr "दोगुना तेज़"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "तीव्र"
 
@@ -1698,7 +1698,7 @@ msgstr "तीव्र"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "स्वाभाविक"
 
@@ -1710,8 +1710,8 @@ msgstr "स्वाभाविक"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "कोमल"
 
@@ -1721,15 +1721,15 @@ msgstr "कोमल"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "दुहेरी कोमल"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr "समान"
 
@@ -1738,14 +1738,14 @@ msgstr "समान"
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "मुख्य"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr "आयोनियन"
 
@@ -1754,14 +1754,14 @@ msgstr "आयोनियन"
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "गौण"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr "आयोलियन"
 
@@ -1802,7 +1802,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr "तुम्ही तुमच्या पिच पूर्वावलोकनासाठी की निवडली आहे."
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "तुमच्याकडे वेटेड-पार्शियल ब्लॉकच्या आत किमान एक पार्शियल ब्लॉक असणे आवश्यक आहे"
 
@@ -1811,7 +1811,7 @@ msgid "synth cannot play chords."
 msgstr "सिंथ कॉर्ड्स वाजवू शकत नाही."
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr "मार्गदर्शक URL"
 
@@ -1828,7 +1828,7 @@ msgstr "शोधा"
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "मीटर"
 
@@ -1897,8 +1897,8 @@ msgstr "अतिरिक्त"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "कार्यक्रम"
 
@@ -1920,7 +1920,7 @@ msgstr "तर्कशास्त्र"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr "संगीत"
 
@@ -2206,7 +2206,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr "साफ करा"
 
@@ -2537,21 +2537,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr "कमी सातवा, एक सप्तक"
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "१ला २रा ३रा ४था ५वा ६वा ७वा ८वा ९वा १०वा ११वा १२वा"
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "वाढलेला"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "कमी"
 
@@ -2560,12 +2560,12 @@ msgstr "कमी"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "संपूर्ण"
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "क्रोमॅटिक"
 
@@ -2578,62 +2578,62 @@ msgid "spanish"
 msgstr "स्पॅनिश"
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr "ऑक्टाटोनिक"
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "हार्मोनिक मेजर"
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "नैसर्गिक लहान"
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "हार्मोनिक लहान"
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "मेलोडिक लहान"
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr "डोरियन"
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr "फ्रिजियन"
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr "लिडियन"
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "मिक्सोलिडियन"
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr "लोक्रीयन"
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "जाझ लहान"
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr "बेबॉप"
 
@@ -2646,7 +2646,7 @@ msgid "byzantine"
 msgstr "बायझेंटाईन"
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "एनीगमॅटिक"
 
@@ -2655,7 +2655,7 @@ msgid "ethiopian"
 msgstr "इथिओपियन"
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "गीझ"
 
@@ -2668,7 +2668,7 @@ msgid "hungarian"
 msgstr "हंगेरियन"
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "रोमानियन लहान"
 
@@ -2677,17 +2677,17 @@ msgid "spanish gypsy"
 msgstr "स्पॅनिश जिप्सी"
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "मक़ाम"
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "लहान ब्लूज"
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr "मोठा ब्लूज"
 
@@ -2696,12 +2696,12 @@ msgid "whole tone"
 msgstr "संपूर्ण टोन"
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "लहान पेंटाटोनिक"
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "मोठा पेंटाटोनिक"
 
@@ -2714,7 +2714,7 @@ msgid "egyptian"
 msgstr "इजिप्शियन"
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "हिराजोशी"
 
@@ -2723,17 +2723,17 @@ msgid "Japan"
 msgstr "जपान"
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "मध्ये"
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "मिन्यो"
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "फिबोनाची"
 
@@ -2750,56 +2750,56 @@ msgstr "फिबोनाची"
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr "सानुकूल."
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr "हायपास"
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr "लोपास"
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr "बँडपास"
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr "हायशेल्फ"
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr "लोशेल्फ"
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr "नॉच"
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr "ऑलपास"
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr "पीकिंग"
 
@@ -2807,7 +2807,7 @@ msgstr "पीकिंग"
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "साइन."
 
@@ -2815,7 +2815,7 @@ msgstr "साइन."
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "चौरस."
 
@@ -2824,7 +2824,7 @@ msgstr "चौरस."
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "त्रिकोण."
 
@@ -2832,7 +2832,7 @@ msgstr "त्रिकोण."
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "सॉटूथ."
 
@@ -2841,8 +2841,8 @@ msgstr "सॉटूथ."
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr "सम"
 
@@ -2850,7 +2850,7 @@ msgstr "सम"
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr "विषम"
 
@@ -2864,116 +2864,116 @@ msgstr "स्केलर"
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr "पियानो."
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr "व्हायोलिन."
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr "व्हायोला."
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "झायलोफोन."
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "वाईब्राफोन."
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr "सेलो."
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr "डबल बास."
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr "गिटार."
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr "अकौस्टिक गिटार."
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr "बासरी."
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr "क्लारिनेट."
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr "सॅक्सोफोन."
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr "टुबा."
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr "तुरही."
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr "ओबो."
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr "ट्रोम्बोन."
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr "इलेक्ट्रॉनिक सिंथ."
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "सरल 1."
 
@@ -2992,19 +2992,19 @@ msgstr "सोपे ४"
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr "पांढरा आवाज."
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "तपकिरी आवाज."
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "गुलाबी आवाज."
 
@@ -3012,61 +3012,61 @@ msgstr "गुलाबी आवाज."
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr "स्नेर ड्रम."
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr "किक ड्रम."
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr "टॉम टॉम."
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr "फ्लोर टॉम."
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr "बास ड्रम."
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "कप ड्रम."
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr "दारबुका ड्रम."
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr "हाय हॅट."
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr "राइड बेल."
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr "काऊ बेल."
 
@@ -3076,149 +3076,149 @@ msgstr "जपानी ढोल"
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr "जपानी बेल."
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr "त्रिकोण बेल."
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr "फिंगर सिम्बल्स."
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "चाइम."
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr "गाँग."
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr "क्लँग."
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr "क्रॅश."
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr "बॉटल."
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr "क्लॅप."
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr "स्लॅप."
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr "स्प्लॅश."
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr "बुडबुडे"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr "पावसाचा थेंब"
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr "मांजर"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr "झिंगे"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr "कुत्रा"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr "बँजो."
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr "कोटो."
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr "डल्सिमर."
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr "इलेक्ट्रिक गिटार."
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr "बॅसून."
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr "सेलेस्टे."
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr "समान"
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "पायथागोरियन"
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr "फक्त ट्यूनिंग"
 
@@ -3227,7 +3227,7 @@ msgstr "फक्त ट्यूनिंग"
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr "मिन्टोन"
 
@@ -3306,22 +3306,22 @@ msgid "previous"
 msgstr "मागील"
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "सरल-2."
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "सरल-3."
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "सरल-4."
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr "ताईको."
 
@@ -3478,7 +3478,7 @@ msgstr "गेट-डिक्ट ब्लॉक निर्दिष्ट �
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "मूल्य मिळवा"
 
@@ -3500,7 +3500,7 @@ msgstr "की2"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "की"
 
@@ -3511,7 +3511,7 @@ msgstr "सेट-डिक्ट ब्लॉक निर्दिष्ट �
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr "मूल्य सेट करा"
 
@@ -3540,7 +3540,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr "प्रत्येक पिचच्या उदाहरणाला ड्रमच्या आवाजाने बदला."
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "पिचला ड्रमच्या आवाजाशी नकाशा करा"
 
@@ -3549,7 +3549,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "वरील उदाहरणात, किक ड्रमचा आवाज सोलच्या ऐवजी वाजवला जाईल."
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "ड्रम सेट करा"
 
@@ -3582,7 +3582,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "हीप-एम्प्टी? ब्लॉक ढिग रिक्त असल्यास ट्रू परत करतो."
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "ढिग रिक्त आहे का?"
 
@@ -3592,7 +3592,7 @@ msgstr "एम्प्टी-हीप ब्लॉक ढिग रिक्�
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "रिक्त ढीग"
 
@@ -3601,7 +3601,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr "रिव्हर्स-हीप ब्लॉक ढिगाचा क्रम उलटवतो."
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr "उलट ढीग"
 
@@ -3610,7 +3610,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr "इंडेक्स-हीप ब्लॉक दिलेल्या स्थानावर हीपमधील मूल्य परत करतो."
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "इंडेक्स हीप"
 
@@ -3633,13 +3633,13 @@ msgstr "सेट-हीप एंट्री ब्लॉक दिलेल�
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "सेट हीप"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "इंडेक्स"
 
@@ -3648,7 +3648,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr "पॉप ब्लॉक हीपच्या शीर्षस्थानील मूल्य काढून टाकतो."
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "पॉप"
 
@@ -3657,7 +3657,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr "पुश ब्लॉक हीपच्या शीर्षस्थानी मूल्य जोडतो."
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "ढकलणे"
 
@@ -3677,7 +3677,7 @@ msgstr "स्वभाव सेट करा"
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "ऑक्टेव्ह"
 
@@ -3702,7 +3702,7 @@ msgid "current interval"
 msgstr "वर्तमान अंतर"
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr "अर्ध-स्वर अंतर मोजणी"
 
@@ -3716,7 +3716,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr "स्केलर अंतर ब्लॉक वर्तमान की आणि मोडमध्ये दोन नोट्समधील अंतर मोजतो."
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr "स्केलर अंतर मोजणी"
 
@@ -3726,7 +3726,7 @@ msgstr "आकृतीमध्ये, आम्ही सोल# सोलम�
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr "अर्ध-स्वर अंतर"
 
@@ -3764,7 +3764,7 @@ msgid "In the figure, we add la to sol."
 msgstr "आकृतीमध्ये, आम्ही ला सोलमध्ये जोडतो."
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr "कस्टम मोड परिभाषित करा"
 
@@ -3773,7 +3773,7 @@ msgid "movable Do"
 msgstr "चालता डो"
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "मोड लांबी"
 
@@ -3786,18 +3786,18 @@ msgid "Most Western scales have 7 notes."
 msgstr "बहुतेक पाश्चिमात्य स्केलमध्ये 7 नोट्स असतात."
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "वर्तमान मोड"
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr "वर्तमान की"
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "की सेट करा"
 
@@ -3918,7 +3918,7 @@ msgstr "स्लर घटक"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr "शेजारी"
 
@@ -3937,7 +3937,7 @@ msgstr "स्लर"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "स्टॅकॅटो"
 
@@ -3946,7 +3946,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -3963,7 +3963,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -3976,7 +3976,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "लोड ढीग"
 
@@ -4005,7 +4005,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -4028,7 +4028,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -4045,7 +4045,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "ढीग जतन करा"
 
@@ -4054,7 +4054,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -4071,7 +4071,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -4080,7 +4080,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -4114,7 +4114,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -4123,7 +4123,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr "ब्लॉक्स कनेक्ट करा"
 
@@ -4140,7 +4140,7 @@ msgid "The Make block block creates a new block."
 msgstr "मेक ब्लॉक ब्लॉक एक नवीन ब्लॉक तयार करतो."
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr "ब्लॉक तयार करा"
 
@@ -4155,7 +4155,7 @@ msgstr "ब्लॉक तयार करा"
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "नोंद"
 
@@ -4189,12 +4189,12 @@ msgstr "नोंद मूल्य 0 पेक्षा जास्त अस
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "स्विंग"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "स्विंग मूल्य"
 
@@ -4203,12 +4203,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr "स्किप नोट्स ब्लॉक नोट्स वगळण्यास कारणीभूत ठरेल."
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "नोट्स वगळा"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "नोंद मूल्य गुणाकार"
 
@@ -4217,13 +4217,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr "टाय ब्लॉक नोट्सच्या जोड्यांवर काम करतो, त्यांना एका नोटमध्ये एकत्र करतो."
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "टाय"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "डॉट"
 
@@ -4241,7 +4241,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr "उदा. डॉट केलेली तिमाही नोट 3/8 (1/4 + 1/8) बीटसाठी वाजेल."
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr "ड्रम साठी नोट मूल्य ब्लॉक"
 
@@ -4273,8 +4273,8 @@ msgstr "ऑक्टेव्ह स्पेस"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "रिदम1"
 
@@ -4330,7 +4330,7 @@ msgstr "पूर्ण नोट"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "टुपलेट"
 
@@ -4487,12 +4487,12 @@ msgid "duplicate factor"
 msgstr "डुप्लिकेट फॅक्टर"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -4502,8 +4502,8 @@ msgstr "बीट्स पर मिनिट ब्लॉक सध्या�
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -4511,12 +4511,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "बीट्स प्रति मिनिट"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgid "The Measure count block returns the current measure."
 msgstr "मेजर काउंट ब्लॉक सध्याचे मापन परत करतो."
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr "बीट संख्या"
 
@@ -4542,7 +4542,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr "उदा 1, 2, 3, किंवा 4."
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr "नोट्सच्या मूल्यांची बेरीज"
 
@@ -4552,12 +4552,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr "नोट काउंटर ब्लॉकचा वापर समाविष्ट नोट्सची संख्या मोजण्यासाठी केला जाऊ शकतो."
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr "नोट काउंटर"
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr "पूर्ण नोट्स प्ले केल्या"
 
@@ -4567,7 +4567,7 @@ msgstr "पूर्ण नोट्स प्ले केलेल्या �
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr "नोट्स प्ले केल्या"
 
@@ -4576,7 +4576,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr "नो क्लॉक ब्लॉक नोट्स मास्टर क्लॉकपासून वेगळ्या करतो."
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "नो क्लॉक"
 
@@ -4626,7 +4626,7 @@ msgstr "ऑन-एव्हरी-नोट ब्लॉक तुम्हा�
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr "मास्टर बीट्स पर मिनिट"
 
@@ -4659,7 +4659,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr "बीट्स पर मिनिट ब्लॉक मिनिटात 1/4 नोट्सची संख्या सेट करतो."
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr "पिकअप"
 
@@ -4668,12 +4668,12 @@ msgid "number of beats"
 msgstr "बीट्सची संख्या"
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "स्थानांतर"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr "स्केलर स्टेप डाउन"
 
@@ -4682,7 +4682,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr "स्केलर स्टेप डाउन ब्लॉक वर्तमान की आणि मोडमध्ये मागील नोटपर्यंत अर्ध-स्वरांची संख्या परतवतो."
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr "स्केलर स्टेप अप"
 
@@ -4691,7 +4691,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr "स्केलर स्टेप अप ब्लॉक वर्तमान की आणि मोडमध्ये पुढील नोटपर्यंत अर्ध-स्वरांची संख्या परतवतो."
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr "स्वरातील बदल"
 
@@ -4700,7 +4700,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr "चेंज इन पिच ब्लॉक हे चालू स्वर आणि मागील स्वर यांच्यातील फरक (अर्ध्या पायर्‍यांमध्ये) आहे."
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr "स्वरातील स्केलर बदल"
 
@@ -4711,8 +4711,8 @@ msgstr "स्वरातील स्केलर बदल"
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr "स्वर संख्या"
 
@@ -4722,7 +4722,7 @@ msgstr "पिच नंबर ब्लॉक सध्या प्ले ह�
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr "हर्ट्जमधील स्वर"
 
@@ -4748,7 +4748,7 @@ msgid "alphabet"
 msgstr "वर्णमाला"
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr "अक्षर वर्ग"
 
@@ -4786,12 +4786,12 @@ msgstr "रंगात स्वर"
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr "एमआयडीआय"
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr "स्वर संख्या ऑफसेट सेट करा"
 
@@ -4803,12 +4803,12 @@ msgstr "सेट पिच नंबर ऑफसेट ब्लॉकचा �
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "संख्या ते स्वर"
 
@@ -4817,7 +4817,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr "नंबर टू पिच ब्लॉक पिच नंबरला पिच नावात रूपांतरित करेल."
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "संख्या ते सप्तक"
 
@@ -4863,22 +4863,22 @@ msgstr "इन्व्हर्ट ब्लॉक कोणत्याही 
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr "इन्व्हर्ट"
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "इन्व्हर्ट (विषम)"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "इन्व्हर्ट (सम)"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr "नोंदणी करा"
 
@@ -4887,7 +4887,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr "नोंदणी ब्लॉक त्यानंतरच्या नोट्सच्या नोंदणी (सप्तक) मध्ये बदल करण्याचा सोपा मार्ग प्रदान करतो."
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr "50 सेंट"
 
@@ -4900,7 +4900,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr "वरील उदाहरणात, सोलला सोल# पर्यंत शिफ्ट केले आहे."
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr "सेमी-टोन ट्रान्सपोझ"
 
@@ -4909,47 +4909,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr "ट्रान्सपोझ बाय रेशो ब्लॉक नोट ब्लॉकमधील स्वरांना गुणोत्तराने वर (किंवा खाली) शिफ्ट करेल"
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr "गुणोत्तराने ट्रान्सपोझ"
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr "सहावा खाली"
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr "तिसरा खाली"
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr "सातवा"
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr "सहावा"
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr "पंचम"
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr "चतुर्थ"
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr "तृतीय"
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr "द्वितीय"
 
@@ -4962,7 +4962,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr "वर दाखवलेल्या उदाहरणात, सोल ला ला पर्यंत हलवले जाते."
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr "स्केलर ट्रान्सपोज"
 
@@ -4971,7 +4971,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr "अॅक्सिडेंटल ब्लॉक शार्प्स आणि फ्लॅट्स तयार करण्यासाठी वापरला जातो"
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr "अॅक्सिडेंटल ओव्हरराइड"
 
@@ -4979,7 +4979,7 @@ msgstr "अॅक्सिडेंटल ओव्हरराइड"
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -4993,8 +4993,8 @@ msgstr "पिच नंबर ब्लॉक त्याच्या नं�
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr "एनथ मोडल पिच"
 
@@ -5023,7 +5023,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr "स्केल डिग्री 1 नेहमी दिलेल्या स्केलमधील पहिले पिच असते, ऑक्टेव्हच्या बाबतीत काहीही नाही."
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr "स्केलर स्टेप"
 
@@ -5048,14 +5048,14 @@ msgstr "ऑस्सिलेटर"
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr "प्रकार"
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr "आंशिक"
 
@@ -5065,7 +5065,7 @@ msgstr "आपण एकाधिक ऑस्सिलेटर ब्लॉक
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr "डुओ सिंथ"
 
@@ -5084,7 +5084,7 @@ msgstr "वायब्रेटो तीव्रता"
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr "एएम सिंथ"
 
@@ -5094,7 +5094,7 @@ msgstr "एएम सिंथ ब्लॉक एक अँप्लिट्�
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr "एफएम सिंथ"
 
@@ -5111,17 +5111,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr "आंशिक ब्लॉक विशिष्ट आंशिक हार्मोनिकसाठी वजन निर्दिष्ट करण्यासाठी वापरला जातो."
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr "आंशिक वजन 0 आणि 1 दरम्यान असले पाहिजे."
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr "आंशिक ब्लॉक वेटेड-आंशिक ब्लॉकच्या आत वापरला पाहिजे."
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr "वेटेड आंशिक"
 
@@ -5130,7 +5130,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr "हार्मोनिक ब्लॉक समाविष्ट नोट्समध्ये हार्मोनिक्स जोडेल."
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr "हार्मोनिक"
 
@@ -5140,7 +5140,7 @@ msgstr "डिस्टॉर्शन ब्लॉक पिचला डिस
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr "डिस्टॉर्शन"
 
@@ -5150,7 +5150,7 @@ msgstr "ट्रेमोलो ब्लॉक एक लहरी प्र�
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr "ट्रेमोलो"
 
@@ -5162,7 +5162,7 @@ msgstr "ट्रेमोलो"
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr "दर"
 
@@ -5170,7 +5170,7 @@ msgstr "दर"
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr "गहराई"
 
@@ -5180,7 +5180,7 @@ msgstr "फेजर ब्लॉक एक झाडलोट आवाज ज�
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr "फेजर"
 
@@ -5201,7 +5201,7 @@ msgstr "कोरस ब्लॉक एक कोरस प्रभाव ज�
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr "कोरस"
 
@@ -5216,7 +5216,7 @@ msgstr "वायब्रेटो ब्लॉक पिचमध्ये ए
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr "वायब्रेटो"
 
@@ -5226,7 +5226,7 @@ msgid "intensity"
 msgstr "तीव्रता"
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr "सिंथ सेट करा"
 
@@ -5240,7 +5240,7 @@ msgstr "डिफॉल्ट वाद्य सेट करा"
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr "वाद्य सेट करा"
 
@@ -5296,7 +5296,7 @@ msgstr "गणना करा"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr "डू ब्लॉक एक कृती आरंभ करण्यासाठी वापरला जातो."
 
@@ -5474,7 +5474,7 @@ msgid "Cannot find start block"
 msgstr "प्रारंभ ब्लॉक सापडत नाही"
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "माऊसचा रंग"
 
@@ -5483,7 +5483,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr "माऊस रंग ब्लॉक निर्दिष्ट माऊसचा पेन रंग परतवतो."
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "कासवाचा रंग"
 
@@ -5492,7 +5492,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr "कासव रंग ब्लॉक निर्दिष्ट कासवाचा पेन रंग परतवतो."
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "माऊस हेडिंग"
 
@@ -5501,7 +5501,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr "माऊस हेडिंग ब्लॉक निर्दिष्ट माऊसचे शीर्षक परतवतो."
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "कासव हेडिंग"
 
@@ -5511,13 +5511,13 @@ msgstr "कासव हेडिंग ब्लॉक निर्दिष्
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr "माऊस सेट करा"
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr "कासव सेट करा"
 
@@ -5530,7 +5530,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr "सेट कासव ब्लॉक निर्दिष्ट कासवद्वारे चालवण्यासाठी ब्लॉक्सचा स्टॅक पाठवतो."
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "माऊस y"
 
@@ -5539,7 +5539,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr "Y माऊस ब्लॉक निर्दिष्ट माऊसची Y स्थिती परतवतो."
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "कासव y"
 
@@ -5548,7 +5548,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr "Y कासव ब्लॉक निर्दिष्ट कासवाची Y स्थिती परतवतो."
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "माऊस x"
 
@@ -5557,7 +5557,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr "X माऊस ब्लॉक निर्दिष्ट माऊसची X स्थिती परतवतो."
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "कासव x"
 
@@ -5566,7 +5566,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr "X कासव ब्लॉक निर्दिष्ट कासवाची X स्थिती परतवतो."
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "माऊसने वाजवलेल्या नोट्स"
 
@@ -5575,7 +5575,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr "माऊस एलेप्स नोट्स ब्लॉक निर्दिष्ट माऊसद्वारे वाजवलेल्या नोट्सची संख्या परतवतो."
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "कासवाने वाजवलेल्या नोट्स"
 
@@ -5584,7 +5584,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr "कासव एलेप्स नोट्स ब्लॉक निर्दिष्ट कासवद्वारे वाजवलेल्या नोट्सची संख्या परतवतो."
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "माउस पिच क्रमांक"
 
@@ -5593,7 +5593,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr "माउस पिच ब्लॉक निर्दिष्ट माउसद्वारे वाजवलेला वर्तमान पिच क्रमांक परत करतो."
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "टर्टल पिच क्रमांक"
 
@@ -5603,17 +5603,17 @@ msgstr "टर्टल पिच ब्लॉक निर्दिष्ट �
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr "माउस नोट मूल्य"
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "टर्टल नोट मूल्य"
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "माउस सिंक"
 
@@ -5622,7 +5622,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "माउस सिंक ब्लॉक माउस दरम्यान बीट गणना संरेखित करतो."
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "टर्टल सिंक"
 
@@ -6049,7 +6049,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr "राइट ब्लॉक कॅनव्हासच्या उजव्या बाजूची स्थिती परत करतो."
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -6103,12 +6103,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr "हाइट ब्लॉक कॅनव्हासची उंची परत करतो."
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "खेळणे / चालणे थांबवा"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr "मीडिया मिटवा"
 
@@ -6117,7 +6117,7 @@ msgid "The Erase Media block erases text and images."
 msgstr "इरेज मीडिया ब्लॉक मजकूर आणि प्रतिमा मिटवतो."
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -6174,7 +6174,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -6192,7 +6192,7 @@ msgstr "अवतार ब्लॉक कासवाचा देखावा
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "आकार"
 
@@ -6205,7 +6205,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr "शो ब्लॉक कॅनव्हासवर मजकूर किंवा प्रतिमा प्रदर्शित करण्यासाठी वापरला जातो."
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -6270,7 +6270,7 @@ msgstr "भरायची अंत"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "बैक्ग्राउन्ड / मागे / पार्श्वभूमी"
 
@@ -6335,7 +6335,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr "होलो लाइन ब्लॉक खोखळ्या केंद्रासह एक ओळ तयार करतो."
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -6344,12 +6344,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "लोखणी वर करा"
 
@@ -6358,7 +6358,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "लोखणी खाली ठेवा"
 
@@ -6367,7 +6367,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "लोखणीचे आकार संच करा"
 
@@ -6376,7 +6376,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -6401,7 +6401,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "राखाडी संच करा"
 
@@ -6536,27 +6536,27 @@ msgstr "कीबोर्ड ब्लॉक संगणक कीबोर्
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr "लिफाफा"
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "आक्रमण"
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "क्षय"
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "सस्टेन"
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "रिलीज"
 
@@ -6582,18 +6582,18 @@ msgstr "आपण एकाधिक लिफाफा ब्लॉक्स �
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr "फिल्टर"
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr "रोलऑफ"
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr "रोलऑफ मूल्य -12, -24, -48 किंवा -96 डेसिबल्स/ऑक्टेव्ह असावे."
 
@@ -6608,7 +6608,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr "नमुना अपलोड करा आणि त्याचे पिच सेंटर समायोजित करा."
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "सॅम्पलर"
 
@@ -6629,7 +6629,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr "कस्टम मोड ब्लॉक संगीत मोड (स्केलमधील नोट्सचे अंतर) शोधण्यासाठी एक साधन उघडतो."
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "कस्टम मोड"
 
@@ -6646,7 +6646,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr "पिच ड्रम मॅट्रिक्सचा वापर पिचेस ड्रम आवाजांशी मॅप करण्यासाठी केला जातो."
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "पिच-ड्रम मॅपर"
 
@@ -6659,7 +6659,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr "पिच स्लायडर टूल निवडलेल्या फ्रिक्वेन्सीजवर पिचेस निर्माण करण्यासाठी वापरला जातो."
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "पिच स्लायडर"
 
@@ -6669,7 +6669,7 @@ msgstr "क्रोमॅटिक कीबोर्ड"
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr "संगीत कीबोर्ड"
 
@@ -6683,7 +6683,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr "पिच स्टेअरकेस टूल दिलेल्या गुणोत्तरापासून पिचेस निर्माण करण्यासाठी वापरला जातो."
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "पिच स्टेअरकेस"
 
@@ -6704,7 +6704,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr "फ्रेज मेकर ब्लॉक संगीत वाक्य तयार करण्यासाठी एक साधन उघडतो."
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "फ्रेज मेकर"
 
@@ -6718,7 +6718,7 @@ msgstr "स्टेटस ब्लॉक म्युझिक ब्लॉक
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr "एआय संगीत"
 
@@ -6905,7 +6905,7 @@ msgstr "वायब्रेटो दर 0 पेक्षा जास्त 
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr "खोलाई श्रेणीबाहेर आहे."
 
@@ -6914,7 +6914,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr "विकृती 0 ते 100 दरम्यान असावी."
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr "आंशिक 0 पेक्षा जास्त किंवा समान असावे."
 
@@ -7036,7 +7036,7 @@ msgid "Undo"
 msgstr "पूर्ववत"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr "मोडसाठी नोट्स निवडण्यासाठी वर्तुळात क्लिक करा."
 
@@ -7119,7 +7119,7 @@ msgid "Save drum machine"
 msgstr "ड्रम मशीन जतन करा"
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr "ताल टॅप करा"
 
@@ -7169,7 +7169,7 @@ msgid "Playback"
 msgstr "प्लेबॅक"
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr "संदर्भ टोन"
 
@@ -7286,7 +7286,7 @@ msgstr "सिंथेसायझर"
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr "परिणाम"
 
@@ -7365,48 +7365,48 @@ msgid "Cannot connect to server"
 msgstr "सर्व्हरशी जोडले जाऊ शकत नाही"
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr "सर्व प्रकल्प"
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr "माझे प्रकल्प"
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr "उदाहरणे"
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr "कला"
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr "गणित"
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr "परस्परसंवादी"
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr "डिझाइन"
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr "खेळ"
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr "कोड स्निपेट"
 
@@ -7839,38 +7839,38 @@ msgstr "हलवा"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr "ट्रैश में पुनर्स्थापित करने के लिए कुछ नहीं है।"
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr "ट्रैश में पुनर्स्थापित करने के लिए कुछ नहीं है।"
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr "तुमच्या प्रकल्पातील ऑडिओ WAV म्हणून जतन करा."
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr "तुमच्या प्रकल्पातील ऑडिओ WAV म्हणून जतन करा."
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr "तुमचा प्रकल्प ABC फाइल म्हणून जतन करा."
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr "तुमचा प्रकल्प ABC फाइल म्हणून जतन करा."
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "तुमचा प्रकल्प लिलिपॉन्ड फाइल म्हणून जतन करा."
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "तुमचा प्रकल्प लिलिपॉन्ड फाइल म्हणून जतन करा."
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr "सह-निर्देशांक ग्रीड दाखवा किंवा लपवा."
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr "सह-निर्देशांक ग्रीड दाखवा किंवा लपवा."
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr "विस्तृत करा/गिरावा"
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr "विस्तृत करा/गिरावा"
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "हे संदेश दर्शवा."
+#~ msgid "Show these messages."
+#~ msgstr "हे संदेश दर्शवा."
 
 #: js/rubrics.js:531
 
@@ -7878,8 +7878,8 @@ msgstr "हलवा"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "सेन्सर्स"
+#~ msgid "sensors"
+#~ msgstr "सेन्सर्स"
 
 #: js/rubrics.js:532
 
@@ -7889,8 +7889,8 @@ msgstr "हलवा"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "मीडिया"
+#~ msgid "media"
+#~ msgstr "मीडिया"
 
 #: js/block-verbose.js:3837
 
@@ -7902,35 +7902,35 @@ msgstr "हलवा"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr "कार्टेसियन+ध्रुवीय"
+#~ msgid "Cartesian+polar"
+#~ msgstr "कार्टेसियन+ध्रुवीय"
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "दाखवा"
+#~ msgid "show"
+#~ msgstr "दाखवा"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr "ब्लॉक दाखवा/लपवा"
+#~ msgid "Show/hide block"
+#~ msgstr "ब्लॉक दाखवा/लपवा"
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "जाल"
+#~ msgid "grid"
+#~ msgstr "जाल"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr "आपण की निवडली आहे "
+#~ msgid "You have chosen key "
+#~ msgstr "आपण की निवडली आहे "
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr "आपल्या पिच पूर्वावलोकनासाठी."
+#~ msgid " for your pitch preview."
+#~ msgstr "आपल्या पिच पूर्वावलोकनासाठी."
 
 #: js/toolbar.js:113
 
@@ -7944,69 +7944,69 @@ msgstr "हलवा"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr "पूर्ण स्क्रीन"
+#~ msgid "Full Screen"
+#~ msgstr "पूर्ण स्क्रीन"
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr "नवीन प्रकल्प"
+#~ msgid "New Project"
+#~ msgstr "नवीन प्रकल्प"
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr "संगीत"
+#~ msgid "music"
+#~ msgstr "संगीत"
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr "जतन करा"
+#~ msgid "save"
+#~ msgstr "जतन करा"
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "स्वच्छ"
+#~ msgid "Clean"
+#~ msgstr "स्वच्छ"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "मंद चालवा"
+#~ msgid "Run slow"
+#~ msgstr "मंद चालवा"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr "कार्यस्थान स्वच्छ करा"
+#~ msgid "Clear Workspace"
+#~ msgstr "कार्यस्थान स्वच्छ करा"
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr "आपण नक्की कार्यस्थान स्वच्छ करू इच्छिता?"
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr "आपण नक्की कार्यस्थान स्वच्छ करू इच्छिता?"
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr "मीनटोन"
+#~ msgid "meantone"
+#~ msgstr "मीनटोन"
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr "सानुकूल"
+#~ msgid "Custom"
+#~ msgstr "सानुकूल"
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "ब्लॉक्स लपवा"
+#~ msgid "hide blocks"
+#~ msgstr "ब्लॉक्स लपवा"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr "नक्कल"
+#~ msgid "duplicate"
+#~ msgstr "नक्कल"
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8026,13 +8026,13 @@ msgstr "हलवा"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "थांबा"
+#~ msgid "stop"
+#~ msgstr "थांबा"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "कालावधी (मिलीसेकंद)"
+#~ msgid "duration (ms)"
+#~ msgstr "कालावधी (मिलीसेकंद)"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8040,58 +8040,58 @@ msgstr "हलवा"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "स्वच्छ"
+#~ msgid "clear"
+#~ msgstr "स्वच्छ"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "उलट"
+#~ msgid "invert"
+#~ msgstr "उलट"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr "ऑसिलेटर"
+#~ msgid "oscillator"
+#~ msgstr "ऑसिलेटर"
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr "विलंब"
+#~ msgid "delay"
+#~ msgstr "विलंब"
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr "लिफाफा"
+#~ msgid "envelope"
+#~ msgstr "लिफाफा"
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr "फिल्टर"
+#~ msgid "filter"
+#~ msgstr "फिल्टर"
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr "एआय संगीत"
+#~ msgid "aimusic"
+#~ msgstr "एआय संगीत"
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr " खाली"
+#~ msgid " below"
+#~ msgstr " खाली"
 
 #: js/widgets/modewidget.js:1017
 
@@ -8107,25 +8107,25 @@ msgstr "हलवा"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr "नवीन क्रिया ब्लॉक तयार केले!"
+#~ msgid "New action block generated!"
+#~ msgstr "नवीन क्रिया ब्लॉक तयार केले!"
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr "रेकॉर्डिंग सुरू झाले..."
+#~ msgid "Recording started..."
+#~ msgstr "रेकॉर्डिंग सुरू झाले..."
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr "रेकॉर्डिंग पूर्ण झाले..."
+#~ msgid "Recording complete..."
+#~ msgstr "रेकॉर्डिंग पूर्ण झाले..."
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "कालावधी"
+#~ msgid "duration"
+#~ msgstr "कालावधी"
 
 #: js/widgets/temperament.js:454
 
@@ -8135,43 +8135,43 @@ msgstr "हलवा"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr "बंद"
+#~ msgid "close"
+#~ msgstr "बंद"
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr "प्रकल्प प्रकाशित करा"
+#~ msgid "Publish Project"
+#~ msgstr "प्रकल्प प्रकाशित करा"
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr "प्ले"
+#~ msgid "play"
+#~ msgstr "प्ले"
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr "लिलीपॉन्ड पिकअप प्रक्रिया करू शकत नाही "
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr "लिलीपॉन्ड पिकअप प्रक्रिया करू शकत नाही "
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr "प्रगत मोडमध्ये बदलण्यासाठी आपला ब्राउझर रीफ्रेश करा."
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr "प्रगत मोडमध्ये बदलण्यासाठी आपला ब्राउझर रीफ्रेश करा."
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr "प्रारंभिक मोडमध्ये बदलण्यासाठी आपला ब्राउझर रीफ्रेश करा."
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr "प्रारंभिक मोडमध्ये बदलण्यासाठी आपला ब्राउझर रीफ्रेश करा."
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr "नवीन कृती ब्लॉक्स तयार केले"
+#~ msgid "New action blocks generated"
+#~ msgstr "नवीन कृती ब्लॉक्स तयार केले"
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr "नवीन कृती ब्लॉक तयार केला"
+#~ msgid "New action block generated"
+#~ msgstr "नवीन कृती ब्लॉक तयार केला"
 
 #: js/toolbar.js:70
 
@@ -8181,190 +8181,190 @@ msgstr "हलवा"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr "JavaScript संपादक परिवर्तन करा"
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr "JavaScript संपादक परिवर्तन करा"
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr "टर्टल पिच ब्लॉक निर्दिष्ट टर्टलद्वारे वाजवलेली सध्याची पिच संख्या परत करतो."
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr "टर्टल पिच ब्लॉक निर्दिष्ट टर्टलद्वारे वाजवलेली सध्याची पिच संख्या परत करतो."
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr "स्केलर स्टेप ब्लॉक नोट ब्लॉकच्या आत वापरणे आवश्यक आहे."
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr "स्केलर स्टेप ब्लॉक नोट ब्लॉकच्या आत वापरणे आवश्यक आहे."
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr "स्केलर स्टेप ब्लॉकच्या आधी पिच ब्लॉक असणे आवश्यक आहे."
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr "स्केलर स्टेप ब्लॉकच्या आधी पिच ब्लॉक असणे आवश्यक आहे."
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr "नवीन कृती ब्लॉक्स तयार केले!"
+#~ msgid "New action blocks generated!"
+#~ msgstr "नवीन कृती ब्लॉक्स तयार केले!"
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr "पूर्ण स्क्रीन"
+#~ msgid "FullScreen"
+#~ msgstr "पूर्ण स्क्रीन"
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr "पूर्ण स्क्रीन मोड परिवर्तन करा."
+#~ msgid "Toggle full screen mode."
+#~ msgstr "पूर्ण स्क्रीन मोड परिवर्तन करा."
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr "टुपलेट ब्लॉक वापरून कमी वेळेत वाजवलेल्या नोट्सच्या गटाची निर्मिती केली जाते."
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr "टुपलेट ब्लॉक वापरून कमी वेळेत वाजवलेल्या नोट्सच्या गटाची निर्मिती केली जाते."
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr "टुपलेट्सचा वापर करून 2 च्या घातावर आधारित नसलेल्या नोट्सच्या गटांची निर्मिती सोपी होते."
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr "टुपलेट्सचा वापर करून 2 च्या घातावर आधारित नसलेल्या नोट्सच्या गटांची निर्मिती सोपी होते."
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr "सेट टेम्परमेंट ब्लॉक वापरून म्युझिक ब्लॉक्सद्वारे वापरलेली ट्यूनिंग प्रणाली निवडली जाते."
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr "सेट टेम्परमेंट ब्लॉक वापरून म्युझिक ब्लॉक्सद्वारे वापरलेली ट्यूनिंग प्रणाली निवडली जाते."
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr "इंटरव्हल नंबर ब्लॉक सध्याच्या इंटरव्हलमधील स्केलर स्टेप्सची संख्या परत करतो."
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr "इंटरव्हल नंबर ब्लॉक सध्याच्या इंटरव्हलमधील स्केलर स्टेप्सची संख्या परत करतो."
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr "सेमी-टोन इंटरव्हल ब्लॉक दोन नोट्समधील अंतर सेमी-टोनमध्ये मोजतो."
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr "सेमी-टोन इंटरव्हल ब्लॉक दोन नोट्समधील अंतर सेमी-टोनमध्ये मोजतो."
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr "सेमी-टोन इंटरव्हल ब्लॉक अर्ध्या स्टेप्सच्या आधारावर सापेक्ष अंतर काढतो."
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr "सेमी-टोन इंटरव्हल ब्लॉक अर्ध्या स्टेप्सच्या आधारावर सापेक्ष अंतर काढतो."
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr "आर्पेजियो ब्लॉक प्रत्येक नोट ब्लॉकला अनेक वेळा चालवेल, निर्दिष्ट कॉर्डच्या आधारे ट्रान्सपोजिशन जोडेल."
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr "आर्पेजियो ब्लॉक प्रत्येक नोट ब्लॉकला अनेक वेळा चालवेल, निर्दिष्ट कॉर्डच्या आधारे ट्रान्सपोजिशन जोडेल."
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr "स्केलर इंटरव्हल ब्लॉक सध्याच्या मोडच्या आधारावर सापेक्ष अंतर काढतो, मोडच्या बाहेरील सर्व नोट्स वगळतो."
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr "स्केलर इंटरव्हल ब्लॉक सध्याच्या मोडच्या आधारावर सापेक्ष अंतर काढतो, मोडच्या बाहेरील सर्व नोट्स वगळतो."
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifying pitch numbers."
-#~msgstr "डिफाइन मोड ब्लॉक तुम्हाला पिच संख्या निर्दिष्ट करून कस्टम मोड परिभाषित करण्याची परवानगी देतो."
+#~ msgid "The Define mode block allows you define a custom mode by specifying pitch numbers."
+#~ msgstr "डिफाइन मोड ब्लॉक तुम्हाला पिच संख्या निर्दिष्ट करून कस्टम मोड परिभाषित करण्याची परवानगी देतो."
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr "जेव्हा मूवेबल डो खोटे असते, तेव्हा सोल्फेज नोट नाव नेहमी विशिष्ट पिचेसशी जोडलेले असतात,"
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr "जेव्हा मूवेबल डो खोटे असते, तेव्हा सोल्फेज नोट नाव नेहमी विशिष्ट पिचेसशी जोडलेले असतात,"
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr "उदा. \"डो\" नेहमी \"C-नॅचरल\" असते जेव्हा मूवेबल डो खरे असते, सोल्फेज नोट नाव स्केल डिग्रीजना दिले जाते \"डो\" नेहमी मेजर स्केलची पहिली डिग्री असते."
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr "उदा. \"डो\" नेहमी \"C-नॅचरल\" असते जेव्हा मूवेबल डो खरे असते, सोल्फेज नोट नाव स्केल डिग्रीजना दिले जाते \"डो\" नेहमी मेजर स्केलची पहिली डिग्री असते."
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr "एक्शन ब्लॉकचा वापर ब्लॉक्स एकत्रित करण्यासाठी केला जातो जेणेकरून त्यांचा एकापेक्षा जास्त वेळा वापर केला जाऊ शकतो."
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr "एक्शन ब्लॉकचा वापर ब्लॉक्स एकत्रित करण्यासाठी केला जातो जेणेकरून त्यांचा एकापेक्षा जास्त वेळा वापर केला जाऊ शकतो."
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr "ग्रेटर-थॅन ब्लॉक सत्य परत करतो जर वरचा क्रमांक खालच्या क्रमांकापेक्षा मोठा असेल."
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr "ग्रेटर-थॅन ब्लॉक सत्य परत करतो जर वरचा क्रमांक खालच्या क्रमांकापेक्षा मोठा असेल."
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr "लेस-थॅन ब्लॉक सत्य परत करतो जर वरचा क्रमांक खालच्या क्रमांकापेक्षा कमी असेल."
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr "लेस-थॅन ब्लॉक सत्य परत करतो जर वरचा क्रमांक खालच्या क्रमांकापेक्षा कमी असेल."
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "या उदाहरणात, माउस उजवीकडे हलतो तोपर्यंत तो कॅनव्हासच्या उजवीकडील काठावर पोहोचतो; मग तो कॅनव्हासच्या डाव्या बाजूला पुन्हा दिसतो."
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "या उदाहरणात, माउस उजवीकडे हलतो तोपर्यंत तो कॅनव्हासच्या उजवीकडील काठावर पोहोचतो; मग तो कॅनव्हासच्या डाव्या बाजूला पुन्हा दिसतो."
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "या उदाहरणात, कासव उजवीकडे हलतो तोपर्यंत ते कॅनव्हासच्या उजवीकडील काठावर पोहोचते; मग ते कॅनव्हासच्या डाव्या बाजूला पुन्हा दिसते."
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "या उदाहरणात, कासव उजवीकडे हलतो तोपर्यंत ते कॅनव्हासच्या उजवीकडील काठावर पोहोचते; मग ते कॅनव्हासच्या डाव्या बाजूला पुन्हा दिसते."
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "या उदाहरणात, माउस वर हलतो तोपर्यंत तो कॅनव्हासच्या वरच्या काठावर पोहोचतो; मग तो कॅनव्हासच्या तळाशी पुन्हा दिसतो."
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "या उदाहरणात, माउस वर हलतो तोपर्यंत तो कॅनव्हासच्या वरच्या काठावर पोहोचतो; मग तो कॅनव्हासच्या तळाशी पुन्हा दिसतो."
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "या उदाहरणात, कासव वर हलतो तोपर्यंत ते कॅनव्हासच्या वरच्या काठावर पोहोचते; मग ते कॅनव्हासच्या तळाशी पुन्हा दिसते."
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "या उदाहरणात, कासव वर हलतो तोपर्यंत ते कॅनव्हासच्या वरच्या काठावर पोहोचते; मग ते कॅनव्हासच्या तळाशी पुन्हा दिसते."
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr "व्हिडिओ सामग्री"
+#~ msgid "video material"
+#~ msgstr "व्हिडिओ सामग्री"
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr "रन ब्लॉक ब्लॉक एक ब्लॉक चालवतो. हे दोन प्रकारचे आर्ग्युमेंट्स स्वीकारते: ब्लॉक नंबर किंवा ब्लॉक नाव."
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr "रन ब्लॉक ब्लॉक एक ब्लॉक चालवतो. हे दोन प्रकारचे आर्ग्युमेंट्स स्वीकारते: ब्लॉक नंबर किंवा ब्लॉक नाव."
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr "सेट ड्रम ब्लॉक कोणत्याही समाविष्ट नोट्सच्या पिचला बदलण्यासाठी एक ड्रम आवाज निवडेल."
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr "सेट ड्रम ब्लॉक कोणत्याही समाविष्ट नोट्सच्या पिचला बदलण्यासाठी एक ड्रम आवाज निवडेल."
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr "नोट व्हॅल्यू ब्लॉक सध्या वाजवली जात असलेली नोटची कालावधीची मूल्य आहे."
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr "नोट व्हॅल्यू ब्लॉक सध्या वाजवली जात असलेली नोटची कालावधीची मूल्य आहे."
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr "मिलीसेकंद ब्लॉक नोट ब्लॉकसारखे आहे, फक्त ते नोट कालावधी निर्दिष्ट करण्यासाठी वेळ (MS मध्ये) वापरते."
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr "मिलीसेकंद ब्लॉक नोट ब्लॉकसारखे आहे, फक्त ते नोट कालावधी निर्दिष्ट करण्यासाठी वेळ (MS मध्ये) वापरते."
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr "स्विंग ब्लॉक नोट्सच्या जोड्यांवर कार्य करते (नोट व्हॅल्यूने निर्दिष्ट केलेले), पहिल्या नोटला काही कालावधी (स्विंग व्हॅल्यूने निर्दिष्ट केलेले) जोडते आणि दुसऱ्या नोटमधून तेच प्रमाण काढते."
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr "स्विंग ब्लॉक नोट्सच्या जोड्यांवर कार्य करते (नोट व्हॅल्यूने निर्दिष्ट केलेले), पहिल्या नोटला काही कालावधी (स्विंग व्हॅल्यूने निर्दिष्ट केलेले) जोडते आणि दुसऱ्या नोटमधून तेच प्रमाण काढते."
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr "मल्टिप्लाय नोट व्हॅल्यू ब्लॉक नोट्सचे कालावधी त्यांच्या नोट व्हॅल्यू बदलून बदलतो."
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr "मल्टिप्लाय नोट व्हॅल्यू ब्लॉक नोट्सचे कालावधी त्यांच्या नोट व्हॅल्यू बदलून बदलतो."
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr "निर्दिष्ट नोट व्हॅल्यू कालावधीची विश्रांती सायलेन्स ब्लॉक वापरून तयार केली जाऊ शकते."
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr "निर्दिष्ट नोट व्हॅल्यू कालावधीची विश्रांती सायलेन्स ब्लॉक वापरून तयार केली जाऊ शकते."
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr "शो-हीप ब्लॉक स्क्रीनच्या वरच्या भागात हीपची सामग्री दर्शवतो."
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr "शो-हीप ब्लॉक स्क्रीनच्या वरच्या भागात हीपची सामग्री दर्शवतो."
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr "उदाहरणाचे आउटपुट आहे: सोल, सोल, सोल, सोल, रे, रे, रे, रे, सोल, सोल, सोल, सोल."
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr "उदाहरणाचे आउटपुट आहे: सोल, सोल, सोल, सोल, रे, रे, रे, रे, सोल, सोल, सोल, सोल."
 
 #: js/FlowBlocks.js:679
 
@@ -8374,305 +8374,305 @@ msgstr "हलवा"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr "कंडिशनल्स तुमच्या प्रोग्रामला स्थितीनुसार विविध कृती घेण्यास अनुमती देतात."
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr "कंडिशनल्स तुमच्या प्रोग्रामला स्थितीनुसार विविध कृती घेण्यास अनुमती देतात."
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr "या उदाहरणात जर माउस बटण दाबलेले असेल तर एक स्नेर ड्रम वाजेल, अन्यथा एक किक ड्रम वाजेल."
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr "या उदाहरणात जर माउस बटण दाबलेले असेल तर एक स्नेर ड्रम वाजेल, अन्यथा एक किक ड्रम वाजेल."
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr "सरल ड्रम मशीनच्या या उदाहरणात एक किक ड्रम 1/4 नोट्स कायमस्वरूपी वाजेल."
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr "सरल ड्रम मशीनच्या या उदाहरणात एक किक ड्रम 1/4 नोट्स कायमस्वरूपी वाजेल."
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr "आर्क ब्लॉक माउसला एका वर्तुळात हलवतो."
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr "आर्क ब्लॉक माउसला एका वर्तुळात हलवतो."
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr "आर्क ब्लॉक कासवाला एका वर्तुळात हलवतो."
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr "आर्क ब्लॉक कासवाला एका वर्तुळात हलवतो."
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr "सेट हेडिंग ब्लॉक माउसची दिशा सेट करतो."
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr "सेट हेडिंग ब्लॉक माउसची दिशा सेट करतो."
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr "रॅप ब्लॉक ग्राफिक्स क्रियांसाठी स्क्रीन वेपिंग सक्षम किंवा अक्षम करतो."
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr "रॅप ब्लॉक ग्राफिक्स क्रियांसाठी स्क्रीन वेपिंग सक्षम किंवा अक्षम करतो."
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr "स्लर ब्लॉक नोट्सच्या कालावधीला लांबवतो तर नोट्सच्या निर्दिष्ट लयबद्ध मूल्याला कायम ठेवतो."
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr "स्लर ब्लॉक नोट्सच्या कालावधीला लांबवतो तर नोट्सच्या निर्दिष्ट लयबद्ध मूल्याला कायम ठेवतो."
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr "स्टॅकटो ब्लॉक वास्तविक नोटची लांबी कमी करतो तर नोट्सच्या निर्दिष्ट लयबद्ध मूल्याला कायम ठेवतो."
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr "स्टॅकटो ब्लॉक वास्तविक नोटची लांबी कमी करतो तर नोट्सच्या निर्दिष्ट लयबद्ध मूल्याला कायम ठेवतो."
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr "डिक्रेसेंडो ब्लॉक प्रत्येक वाजवलेल्या नोटसाठी समाविष्ट नोट्सचे व्हॉल्यूम एका निर्दिष्ट प्रमाणात कमी करेल."
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "डिक्रेसेंडो ब्लॉक प्रत्येक वाजवलेल्या नोटसाठी समाविष्ट नोट्सचे व्हॉल्यूम एका निर्दिष्ट प्रमाणात कमी करेल."
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr "उदाहरणार्थ, जर तुमच्याकडे 5 मूल्य असलेल्या डिक्रेसेंडो ब्लॉकमध्ये अनुक्रमे 7 नोट्स असतील तर अंतिम नोट प्रारंभिक व्हॉल्यूमपेक्षा 35% कमी असेल."
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr "उदाहरणार्थ, जर तुमच्याकडे 5 मूल्य असलेल्या डिक्रेसेंडो ब्लॉकमध्ये अनुक्रमे 7 नोट्स असतील तर अंतिम नोट प्रारंभिक व्हॉल्यूमपेक्षा 35% कमी असेल."
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr "क्रेसेंडो ब्लॉक प्रत्येक वाजवलेल्या नोटसाठी समाविष्ट नोट्सचे व्हॉल्यूम एका निर्दिष्ट प्रमाणात वाढवेल."
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "क्रेसेंडो ब्लॉक प्रत्येक वाजवलेल्या नोटसाठी समाविष्ट नोट्सचे व्हॉल्यूम एका निर्दिष्ट प्रमाणात वाढवेल."
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr "उदाहरणार्थ, जर तुमच्याकडे 5 मूल्य असलेल्या क्रेसेंडो ब्लॉकमध्ये अनुक्रमे 7 नोट्स असतील तर अंतिम नोट प्रारंभिक व्हॉल्यूमपेक्षा 35% अधिक असेल."
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr "उदाहरणार्थ, जर तुमच्याकडे 5 मूल्य असलेल्या क्रेसेंडो ब्लॉकमध्ये अनुक्रमे 7 नोट्स असतील तर अंतिम नोट प्रारंभिक व्हॉल्यूमपेक्षा 35% अधिक असेल."
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr "पार्शिअल ब्लॉक विशिष्ट अंशात्मक हार्मोनिकसाठी वजन निर्दिष्ट करण्यासाठी वापरला जातो."
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr "पार्शिअल ब्लॉक विशिष्ट अंशात्मक हार्मोनिकसाठी वजन निर्दिष्ट करण्यासाठी वापरला जातो."
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr "वेटेड पार्शिअल्स ब्लॉक टिंबरशी संबंधित आंशिक निर्दिष्ट करण्यासाठी वापरला जातो."
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr "वेटेड पार्शिअल्स ब्लॉक टिंबरशी संबंधित आंशिक निर्दिष्ट करण्यासाठी वापरला जातो."
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr "सेट डिफॉल्ट इंस्ट्रुमेंट ब्लॉक इलेक्ट्रॉनिक सिंथवरून तुमच्या पसंतीच्या वाद्यावर डिफॉल्ट इंस्ट्रुमेंट बदलतो."
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr "सेट डिफॉल्ट इंस्ट्रुमेंट ब्लॉक इलेक्ट्रॉनिक सिंथवरून तुमच्या पसंतीच्या वाद्यावर डिफॉल्ट इंस्ट्रुमेंट बदलतो."
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr "बीट फॅक्टर ब्लॉक नोट व्हॅल्यू आणि मीटर नोट व्हॅल्यूचे गुणोत्तर परत करतो."
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr "बीट फॅक्टर ब्लॉक नोट व्हॅल्यू आणि मीटर नोट व्हॅल्यूचे गुणोत्तर परत करतो."
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr "आकृतीत, हे प्रत्येक मापाच्या पहिल्या बीटवर कृती घेण्यासाठी वापरले जाते."
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr "आकृतीत, हे प्रत्येक मापाच्या पहिल्या बीटवर कृती घेण्यासाठी वापरले जाते."
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr "(डिफॉल्टनुसार, हे क्वार्टर नोट्स मोजते.)"
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr "(डिफॉल्टनुसार, हे क्वार्टर नोट्स मोजते.)"
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr "शो-डिक्शनरी ब्लॉक स्क्रीनच्या वरच्या भागात डिक्शनरीची सामग्री दर्शवतो."
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr "शो-डिक्शनरी ब्लॉक स्क्रीनच्या वरच्या भागात डिक्शनरीची सामग्री दर्शवतो."
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr "प्रोग्राम स्लो मोडमध्ये चालू असताना कमेंट ब्लॉक स्क्रीनच्या वरच्या भागात टिप्पणी छापतो."
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr "प्रोग्राम स्लो मोडमध्ये चालू असताना कमेंट ब्लॉक स्क्रीनच्या वरच्या भागात टिप्पणी छापतो."
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr "कर्सर ओव्हर ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर माउसवर हलविला जातो."
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr "कर्सर ओव्हर ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर माउसवर हलविला जातो."
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr "कर्सर ओव्हर ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर कासवावर हलविला जातो."
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr "कर्सर ओव्हर ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर कासवावर हलविला जातो."
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr "कर्सर आउट ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर माउसवरून हलविला जातो."
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr "कर्सर आउट ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर माउसवरून हलविला जातो."
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr "कर्सर आउट ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर कासवावरून हलविला जातो."
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr "कर्सर आउट ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर कासवावरून हलविला जातो."
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr "कर्सर बटण डाउन ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर बटण माउसवर दाबला जातो."
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr "कर्सर बटण डाउन ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर बटण माउसवर दाबला जातो."
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr "कर्सर बटण डाउन ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर बटण कासवावर दाबला जातो."
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr "कर्सर बटण डाउन ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर बटण कासवावर दाबला जातो."
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr "कर्सर बटण अप ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर बटण माउसवरून सोडले जाते."
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr "कर्सर बटण अप ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर बटण माउसवरून सोडले जाते."
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr "कर्सर बटण अप ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर बटण कासवावरून सोडले जाते."
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr "कर्सर बटण अप ब्लॉक एक इव्हेंट ट्रिगर करतो जेव्हा कर्सर बटण कासवावरून सोडले जाते."
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr "गेट ब्लू ब्लॉक पिक्सेलच्या माउसखालील निळा घटक परत करतो."
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr "गेट ब्लू ब्लॉक पिक्सेलच्या माउसखालील निळा घटक परत करतो."
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr "गेट ब्लू ब्लॉक पिक्सेलच्या कासवाखालील निळा घटक परत करतो."
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr "गेट ब्लू ब्लॉक पिक्सेलच्या कासवाखालील निळा घटक परत करतो."
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr "गेट ग्रीन ब्लॉक पिक्सेलच्या माउसखालील हिरवा घटक परत करतो."
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr "गेट ग्रीन ब्लॉक पिक्सेलच्या माउसखालील हिरवा घटक परत करतो."
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr "गेट ग्रीन ब्लॉक पिक्सेलच्या कासवाखालील हिरवा घटक परत करतो."
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr "गेट ग्रीन ब्लॉक पिक्सेलच्या कासवाखालील हिरवा घटक परत करतो."
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr "टाइम ब्लॉक परत करतो किती सेकंद प्रोग्राम चालू आहे."
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr "टाइम ब्लॉक परत करतो किती सेकंद प्रोग्राम चालू आहे."
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr "अधिक तपशील"
+#~ msgid "More Details"
+#~ msgstr "अधिक तपशील"
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr "प्रकल्प सामायिक करा"
+#~ msgid "Share project"
+#~ msgstr "प्रकल्प सामायिक करा"
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr "लिंक क्लिपबोर्डवर कॉपी करा"
+#~ msgid "Copy link to clipboard"
+#~ msgstr "लिंक क्लिपबोर्डवर कॉपी करा"
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr "स्टार्टअपवर प्रकल्प चालवा."
+#~ msgid "Run project on startup."
+#~ msgstr "स्टार्टअपवर प्रकल्प चालवा."
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr "स्टार्टअपवर कोड ब्लॉक दाखवा."
+#~ msgid "Show code blocks on startup."
+#~ msgstr "स्टार्टअपवर कोड ब्लॉक दाखवा."
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr "स्टार्टअपवर कोड ब्लॉक गुंडाळा."
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr "स्टार्टअपवर कोड ब्लॉक गुंडाळा."
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr "प्रगत पर्याय"
+#~ msgid "Advanced Options"
+#~ msgstr "प्रगत पर्याय"
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr "हर्ट्ज ब्लॉक: तुम्हाला नोट ब्लॉक वापरायचा आहे का?"
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr "हर्ट्ज ब्लॉक: तुम्हाला नोट ब्लॉक वापरायचा आहे का?"
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr "प्रकल्प आवडला नाही"
+#~ msgid "Unlike project"
+#~ msgstr "प्रकल्प आवडला नाही"
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr "प्रकल्प आवडला"
+#~ msgid "Like project"
+#~ msgstr "प्रकल्प आवडला"
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr "वैशिष्ट्य उपलब्ध नाही - सर्व्हरशी कनेक्ट करू शकत नाही. पुन्हा प्रयत्न करण्यासाठी टर्टल ब्लॉक्स रीलोड करा."
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr "वैशिष्ट्य उपलब्ध नाही - सर्व्हरशी कनेक्ट करू शकत नाही. पुन्हा प्रयत्न करण्यासाठी टर्टल ब्लॉक्स रीलोड करा."
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr "प्रकल्प पुन्हा प्रकाशित करा"
+#~ msgid "Republish Project"
+#~ msgstr "प्रकल्प पुन्हा प्रकाशित करा"
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr "ऑडिओ फाइल1"
+#~ msgid "audio file1"
+#~ msgstr "ऑडिओ फाइल1"
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr "ऑडिओ फाइल2"
+#~ msgid "audio file2"
+#~ msgstr "ऑडिओ फाइल2"
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr "चेतावणी: नोट मूल्य 2 पेक्षा जास्त आहे."
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr "चेतावणी: नोट मूल्य 2 पेक्षा जास्त आहे."
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr "तंतू5"
+#~ msgid "chord5"
+#~ msgstr "तंतू5"
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr "तंतू4"
+#~ msgid "chord4"
+#~ msgstr "तंतू4"
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr "तंतू1"
+#~ msgid "chord1"
+#~ msgstr "तंतू1"
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr "कर्सर Y ब्लॉक कासवाची उभ्या स्थिती परत करतो."
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr "कर्सर Y ब्लॉक कासवाची उभ्या स्थिती परत करतो."
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr "कर्सर X ब्लॉक कासवाची आडवी स्थिती परत करतो."
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr "कर्सर X ब्लॉक कासवाची आडवी स्थिती परत करतो."
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr "Nth-कासव नाव ब्लॉक nth कासवाचे नाव परत करतो."
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr "Nth-कासव नाव ब्लॉक nth कासवाचे नाव परत करतो."
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "वेगाने चालवा"
+#~ msgid "Run fast"
+#~ msgstr "वेगाने चालवा"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "विस्तृत/संकुचित करा संकुचित होणारे ब्लॉक"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "विस्तृत/संकुचित करा संकुचित होणारे ब्लॉक"
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr "Nth-माउस नाव ब्लॉक nth माउसचे नाव परत करतो."
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr "Nth-माउस नाव ब्लॉक nth माउसचे नाव परत करतो."
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr "ब्लॉक शोधा"
+#~ msgid "search for blocks"
+#~ msgstr "ब्लॉक शोधा"
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr "कृपया ब्राउझर झूम स्तर 100% वर सेट करा"
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr "कृपया ब्राउझर झूम स्तर 100% वर सेट करा"
 
 #: js/toolbar.js:54
 
@@ -8682,97 +8682,97 @@ msgstr "हलवा"
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr "सहाय्यक मेनू"
+#~ msgid "Auxilary menu"
+#~ msgstr "सहाय्यक मेनू"
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr "हा प्रकल्प चालवण्यासाठी, म्युझिक ब्लॉक्स वेब ब्राउझरमध्ये उघडा आणि ही फाइल ब्राउझर विंडोमध्ये ड्रॅग आणि ड्रॉप करा."
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr "हा प्रकल्प चालवण्यासाठी, म्युझिक ब्लॉक्स वेब ब्राउझरमध्ये उघडा आणि ही फाइल ब्राउझर विंडोमध्ये ड्रॅग आणि ड्रॉप करा."
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr "तुमच्याकडे नेहमी किमान एक प्रारंभ ब्लॉक असणे आवश्यक आहे."
+#~ msgid "You must always have at least one start block."
+#~ msgstr "तुमच्याकडे नेहमी किमान एक प्रारंभ ब्लॉक असणे आवश्यक आहे."
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr "पिच अप"
+#~ msgid "pitch up"
+#~ msgstr "पिच अप"
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr "पिच डाउन"
+#~ msgid "pitch down"
+#~ msgstr "पिच डाउन"
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr "अपघात अप"
+#~ msgid "accidental up"
+#~ msgstr "अपघात अप"
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr "अपघात डाउन"
+#~ msgid "accidental down"
+#~ msgstr "अपघात डाउन"
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr "ऑक्टेव्ह अप"
+#~ msgid "octave up"
+#~ msgstr "ऑक्टेव्ह अप"
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr "ऑक्टेव्ह डाउन"
+#~ msgid "octave down"
+#~ msgstr "ऑक्टेव्ह डाउन"
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "चलन"
+#~ msgid "currency"
+#~ msgstr "चलन"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "पासून"
+#~ msgid "from"
+#~ msgstr "पासून"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "स्टॉकची किंमत"
+#~ msgid "stock price"
+#~ msgstr "स्टॉकची किंमत"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "अनुवाद"
+#~ msgid "translate"
+#~ msgstr "अनुवाद"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "हॅलो"
+#~ msgid "hello"
+#~ msgstr "हॅलो"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "भाषा शोधणे"
+#~ msgid "detect lang"
+#~ msgstr "भाषा शोधणे"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "भाषा संच करा"
+#~ msgid "set lang"
+#~ msgstr "भाषा संच करा"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "शहर अक्षांश"
+#~ msgid "city latitude"
+#~ msgstr "शहर अक्षांश"
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "शहर रेखांश"
+#~ msgid "city longitude"
+#~ msgstr "शहर रेखांश"
 
 #: plugins/gmap.rtp:71
 
@@ -8782,144 +8782,144 @@ msgstr "हलवा"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "समन्वय डेटा उपलब्ध नाही."
+#~ msgid "Coordinate data not available."
+#~ msgstr "समन्वय डेटा उपलब्ध नाही."
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "Google नकाशा"
+#~ msgid "Google map"
+#~ msgstr "Google नकाशा"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "समन्वय"
+#~ msgid "coordinates"
+#~ msgstr "समन्वय"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "झूम घटक"
+#~ msgid "zoom factor"
+#~ msgstr "झूम घटक"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "मोठा आणि छोटा करा"
+#~ msgid "zoom"
+#~ msgstr "मोठा आणि छोटा करा"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "अक्षांश"
+#~ msgid "latitude"
+#~ msgstr "अक्षांश"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "रेखांश"
+#~ msgid "longitude"
+#~ msgstr "रेखांश"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "अंश"
+#~ msgid "degrees"
+#~ msgstr "अंश"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "त्रिज्यी"
+#~ msgid "radians"
+#~ msgstr "त्रिज्यी"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "परिभाषित"
+#~ msgid "define"
+#~ msgstr "परिभाषित"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "बिटकॉइन"
+#~ msgid "bitcoin"
+#~ msgstr "बिटकॉइन"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr "तुम्हाला एक फाइल निवडावी लागेल."
+#~ msgid "You need to select a file."
+#~ msgstr "तुम्हाला एक फाइल निवडावी लागेल."
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr "ट्रिबल दाखवा"
+#~ msgid "show treble"
+#~ msgstr "ट्रिबल दाखवा"
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr "पोलर लपवा"
+#~ msgid "hide Polar"
+#~ msgstr "पोलर लपवा"
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr "बास दाखवा"
+#~ msgid "show bass"
+#~ msgstr "बास दाखवा"
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr "मेझो-सोप्रानो दाखवा"
+#~ msgid "show mezzo-soprano"
+#~ msgstr "मेझो-सोप्रानो दाखवा"
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr "अल्टो दाखवा"
+#~ msgid "show alto"
+#~ msgstr "अल्टो दाखवा"
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr "टेनर दाखवा"
+#~ msgid "show tenor"
+#~ msgstr "टेनर दाखवा"
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr "बास लपवा"
+#~ msgid "hide bass"
+#~ msgstr "बास लपवा"
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr "पोलर दाखवा"
+#~ msgid "show Polar"
+#~ msgstr "पोलर दाखवा"
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr "कार्टेशियन लपवा"
+#~ msgid "hide Cartesian"
+#~ msgstr "कार्टेशियन लपवा"
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr "लिलीपॉन्ड टेम्पो प्रक्रिया करू शकत नाही "
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr "लिलीपॉन्ड टेम्पो प्रक्रिया करू शकत नाही "
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr "PDF म्हणून जतन करा"
+#~ msgid "Save as PDF"
+#~ msgstr "PDF म्हणून जतन करा"
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr "लिलीपॉन्ड दुर्लक्ष मोड"
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr "लिलीपॉन्ड दुर्लक्ष मोड"
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr "झूम इन"
+#~ msgid "ZOOM IN"
+#~ msgstr "झूम इन"
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr "झूम आउट"
+#~ msgid "ZOOM OUT"
+#~ msgstr "झूम आउट"
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr "ब्लॉक निवडण्यासाठी क्लिक करा."
+#~ msgid "Click to select a block."
+#~ msgstr "ब्लॉक निवडण्यासाठी क्लिक करा."
 
 #: js/palette.js:1205
 
@@ -8929,15 +8929,15 @@ msgstr "हलवा"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr "लपवा"
+#~ msgid "hide"
+#~ msgstr "लपवा"
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr "दाखवा2"
+#~ msgid "show2"
+#~ msgstr "दाखवा2"
 
 #: js/palette.js:1222
 
@@ -8947,23 +8947,23 @@ msgstr "हलवा"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr "पॉपआउट"
+#~ msgid "popout"
+#~ msgstr "पॉपआउट"
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr "मायब्लॉक्स"
+#~ msgid "myblocks"
+#~ msgstr "मायब्लॉक्स"
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr "तुम्हाला तुमचा प्रकल्प जतन करायचा आहे का?"
+#~ msgid "Do you want to save your project?"
+#~ msgstr "तुम्हाला तुमचा प्रकल्प जतन करायचा आहे का?"
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr "ड्रम ब्लॉक: तुम्हाला नोट ब्लॉक वापरायचा आहे का?"
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr "ड्रम ब्लॉक: तुम्हाला नोट ब्लॉक वापरायचा आहे का?"
 
 #: js/pitchtracker.js:181
 
@@ -8973,8 +8973,8 @@ msgstr "हलवा"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr "रेकॉर्डिंग सुरू करा"
+#~ msgid "Start Recording"
+#~ msgstr "रेकॉर्डिंग सुरू करा"
 
 #: js/pitchtracker.js:188
 
@@ -8982,224 +8982,224 @@ msgstr "हलवा"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr "रेकॉर्डिंग थांबवा"
+#~ msgid "Stop Recording"
+#~ msgstr "रेकॉर्डिंग थांबवा"
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr "ताल जतन करा"
+#~ msgid "save rhythms"
+#~ msgstr "ताल जतन करा"
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr "ओढा"
+#~ msgid "drag"
+#~ msgstr "ओढा"
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr "पिच ब्लॉक: तुम्हाला नोट ब्लॉक वापरायचा आहे का?"
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr "पिच ब्लॉक: तुम्हाला नोट ब्लॉक वापरायचा आहे का?"
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr "श्री. माउस\", 0, 0)]"
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr "श्री. माउस\", 0, 0)]"
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr "क्लिक ब्लॉक खरे परत करतो जर माउस क्लिक केला असेल."
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr "क्लिक ब्लॉक खरे परत करतो जर माउस क्लिक केला असेल."
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr "बॉक्स2 ब्लॉक बॉक्स2 मध्ये संग्रहित मूल्य परत करतो."
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr "बॉक्स2 ब्लॉक बॉक्स2 मध्ये संग्रहित मूल्य परत करतो."
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr "बॉक्स1 ब्लॉक बॉक्स1 मध्ये संग्रहित मूल्य परत करतो."
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr "बॉक्स1 ब्लॉक बॉक्स1 मध्ये संग्रहित मूल्य परत करतो."
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr "ब्लॉक लपवा."
+#~ msgid "Hide blocks."
+#~ msgstr "ब्लॉक लपवा."
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr "पुढे कमी केले जाऊ शकत नाही"
+#~ msgid "Cannot be further decreased"
+#~ msgstr "पुढे कमी केले जाऊ शकत नाही"
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr "पुढे वाढवता येत नाही"
+#~ msgid "Cannot be further increased"
+#~ msgstr "पुढे वाढवता येत नाही"
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr "त्रुटी: स्थानिक संचयन संपल्यामुळे जतन करू शकत नाही. काही जतन केलेले प्रकल्प हटवून पहा."
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr "त्रुटी: स्थानिक संचयन संपल्यामुळे जतन करू शकत नाही. काही जतन केलेले प्रकल्प हटवून पहा."
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr "माउस ब्लिंक बंद करीत आहे; FPS 10 वर सेट करीत आहे."
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr "माउस ब्लिंक बंद करीत आहे; FPS 10 वर सेट करीत आहे."
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr "माउस ब्लिंक चालू करीत आहे; FPS 30 वर सेट करीत आहे."
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr "माउस ब्लिंक चालू करीत आहे; FPS 30 वर सेट करीत आहे."
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr "स्केलर ट्रान्सपोजिशन्स कस्टम टेम्परामेंटसाठी सेमिटोन ट्रान्सपोजिशन्ससारखेच आहेत."
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr "स्केलर ट्रान्सपोजिशन्स कस्टम टेम्परामेंटसाठी सेमिटोन ट्रान्सपोजिशन्ससारखेच आहेत."
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr "आपण फक्त त्याच पिचच्या नोट्स एकत्र करू शकता. आपण स्लर वापरण्याचा विचार करत होता का?"
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr "आपण फक्त त्याच पिचच्या नोट्स एकत्र करू शकता. आपण स्लर वापरण्याचा विचार करत होता का?"
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr "चेतावणी: नोट मूल्य 2 पेक्षा जास्त आहे."
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr "चेतावणी: नोट मूल्य 2 पेक्षा जास्त आहे."
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr "नोट नाव A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ किंवा A♭ पैकी एक असावे."
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr "नोट नाव A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ किंवा A♭ पैकी एक असावे."
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr "आपण आपल्या \"%s\" पॅलेटमधून सर्व स्टॅक्स काढू इच्छिता का?"
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr "आपण आपल्या \"%s\" पॅलेटमधून सर्व स्टॅक्स काढू इच्छिता का?"
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr "हा बटण प्रकल्प शेअर करण्यासाठी आणि उदाहरण प्रकल्प शोधण्यासाठी दर्शक उघडतो."
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr "हा बटण प्रकल्प शेअर करण्यासाठी आणि उदाहरण प्रकल्प शोधण्यासाठी दर्शक उघडतो."
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr "अतिरिक्त टूलबार विस्तृत किंवा संकुचित करण्यासाठी या बटणावर क्लिक करा."
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr "अतिरिक्त टूलबार विस्तृत किंवा संकुचित करण्यासाठी या बटणावर क्लिक करा."
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr "संगीताचा ताल मीटर ब्लॉकद्वारे निश्चित केला जातो (डीफॉल्टनुसार, प्रत्येक मोजणीसाठी 4 1/4 नोट्स)."
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr "संगीताचा ताल मीटर ब्लॉकद्वारे निश्चित केला जातो (डीफॉल्टनुसार, प्रत्येक मोजणीसाठी 4 1/4 नोट्स)."
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr "मास्टर बीट्स प्रति मिनिट ब्लॉक प्रत्येक आवाजासाठी प्रति मिनिट 1/4 नोट्सची संख्या सेट करतो."
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr "मास्टर बीट्स प्रति मिनिट ब्लॉक प्रत्येक आवाजासाठी प्रति मिनिट 1/4 नोट्सची संख्या सेट करतो."
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr "ऑन-एव्हरी-नोट ब्लॉक आपल्याला प्रत्येक नोटवर घेण्याच्या क्रियांची निर्दिष्ट करण्याची परवानगी देतो."
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr "ऑन-एव्हरी-नोट ब्लॉक आपल्याला प्रत्येक नोटवर घेण्याच्या क्रियांची निर्दिष्ट करण्याची परवानगी देतो."
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr "नोट्स प्लेड ब्लॉक ही वाजवलेल्या नोट्सची संख्या आहे."
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr "नोट्स प्लेड ब्लॉक ही वाजवलेल्या नोट्सची संख्या आहे."
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr "पिच नंबर ब्लॉक त्याच्या क्रमांकाद्वारे संबंधित पिच वाजवेल जसे C साठी 0 आणि G साठी 7."
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr "पिच नंबर ब्लॉक त्याच्या क्रमांकाद्वारे संबंधित पिच वाजवेल जसे C साठी 0 आणि G साठी 7."
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr "पिच-स्लायडर ब्लॉक एक साधन उघडतो जे मनमानी पिचेस निर्माण करतो."
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr "पिच-स्लायडर ब्लॉक एक साधन उघडतो जे मनमानी पिचेस निर्माण करतो."
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr "प्ले बटण दाबल्यावर सर्व स्टार्ट ब्लॉक एकाच वेळी चालतात."
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr "प्ले बटण दाबल्यावर सर्व स्टार्ट ब्लॉक एकाच वेळी चालतात."
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr "स्टोअर इन बॉक्स1 ब्लॉक बॉक्स1 मध्ये मूल्य साठवण्यासाठी वापरला जातो."
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr "स्टोअर इन बॉक्स1 ब्लॉक बॉक्स1 मध्ये मूल्य साठवण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr "स्टोअर इन बॉक्स2 ब्लॉक बॉक्स2 मध्ये मूल्य साठवण्यासाठी वापरला जातो."
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr "स्टोअर इन बॉक्स2 ब्लॉक बॉक्स2 मध्ये मूल्य साठवण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr "शेल ब्लॉक माउसची रूपरेखा बदलण्यासाठी वापरला जातो."
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr "शेल ब्लॉक माउसची रूपरेखा बदलण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr "पिकअप ब्लॉक बीटच्या आधी येणाऱ्या कोणत्याही नोट्स समायोजित करण्यासाठी वापरला जातो."
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr "पिकअप ब्लॉक बीटच्या आधी येणाऱ्या कोणत्याही नोट्स समायोजित करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr "बीट्स प्रति मिनिट ब्लॉक कोणत्याही समाविष्ट नोट्सच्या बीट्स प्रति मिनिट बदलतो."
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr "बीट्स प्रति मिनिट ब्लॉक कोणत्याही समाविष्ट नोट्सच्या बीट्स प्रति मिनिट बदलतो."
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr "ऑन-स्ट्रॉंग-बीट ब्लॉक आपल्याला निर्दिष्ट बीट्सवर घेण्याच्या क्रियांची निर्दिष्ट करण्याची परवानगी देतो."
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr "ऑन-स्ट्रॉंग-बीट ब्लॉक आपल्याला निर्दिष्ट बीट्सवर घेण्याच्या क्रियांची निर्दिष्ट करण्याची परवानगी देतो."
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr "ऑन-वीक-बीट ब्लॉक आपल्याला दुर्बल (ऑफ) बीट्सवर घेण्याच्या क्रियांची निर्दिष्ट करण्याची परवानगी देतो."
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr "ऑन-वीक-बीट ब्लॉक आपल्याला दुर्बल (ऑफ) बीट्सवर घेण्याच्या क्रियांची निर्दिष्ट करण्याची परवानगी देतो."
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "उदा \"do\" नेहमी \"C-natural\" असतो); जेव्हा मूवेबल do खरे असते, तेव्हा सोलफेज नोट नावांना स्केल डिग्रीजमध्ये असाइन केले जाते (\"do\" नेहमी मेजर स्केलची पहिली डिग्री असते)."
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "उदा \"do\" नेहमी \"C-natural\" असतो); जेव्हा मूवेबल do खरे असते, तेव्हा सोलफेज नोट नावांना स्केल डिग्रीजमध्ये असाइन केले जाते (\"do\" नेहमी मेजर स्केलची पहिली डिग्री असते)."
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr "नोट व्हॉल्यूम ब्लॉक वर्तमान सिंथेसायझरची वर्तमान व्हॉल्यूम परत करतो."
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr "नोट व्हॉल्यूम ब्लॉक वर्तमान सिंथेसायझरची वर्तमान व्हॉल्यूम परत करतो."
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr "डीफॉल्ट ब्लॉक स्विचच्या आत डीफॉल्ट क्रिया परिभाषित करण्यासाठी वापरला जातो."
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr "डीफॉल्ट ब्लॉक स्विचच्या आत डीफॉल्ट क्रिया परिभाषित करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr "माउस नोट ब्लॉक निर्दिष्ट माउसद्वारे वाजवलेले वर्तमान नोट मूल्य परत करतो."
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr "माउस नोट ब्लॉक निर्दिष्ट माउसद्वारे वाजवलेले वर्तमान नोट मूल्य परत करतो."
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr "डाउन मायनर"
+#~ msgid "down minor"
+#~ msgstr "डाउन मायनर"
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr "डाउन मेजर"
+#~ msgid "down major"
+#~ msgstr "डाउन मेजर"
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr "मूल्यमापन"
+#~ msgid "eval"
+#~ msgstr "मूल्यमापन"
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr "१००"
+#~ msgid "100"
+#~ msgstr "१००"
 
 #: js/playback.js:87
 
@@ -9215,37 +9215,37 @@ msgstr "हलवा"
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr "ड्रॅग"
+#~ msgid "Drag"
+#~ msgstr "ड्रॅग"
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr "प्लेबॅक संगीत"
+#~ msgid "playback music"
+#~ msgstr "प्लेबॅक संगीत"
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr "प्लेबॅक विराम"
+#~ msgid "pause playback"
+#~ msgstr "प्लेबॅक विराम"
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr "प्लेबॅक पुनःप्रारंभ करा"
+#~ msgid "restart playback"
+#~ msgstr "प्लेबॅक पुनःप्रारंभ करा"
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr "प्लेबॅकसाठी संगीत तयार करा"
+#~ msgid "prepare music for playback"
+#~ msgstr "प्लेबॅकसाठी संगीत तयार करा"
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr "ब्लॉक्स लोड करा"
+#~ msgid "Load blocks"
+#~ msgstr "ब्लॉक्स लोड करा"
 
 #: js/turtledefs.js:304
 
@@ -9253,28 +9253,28 @@ msgstr "हलवा"
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr "सेट टिंबर ब्लॉक सिंथेसायझरसाठी आवाज निवडतो,"
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr "सेट टिंबर ब्लॉक सिंथेसायझरसाठी आवाज निवडतो,"
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr "रन ब्लॉक ब्लॉक एक ब्लॉक चालवतो."
+#~ msgid "The Run block block runs a block."
+#~ msgstr "रन ब्लॉक ब्लॉक एक ब्लॉक चालवतो."
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr "टिंबर सेट करा"
+#~ msgid "set timbre"
+#~ msgstr "टिंबर सेट करा"
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr "उजव्या2"
+#~ msgid "right2"
+#~ msgstr "उजव्या2"
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr "डाव्या2"
+#~ msgid "left2"
+#~ msgstr "डाव्या2"
 
 #: js/pitchtimematrix.js:323
 
@@ -9288,8 +9288,8 @@ msgstr "हलवा"
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr "विस्तृत करा"
+#~ msgid "expand"
+#~ msgstr "विस्तृत करा"
 
 #: js/pitchtimematrix.js:338
 
@@ -9299,65 +9299,65 @@ msgstr "हलवा"
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr "संकुचित करा"
+#~ msgid "collapse"
+#~ msgstr "संकुचित करा"
 
-#~msgid "crescendo factor"
-#~msgstr "क्रेसेन्डो फॅक्टर"
+#~ msgid "crescendo factor"
+#~ msgstr "क्रेसेन्डो फॅक्टर"
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr "म्युझिक ब्लॉक्सच्या मध्यभागी <em>नोट</em> ब्लॉक आहे. <em>नोट</em> ब्लॉक <em>पिच</em> ब्लॉकसाठी एक कंटेनर आहे ज्यामध्ये पिचची कालावधी (नोट मूल्य) निर्दिष्ट केले जाते."
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr "म्युझिक ब्लॉक्सच्या मध्यभागी <em>नोट</em> ब्लॉक आहे. <em>नोट</em> ब्लॉक <em>पिच</em> ब्लॉकसाठी एक कंटेनर आहे ज्यामध्ये पिचची कालावधी (नोट मूल्य) निर्दिष्ट केले जाते."
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr "टाइम ब्लॉक प्रोग्राम चालू असलेल्या सेकंदांची संख्या परत करतो."
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr "टाइम ब्लॉक प्रोग्राम चालू असलेल्या सेकंदांची संख्या परत करतो."
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr "स्टोअर इन बॉक्स1 ब्लॉक <em>बॉक्स1</em> मध्ये मूल्य साठवण्यासाठी वापरला जातो."
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr "स्टोअर इन बॉक्स1 ब्लॉक <em>बॉक्स1</em> मध्ये मूल्य साठवण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr "मल्टिप्लाय ब्लॉक गुणण्यासाठी वापरला जातो."
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr "मल्टिप्लाय ब्लॉक गुणण्यासाठी वापरला जातो."
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr "कुठलाही ब्लॉक निवडलेला नाही."
+#~ msgid "There is no block is selected."
+#~ msgstr "कुठलाही ब्लॉक निवडलेला नाही."
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr "स्केलर ट्रान्सपोजिशन ब्लॉक नोट ब्लॉक्समध्ये समाविष्ट पिचेस स्केलमध्ये वर (किंवा खाली) शिफ्ट करेल. वर दर्शविलेल्या उदाहरणात, सोल ला पर्यंत वर शिफ्ट केले आहे."
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr "स्केलर ट्रान्सपोजिशन ब्लॉक नोट ब्लॉक्समध्ये समाविष्ट पिचेस स्केलमध्ये वर (किंवा खाली) शिफ्ट करेल. वर दर्शविलेल्या उदाहरणात, सोल ला पर्यंत वर शिफ्ट केले आहे."
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr "नवीन प्रकल्प प्रारंभ करा."
+#~ msgid "Initialise a new project."
+#~ msgstr "नवीन प्रकल्प प्रारंभ करा."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr "जपानी"
+#~ msgid "japanese"
+#~ msgstr "जपानी"
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr "सातवा"
+#~ msgid "7th"
+#~ msgstr "सातवा"
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr "तार' + ' ' + 'V"
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr "तार' + ' ' + 'V"
 
 #: js/musicutils.js:345
 
@@ -9365,8 +9365,8 @@ msgstr "हलवा"
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr "चिन"
+#~ msgid "chine"
+#~ msgstr "चिन"
 
 #: js/timbre.js:743
 
@@ -9376,127 +9376,127 @@ msgstr "हलवा"
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr "पूर्ववत करा"
+#~ msgid "undo"
+#~ msgstr "पूर्ववत करा"
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr "तार' + ' ' + 'I"
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr "तार' + ' ' + 'I"
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr "प्लेसहोल्डर"
+#~ msgid "placeholder"
+#~ msgstr "प्लेसहोल्डर"
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr "मूव्ह ब्लॉक ब्लॉक एक ब्लॉक हलवतो."
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr "मूव्ह ब्लॉक ब्लॉक एक ब्लॉक हलवतो."
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr "अॅक्सिडेंटल ब्लॉक शार्प्स आणि फ्लॅट्स निर्माण करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr "अॅक्सिडेंटल ब्लॉक शार्प्स आणि फ्लॅट्स निर्माण करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr "हाईड ब्लॉक्स ब्लॉक ब्लॉक्स लपवतो."
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr "हाईड ब्लॉक्स ब्लॉक ब्लॉक्स लपवतो."
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr "वेटफॉर ब्लॉक स्थिती खरे होईपर्यंत प्रतीक्षा करेल."
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr "वेटफॉर ब्लॉक स्थिती खरे होईपर्यंत प्रतीक्षा करेल."
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr "व्हॉल्यूम सेट करा"
+#~ msgid "set volume"
+#~ msgstr "व्हॉल्यूम सेट करा"
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr "प्ले नॉइज ब्लॉक पांढरा, गुलाबी किंवा तपकिरी आवाज निर्माण करेल."
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr "प्ले नॉइज ब्लॉक पांढरा, गुलाबी किंवा तपकिरी आवाज निर्माण करेल."
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr "बेझियर ब्लॉक बेझियर वक्र काढतो."
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr "बेझियर ब्लॉक बेझियर वक्र काढतो."
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr "तासांपूर्वी"
+#~ msgid "hours ago"
+#~ msgstr "तासांपूर्वी"
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr "मेजर ब्लूज"
+#~ msgid "Major Blues"
+#~ msgstr "मेजर ब्लूज"
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr "बॅक ब्लॉक माउसला मागे हलवतो."
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr "बॅक ब्लॉक माउसला मागे हलवतो."
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr "सेट-नेम ब्लॉक माउसचे नाव ठेवण्यासाठी वापरला जातो."
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr "सेट-नेम ब्लॉक माउसचे नाव ठेवण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr "स्टेटस ब्लॉक म्युझिक ब्लॉक्स चालू असताना स्थिती तपासण्यासाठी एक साधन उघडतो."
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr "स्टेटस ब्लॉक म्युझिक ब्लॉक्स चालू असताना स्थिती तपासण्यासाठी एक साधन उघडतो."
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr "प्ले स्केल"
+#~ msgid "play scale"
+#~ msgstr "प्ले स्केल"
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr "हे टूलबार पॅलेट बटणं मॅट्रिक्स, नोट, टोन, टर्टल आणि अधिक समाविष्ट आहे. ब्लॉक्सचे पॅलेट्स दाखवण्यासाठी क्लिक करा आणि ब्ल"
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr "हे टूलबार पॅलेट बटणं मॅट्रिक्स, नोट, टोन, टर्टल आणि अधिक समाविष्ट आहे. ब्लॉक्सचे पॅलेट्स दाखवण्यासाठी क्लिक करा आणि ब्ल"
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr "बिट्स प्रति मिनिट ब्लॉक सध्याचे बिट्स प्रति मिनिट परत करते."
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr "बिट्स प्रति मिनिट ब्लॉक सध्याचे बिट्स प्रति मिनिट परत करते."
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr "स्केलर स्टेप ब्लॉक (संख्या ब्लॉकसह) स्केलमधील पुढील पिच वाजवेल,"
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr "स्केलर स्टेप ब्लॉक (संख्या ब्लॉकसह) स्केलमधील पुढील पिच वाजवेल,"
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr "पिच <em>नि ध प म ग रे स<em> च्या रूपात निर्दिष्ट केले जाऊ शकते."
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr "पिच <em>नि ध प म ग रे स<em> च्या रूपात निर्दिष्ट केले जाऊ शकते."
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr "गूढ"
+#~ msgid "Enigmatic"
+#~ msgstr "गूढ"
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr "पाचवे"
+#~ msgid "fifths"
+#~ msgstr "पाचवे"
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr "मिली"
+#~ msgid "ml"
+#~ msgstr "मिली"
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr "मि"
+#~ msgid "mi"
+#~ msgstr "मि"
 
 #: js/turtledefs.js:251
 
@@ -9504,608 +9504,608 @@ msgstr "हलवा"
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr "<em>डो</em> ब्लॉक क्रिया सुरू करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr "<em>डो</em> ब्लॉक क्रिया सुरू करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr "इंडेक्सहेप ब्लॉक निर्दिष्ट ठिकाणी ढिगार्‍यातील मूल्य परत करते."
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr "इंडेक्सहेप ब्लॉक निर्दिष्ट ठिकाणी ढिगार्‍यातील मूल्य परत करते."
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr "<em>पेन-अप</em> ब्लॉक पेन उचलतो जेणेकरून ते काढले जात नाही."
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr "<em>पेन-अप</em> ब्लॉक पेन उचलतो जेणेकरून ते काढले जात नाही."
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr "<em>नवीन माउस</em> ब्लॉक नवीन माउस तयार करेल."
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr "<em>नवीन माउस</em> ब्लॉक नवीन माउस तयार करेल."
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr "प्लेबॅक"
+#~ msgid "playback"
+#~ msgstr "प्लेबॅक"
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr "फाईलमधून प्रकल्प विलीन करा"
+#~ msgid "Merge project from file"
+#~ msgstr "फाईलमधून प्रकल्प विलीन करा"
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr "<em>लेफ्ट</em> ब्लॉक कॅनव्हासच्या डाव्या बाजूची स्थिती परत करते."
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr "<em>लेफ्ट</em> ब्लॉक कॅनव्हासच्या डाव्या बाजूची स्थिती परत करते."
 
-#~msgid "eatme"
-#~msgstr "मला खावा"
+#~ msgid "eatme"
+#~ msgstr "मला खावा"
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr "<em>पूर्ण नोट्स वाजवल्या</em> ब्लॉक वाजवलेल्या पूर्ण नोट्सची एकूण संख्या परत करते."
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr "<em>पूर्ण नोट्स वाजवल्या</em> ब्लॉक वाजवलेल्या पूर्ण नोट्सची एकूण संख्या परत करते."
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr "हलवता येणारे"
+#~ msgid "movable"
+#~ msgstr "हलवता येणारे"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr "ब्राउन-नॉइज"
+#~ msgid "brown-noise"
+#~ msgstr "ब्राउन-नॉइज"
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr "जपानी"
+#~ msgid "Japanese"
+#~ msgstr "जपानी"
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr "त्रिकोण घंटा"
+#~ msgid "triangle-bell"
+#~ msgstr "त्रिकोण घंटा"
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr "ग्रिड लपवा"
+#~ msgid "Hide grid"
+#~ msgstr "ग्रिड लपवा"
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr "<em>एफएम सिंथ</em> ब्लॉक एक फ्रिक्वेंसी मॅड्युलेटर आहे जो टिंबर परिभाषित करण्यासाठी वापरला जातो."
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr "<em>एफएम सिंथ</em> ब्लॉक एक फ्रिक्वेंसी मॅड्युलेटर आहे जो टिंबर परिभाषित करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr "शो हिप ब्लॉक स्क्रीनच्या शीर्षस्थानी ढिगार्‍यातील सामग्री प्रदर्शित करते."
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr "शो हिप ब्लॉक स्क्रीनच्या शीर्षस्थानी ढिगार्‍यातील सामग्री प्रदर्शित करते."
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr "<em>संख्या</em> ब्लॉक एक संख्या धरतो."
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr "<em>संख्या</em> ब्लॉक एक संख्या धरतो."
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr "<em>केस</em> ब्लॉक <em>स्विच</em> च्या आत जुळणारे परिभाषित करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr "<em>केस</em> ब्लॉक <em>स्विच</em> च्या आत जुळणारे परिभाषित करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr "बॅकग्राउंड ब्लॉक पार्श्वभूमीचा रंग सेट करते."
+#~ msgid "The Background block sets the background color."
+#~ msgstr "बॅकग्राउंड ब्लॉक पार्श्वभूमीचा रंग सेट करते."
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr "मागील पृष्ठ"
+#~ msgid "Previous page"
+#~ msgstr "मागील पृष्ठ"
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr "<em>ओपन फाईल</em> ब्लॉक <em>शो</em> ब्लॉकसह वापरण्यासाठी फाईल उघडतो."
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr "<em>ओपन फाईल</em> ब्लॉक <em>शो</em> ब्लॉकसह वापरण्यासाठी फाईल उघडतो."
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr "<em>सेट-कलर</em> ब्लॉक पेनचा रंग बदलतो."
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr "<em>सेट-कलर</em> ब्लॉक पेनचा रंग बदलतो."
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr "कॉर्ड' + ' ' + 'IV"
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr "कॉर्ड' + ' ' + 'IV"
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr "परिणाम"
+#~ msgid "effects"
+#~ msgstr "परिणाम"
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr "फ्लोर-टॉम"
+#~ msgid "floor-tom"
+#~ msgstr "फ्लोर-टॉम"
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr "<em>उंची</em> ब्लॉक कॅनव्हासची उंची परत करते."
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr "<em>उंची</em> ब्लॉक कॅनव्हासची उंची परत करते."
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr "फेसबुकवर शेअर करा"
+#~ msgid "Share on Facebook"
+#~ msgstr "फेसबुकवर शेअर करा"
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr "<em>शेड</em> ब्लॉक सध्याचे पेन शेड मूल्य परत करते."
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr "<em>शेड</em> ब्लॉक सध्याचे पेन शेड मूल्य परत करते."
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr "ऑन-एव्हरी-बीट ब्लॉक तुम्हाला प्रत्येक बीटवर घ्यायच्या क्रिया निर्दिष्ट करण्याची परवानगी देतो."
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr "ऑन-एव्हरी-बीट ब्लॉक तुम्हाला प्रत्येक बीटवर घ्यायच्या क्रिया निर्दिष्ट करण्याची परवानगी देतो."
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr "मिस्टर माउस आमचा म्युझिक ब्लॉक्स कंडक्टर आहे. मिस्टर माउस तुम्हाला म्युझिक ब्लॉक्स एक्सप्लोर करण्यास प्रोत्साहित करतो. चला आपल्या सहलीला सुरुवात करूया!"
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr "मिस्टर माउस आमचा म्युझिक ब्लॉक्स कंडक्टर आहे. मिस्टर माउस तुम्हाला म्युझिक ब्लॉक्स एक्सप्लोर करण्यास प्रोत्साहित करतो. चला आपल्या सहलीला सुरुवात करूया!"
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr "रे"
+#~ msgid "re"
+#~ msgstr "रे"
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr "स्पॅनिश जिप्सी"
+#~ msgid "Spanish Gypsy"
+#~ msgstr "स्पॅनिश जिप्सी"
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr "नोट मूल्य विभाजित करा"
+#~ msgid "divide note value"
+#~ msgstr "नोट मूल्य विभाजित करा"
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr "उदा., C मेजर"
+#~ msgid "e.g., C Major"
+#~ msgstr "उदा., C मेजर"
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr "संगीत हळू चालवण्यासाठी अतिरिक्त-लांब दाबा"
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr "संगीत हळू चालवण्यासाठी अतिरिक्त-लांब दाबा"
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr "ड्रम मशीन जतन करा"
+#~ msgid "save drum machine"
+#~ msgstr "ड्रम मशीन जतन करा"
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr "आडव्या स्क्रोलिंगला सक्षम करा"
+#~ msgid "enable horizontal scrolling"
+#~ msgstr "आडव्या स्क्रोलिंगला सक्षम करा"
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr "<em>पिकअप</em> ब्लॉक बीटच्या आधी येणार्‍या कोणत्याही नोट्सला सामावून घेण्यासाठी वापरला जातो."
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr "<em>पिकअप</em> ब्लॉक बीटच्या आधी येणार्‍या कोणत्याही नोट्सला सामावून घेण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr "<em>होलो लाइन</em> ब्लॉक पोकळ केंद्रासह एक रेषा तयार करते."
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr "<em>होलो लाइन</em> ब्लॉक पोकळ केंद्रासह एक रेषा तयार करते."
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr "स्टॅक क्लिपबोर्डवर कॉपी करण्यासाठी, स्टॅकवर उजवे क्लिक करा."
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr "स्टॅक क्लिपबोर्डवर कॉपी करण्यासाठी, स्टॅकवर उजवे क्लिक करा."
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr "<em>स्टॉपप्लेबॅक</em> ब्लॉक"
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr "<em>स्टॉपप्लेबॅक</em> ब्लॉक"
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr "abc म्हणून जतन करा"
+#~ msgid "Save as abc"
+#~ msgstr "abc म्हणून जतन करा"
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr "<em>टू फ्रिक्वेंसी</em> ब्लॉक पिच नाव आणि सप्तक हर्ट्झमध्ये रूपांतरित करते."
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr "<em>टू फ्रिक्वेंसी</em> ब्लॉक पिच नाव आणि सप्तक हर्ट्झमध्ये रूपांतरित करते."
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr "वर"
+#~ msgid "top"
+#~ msgstr "वर"
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "म्युझिक ब्लॉक्स कॉन्फिगर करण्यासाठी एक पॅनेल उघडा."
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "म्युझिक ब्लॉक्स कॉन्फिगर करण्यासाठी एक पॅनेल उघडा."
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr "<em>आणि</em> ब्लॉक लॉजिकल ऑपरॅटर आहे."
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr "<em>आणि</em> ब्लॉक लॉजिकल ऑपरॅटर आहे."
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ".wav म्हणून जतन करा"
+#~ msgid "Save as .wav"
+#~ msgstr ".wav म्हणून जतन करा"
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr "ग्रह उपलब्ध नाही."
+#~ msgid "The Planet is unavailable."
+#~ msgstr "ग्रह उपलब्ध नाही."
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr "आपण <em>नोट</em> ब्लॉकमध्ये एकाधिक <em>ड्रम</em> ब्लॉक वापरू शकता."
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr "आपण <em>नोट</em> ब्लॉकमध्ये एकाधिक <em>ड्रम</em> ब्लॉक वापरू शकता."
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr "तुम्ही Alt+V देखील वापरू शकता ब्लॉक्सचा स्टॅक पेस्ट करण्यासाठी."
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr "तुम्ही Alt+V देखील वापरू शकता ब्लॉक्सचा स्टॅक पेस्ट करण्यासाठी."
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr "<em>व्हिडिओ</em> ब्लॉक <em>शो</em> ब्लॉकसह वापरण्यासाठी व्हिडिओ निवडतो."
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr "<em>व्हिडिओ</em> ब्लॉक <em>शो</em> ब्लॉकसह वापरण्यासाठी व्हिडिओ निवडतो."
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "जेव्हा <em>मूवेबल डो</em> खोटे असते, तेव्हा सोलफेज नोट नावे नेहमी विशिष्ट पिचेसशी बांधलेली असतात (उदा. \"डो\" नेहमी \"C-नॅचरल\" असते); जेव्हा <em>मूवेबल डो</em> खरे असते, तेव्हा सोलफेज नोट नावे स्केल डिग्रीला नियुक्त केली जातात (\"डो\" नेहमी प्रमुख स्केलची पहिली डिग्री असते)."
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "जेव्हा <em>मूवेबल डो</em> खोटे असते, तेव्हा सोलफेज नोट नावे नेहमी विशिष्ट पिचेसशी बांधलेली असतात (उदा. \"डो\" नेहमी \"C-नॅचरल\" असते); जेव्हा <em>मूवेबल डो</em> खरे असते, तेव्हा सोलफेज नोट नावे स्केल डिग्रीला नियुक्त केली जातात (\"डो\" नेहमी प्रमुख स्केलची पहिली डिग्री असते)."
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr "<em>पॉप</em> ब्लॉक ढिगार्‍याच्या शीर्षस्थानी असलेले मूल्य काढून टाकतो."
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr "<em>पॉप</em> ब्लॉक ढिगार्‍याच्या शीर्षस्थानी असलेले मूल्य काढून टाकतो."
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr "<em>डिक्रिसेंडो</em> ब्लॉक वाजवलेल्या प्रत्येक नोटसाठी निर्दिष्ट रकमेने समाविष्ट नोट्सचा आवाज कमी करेल. उदाहरणार्थ, तुमच्याकडे 5 मूल्य असलेल्या <em>डिक्रिसेंडो</em> ब्लॉकमध्ये अनुक्रमे 7 नोट्स असल्यास, अंतिम नोट प्रारंभिक आवाजाच्या 35% कमी असेल."
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr "<em>डिक्रिसेंडो</em> ब्लॉक वाजवलेल्या प्रत्येक नोटसाठी निर्दिष्ट रकमेने समाविष्ट नोट्सचा आवाज कमी करेल. उदाहरणार्थ, तुमच्याकडे 5 मूल्य असलेल्या <em>डिक्रिसेंडो</em> ब्लॉकमध्ये अनुक्रमे 7 नोट्स असल्यास, अंतिम नोट प्रारंभिक आवाजाच्या 35% कमी असेल."
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr "सेव्ह-स्टॅक बटण एक स्टॅक सानुकूल पॅलेटवर जतन करते."
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr "सेव्ह-स्टॅक बटण एक स्टॅक सानुकूल पॅलेटवर जतन करते."
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr "इजिप्शियन"
+#~ msgid "Egyptian"
+#~ msgstr "इजिप्शियन"
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr "क्लिपबोर्डवर ब्लॉक्स कॉपी केले असताना पेस्ट बटण सक्षम केले जाते."
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr "क्लिपबोर्डवर ब्लॉक्स कॉपी केले असताना पेस्ट बटण सक्षम केले जाते."
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr "अल्जेरियन"
+#~ msgid "Algerian"
+#~ msgstr "अल्जेरियन"
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr "हरिण"
+#~ msgid "denominator"
+#~ msgstr "हरिण"
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr "एम्प्टीहेप ब्लॉक ढिगारा रिकामा करतो."
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr "एम्प्टीहेप ब्लॉक ढिगारा रिकामा करतो."
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr "<em>फेझर</em> ब्लॉक स्विपिंग ध्वनी जोडतो."
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr "<em>फेझर</em> ब्लॉक स्विपिंग ध्वनी जोडतो."
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr "<em>ओपन प्रोजेक्ट</em> ब्लॉक वेब पेजवरून प्रोजेक्ट उघडण्यासाठी वापरला जातो."
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr "<em>ओपन प्रोजेक्ट</em> ब्लॉक वेब पेजवरून प्रोजेक्ट उघडण्यासाठी वापरला जातो."
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr "प्रभाव डेटा उपलब्ध नाही."
+#~ msgid "Impact data not available."
+#~ msgstr "प्रभाव डेटा उपलब्ध नाही."
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr "संगीत स्लो मोडमध्ये चालवण्यासाठी रन बटण अतिरिक्त लांब दाबा."
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr "संगीत स्लो मोडमध्ये चालवण्यासाठी रन बटण अतिरिक्त लांब दाबा."
 
-#~msgid "mashape"
-#~msgstr "माशाप"
+#~ msgid "mashape"
+#~ msgstr "माशाप"
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr "तिसरे"
+#~ msgid "thirds"
+#~ msgstr "तिसरे"
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr "<em>एक्स</em> ब्लॉक माऊसची आडवी स्थिती परत करते."
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr "<em>एक्स</em> ब्लॉक माऊसची आडवी स्थिती परत करते."
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr "<em>डिलीट ब्लॉक</em> ब्लॉक ब्लॉक काढून टाकतो."
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr "<em>डिलीट ब्लॉक</em> ब्लॉक ब्लॉक काढून टाकतो."
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr "<em>स्क्रोल एक्सवाय</em> ब्लॉक कॅनव्हास हलवतो."
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr "<em>स्क्रोल एक्सवाय</em> ब्लॉक कॅनव्हास हलवतो."
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr "<em>रिटर्न टू यूआरएल</em> ब्लॉक वेबपेजवर मूल्य परत करेल."
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr "<em>रिटर्न टू यूआरएल</em> ब्लॉक वेबपेजवर मूल्य परत करेल."
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr "<em>लेफ्ट</em> ब्लॉक माउस डावीकडे वळतो."
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr "<em>लेफ्ट</em> ब्लॉक माउस डावीकडे वळतो."
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr "चालवा"
+#~ msgid "Run"
+#~ msgstr "चालवा"
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "आपण फाइल प्रणाली मधुन नवीन ब्लॉ"
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "आपण फाइल प्रणाली मधुन नवीन ब्लॉ"
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr "सेटिंग"
+#~ msgid "Settings"
+#~ msgstr "सेटिंग"
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr "<em>बुलियन</em> ब्लॉकचा वापर सत्य किंवा असत्य निर्दिष्ट करण्यासाठी केला जातो."
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr "<em>बुलियन</em> ब्लॉकचा वापर सत्य किंवा असत्य निर्दिष्ट करण्यासाठी केला जातो."
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr "<em>ऑन-स्टॉंग-बीट</em> ब्लॉक तुम्हाला निर्दिष्ट बीट्सवर घ्यायच्या क्रिया निर्दिष्ट करण्याची परवानगी देतो."
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr "<em>ऑन-स्टॉंग-बीट</em> ब्लॉक तुम्हाला निर्दिष्ट बीट्सवर घ्यायच्या क्रिया निर्दिष्ट करण्याची परवानगी देतो."
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr "<em>इंडेक्सहीप</em> ब्लॉक निर्दिष्ट स्थळी हीपमधील मूल्य परत करते."
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr "<em>इंडेक्सहीप</em> ब्लॉक निर्दिष्ट स्थळी हीपमधील मूल्य परत करते."
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr "<em>आर्ग</em> ब्लॉकमध्ये कृतीस दिलेल्या युक्तिवादाचे मूल्य असते."
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr "<em>आर्ग</em> ब्लॉकमध्ये कृतीस दिलेल्या युक्तिवादाचे मूल्य असते."
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr "खाली हलवा"
+#~ msgid "move down"
+#~ msgstr "खाली हलवा"
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr "व्यंजन चरण वाढवा"
+#~ msgid "consonant step up"
+#~ msgstr "व्यंजन चरण वाढवा"
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr "<em>एम्प्टीहीप</em> ब्लॉक हीप रिकामी करते."
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr "<em>एम्प्टीहीप</em> ब्लॉक हीप रिकामी करते."
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr "<em>स्विच</em> च्या आत <em>डीफॉल्ट</em> ब्लॉकचा वापर डीफॉल्ट कृती परिभाषित करण्यासाठी केला जातो."
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr "<em>स्विच</em> च्या आत <em>डीफॉल्ट</em> ब्लॉकचा वापर डीफॉल्ट कृती परिभाषित करण्यासाठी केला जातो."
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr "<em>स्केलर स्टेप अप</em> ब्लॉक वर्तमान की आणि मोडमध्ये पुढील नोटपर्यंतची अर्ध-टोन संख्या परत करते."
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr "<em>स्केलर स्टेप अप</em> ब्लॉक वर्तमान की आणि मोडमध्ये पुढील नोटपर्यंतची अर्ध-टोन संख्या परत करते."
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr "<em>रिदम मेकर</em> ब्लॉक ड्रम मशीन तयार करण्यासाठी एक साधन उघडते."
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr "<em>रिदम मेकर</em> ब्लॉक ड्रम मशीन तयार करण्यासाठी एक साधन उघडते."
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr "<em>माऊस हेडिंग</em> ब्लॉक निर्दिष्ट माऊसचा शीर्षक परत करते."
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr "<em>माऊस हेडिंग</em> ब्लॉक निर्दिष्ट माऊसचा शीर्षक परत करते."
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr "पिचस्लायडर"
+#~ msgid "pitchslider"
+#~ msgstr "पिचस्लायडर"
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr "अधिक पहा"
+#~ msgid "View More"
+#~ msgstr "अधिक पहा"
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr "संकुचित"
+#~ msgid "collpase"
+#~ msgstr "संकुचित"
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr "हीप रिकामी असल्यास <em>हीप-रिकामी?</em> ब्लॉक सत्य परत करते."
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr "हीप रिकामी असल्यास <em>हीप-रिकामी?</em> ब्लॉक सत्य परत करते."
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr "फिबोनाची"
+#~ msgid "Fibonacci"
+#~ msgstr "फिबोनाची"
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr "संगीत हळूहळू चालवा"
+#~ msgid "Run music slowly"
+#~ msgstr "संगीत हळूहळू चालवा"
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr "<em>सेट ट्रान्सलूसन्सी</em> ब्लॉक पेनची अस्पष्टता बदलते."
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr "<em>सेट ट्रान्सलूसन्सी</em> ब्लॉक पेनची अस्पष्टता बदलते."
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr "<em>पिच</em> ब्लॉक नोटची वारंवारता निश्चित करणारी नोटची पिच नाव आणि पिच सप्तक निर्दिष्ट करते."
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr "<em>पिच</em> ब्लॉक नोटची वारंवारता निश्चित करणारी नोटची पिच नाव आणि पिच सप्तक निर्दिष्ट करते."
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr "<em>स्टाकाटो</em> ब्लॉक प्रत्यक्ष नोटची लांबी कमी करते—त्यांना घट्ट उधळणी बनवते—तर निर्दिष्ट लयबद्ध मूल्य राखते."
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr "<em>स्टाकाटो</em> ब्लॉक प्रत्यक्ष नोटची लांबी कमी करते—त्यांना घट्ट उधळणी बनवते—तर निर्दिष्ट लयबद्ध मूल्य राखते."
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr "पिच बदलण्यासाठी स्लाइडर वापरा."
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr "पिच बदलण्यासाठी स्लाइडर वापरा."
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr "<em>राइट</em> ब्लॉक कॅनव्हासच्या उजवीकडील स्थिती परत करते."
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr "<em>राइट</em> ब्लॉक कॅनव्हासच्या उजवीकडील स्थिती परत करते."
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr "<em>सेट सिंथ व्हॉल्यूम</em> ब्लॉक विशिष्ट सिंथचा आवाज बदलतो, उदा. गिटार, व्हायोलिन, स्नेअर ड्रम, इत्यादी. डीफॉल्ट व्हॉल्यूम 50 आहे; श्रेणी 0 (शांतता) ते 100 (पूर्ण आवाज)."
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr "<em>सेट सिंथ व्हॉल्यूम</em> ब्लॉक विशिष्ट सिंथचा आवाज बदलतो, उदा. गिटार, व्हायोलिन, स्नेअर ड्रम, इत्यादी. डीफॉल्ट व्हॉल्यूम 50 आहे; श्रेणी 0 (शांतता) ते 100 (पूर्ण आवाज)."
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr "<em>क्रेशेंडो</em> ब्लॉक प्रत्येक नोट वाजवल्यावर त्यात असलेल्या नोट्सचा आवाज निर्दिष्ट प्रमाणात वाढवेल. उदाहरणार्थ, जर तुमच्याकडे 5 मूल्यासह <em>क्रेशेंडो</em> ब्लॉकमध्ये अनुक्रमे 7 नोट्स असतील, तर अंतिम नोट प्रारंभिक आवाजाच्या 35% अधिक असेल."
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr "<em>क्रेशेंडो</em> ब्लॉक प्रत्येक नोट वाजवल्यावर त्यात असलेल्या नोट्सचा आवाज निर्दिष्ट प्रमाणात वाढवेल. उदाहरणार्थ, जर तुमच्याकडे 5 मूल्यासह <em>क्रेशेंडो</em> ब्लॉकमध्ये अनुक्रमे 7 नोट्स असतील, तर अंतिम नोट प्रारंभिक आवाजाच्या 35% अधिक असेल."
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr "नोट व्हॉल्यूम"
+#~ msgid "note volume"
+#~ msgstr "नोट व्हॉल्यूम"
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr "फिंगर-सिंबॉल्स"
+#~ msgid "finger-cymbals"
+#~ msgstr "फिंगर-सिंबॉल्स"
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr "पिच-ड्रम मॅट्रिक्स"
+#~ msgid "pitch-drum matrix"
+#~ msgstr "पिच-ड्रम मॅट्रिक्स"
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr "ट्युप्लेट ब्लॉक: तुम्हाला मॅट्रिक्स ब्लॉक वापरायचा आहे का?"
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr "ट्युप्लेट ब्लॉक: तुम्हाला मॅट्रिक्स ब्लॉक वापरायचा आहे का?"
 
-#~msgid "set beats per minute"
-#~msgstr "प्रति मिनिट बीट सेट करा"
+#~ msgid "set beats per minute"
+#~ msgstr "प्रति मिनिट बीट सेट करा"
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr "सर्व हटवा"
+#~ msgid "Delete all"
+#~ msgstr "सर्व हटवा"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr "पिंक-नॉईज"
+#~ msgid "pink-noise"
+#~ msgstr "पिंक-नॉईज"
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr "यूआयडी"
+#~ msgid "UID"
+#~ msgstr "यूआयडी"
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr "क्रोमॅटिक"
+#~ msgid "Chromatic"
+#~ msgstr "क्रोमॅटिक"
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr "घड्याळाच्या दिशेने फिरवा"
+#~ msgid "rotate clockwise"
+#~ msgstr "घड्याळाच्या दिशेने फिरवा"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr "हिराजोशी (जपान)"
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr "हिराजोशी (जपान)"
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr "मायनर ब्लॉकमध्ये दिलेला इनपुट 2, 3, 6, किंवा 7 असावा."
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr "मायनर ब्लॉकमध्ये दिलेला इनपुट 2, 3, 6, किंवा 7 असावा."
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr "तळ"
+#~ msgid "bottom"
+#~ msgstr "तळ"
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr "<em>सेट की</em> ब्लॉक की आणि मोड सेट करण्यासाठी वापरला जातो, उदा. <em>C मेजर</em>"
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr "<em>सेट की</em> ब्लॉक की आणि मोड सेट करण्यासाठी वापरला जातो, उदा. <em>C मेजर</em>"
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr "<em>मल्टिप्लाय नोट व्हॅल्यू</em> ब्लॉक नोट्सचे मूल्य बदलून त्यांची कालावधी बदलतो."
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr "<em>मल्टिप्लाय नोट व्हॅल्यू</em> ब्लॉक नोट्सचे मूल्य बदलून त्यांची कालावधी बदलतो."
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr "<em>Y</em> ब्लॉक माउसची अनुलंब स्थिती परत करतो."
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr "<em>Y</em> ब्लॉक माउसची अनुलंब स्थिती परत करतो."
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr "छेद"
+#~ msgid "numerator"
+#~ msgstr "छेद"
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr "कप-ड्रम"
+#~ msgid "cup-drum"
+#~ msgstr "कप-ड्रम"
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr "हाय-हॅट"
+#~ msgid "hi-hat"
+#~ msgstr "हाय-हॅट"
 
 #: js/palette.js:1763
 
@@ -10115,165 +10115,165 @@ msgstr "हलवा"
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr "सोल"
+#~ msgid "sol"
+#~ msgstr "सोल"
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr "<em>Arc</em> ब्लॉक माऊसला एका वर्तुळात हलवतो."
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr "<em>Arc</em> ब्लॉक माऊसला एका वर्तुळात हलवतो."
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr "<em>Pitch staircase</em> साधन दिलेल्या प्रमाणातून पिच तयार करण्यासाठी वापरले जाते."
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr "<em>Pitch staircase</em> साधन दिलेल्या प्रमाणातून पिच तयार करण्यासाठी वापरले जाते."
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr "<em>Note volume</em> ब्लॉक सध्याच्या सिंथेसायझरचे वर्तमान व्हॉल्यूम परत करतो."
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr "<em>Note volume</em> ब्लॉक सध्याच्या सिंथेसायझरचे वर्तमान व्हॉल्यूम परत करतो."
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr "संगीताचा ठेका <em>Meter</em> ब्लॉकद्वारे ठरवला जातो (मूलतः, प्रति मापन ४ १/४ नोट्स)."
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr "संगीताचा ठेका <em>Meter</em> ब्लॉकद्वारे ठरवला जातो (मूलतः, प्रति मापन ४ १/४ नोट्स)."
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr "<em>Accidental selector</em> ब्लॉक डबल-शार्प, शार्प, नॅचरल, फ्लॅट आणि डबल-फ्लॅट यांच्यात निवडण्यासाठी वापरला जातो."
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr "<em>Accidental selector</em> ब्लॉक डबल-शार्प, शार्प, नॅचरल, फ्लॅट आणि डबल-फ्लॅट यांच्यात निवडण्यासाठी वापरला जातो."
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr "फ्रिगियन"
+#~ msgid "Phrygian"
+#~ msgstr "फ्रिगियन"
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr "<em>Define mode</em> ब्लॉक तुम्हाला पिच नंबर निर्दिष्ट करून कस्टम मोड परिभाषित करण्याची परवानगी देतो."
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr "<em>Define mode</em> ब्लॉक तुम्हाला पिच नंबर निर्दिष्ट करून कस्टम मोड परिभाषित करण्याची परवानगी देतो."
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr "जलद चालवा / हळू चालवण्यासाठी दीर्घ दाबा / संगीत हळू चालवण्यासाठी अतिरिक्त-दीर्घ दाबा"
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr "जलद चालवा / हळू चालवण्यासाठी दीर्घ दाबा / संगीत हळू चालवण्यासाठी अतिरिक्त-दीर्घ दाबा"
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr "म्युझिक ब्लॉक्स ही एकत्रित आणि मजेदार पद्धतीने मूलभूत संगीत संकल्पनांचा शोध घेण्यासाठी हाताळणी साधनांचे संग्रह आहे."
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr "म्युझिक ब्लॉक्स ही एकत्रित आणि मजेदार पद्धतीने मूलभूत संगीत संकल्पनांचा शोध घेण्यासाठी हाताळणी साधनांचे संग्रह आहे."
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr "ला"
+#~ msgid "la"
+#~ msgstr "ला"
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr "अंतर पहा"
+#~ msgid "see distance"
+#~ msgstr "अंतर पहा"
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr "<em>Tuplet</em> ब्लॉक कमी वेळेत वाजवल्या जाणाऱ्या नोट्सच्या गटाचे निर्माण करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr "<em>Tuplet</em> ब्लॉक कमी वेळेत वाजवल्या जाणाऱ्या नोट्सच्या गटाचे निर्माण करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr "स्विच ब्लॉक मॅचिंग केसमध्ये कोड चालवेल."
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr "स्विच ब्लॉक मॅचिंग केसमध्ये कोड चालवेल."
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr "सापेक्ष अंतर"
+#~ msgid "relative interval"
+#~ msgstr "सापेक्ष अंतर"
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr "<em>Beats per minute</em> ब्लॉक मिनिटात १/४ नोट्सची संख्या सेट करतो."
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr "<em>Beats per minute</em> ब्लॉक मिनिटात १/४ नोट्सची संख्या सेट करतो."
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr "<em>Width</em> ब्लॉक कॅनव्हासची रुंदी परत करतो."
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr "<em>Width</em> ब्लॉक कॅनव्हासची रुंदी परत करतो."
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr "संगीत (आणि कासव) थांबवा."
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr "संगीत (आणि कासव) थांबवा."
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr "फ्लोर-टॉम-टॉम"
+#~ msgid "floor-tom-tom"
+#~ msgstr "फ्लोर-टॉम-टॉम"
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr "<em>Tie</em> ब्लॉक नोट्सच्या जोडीवर कार्य करतो, त्यांना एक नोटमध्ये एकत्र करतो."
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr "<em>Tie</em> ब्लॉक नोट्सच्या जोडीवर कार्य करतो, त्यांना एक नोटमध्ये एकत्र करतो."
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr "पिच <em>do re mi fa sol la ti<em> च्या रूपात निर्दिष्ट केले जाऊ शकते."
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr "पिच <em>do re mi fa sol la ti<em> च्या रूपात निर्दिष्ट केले जाऊ शकते."
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr "<em>Show</em> ब्लॉक कॅनव्हासवर मजकूर किंवा प्रतिमा प्रदर्शित करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr "<em>Show</em> ब्लॉक कॅनव्हासवर मजकूर किंवा प्रतिमा प्रदर्शित करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr "<em>Background</em> ब्लॉक पार्श्वभूमीचा रंग सेट करतो."
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr "<em>Background</em> ब्लॉक पार्श्वभूमीचा रंग सेट करतो."
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr "कासव नोट"
+#~ msgid "turtle note"
+#~ msgstr "कासव नोट"
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr "या साधनपट्टीमध्ये पॅलेट बटणे आहेत, ज्यात रिदम पिच टोन कासव आणि अधिक समाविष्ट आहे."
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr "या साधनपट्टीमध्ये पॅलेट बटणे आहेत, ज्यात रिदम पिच टोन कासव आणि अधिक समाविष्ट आहे."
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr "<em>While</em> ब्लॉक अट खरी असताना पुनरावृत्ती करेल."
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr "<em>While</em> ब्लॉक अट खरी असताना पुनरावृत्ती करेल."
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr "<em>Minus</em> ब्लॉक वजा करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr "<em>Minus</em> ब्लॉक वजा करण्यासाठी वापरला जातो."
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr "ब्लॉक आर्टवर्क"
+#~ msgid "block artwork"
+#~ msgstr "ब्लॉक आर्टवर्क"
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr "<em>Neighbor</em> ब्लॉक शेजारील पिचेसमध्ये जलद स्विच करतो."
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr "<em>Neighbor</em> ब्लॉक शेजारील पिचेसमध्ये जलद स्विच करतो."
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr "<em>Distortion</em> ब्लॉक पिचमध्ये विकृती जोडतो."
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr "<em>Distortion</em> ब्लॉक पिचमध्ये विकृती जोडतो."
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr "ब्र"
+#~ msgid "br"
+#~ msgstr "ब्र"
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr "पहिला"
+#~ msgid "1st"
+#~ msgstr "पहिला"
 
 #: js/logo.js:2177
 
@@ -10287,28 +10287,28 @@ msgstr "हलवा"
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr "कासव सापडले नाही"
+#~ msgid "Could not find turtle"
+#~ msgstr "कासव सापडले नाही"
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr "<em>Slur</em> ब्लॉक नोट्सची निर्दिष्ट लयात्मक मूल्य राखून नोट्सचे टिकाव वाढवतो."
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr "<em>Slur</em> ब्लॉक नोट्सची निर्दिष्ट लयात्मक मूल्य राखून नोट्सचे टिकाव वाढवतो."
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr "हंगेरियन"
+#~ msgid "Hungarian"
+#~ msgstr "हंगेरियन"
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr "कॉर्ड वाजवा"
+#~ msgid "play chord"
+#~ msgstr "कॉर्ड वाजवा"
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr "प्रतिक्रिया अनुकूल करा"
+#~ msgid "Optimize feedback"
+#~ msgstr "प्रतिक्रिया अनुकूल करा"
 
 #: js/turtledefs.js:187
 
@@ -10316,133 +10316,133 @@ msgstr "हलवा"
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr "ब्लॉक आर्टवर्क जतन करा"
+#~ msgid "Save block artwork"
+#~ msgstr "ब्लॉक आर्टवर्क जतन करा"
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr "<em>Pitch-slider<em> ब्लॉक मनमानी पिचेस तयार करण्यासाठी एक साधन उघडतो."
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr "<em>Pitch-slider<em> ब्लॉक मनमानी पिचेस तयार करण्यासाठी एक साधन उघडतो."
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr "स्केलर स्टेप ब्लॉक नोट ब्लॉकच्या आत वापरला पाहिजे."
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr "स्केलर स्टेप ब्लॉक नोट ब्लॉकच्या आत वापरला पाहिजे."
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr "म्युझिक ब्लॉक्स हे संगीत संकल्पनांचा शोध घेण्यासाठी खुले स्रोत साधनांचे संग्रह आहे. योगदानकर्त्यांची संपूर्ण यादी म्युझिक ब्लॉक्स GitHub रेपॉजिटरीमध्ये मिळू शकते. म्युझिक ब्लॉक्स AGPL अंतर्गत परवानाधारक आहे. वर्तमान आवृत्ती आहे:"
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr "म्युझिक ब्लॉक्स हे संगीत संकल्पनांचा शोध घेण्यासाठी खुले स्रोत साधनांचे संग्रह आहे. योगदानकर्त्यांची संपूर्ण यादी म्युझिक ब्लॉक्स GitHub रेपॉजिटरीमध्ये मिळू शकते. म्युझिक ब्लॉक्स AGPL अंतर्गत परवानाधारक आहे. वर्तमान आवृत्ती आहे:"
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr "चौथ्या"
+#~ msgid "fourths"
+#~ msgstr "चौथ्या"
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr "<em>Cursor Y</em> ब्लॉक माऊसची अनुलंब स्थिती परत करतो."
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr "<em>Cursor Y</em> ब्लॉक माऊसची अनुलंब स्थिती परत करतो."
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr "Crescendo ब्लॉक प्रत्येक वाजवलेल्या नोटसाठी निर्दिष्ट केलेल्या रकमेने समाविष्ट नोट्सचे व्हॉल्यूम वाढवेल (किंवा कमी करेल). उदाहरणार्थ, जर तुमच्याकडे ७ नोट्स <em>Crescendo</em> ब्लॉकमध्ये अनुक्रमे ५ मुल्यांसह समाविष्ट असतील, तर अंतिम नोट प्रारंभिक व्हॉल्यूमपेक्षा ३५% जास्त असेल."
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr "Crescendo ब्लॉक प्रत्येक वाजवलेल्या नोटसाठी निर्दिष्ट केलेल्या रकमेने समाविष्ट नोट्सचे व्हॉल्यूम वाढवेल (किंवा कमी करेल). उदाहरणार्थ, जर तुमच्याकडे ७ नोट्स <em>Crescendo</em> ब्लॉकमध्ये अनुक्रमे ५ मुल्यांसह समाविष्ट असतील, तर अंतिम नोट प्रारंभिक व्हॉल्यूमपेक्षा ३५% जास्त असेल."
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr "<em>Keyboard</em> ब्लॉक संगणकाचे कीबोर्ड इनपुट परत करतो."
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr "<em>Keyboard</em> ब्लॉक संगणकाचे कीबोर्ड इनपुट परत करतो."
 
-#~msgid "Save your project to a server."
-#~msgstr "सर्व्हर वर आपले प्रकल्प जतन करा."
+#~ msgid "Save your project to a server."
+#~ msgstr "सर्व्हर वर आपले प्रकल्प जतन करा."
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr "बीट मूल्य गुणाकार करा"
+#~ msgid "multiply beat value"
+#~ msgstr "बीट मूल्य गुणाकार करा"
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr "संपूर्ण टोन"
+#~ msgid "Whole Tone"
+#~ msgstr "संपूर्ण टोन"
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr "<em>Int</em> ब्लॉक पूर्णांक परत करतो."
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr "<em>Int</em> ब्लॉक पूर्णांक परत करतो."
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr "<em>box2</em> ब्लॉक <em>box2</em> मध्ये संग्रहित मूल्य परत करतो."
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr "<em>box2</em> ब्लॉक <em>box2</em> मध्ये संग्रहित मूल्य परत करतो."
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr "फक्त संगीत हळू मोडमध्ये चालवण्यासाठी क्लिक करा."
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr "फक्त संगीत हळू मोडमध्ये चालवण्यासाठी क्लिक करा."
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr "<em>Speak</em> ब्लॉक मजकूर ते आवाज सिंथेसायझरला आउटपुट करतो."
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr "<em>Speak</em> ब्लॉक मजकूर ते आवाज सिंथेसायझरला आउटपुट करतो."
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr "<em>Grey</em> ब्लॉक वर्तमान पेन ग्रे मूल्य परत करतो."
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr "<em>Grey</em> ब्लॉक वर्तमान पेन ग्रे मूल्य परत करतो."
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr "सहावा"
+#~ msgid "6th"
+#~ msgstr "सहावा"
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "Augmented ब्लॉकमध्ये इनपुट १, २, ३, ४, ५, ६, ७ किंवा ८ असायला हवे"
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "Augmented ब्लॉकमध्ये इनपुट १, २, ३, ४, ५, ६, ७ किंवा ८ असायला हवे"
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr "<em>Drum name</em> ब्लॉक ड्रम निवडण्यासाठी वापरला जातो."
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr "<em>Drum name</em> ब्लॉक ड्रम निवडण्यासाठी वापरला जातो."
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr "जलद चालवा / हळू चालवण्यासाठी दीर्घ दाबा / संगीत हळू चालवण्यासाठी अतिरिक्त-दीर्घ दाबा"
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr "जलद चालवा / हळू चालवण्यासाठी दीर्घ दाबा / संगीत हळू चालवण्यासाठी अतिरिक्त-दीर्घ दाबा"
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr "lilypond म्हणून जतन करा"
+#~ msgid "save as lilypond"
+#~ msgstr "lilypond म्हणून जतन करा"
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr "<em>Divide</em> ब्लॉक विभाजित करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr "<em>Divide</em> ब्लॉक विभाजित करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr "<em>Partial</em> ब्लॉक एका विशिष्ट हार्मोनिकसाठी वजन निर्दिष्ट करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr "<em>Partial</em> ब्लॉक एका विशिष्ट हार्मोनिकसाठी वजन निर्दिष्ट करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr "<em>Temperament name</em> ब्लॉक ट्यूनिंग पद्धत निवडण्यासाठी वापरला जातो."
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr "<em>Temperament name</em> ब्लॉक ट्यूनिंग पद्धत निवडण्यासाठी वापरला जातो."
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr "कमी केलेले"
+#~ msgid "Diminished"
+#~ msgstr "कमी केलेले"
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr "साधनपट्टी दाखवा/लपवा"
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr "साधनपट्टी दाखवा/लपवा"
 
 #: js/turtledefs.js:187
 
@@ -10450,136 +10450,136 @@ msgstr "हलवा"
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr "SVG म्हणून जतन करा"
+#~ msgid "Save as SVG"
+#~ msgstr "SVG म्हणून जतन करा"
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr "Loadheap ब्लॉक फाइलमधून हीप लोड करतो."
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr "Loadheap ब्लॉक फाइलमधून हीप लोड करतो."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr "मध्ये (जपान)"
+#~ msgid "in (Japan)"
+#~ msgstr "मध्ये (जपान)"
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr "वैकल्पिकरित्या, तुम्ही ENTER किंवा RETURN की दाबू शकता."
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr "वैकल्पिकरित्या, तुम्ही ENTER किंवा RETURN की दाबू शकता."
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr "<em>Set timbre</em> ब्लॉक सिंथेसायझरसाठी एक आवाज निवडतो, उदाहरणार्थ, गिटार, पियानो, व्हायोलिन किंवा सेलो."
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr "<em>Set timbre</em> ब्लॉक सिंथेसायझरसाठी एक आवाज निवडतो, उदाहरणार्थ, गिटार, पियानो, व्हायोलिन किंवा सेलो."
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "कासव"
+#~ msgid "turtle"
+#~ msgstr "कासव"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr "<em>Y mouse</em> ब्लॉक निर्दिष्ट माऊसची Y स्थिती परत करतो."
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr "<em>Y mouse</em> ब्लॉक निर्दिष्ट माऊसची Y स्थिती परत करतो."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr "मिन्यो (जपान)"
+#~ msgid "minyo (Japan)"
+#~ msgstr "मिन्यो (जपान)"
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr "इम्पॅक्ट टाइम सापडले नाही."
+#~ msgid "Impact Time not found."
+#~ msgstr "इम्पॅक्ट टाइम सापडले नाही."
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr "बीट्स प्रति मिनिट ब्लॉक कोणत्याही समाविष्ट नोट्सच्या बीट्स प्रति मिनिट बदलतो."
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr "बीट्स प्रति मिनिट ब्लॉक कोणत्याही समाविष्ट नोट्सच्या बीट्स प्रति मिनिट बदलतो."
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr "स्टॉप माउस ब्लॉक निर्दिष्ट माउस थांबवतो."
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr "स्टॉप माउस ब्लॉक निर्दिष्ट माउस थांबवतो."
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr "तिसरा"
+#~ msgid "3rd"
+#~ msgstr "तिसरा"
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr "डुप्लिकेट ब्लॉक प्रत्येक ब्लॉक अनेक वेळा चालवेल. उदाहरणाचे आउटपुट आहे: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr "डुप्लिकेट ब्लॉक प्रत्येक ब्लॉक अनेक वेळा चालवेल. उदाहरणाचे आउटपुट आहे: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr "डबल्ली ब्लॉक अंतराच्या आकाराला दुप्पट करेल."
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr "डबल्ली ब्लॉक अंतराच्या आकाराला दुप्पट करेल."
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr "रन ब्लॉक ब्लॉक एक ब्लॉक चालवतो."
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr "रन ब्लॉक ब्लॉक एक ब्लॉक चालवतो."
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr "आगे वाजवा"
+#~ msgid "play forward"
+#~ msgstr "आगे वाजवा"
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr "बास"
+#~ msgid "basse"
+#~ msgstr "बास"
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr "हर्ट्ज ब्लॉक (संख्या ब्लॉकसह) निर्दिष्ट वारंवारता वर एक आवाज वाजवेल."
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr "हर्ट्ज ब्लॉक (संख्या ब्लॉकसह) निर्दिष्ट वारंवारता वर एक आवाज वाजवेल."
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr "स्टक्काटो ब्लॉक वास्तविक नोटची लांबी कमी करतो आणि नोट्सचा निर्दिष्ट लयबद्ध मूल्य राखतो."
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr "स्टक्काटो ब्लॉक वास्तविक नोटची लांबी कमी करतो आणि नोट्सचा निर्दिष्ट लयबद्ध मूल्य राखतो."
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr "टू ASCII ब्लॉक संख्या अक्षरांमध्ये रूपांतरित करतो."
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr "टू ASCII ब्लॉक संख्या अक्षरांमध्ये रूपांतरित करतो."
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr "मोड लांबी ब्लॉक सध्याच्या स्केलमध्ये नोट्सची संख्या आहे. बहुतेक पश्चिमी स्केलमध्ये ७ नोट्स असतात."
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr "मोड लांबी ब्लॉक सध्याच्या स्केलमध्ये नोट्सची संख्या आहे. बहुतेक पश्चिमी स्केलमध्ये ७ नोट्स असतात."
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to</em> block adds one to the value stored in a box."
-#~msgstr "अॅड-१-टू ब्लॉक एका बॉक्समध्ये संग्रहित मूल्यात एक जोडतो."
+#~ msgid "The <em>Add-1-to</em> block adds one to the value stored in a box."
+#~ msgstr "अॅड-१-टू ब्लॉक एका बॉक्समध्ये संग्रहित मूल्यात एक जोडतो."
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr "४४० हर्ट्ज"
+#~ msgid "440 hertz"
+#~ msgstr "४४० हर्ट्ज"
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr "सेट XY ब्लॉक माउसला स्क्रीनवरील विशिष्ट स्थानावर हलवतो."
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr "सेट XY ब्लॉक माउसला स्क्रीनवरील विशिष्ट स्थानावर हलवतो."
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr "कामगिरी अनुकूलित करा"
+#~ msgid "Optimize performance"
+#~ msgstr "कामगिरी अनुकूलित करा"
 
 #: js/playback.js:31
 
@@ -10589,127 +10589,127 @@ msgstr "हलवा"
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr "सर्व वाजवा"
+#~ msgid "play all"
+#~ msgstr "सर्व वाजवा"
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr "कॅमेरा ब्लॉक वेबकॅमला शो ब्लॉकशी जोडतो."
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr "कॅमेरा ब्लॉक वेबकॅमला शो ब्लॉकशी जोडतो."
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr "फिंगर सिंबल्स"
+#~ msgid "finger cymbols"
+#~ msgstr "फिंगर सिंबल्स"
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr "सिंपल-१"
+#~ msgid "simple-1"
+#~ msgstr "सिंपल-१"
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr "सहस्वर खाली उतरणे"
+#~ msgid "consonant step down"
+#~ msgstr "सहस्वर खाली उतरणे"
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr "राइड-बेल"
+#~ msgid "ride-bell"
+#~ msgstr "राइड-बेल"
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr "म्युझिक ब्लॉक्स संगीत संकल्पनांचा शोध घेण्यासाठी साधनांचा संग्रह आहे."
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr "म्युझिक ब्लॉक्स संगीत संकल्पनांचा शोध घेण्यासाठी साधनांचा संग्रह आहे."
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr "पिक्सेल रंग वाचू शकत नाही"
+#~ msgid "Cannot read pixel color"
+#~ msgstr "पिक्सेल रंग वाचू शकत नाही"
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr "रिदम रूलर ब्लॉक ड्रम मशीन तयार करण्यासाठी एक साधन उघडतो."
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr "रिदम रूलर ब्लॉक ड्रम मशीन तयार करण्यासाठी एक साधन उघडतो."
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr "स्क्वेअर रूट ब्लॉक वर्गमूळ परत करतो."
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr "स्क्वेअर रूट ब्लॉक वर्गमूळ परत करतो."
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr "नोट काउंटर ब्लॉक वापरून समाविष्ट नोट्सची संख्या मोजता येते."
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr "नोट काउंटर ब्लॉक वापरून समाविष्ट नोट्सची संख्या मोजता येते."
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is empty."
-#~msgstr "हीप रिकामा आहे का? ब्लॉक खरे परत करतो जर हीप रिकामा असेल तर."
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is empty."
+#~ msgstr "हीप रिकामा आहे का? ब्लॉक खरे परत करतो जर हीप रिकामा असेल तर."
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr "लिडियन"
+#~ msgid "Lydian"
+#~ msgstr "लिडियन"
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr "नॉईज नेम ब्लॉक एक आवाज सिंथेसायझर निवडण्यासाठी वापरला जातो."
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr "नॉईज नेम ब्लॉक एक आवाज सिंथेसायझर निवडण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr "पिच ड्रम मॅट्रिक्स पिचेस ड्रम ध्वनींशी जोडण्यासाठी वापरला जातो."
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr "पिच ड्रम मॅट्रिक्स पिचेस ड्रम ध्वनींशी जोडण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr "डॉट ब्लॉक एका नोटची कालावधी ५०% ने वाढवतो. उदा., एक डॉटेड क्वार्टर नोट ३/८ (१/४ + १/८) बीटसाठी वाजवेल."
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr "डॉट ब्लॉक एका नोटची कालावधी ५०% ने वाढवतो. उदा., एक डॉटेड क्वार्टर नोट ३/८ (१/४ + १/८) बीटसाठी वाजवेल."
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr "बॉक्स२ वर संग्रहित मूल्य परत करते."
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr "बॉक्स२ वर संग्रहित मूल्य परत करते."
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr "पिच नंबर ब्लॉक त्याच्या नंबरने संबंधित पिच वाजवेल, उदा., C साठी 1, G साठी 7."
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr "पिच नंबर ब्लॉक त्याच्या नंबरने संबंधित पिच वाजवेल, उदा., C साठी 1, G साठी 7."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr "हार्मोनिक-मेजर"
+#~ msgid "harmonic-major"
+#~ msgstr "हार्मोनिक-मेजर"
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr "अतिरिक्त मेनू"
+#~ msgid "Auxillary menu"
+#~ msgstr "अतिरिक्त मेनू"
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr "प्रकाशित करा"
+#~ msgid "Publish"
+#~ msgstr "प्रकाशित करा"
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr "पुश ब्लॉक हीपच्या शीर्षस्थानी एक मूल्य जोडतो."
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr "पुश ब्लॉक हीपच्या शीर्षस्थानी एक मूल्य जोडतो."
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr "रोमेनियन माइनर"
+#~ msgid "Romanian Minor"
+#~ msgstr "रोमेनियन माइनर"
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr "उदाहरणात, हे एक ब्लॉकसह वापरले जाते एक यादृच्छिक फेज निवडण्यासाठी."
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr "उदाहरणात, हे एक ब्लॉकसह वापरले जाते एक यादृच्छिक फेज निवडण्यासाठी."
 
 #: js/activity.js:2433
 
@@ -10717,397 +10717,397 @@ msgstr "हलवा"
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr "शीर्षकहीन"
+#~ msgid "untitled"
+#~ msgstr "शीर्षकहीन"
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr "जगभरात"
+#~ msgid "Worldwide"
+#~ msgstr "जगभरात"
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr "उदा., एक डॉटेड क्वार्टर नोट ३/८ (१/४ + १/८) बीटसाठी वाजवेल."
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr "उदा., एक डॉटेड क्वार्टर नोट ३/८ (१/४ + १/८) बीटसाठी वाजवेल."
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr "हळू चालवण्यासाठी दीर्घ दाबा"
+#~ msgid "long press to run slowly"
+#~ msgstr "हळू चालवण्यासाठी दीर्घ दाबा"
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr "सेव्ह हीप टू अॅप ब्लॉक हीपला वेब पेजवर सेव्ह करतो."
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr "सेव्ह हीप टू अॅप ब्लॉक हीपला वेब पेजवर सेव्ह करतो."
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr "तोडणे"
+#~ msgid "pluck"
+#~ msgstr "तोडणे"
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr "माउस नोट ब्लॉक निर्दिष्ट माउसद्वारे वाजवली जात असलेली वर्तमान नोट मूल्य परत करतो."
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr "माउस नोट ब्लॉक निर्दिष्ट माउसद्वारे वाजवली जात असलेली वर्तमान नोट मूल्य परत करतो."
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr "स्लर ब्लॉक नोट्सची स्थिरता वाढवतो—नोटेड कालावधीपेक्षा जास्त चालवतो आणि पुढील नोटमध्ये मिसळतो—नोट्सचा निर्दिष्ट लयबद्ध मूल्य राखताना."
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr "स्लर ब्लॉक नोट्सची स्थिरता वाढवतो—नोटेड कालावधीपेक्षा जास्त चालवतो आणि पुढील नोटमध्ये मिसळतो—नोट्सचा निर्दिष्ट लयबद्ध मूल्य राखताना."
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr "कमकुवत बीटवर"
+#~ msgid "on weak beat"
+#~ msgstr "कमकुवत बीटवर"
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr "नो क्लॉक ब्लॉक नोट्सला मास्टर क्लॉकपासून डिस्कपल करतो."
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr "नो क्लॉक ब्लॉक नोट्सला मास्टर क्लॉकपासून डिस्कपल करतो."
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr "सेट-पेन-साइज ब्लॉक पेनचा आकार बदलतो."
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr "सेट-पेन-साइज ब्लॉक पेनचा आकार बदलतो."
 
-#~msgid "end hollow line"
-#~msgstr "रिकामा ओळ समाप्त करा"
+#~ msgid "end hollow line"
+#~ msgstr "रिकामा ओळ समाप्त करा"
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr "फिल ब्लॉक एक आकार रंगाने भरतो."
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr "फिल ब्लॉक एक आकार रंगाने भरतो."
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr "स्किप फॅक्टर"
+#~ msgid "skip factor"
+#~ msgstr "स्किप फॅक्टर"
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr "वायब्रेटो ब्लॉक पिचमध्ये जलद, थोडा फरक जोडतो."
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr "वायब्रेटो ब्लॉक पिचमध्ये जलद, थोडा फरक जोडतो."
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr "माउस-सिंक ब्लॉक माउस दरम्यान बीट काउंट संरेखित करतो."
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr "माउस-सिंक ब्लॉक माउस दरम्यान बीट काउंट संरेखित करतो."
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "उघडा"
+#~ msgid "Open"
+#~ msgstr "उघडा"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr "स्केलर स्टेप ब्लॉक (संख्या ब्लॉकसह) स्केलमधील पुढील पिच वाजवेल, उदा., जर शेवटची वाजवलेली नोट सोल असेल तर, स्केलर स्टेप १ ला वाजवेल."
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr "स्केलर स्टेप ब्लॉक (संख्या ब्लॉकसह) स्केलमधील पुढील पिच वाजवेल, उदा., जर शेवटची वाजवलेली नोट सोल असेल तर, स्केलर स्टेप १ ला वाजवेल."
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr "टेम्परामेंट X परिभाषित करा"
+#~ msgid "define temperamentX"
+#~ msgstr "टेम्परामेंट X परिभाषित करा"
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr "स्विंग ब्लॉक नोटच्या जोड्यांवर कार्य करतो (नोट मूल्याद्वारे निर्दिष्ट), पहिल्या नोटला काही कालावधी जोडतो (स्विंग मूल्याद्वारे निर्दिष्ट) आणि दुसऱ्या नोटमधून समान रक्कम घेतो."
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr "स्विंग ब्लॉक नोटच्या जोड्यांवर कार्य करतो (नोट मूल्याद्वारे निर्दिष्ट), पहिल्या नोटला काही कालावधी जोडतो (स्विंग मूल्याद्वारे निर्दिष्ट) आणि दुसऱ्या नोटमधून समान रक्कम घेतो."
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr "आवाज सेट करा"
+#~ msgid "set voice"
+#~ msgstr "आवाज सेट करा"
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr "अन्यथा एक किक ड्रम वाजेल."
+#~ msgid "Else a kick drum will play."
+#~ msgstr "अन्यथा एक किक ड्रम वाजेल."
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr "WAV म्हणून सेव्ह करा"
+#~ msgid "Save as wav"
+#~ msgstr "WAV म्हणून सेव्ह करा"
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr "येथे पेस्ट करण्यासाठी क्लिक करा."
+#~ msgid "Click here to paste."
+#~ msgstr "येथे पेस्ट करण्यासाठी क्लिक करा."
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr "पिच ब्लॉक पिच नाव आणि एका नोटचा सप्तक निर्दिष्ट करतो जे एकत्र नोटची वारंवारता ठरवतात."
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr "पिच ब्लॉक पिच नाव आणि एका नोटचा सप्तक निर्दिष्ट करतो जे एकत्र नोटची वारंवारता ठरवतात."
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr "टॉम-टॉम"
+#~ msgid "tom-tom"
+#~ msgstr "टॉम-टॉम"
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr "आयोनियन"
+#~ msgid "Ionian"
+#~ msgstr "आयोनियन"
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr "ch"
+#~ msgid "ch"
+#~ msgstr "ch"
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr "स्लर ब्लॉक नोट्सची स्थिरता वाढवतो आणि नोट्सचा निर्दिष्ट लयबद्ध मूल्य राखतो."
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr "स्लर ब्लॉक नोट्सची स्थिरता वाढवतो आणि नोट्सचा निर्दिष्ट लयबद्ध मूल्य राखतो."
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr "पिचेस जोडा"
+#~ msgid "add pitches"
+#~ msgstr "पिचेस जोडा"
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr "X माउस ब्लॉक निर्दिष्ट माउसची X स्थिती परत करतो."
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr "X माउस ब्लॉक निर्दिष्ट माउसची X स्थिती परत करतो."
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr "म्युझिक ब्लॉक्स हे संगीत संकल्पनांचा शोध घेण्यासाठी खुल्या स्रोताच्या साधनांचा संग्रह आहे. योगदानकर्त्यांची संपूर्ण यादी म्युझिक ब्लॉक्स GitHub रेपॉजिटरीमध्ये आढळू शकते. म्युझिक ब्लॉक्स AGPL अंतर्गत परवाना आहे. वर्तमान आवृत्ती आहे:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr "म्युझिक ब्लॉक्स हे संगीत संकल्पनांचा शोध घेण्यासाठी खुल्या स्रोताच्या साधनांचा संग्रह आहे. योगदानकर्त्यांची संपूर्ण यादी म्युझिक ब्लॉक्स GitHub रेपॉजिटरीमध्ये आढळू शकते. म्युझिक ब्लॉक्स AGPL अंतर्गत परवाना आहे. वर्तमान आवृत्ती आहे:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr "cb"
+#~ msgid "cb"
+#~ msgstr "cb"
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr "संदर्भ पिच"
+#~ msgid "reference pitch"
+#~ msgstr "संदर्भ पिच"
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr "संगीत नोट बाय नोट चालवण्यासाठी क्लिक करा."
+#~ msgid "Click to run the music note by note."
+#~ msgstr "संगीत नोट बाय नोट चालवण्यासाठी क्लिक करा."
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr "पॉली"
+#~ msgid "poly"
+#~ msgstr "पॉली"
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr "एका प्रकल्पासाठी शोधा\","
+#~ msgid "Search for a project\","
+#~ msgstr "एका प्रकल्पासाठी शोधा\","
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr "वर हलवा"
+#~ msgid "move up"
+#~ msgstr "वर हलवा"
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr "पुष्टी"
+#~ msgid "confirm"
+#~ msgstr "पुष्टी"
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr "ब्लॉक दरम्यान जागा वाढवण्यासाठी <em>Space</em> ब्लॉक वापरला जातो."
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr "ब्लॉक दरम्यान जागा वाढवण्यासाठी <em>Space</em> ब्लॉक वापरला जातो."
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr "माउस दरम्यान बीट काउंट जुळवण्यासाठी <em>Mouse sync</em> ब्लॉक वापरला जातो."
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr "माउस दरम्यान बीट काउंट जुळवण्यासाठी <em>Mouse sync</em> ब्लॉक वापरला जातो."
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr "मक़ाम"
+#~ msgid "Maqam"
+#~ msgstr "मक़ाम"
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr "एओलियन"
+#~ msgid "Aeolian"
+#~ msgstr "एओलियन"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr "हार्मोनिक-मायनर"
+#~ msgid "harmonic-minor"
+#~ msgstr "हार्मोनिक-मायनर"
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr "उदाहरणार्थ, जर तुमच्याकडे 5 मूल्याच्या Decrescendo ब्लॉकमध्ये 7 नोट्स असतील, तर अंतिम नोट सुरुवातीच्या आवाजापेक्षा 35% कमी असेल."
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr "उदाहरणार्थ, जर तुमच्याकडे 5 मूल्याच्या Decrescendo ब्लॉकमध्ये 7 नोट्स असतील, तर अंतिम नोट सुरुवातीच्या आवाजापेक्षा 35% कमी असेल."
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr "जर वरची संख्या खालच्या संख्येपेक्षा जास्त असेल तर <em>Greater-than</em> ब्लॉक <em>True</em> परत करतो."
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr "जर वरची संख्या खालच्या संख्येपेक्षा जास्त असेल तर <em>Greater-than</em> ब्लॉक <em>True</em> परत करतो."
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr "बॉक्समध्ये साठवलेल्या मूल्यामध्ये वाढ करण्यासाठी <em>Add-to</em> ब्लॉक वापरला जातो. हे इतर ब्लॉकसोबत देखील वापरले जाऊ शकते, जसे की <em>Color</em>, <em>Pen-size</em> इ."
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr "बॉक्समध्ये साठवलेल्या मूल्यामध्ये वाढ करण्यासाठी <em>Add-to</em> ब्लॉक वापरला जातो. हे इतर ब्लॉकसोबत देखील वापरले जाऊ शकते, जसे की <em>Color</em>, <em>Pen-size</em> इ."
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr "Reverseheap ब्लॉक हीपचा क्रम उलटा करतो."
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr "Reverseheap ब्लॉक हीपचा क्रम उलटा करतो."
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr "<em>One-of</em> ब्लॉक दोन पर्यायांपैकी एक परत करतो."
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr "<em>One-of</em> ब्लॉक दोन पर्यायांपैकी एक परत करतो."
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr "लोक्रियन"
+#~ msgid "Locrian"
+#~ msgstr "लोक्रियन"
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr "<em>Set hue</em> ब्लॉक पेनचा रंग बदलतो."
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr "<em>Set hue</em> ब्लॉक पेनचा रंग बदलतो."
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr "<em>Store in</em> ब्लॉक बॉक्समध्ये एक मूल्य साठवेल."
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr "<em>Store in</em> ब्लॉक बॉक्समध्ये एक मूल्य साठवेल."
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ".svg म्हणून जतन करा"
+#~ msgid "Save as .svg"
+#~ msgstr ".svg म्हणून जतन करा"
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr "ब्लूज"
+#~ msgid "Blues"
+#~ msgstr "ब्लूज"
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr "तुम्ही \"d\" टाइप करून \"do\" ब्लॉक तयार करू शकता, \"r\" टाइप करून \"re\" ब्लॉक तयार करू शकता, इ."
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr "तुम्ही \"d\" टाइप करून \"do\" ब्लॉक तयार करू शकता, \"r\" टाइप करून \"re\" ब्लॉक तयार करू शकता, इ."
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr "इम्पॅक्ट डेटा पार्स करू शकत नाही."
+#~ msgid "Cannot parse Impact data."
+#~ msgstr "इम्पॅक्ट डेटा पार्स करू शकत नाही."
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr "उदा., गिटार, व्हायोलिन, स्नेर ड्रम, इ."
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr "उदा., गिटार, व्हायोलिन, स्नेर ड्रम, इ."
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr "<em>Tempo</em> ब्लॉक बीटला व्हिज्युअलाइझ करण्यासाठी मेट्रोनोम उघडतो."
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr "<em>Tempo</em> ब्लॉक बीटला व्हिज्युअलाइझ करण्यासाठी मेट्रोनोम उघडतो."
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr "<em>Invert</em> ब्लॉक एखाद्या टार्गेट नोटभोवती कोणत्याही नोट्स फिरवतो."
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr "<em>Invert</em> ब्लॉक एखाद्या टार्गेट नोटभोवती कोणत्याही नोट्स फिरवतो."
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr "फील्ड"
+#~ msgid "field"
+#~ msgstr "फील्ड"
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr "म"
+#~ msgid "m"
+#~ msgstr "म"
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr "<em>On-every-beat</em> ब्लॉक तुम्हाला प्रत्येक बीटवर घेण्याच्या क्रिया निर्दिष्ट करू देतो."
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr "<em>On-every-beat</em> ब्लॉक तुम्हाला प्रत्येक बीटवर घेण्याच्या क्रिया निर्दिष्ट करू देतो."
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr "अधिक माहितीसाठी, कृपया <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">म्युझिक ब्लॉक्स गाइड</a> पहा."
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr "अधिक माहितीसाठी, कृपया <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">म्युझिक ब्लॉक्स गाइड</a> पहा."
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr "आरएस"
+#~ msgid "rs"
+#~ msgstr "आरएस"
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr "जर माउस क्लिक केले असेल तर <em>Click</em> ब्लॉक <em>True</em> परत करतो."
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr "जर माउस क्लिक केले असेल तर <em>Click</em> ब्लॉक <em>True</em> परत करतो."
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr "इम्पॅक्ट फील्ड सापडले नाही."
+#~ msgid "Impact field not found."
+#~ msgstr "इम्पॅक्ट फील्ड सापडले नाही."
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr "जीएस"
+#~ msgid "gs"
+#~ msgstr "जीएस"
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr "मायनर"
+#~ msgid "Minor"
+#~ msgstr "मायनर"
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr " "
+#~ msgid " "
+#~ msgstr " "
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr "बायझंटाइन"
+#~ msgid "Byzantine"
+#~ msgstr "बायझंटाइन"
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr "जॅझ मायनर"
+#~ msgid "Jazz Minor"
+#~ msgstr "जॅझ मायनर"
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr "<em>Do</em> ब्लॉक क्रिया सुरू करण्यासाठी वापरला जातो. उदाहरणात, तो <em>One of</em> ब्लॉकसह वापरला जातो ज्यामुळे एक रँडम फेज निवडला जातो."
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr "<em>Do</em> ब्लॉक क्रिया सुरू करण्यासाठी वापरला जातो. उदाहरणात, तो <em>One of</em> ब्लॉकसह वापरला जातो ज्यामुळे एक रँडम फेज निवडला जातो."
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr "HTML म्हणून जतन करा"
+#~ msgid "Save as HTML"
+#~ msgstr "HTML म्हणून जतन करा"
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr "बीटवर"
+#~ msgid "on beat"
+#~ msgstr "बीटवर"
 
 #: js/activity.js:3857
 
@@ -11119,196 +11119,196 @@ msgstr "हलवा"
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr "फाईलमधून प्रोजेक्ट लोड करा"
+#~ msgid "Load project from files"
+#~ msgstr "फाईलमधून प्रोजेक्ट लोड करा"
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr "<em>Set temperament</em> ब्लॉक म्युझिक ब्लॉक्सद्वारे वापरलेले ट्यूनिंग सिस्टम निवडण्यासाठी वापरला जातो."
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr "<em>Set temperament</em> ब्लॉक म्युझिक ब्लॉक्सद्वारे वापरलेले ट्यूनिंग सिस्टम निवडण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr "<em>Dispatch</em> ब्लॉक इव्हेंट ट्रिगर करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr "<em>Dispatch</em> ब्लॉक इव्हेंट ट्रिगर करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "ब्लॉक आणि पॅलेट दाखवा/लपवा"
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "ब्लॉक आणि पॅलेट दाखवा/लपवा"
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr "जलद चालवा / हळूहळू चालवण्यासाठी लांब दाबा"
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr "जलद चालवा / हळूहळू चालवण्यासाठी लांब दाबा"
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr "ग्रिड लपवा"
+#~ msgid "hide grid"
+#~ msgstr "ग्रिड लपवा"
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr "स्नेर-ड्रम"
+#~ msgid "snare-drum"
+#~ msgstr "स्नेर-ड्रम"
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr "<em>Measure count</em> ब्लॉक वर्तमान माप परत करतो."
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr "<em>Measure count</em> ब्लॉक वर्तमान माप परत करतो."
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr "जर निर्दिष्ट माउस सापडला तर <em>Found mouse</em> ब्लॉक true परत करेल."
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr "जर निर्दिष्ट माउस सापडला तर <em>Found mouse</em> ब्लॉक true परत करेल."
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr "Dispatch ब्लॉक इव्हेंट ट्रिगर करण्यासाठी वापरला जातो."
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr "Dispatch ब्लॉक इव्हेंट ट्रिगर करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr "शोधा"
+#~ msgid "Search"
+#~ msgstr "शोधा"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr "व्हाइट-नॉईज"
+#~ msgid "white-noise"
+#~ msgstr "व्हाइट-नॉईज"
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr "ऑक्टाटोनिक"
+#~ msgid "Octatonic"
+#~ msgstr "ऑक्टाटोनिक"
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr "Pitch-time Matrix ब्लॉक म्युझिकल फ्रेसेस तयार करण्यासाठी एक साधन उघडतो."
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr "Pitch-time Matrix ब्लॉक म्युझिकल फ्रेसेस तयार करण्यासाठी एक साधन उघडतो."
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr "<em>Top</em> ब्लॉक कॅनव्हासच्या वरच्या स्थितीला परत करतो."
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr "<em>Top</em> ब्लॉक कॅनव्हासच्या वरच्या स्थितीला परत करतो."
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr "<em>Listen</em> ब्लॉक माउस क्लिक सारख्या इव्हेंटसाठी ऐकण्यासाठी वापरला जातो. जेव्हा इव्हेंट घडतो, तेव्हा एक <em>action</em> घेतली जाते."
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr "<em>Listen</em> ब्लॉक माउस क्लिक सारख्या इव्हेंटसाठी ऐकण्यासाठी वापरला जातो. जेव्हा इव्हेंट घडतो, तेव्हा एक <em>action</em> घेतली जाते."
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr "डावा सेन्स"
+#~ msgid "sense left"
+#~ msgstr "डावा सेन्स"
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr "<em>Music keyboard</em> ब्लॉक एक पियानो कीबोर्ड उघडतो ज्याचा वापर नोट्स तयार करण्यासाठी केला जाऊ शकतो."
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr "<em>Music keyboard</em> ब्लॉक एक पियानो कीबोर्ड उघडतो ज्याचा वापर नोट्स तयार करण्यासाठी केला जाऊ शकतो."
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr "<em>Setheapentry</em> ब्लॉक निर्दिष्ट ठिकाणी हीपमध्ये एक मूल्य सेट करतो."
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr "<em>Setheapentry</em> ब्लॉक निर्दिष्ट ठिकाणी हीपमध्ये एक मूल्य सेट करतो."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr "जॅझ-मायनर"
+#~ msgid "jazz-minor"
+#~ msgstr "जॅझ-मायनर"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr "मायनर-ब्लूज"
+#~ msgid "minor-blues"
+#~ msgstr "मायनर-ब्लूज"
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr "मागील पृष्ठ"
+#~ msgid "previous page"
+#~ msgstr "मागील पृष्ठ"
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr "<em>Pen-down</em> ब्लॉक पेन खाली करतो ज्यामुळे ते ड्रॉ करतं."
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr "<em>Pen-down</em> ब्लॉक पेन खाली करतो ज्यामुळे ते ड्रॉ करतं."
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr "<em>Semi-tone transposition</em> ब्लॉक <em>Note</em> ब्लॉक्समध्ये असलेल्या पिचेसला अर्ध्या स्टेप्सने वर (किंवा खाली) शिफ्ट करतो. वर दाखवलेल्या उदाहरणात, <em>sol</em> वर शिफ्ट केले जाते <em>sol#</em>."
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr "<em>Semi-tone transposition</em> ब्लॉक <em>Note</em> ब्लॉक्समध्ये असलेल्या पिचेसला अर्ध्या स्टेप्सने वर (किंवा खाली) शिफ्ट करतो. वर दाखवलेल्या उदाहरणात, <em>sol</em> वर शिफ्ट केले जाते <em>sol#</em>."
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr "तुम्ही नावे वापरून ब्लॉक्स शोधू शकता."
+#~ msgid "You can search for blocks by name."
+#~ msgstr "तुम्ही नावे वापरून ब्लॉक्स शोधू शकता."
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr "काऊ-बेल"
+#~ msgid "cow-bell"
+#~ msgstr "काऊ-बेल"
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr "दुसरा"
+#~ msgid "2nd"
+#~ msgstr "दुसरा"
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr "<em>Media</em> ब्लॉक एक इमेज आयात करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr "<em>Media</em> ब्लॉक एक इमेज आयात करण्यासाठी वापरला जातो."
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr "ऑफलाइन. शेअरिंग उपलब्ध नाही."
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr "ऑफलाइन. शेअरिंग उपलब्ध नाही."
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr "एफएस"
+#~ msgid "fs"
+#~ msgstr "एफएस"
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr "Stopplayback ब्लॉक"
+#~ msgid "The Stopplayback block"
+#~ msgstr "Stopplayback ब्लॉक"
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr "शर्ती तुमच्या प्रोग्रामला <em>condition</em> वर अवलंबून विविध क्रिया घेऊ देतात. या उदाहरणात, <em>if</em> माउस बटण दाबले जाते, तर स्नेर ड्रम वाजेल. अन्यथा (<em>else</em>) एक किक ड्रम वाजेल."
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr "शर्ती तुमच्या प्रोग्रामला <em>condition</em> वर अवलंबून विविध क्रिया घेऊ देतात. या उदाहरणात, <em>if</em> माउस बटण दाबले जाते, तर स्नेर ड्रम वाजेल. अन्यथा (<em>else</em>) एक किक ड्रम वाजेल."
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr "<em>Loudness</em> ब्लॉक मायक्रोफोनद्वारे शोधलेला आवाज परत करतो."
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr "<em>Loudness</em> ब्लॉक मायक्रोफोनद्वारे शोधलेला आवाज परत करतो."
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr "<em>Show blocks</em> ब्लॉक ब्लॉक्स दाखवतो."
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr "<em>Show blocks</em> ब्लॉक ब्लॉक्स दाखवतो."
 
-#~msgid "food"
-#~msgstr "अन्न"
+#~ msgid "food"
+#~ msgstr "अन्न"
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr "ऑस्कटाइम"
+#~ msgid "osctime"
+#~ msgstr "ऑस्कटाइम"
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr "बीट मूल्य विभाजित करा"
+#~ msgid "divide beat value"
+#~ msgstr "बीट मूल्य विभाजित करा"
 
 #: js/turtledefs.js:187
 
@@ -11316,155 +11316,155 @@ msgstr "हलवा"
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr "PNG म्हणून जतन करा"
+#~ msgid "Save as PNG"
+#~ msgstr "PNG म्हणून जतन करा"
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr "जेव्हा प्रोग्राम स्लो मोडमध्ये चालतो, तेव्हा <em>Comment</em> ब्लॉक स्क्रीनच्या वरती एक टिप्पणी मुद्रित करतो."
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr "जेव्हा प्रोग्राम स्लो मोडमध्ये चालतो, तेव्हा <em>Comment</em> ब्लॉक स्क्रीनच्या वरती एक टिप्पणी मुद्रित करतो."
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr "<em>Stop media</em> ब्लॉक ऑडिओ किंवा व्हिडिओ प्लेबॅक थांबवतो."
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr "<em>Stop media</em> ब्लॉक ऑडिओ किंवा व्हिडिओ प्लेबॅक थांबवतो."
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr "जर माउस बटण दाबले गेले असेल तर <em>Mouse-button</em> ब्लॉक <em>True</em> परत करतो."
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr "जर माउस बटण दाबले गेले असेल तर <em>Mouse-button</em> ब्लॉक <em>True</em> परत करतो."
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr "ब्लूज"
+#~ msgid "blues"
+#~ msgstr "ब्लूज"
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr "अधिक"
+#~ msgid "More"
+#~ msgstr "अधिक"
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr "Cursor Y ब्लॉक माउसच्या उभ्या स्थितीला परत करतो."
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr "Cursor Y ब्लॉक माउसच्या उभ्या स्थितीला परत करतो."
 
-#~msgid "maths"
-#~msgstr "गणित"
+#~ msgid "maths"
+#~ msgstr "गणित"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr "अन्यथा (else) किक ड्रम वाजेल."
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr "अन्यथा (else) किक ड्रम वाजेल."
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr "फाइलमधून प्रकल्प उघडा"
+#~ msgid "Open project from file\","
+#~ msgstr "फाइलमधून प्रकल्प उघडा"
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr "त्रितोन"
+#~ msgid "tritone"
+#~ msgstr "त्रितोन"
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr "डोरियन"
+#~ msgid "Dorian"
+#~ msgstr "डोरियन"
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr "हे टूलबार पॅलेट बटणांचे मॅट्रिक्स नोट्स टोन टर्टल आणि अधिक समाविष्ट करते."
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr "हे टूलबार पॅलेट बटणांचे मॅट्रिक्स नोट्स टोन टर्टल आणि अधिक समाविष्ट करते."
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr "किक-ड्रम"
+#~ msgid "kick-drum"
+#~ msgstr "किक-ड्रम"
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr "पंचम"
+#~ msgid "5th"
+#~ msgstr "पंचम"
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr "Mouse elapse notes ब्लॉक निर्दिष्ट माउसने वाजवलेल्या नोट्सची संख्या परत करतो."
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr "Mouse elapse notes ब्लॉक निर्दिष्ट माउसने वाजवलेल्या नोट्सची संख्या परत करतो."
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr "Mouse pitch ब्लॉक निर्दिष्ट माउसने वाजवलेला सध्याचा पिच नंबर परत करतो."
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr "Mouse pitch ब्लॉक निर्दिष्ट माउसने वाजवलेला सध्याचा पिच नंबर परत करतो."
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr "हे टूलबार पॅलेट बटणांचे, ज्यामध्ये रिदम पिच टोन अॅक्शन आणि अधिक समाविष्ट आहेत."
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr "हे टूलबार पॅलेट बटणांचे, ज्यामध्ये रिदम पिच टोन अॅक्शन आणि अधिक समाविष्ट आहेत."
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr "पुढील पृष्ठ"
+#~ msgid "next page"
+#~ msgstr "पुढील पृष्ठ"
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr "Repeat ब्लॉक समाविष्ट ब्लॉक्सची पुनरावृत्ती करेल. या उदाहरणात, नोट 4 वेळा वाजवली जाईल."
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr "Repeat ब्लॉक समाविष्ट ब्लॉक्सची पुनरावृत्ती करेल. या उदाहरणात, नोट 4 वेळा वाजवली जाईल."
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr "सेव्ह-स्टॅक बटण स्टॅकला सानुकूल पॅलेटवर सेव्ह करते. स्टॅकवर \"लांब प्रेस\" केल्यानंतर ते दिसते."
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr "सेव्ह-स्टॅक बटण स्टॅकला सानुकूल पॅलेटवर सेव्ह करते. स्टॅकवर \"लांब प्रेस\" केल्यानंतर ते दिसते."
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr "ताल"
+#~ msgid "Rhythm"
+#~ msgstr "ताल"
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr "Number to octave ब्लॉक पिच नंबरला ऑक्टेव्हमध्ये रूपांतरित करेल."
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr "Number to octave ब्लॉक पिच नंबरला ऑक्टेव्हमध्ये रूपांतरित करेल."
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr "स्टॅकला क्लिपबोर्डवर कॉपी करण्यासाठी, स्टॅकवर \"लांब प्रेस\" करा. पेस्ट बटण हायलाइट होईल."
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr "स्टॅकला क्लिपबोर्डवर कॉपी करण्यासाठी, स्टॅकवर \"लांब प्रेस\" करा. पेस्ट बटण हायलाइट होईल."
 
-#~msgid "hspace"
-#~msgstr "एचस्पेस"
+#~ msgid "hspace"
+#~ msgstr "एचस्पेस"
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr "ब्लॉक(स)वर कॉपी करण्यासाठी लांब प्रेस करा. येथे पेस्ट करण्यासाठी क्लिक करा."
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr "ब्लॉक(स)वर कॉपी करण्यासाठी लांब प्रेस करा. येथे पेस्ट करण्यासाठी क्लिक करा."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr "मेलोडिक-मायनर"
+#~ msgid "melodic-minor"
+#~ msgstr "मेलोडिक-मायनर"
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is empty."
-#~msgstr "Heap empty? ब्लॉक हिप रिक्त असल्यास true परत करतो."
+#~ msgid "The Heap empty? block returns true if the heap is empty."
+#~ msgstr "Heap empty? ब्लॉक हिप रिक्त असल्यास true परत करतो."
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr "प्लेबॅक ब्लॉक"
+#~ msgid "The Playback block"
+#~ msgstr "प्लेबॅक ब्लॉक"
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr "Note value ब्लॉक सध्या वाजवलेल्या नोटची कालावधी दर्शवतो."
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr "Note value ब्लॉक सध्या वाजवलेल्या नोटची कालावधी दर्शवतो."
 
 #: js/turtledefs.js:187
 
@@ -11472,252 +11472,252 @@ msgstr "हलवा"
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr "WAV म्हणून सेव्ह करा"
+#~ msgid "Save as WAV"
+#~ msgstr "WAV म्हणून सेव्ह करा"
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr "Tremolo ब्लॉक एक दोलायमान प्रभाव जोडतो."
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr "Tremolo ब्लॉक एक दोलायमान प्रभाव जोडतो."
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr "Set grey ब्लॉक पेन रंगाची जीवंतता बदलतो."
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr "Set grey ब्लॉक पेन रंगाची जीवंतता बदलतो."
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr "Text ब्लॉक एक मजकूर स्ट्रिंग ठेवतो."
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr "Text ब्लॉक एक मजकूर स्ट्रिंग ठेवतो."
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr "क्रिया"
+#~ msgid "actions"
+#~ msgstr "क्रिया"
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr "Register ब्लॉक नंतर येणाऱ्या नोट्सच्या रजिस्टर (ऑक्टेव्ह) बदलण्यासाठी एक सोपी पद्धत प्रदान करतो."
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr "Register ब्लॉक नंतर येणाऱ्या नोट्सच्या रजिस्टर (ऑक्टेव्ह) बदलण्यासाठी एक सोपी पद्धत प्रदान करतो."
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr "नोट मूल्य 0 पेक्षा मोठे असले पाहिजे"
+#~ msgid "Note value must be greater than 0"
+#~ msgstr "नोट मूल्य 0 पेक्षा मोठे असले पाहिजे"
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr "Tuplets हे नोट्सचे संग्रह आहेत जे विशिष्ट कालावधीत स्केल केले जातात. Tuplets वापरल्याने अशा नोट्सच्या गटांची निर्मिती करणे सोपे होते जे 2 च्या शक्तीवर आधारित नाहीत."
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr "Tuplets हे नोट्सचे संग्रह आहेत जे विशिष्ट कालावधीत स्केल केले जातात. Tuplets वापरल्याने अशा नोट्सच्या गटांची निर्मिती करणे सोपे होते जे 2 च्या शक्तीवर आधारित नाहीत."
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr "पिच-टाइम मॅट्रिक्स"
+#~ msgid "pitch-time matrix"
+#~ msgstr "पिच-टाइम मॅट्रिक्स"
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr "उदा. गिटार, व्हायोलिन, स्नेर ड्रम, इत्यादी."
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr "उदा. गिटार, व्हायोलिन, स्नेर ड्रम, इत्यादी."
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr "Scalar interval ब्लॉक दोन नोट्समधील अंतर सेमी-टोनमध्ये मोजतो."
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr "Scalar interval ब्लॉक दोन नोट्समधील अंतर सेमी-टोनमध्ये मोजतो."
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr "प्रकल्प स्लो मोडमध्ये चालवण्यासाठी रन बटणावर लांब प्रेस करा."
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr "प्रकल्प स्लो मोडमध्ये चालवण्यासाठी रन बटणावर लांब प्रेस करा."
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr "Set pitch number offset ब्लॉक पिच नंबरला पिच आणि ऑक्टेव्हमध्ये मॅप करण्यासाठी ऑफसेट सेट करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr "Set pitch number offset ब्लॉक पिच नंबरला पिच आणि ऑक्टेव्हमध्ये मॅप करण्यासाठी ऑफसेट सेट करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "ध्रुवीय-समन्वय ग्रीड दाखवा/लपवा"
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "ध्रुवीय-समन्वय ग्रीड दाखवा/लपवा"
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr "हे इतर ब्लॉक्ससह देखील वापरले जाऊ शकते, जसे की रंग, पेन-आकार."
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr "हे इतर ब्लॉक्ससह देखील वापरले जाऊ शकते, जसे की रंग, पेन-आकार."
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr "आपला प्रकल्प शेअर करण्यासाठी हा लिंक कॉपी करा."
+#~ msgid "Copy this link to share your project."
+#~ msgstr "आपला प्रकल्प शेअर करण्यासाठी हा लिंक कॉपी करा."
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "स्क्रीन साफ करा आणि कासवाला त्याच्या प्रारंभिक स्थितीत परत आणा."
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "स्क्रीन साफ करा आणि कासवाला त्याच्या प्रारंभिक स्थितीत परत आणा."
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr "box1 परत करते <em>box1</em> वर संग्रहित मूल्य."
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr "box1 परत करते <em>box1</em> वर संग्रहित मूल्य."
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr "Step Pitch ब्लॉक नोट ब्लॉकच्या आत वापरला गेला पाहिजे."
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr "Step Pitch ब्लॉक नोट ब्लॉकच्या आत वापरला गेला पाहिजे."
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr "ब्लिंक (मि.से.)"
+#~ msgid "blink (ms)"
+#~ msgstr "ब्लिंक (मि.से.)"
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr "Duo synth ब्लॉक एक ड्युओ-फ्रिक्वेंसी मॉड्युलेटर आहे जो टिंबर परिभाषित करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr "Duo synth ब्लॉक एक ड्युओ-फ्रिक्वेंसी मॉड्युलेटर आहे जो टिंबर परिभाषित करण्यासाठी वापरला जातो."
 
-#~msgid "begin hollow line"
-#~msgstr "पोकळ रेषा सुरू करा"
+#~ msgid "begin hollow line"
+#~ msgstr "पोकळ रेषा सुरू करा"
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr "गीझ"
+#~ msgid "Geez"
+#~ msgstr "गीझ"
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr "रिदम ब्लॉक: तुम्हाला नोट ब्लॉक वापरायचा आहे का?"
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr "रिदम ब्लॉक: तुम्हाला नोट ब्लॉक वापरायचा आहे का?"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr "या उदाहरणात, माउस बटण दाबल्यास, स्नेर ड्रम वाजेल."
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr "या उदाहरणात, माउस बटण दाबल्यास, स्नेर ड्रम वाजेल."
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr "हे टूलबार पॅलेट बटणांचे मॅट्रिक्स, नोट्स, टोन, टर्टल आणि अधिक समाविष्ट करते. ब्लॉक्सचे पॅलेट्स दाखवण्यासाठी क्लिक करा आणि पॅलेट्समधून ब्लॉक्स कॅनव्हासवर ड्रॅग करा."
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr "हे टूलबार पॅलेट बटणांचे मॅट्रिक्स, नोट्स, टोन, टर्टल आणि अधिक समाविष्ट करते. ब्लॉक्सचे पॅलेट्स दाखवण्यासाठी क्लिक करा आणि पॅलेट्समधून ब्लॉक्स कॅनव्हासवर ड्रॅग करा."
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr "Dock block ब्लॉक दोन ब्लॉक्सला जोडतो."
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr "Dock block ब्लॉक दोन ब्लॉक्सला जोडतो."
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr "Step pitch ब्लॉक (Number ब्लॉकसह) स्केलमध्ये पुढील पिच वाजवेल, उदाहरणार्थ, शेवटची वाजवलेली नोट <em>sol</em> असेल, तर Step pitch 1 <em>la</em> वाजवेल."
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr "Step pitch ब्लॉक (Number ब्लॉकसह) स्केलमध्ये पुढील पिच वाजवेल, उदाहरणार्थ, शेवटची वाजवलेली नोट <em>sol</em> असेल, तर Step pitch 1 <em>la</em> वाजवेल."
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr "Backward ब्लॉक कोड उलट क्रमाने चालवतो (संगीतात्मक प्रतिगमन)."
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr "Backward ब्लॉक कोड उलट क्रमाने चालवतो (संगीतात्मक प्रतिगमन)."
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr "अप्रचलित नोट मूल्य"
+#~ msgid "deprecated note value"
+#~ msgstr "अप्रचलित नोट मूल्य"
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr "अरबी"
+#~ msgid "Arabic"
+#~ msgstr "अरबी"
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr "या उदाहरणात, एक साधी ड्रम मशीन, एक किक ड्रम कायमस्वरूपी 1/4 नोट्स वाजवेल."
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr "या उदाहरणात, एक साधी ड्रम मशीन, एक किक ड्रम कायमस्वरूपी 1/4 नोट्स वाजवेल."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr "मेजर-ब्लूज"
+#~ msgid "major-blues"
+#~ msgstr "मेजर-ब्लूज"
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr "Mod ब्लॉक भागाकारातून उर्वरित परत करतो."
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr "Mod ब्लॉक भागाकारातून उर्वरित परत करतो."
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr "पिच <em>C D E F G A B</em> च्या दृष्टीने निर्दिष्ट केले जाऊ शकते."
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr "पिच <em>C D E F G A B</em> च्या दृष्टीने निर्दिष्ट केले जाऊ शकते."
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr "हिंदू"
+#~ msgid "Hindu"
+#~ msgstr "हिंदू"
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr "Milliseconds ब्लॉक नोट ब्लॉकसारखा आहे परंतु तो नोट कालावधी निर्दिष्ट करण्यासाठी वेळ (मिलीसेकंदांत) वापरतो."
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr "Milliseconds ब्लॉक नोट ब्लॉकसारखा आहे परंतु तो नोट कालावधी निर्दिष्ट करण्यासाठी वेळ (मिलीसेकंदांत) वापरतो."
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr "Not ब्लॉक तार्किक not ऑपरेटर आहे."
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr "Not ब्लॉक तार्किक not ऑपरेटर आहे."
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr "नवीन प्रकल्प"
+#~ msgid "New project\","
+#~ msgstr "नवीन प्रकल्प"
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr "स्टेप पिच"
+#~ msgid "step pitch"
+#~ msgstr "स्टेप पिच"
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr "Store in box2 ब्लॉक box2 मध्ये मूल्य संग्रहित करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr "Store in box2 ब्लॉक box2 मध्ये मूल्य संग्रहित करण्यासाठी वापरला जातो."
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr "PNG म्हणून सेव्ह करा"
+#~ msgid "Save as png"
+#~ msgstr "PNG म्हणून सेव्ह करा"
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr "Skip notes ब्लॉक नोट्स वगळल्या जातील."
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr "Skip notes ब्लॉक नोट्स वगळल्या जातील."
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr "Scalar interval ब्लॉक सध्याच्या मोडच्या आधारे एक सापेक्ष अंतर मोजतो, मोडच्या बाहेरील सर्व नोट्स वगळतो. आकृत्यामध्ये, आम्ही <em>la</em> ला <em>sol</em> मध्ये जोडतो."
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr "Scalar interval ब्लॉक सध्याच्या मोडच्या आधारे एक सापेक्ष अंतर मोजतो, मोडच्या बाहेरील सर्व नोट्स वगळतो. आकृत्यामध्ये, आम्ही <em>la</em> ला <em>sol</em> मध्ये जोडतो."
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr "उलट वाजवा"
+#~ msgid "play backward"
+#~ msgstr "उलट वाजवा"
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr "Change in pitch ब्लॉक सध्याच्या वाजवलेल्या पिच आणि मागील वाजवलेल्या पिचमध्ये (अर्ध्या चरणांमध्ये) फरक आहे."
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr "Change in pitch ब्लॉक सध्याच्या वाजवलेल्या पिच आणि मागील वाजवलेल्या पिचमध्ये (अर्ध्या चरणांमध्ये) फरक आहे."
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr "Control-point 1 ब्लॉक बेझियर वक्रासाठी पहिला नियंत्रण बिंदू सेट करतो."
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr "Control-point 1 ब्लॉक बेझियर वक्रासाठी पहिला नियंत्रण बिंदू सेट करतो."
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr "बीके"
+#~ msgid "bk"
+#~ msgstr "बीके"
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr "बीटी"
+#~ msgid "bt"
+#~ msgstr "बीटी"
 
 #: js/logo.js:2175
 
@@ -11731,218 +11731,218 @@ msgstr "हलवा"
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr "माउस सापडला नाही"
+#~ msgid "Could not find mouse"
+#~ msgstr "माउस सापडला नाही"
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr "Get green ब्लॉक माउसखालील पिक्सेलचा हिरवा घटक परत करतो."
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr "Get green ब्लॉक माउसखालील पिक्सेलचा हिरवा घटक परत करतो."
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr "<em>कर्सर X</em> ब्लॉक माऊसची आडवी स्थिती परतवतो."
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr "<em>कर्सर X</em> ब्लॉक माऊसची आडवी स्थिती परतवतो."
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr "प्रकल्प जतन करा"
+#~ msgid "Save Project"
+#~ msgstr "प्रकल्प जतन करा"
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr "<em>फॉन्ट सेट</em> ब्लॉक <em>शो</em> ब्लॉकद्वारे वापरलेला फॉन्ट सेट करतो."
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr "<em>फॉन्ट सेट</em> ब्लॉक <em>शो</em> ब्लॉकद्वारे वापरलेला फॉन्ट सेट करतो."
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr "दो रे मी फा सोल ला ती"
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr "दो रे मी फा सोल ला ती"
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr "<em>अनटिल</em> ब्लॉक स्थिती खरी होईपर्यंत पुनरावृत्ती करतो."
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr "<em>अनटिल</em> ब्लॉक स्थिती खरी होईपर्यंत पुनरावृत्ती करतो."
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr "<em>ऑर</em> ब्लॉक तर्कशुद्ध किंवा ऑपरेटर आहे."
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr "<em>ऑर</em> ब्लॉक तर्कशुद्ध किंवा ऑपरेटर आहे."
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr "घड्याळाच्या विरुद्ध दिशेने फिरवा"
+#~ msgid "rotate counter clockwise"
+#~ msgstr "घड्याळाच्या विरुद्ध दिशेने फिरवा"
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr "इत्यादी."
+#~ msgid "etc."
+#~ msgstr "इत्यादी."
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr "क्रमवारी लावा"
+#~ msgid "sort"
+#~ msgstr "क्रमवारी लावा"
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr "पिच ब्लॉक: तुम्हाला नोट ब्लॉक वापरायचा आहे का?"
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr "पिच ब्लॉक: तुम्हाला नोट ब्लॉक वापरायचा आहे का?"
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr "विकृती श्रेणीत नाही"
+#~ msgid "Distortion not in range"
+#~ msgstr "विकृती श्रेणीत नाही"
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr "<em>पेन आकार</em> ब्लॉक वर्तमान पेन आकार मूल्य परतवतो."
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr "<em>पेन आकार</em> ब्लॉक वर्तमान पेन आकार मूल्य परतवतो."
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr "<em>सेव हीप टू अॅप</em> ब्लॉक वेब पृष्ठावर हीप जतन करतो."
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr "<em>सेव हीप टू अॅप</em> ब्लॉक वेब पृष्ठावर हीप जतन करतो."
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr "<em>रँडम</em> ब्लॉक अनियंत्रित संख्या परतवतो."
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr "<em>रँडम</em> ब्लॉक अनियंत्रित संख्या परतवतो."
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr "ध्रुवीय"
+#~ msgid "Polar"
+#~ msgstr "ध्रुवीय"
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr "वर्तमान पिच नाव"
+#~ msgid "current pitch name"
+#~ msgstr "वर्तमान पिच नाव"
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "कार्टेशियन-समन्वय ग्रीड दाखवा/लपवा"
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "कार्टेशियन-समन्वय ग्रीड दाखवा/लपवा"
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr "<em>शो हीप</em> ब्लॉक स्क्रीनच्या वरच्या बाजूस हीपची सामग्री दर्शवतो."
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr "<em>शो हीप</em> ब्लॉक स्क्रीनच्या वरच्या बाजूस हीपची सामग्री दर्शवतो."
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr "<em>माऊस-नेम</em> ब्लॉक माऊसचे नाव परतवतो."
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr "<em>माऊस-नेम</em> ब्लॉक माऊसचे नाव परतवतो."
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ".png म्हणून जतन करा"
+#~ msgid "Save as .png"
+#~ msgstr ".png म्हणून जतन करा"
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr "मिक्सोलिडियन"
+#~ msgid "Mixolydian"
+#~ msgstr "मिक्सोलिडियन"
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr "<em>स्टॉप</em> ब्लॉक लूप थांबवेल (जसे की, फॉरएव्हर, रिपीट, व्हाईल, किंवा अनटिल)."
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr "<em>स्टॉप</em> ब्लॉक लूप थांबवेल (जसे की, फॉरएव्हर, रिपीट, व्हाईल, किंवा अनटिल)."
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr "<em>पिच नंबर</em> ब्लॉक सध्या वाजविल्या जाणार्‍या नोटचा पिचचा मूल्य आहे."
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr "<em>पिच नंबर</em> ब्लॉक सध्या वाजविल्या जाणार्‍या नोटचा पिचचा मूल्य आहे."
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr "<em>शेल</em> ब्लॉक माऊसचे स्वरूप बदलण्यासाठी वापरला जातो."
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr "<em>शेल</em> ब्लॉक माऊसचे स्वरूप बदलण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr "<em>इक्वल</em> ब्लॉक दोन संख्या समान असल्यास <em>ट्रू</em> परतवतो."
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr "<em>इक्वल</em> ब्लॉक दोन संख्या समान असल्यास <em>ट्रू</em> परतवतो."
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr "प्लॅनेटला अपलोड करा"
+#~ msgid "Upload to Planet"
+#~ msgstr "प्लॅनेटला अपलोड करा"
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr "<em>स्केलर स्टेप डाउन</em> ब्लॉक वर्तमान की आणि मोडमध्ये मागील नोटपर्यंत अर्ध-स्वरांची संख्या परतवतो."
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr "<em>स्केलर स्टेप डाउन</em> ब्लॉक वर्तमान की आणि मोडमध्ये मागील नोटपर्यंत अर्ध-स्वरांची संख्या परतवतो."
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr "<em>गेट पिक्सेल</em> ब्लॉक माऊसखाली असलेल्या पिक्सेलचा रंग परतवतो."
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr "<em>गेट पिक्सेल</em> ब्लॉक माऊसखाली असलेल्या पिक्सेलचा रंग परतवतो."
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr "फाइल मधुन प्लगइन लोड करा"
+#~ msgid "Load plugin from file"
+#~ msgstr "फाइल मधुन प्लगइन लोड करा"
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ".abc म्हणून जतन करा"
+#~ msgid "Save as .abc"
+#~ msgstr ".abc म्हणून जतन करा"
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr "<em>हर्ट्झमधील पिच</em> ब्लॉक सध्या वाजविल्या जाणार्‍या नोटच्या पिचचे हर्ट्झमधील मूल्य आहे."
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr "<em>हर्ट्झमधील पिच</em> ब्लॉक सध्या वाजविल्या जाणार्‍या नोटच्या पिचचे हर्ट्झमधील मूल्य आहे."
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr "गाणे"
+#~ msgid "sing"
+#~ msgstr "गाणे"
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr "<em>कंट्रोल-पॉईंट 2</em> ब्लॉक बेझियर वक्रासाठी दुसरा कंट्रोल पॉईंट सेट करतो."
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr "<em>कंट्रोल-पॉईंट 2</em> ब्लॉक बेझियर वक्रासाठी दुसरा कंट्रोल पॉईंट सेट करतो."
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr "चीनी"
+#~ msgid "Chinese"
+#~ msgstr "चीनी"
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr "संगीत वाजवा"
+#~ msgid "Play music"
+#~ msgstr "संगीत वाजवा"
 
 #: js/samplesviewer.js:91
 
@@ -11952,144 +11952,144 @@ msgstr "हलवा"
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr "डाउनलोड"
+#~ msgid "Download"
+#~ msgstr "डाउनलोड"
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr "<em>सेमी-टोन अंतर</em> ब्लॉक अर्ध-पायऱ्यांवर आधारित सापेक्ष अंतर गणना करतो. आकृतीमध्ये, आम्ही <em>sol#</em> ला <em>sol</em> मध्ये जोडतो."
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr "<em>सेमी-टोन अंतर</em> ब्लॉक अर्ध-पायऱ्यांवर आधारित सापेक्ष अंतर गणना करतो. आकृतीमध्ये, आम्ही <em>sol#</em> ला <em>sol</em> मध्ये जोडतो."
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr "<em>प्लस</em> ब्लॉक जोडण्यासाठी वापरला जातो."
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr "<em>प्लस</em> ब्लॉक जोडण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr "उदा., 1, 2, 3, किंवा 4."
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr "उदा., 1, 2, 3, किंवा 4."
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr "<em>लोडहीप</em> ब्लॉक फाइलमधून हीप लोड करतो."
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr "<em>लोडहीप</em> ब्लॉक फाइलमधून हीप लोड करतो."
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr "<em>बॉटम</em> ब्लॉक कॅनव्हासच्या तळाशी स्थिती परतवतो."
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr "<em>बॉटम</em> ब्लॉक कॅनव्हासच्या तळाशी स्थिती परतवतो."
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr "svg म्हणून जतन करा"
+#~ msgid "Save as svg"
+#~ msgstr "svg म्हणून जतन करा"
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr "सोलफा"
+#~ msgid "Solfa"
+#~ msgstr "सोलफा"
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr "तुम्ही ब्लॉक्सचा स्टॅक कॉपी करण्यासाठी Alt+C देखील वापरू शकता."
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr "तुम्ही ब्लॉक्सचा स्टॅक कॉपी करण्यासाठी Alt+C देखील वापरू शकता."
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr "पॅलेटलेट्स दाखवा/लपवा"
+#~ msgid "Show/hide palettes"
+#~ msgstr "पॅलेटलेट्स दाखवा/लपवा"
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr "<em>स्टार्ट माऊस</em> ब्लॉक निर्दिष्ट माऊस सुरू करतो."
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr "<em>स्टार्ट माऊस</em> ब्लॉक निर्दिष्ट माऊस सुरू करतो."
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr "<em>बॉक्स</em> ब्लॉक बॉक्समध्ये साठवलेले मूल्य परतवतो."
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr "<em>बॉक्स</em> ब्लॉक बॉक्समध्ये साठवलेले मूल्य परतवतो."
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr "<em>सेट माऊस</em> ब्लॉक निर्दिष्ट माऊसद्वारे चालवण्यासाठी ब्लॉक्सचा स्टॅक पाठवतो."
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr "<em>सेट माऊस</em> ब्लॉक निर्दिष्ट माऊसद्वारे चालवण्यासाठी ब्लॉक्सचा स्टॅक पाठवतो."
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr "<em>बॉक्स1</em> ब्लॉक <em>बॉक्स1</em> मध्ये साठवलेले मूल्य परतवतो."
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr "<em>बॉक्स1</em> ब्लॉक <em>बॉक्स1</em> मध्ये साठवलेले मूल्य परतवतो."
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr "तुम्ही ब्लॉक्सचा स्टॅक पेस्ट करण्यासाठी Alt+P देखील वापरू शकता."
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr "तुम्ही ब्लॉक्सचा स्टॅक पेस्ट करण्यासाठी Alt+P देखील वापरू शकता."
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr "पेंटाटोनिक"
+#~ msgid "pentatonic"
+#~ msgstr "पेंटाटोनिक"
 
-#~msgid "blocks"
-#~msgstr "ब्लॉक"
+#~ msgid "blocks"
+#~ msgstr "ब्लॉक"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr "<em>पिच-टाइम मॅट्रिक्स</em> ब्लॉक संगीतवाक्ये तयार करण्यासाठी एक साधन उघडतो."
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr "<em>पिच-टाइम मॅट्रिक्स</em> ब्लॉक संगीतवाक्ये तयार करण्यासाठी एक साधन उघडतो."
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr "<em>हेडिंग</em> ब्लॉक माऊसचे अभिमुखता परतवतो."
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr "<em>हेडिंग</em> ब्लॉक माऊसचे अभिमुखता परतवतो."
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr "<em>अॅब्स</em> ब्लॉक परतवतो."
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr "<em>अॅब्स</em> ब्लॉक परतवतो."
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr "उदाहरणार्थ, जर तुमच्याकडे एकमेकांमध्ये 7 नोट्स असतील आणि त्यांचे मूल्य 5 असलेले क्रेस्केंडो ब्लॉक असेल, तर अंतिम नोट प्रारंभिक व्हॉल्युमपेक्षा 35% अधिक असेल."
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr "उदाहरणार्थ, जर तुमच्याकडे एकमेकांमध्ये 7 नोट्स असतील आणि त्यांचे मूल्य 5 असलेले क्रेस्केंडो ब्लॉक असेल, तर अंतिम नोट प्रारंभिक व्हॉल्युमपेक्षा 35% अधिक असेल."
 
 #: js/block.js:962
 
@@ -12097,57 +12097,57 @@ msgstr "हलवा"
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr "तालाचे शासक"
+#~ msgid "rhythm ruler"
+#~ msgstr "तालाचे शासक"
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr "प्रविष्ट केलेली खोली श्रेणीत नाही"
+#~ msgid "Depth entered is out of range"
+#~ msgstr "प्रविष्ट केलेली खोली श्रेणीत नाही"
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr "<em>स्केलर अंतर</em> ब्लॉक वर्तमान की आणि मोडमध्ये दोन नोट्समधील अंतर मोजतो."
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr "<em>स्केलर अंतर</em> ब्लॉक वर्तमान की आणि मोडमध्ये दोन नोट्समधील अंतर मोजतो."
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr "<em>फॉरवर्ड</em> ब्लॉक माऊस पुढे हलवतो."
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr "<em>फॉरवर्ड</em> ब्लॉक माऊस पुढे हलवतो."
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr "पेंटाटोनिक"
+#~ msgid "Pentatonic"
+#~ msgstr "पेंटाटोनिक"
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr "<em>टेम्परमेंट</em> साधन कस्टम ट्यूनिंग परिभाषित करण्यासाठी वापरले जाते."
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr "<em>टेम्परमेंट</em> साधन कस्टम ट्यूनिंग परिभाषित करण्यासाठी वापरले जाते."
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr "मेजर ब्लॉकमध्ये इनपुट 2, 3, 6, किंवा 7 असणे आवश्यक आहे"
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr "मेजर ब्लॉकमध्ये इनपुट 2, 3, 6, किंवा 7 असणे आवश्यक आहे"
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr "<em>प्रिंट</em> ब्लॉक स्क्रीनच्या वरच्या बाजूस मजकूर दर्शवतो."
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr "<em>प्रिंट</em> ब्लॉक स्क्रीनच्या वरच्या बाजूस मजकूर दर्शवतो."
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr "<em>वेटेड पार्टियल्स</em> ब्लॉक टिंबरशी संबंधित पार्टियल्स निर्दिष्ट करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr "<em>वेटेड पार्टियल्स</em> ब्लॉक टिंबरशी संबंधित पार्टियल्स निर्दिष्ट करण्यासाठी वापरला जातो."
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr "उच्चार"
+#~ msgid "articulation"
+#~ msgstr "उच्चार"
 
 #: js/turtledefs.js:387
 
@@ -12157,30 +12157,30 @@ msgstr "हलवा"
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr "<em>Calculate</em> ब्लॉक क्रियेद्वारे गणना केलेले मूल्य परत करतो."
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr "<em>Calculate</em> ब्लॉक क्रियेद्वारे गणना केलेले मूल्य परत करतो."
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr "प्रगत पर्याय"
+#~ msgid "Advanced options"
+#~ msgstr "प्रगत पर्याय"
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr "<em>Return</em> ब्लॉक क्रियेतून एक मूल्य परत करेल."
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr "<em>Return</em> ब्लॉक क्रियेतून एक मूल्य परत करेल."
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr "<em>Action</em> ब्लॉक ब्लॉकला एकत्रित करण्यासाठी वापरले जाते जेणेकरून ते एकापेक्षा जास्त वेळा वापरता येतील. हे वारंवार पुनरावृत्ती होणाऱ्या संगीताच्या वाक्यांशाचे संचयित करण्यासाठी वापरले जाते."
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr "<em>Action</em> ब्लॉक ब्लॉकला एकत्रित करण्यासाठी वापरले जाते जेणेकरून ते एकापेक्षा जास्त वेळा वापरता येतील. हे वारंवार पुनरावृत्ती होणाऱ्या संगीताच्या वाक्यांशाचे संचयित करण्यासाठी वापरले जाते."
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr "<em>Get blue</em> ब्लॉक माऊसखालील पिक्सेलचा निळा घटक परत करतो."
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr "<em>Get blue</em> ब्लॉक माऊसखालील पिक्सेलचा निळा घटक परत करतो."
 
 #: js/turtledefs.js:187
 
@@ -12188,112 +12188,112 @@ msgstr "हलवा"
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr "शिट म्युझिक जतन करा"
+#~ msgid "Save sheet music"
+#~ msgstr "शिट म्युझिक जतन करा"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr "रोमेनियन-मायनर"
+#~ msgid "romanian-minor"
+#~ msgstr "रोमेनियन-मायनर"
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr "चौथा"
+#~ msgid "4th"
+#~ msgstr "चौथा"
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr "<em>Set relative volume</em> ब्लॉक समाविष्ट नोट्सचा आवाज बदलतो."
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr "<em>Set relative volume</em> ब्लॉक समाविष्ट नोट्सचा आवाज बदलतो."
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matching <em>Case</em>."
-#~msgstr "<em>Switch</em> ब्लॉक जुळणाऱ्या <em>Case</em> मध्ये कोड चालवेल."
+#~ msgid "The <em>Switch</em> block will run the code in the matching <em>Case</em>."
+#~ msgstr "<em>Switch</em> ब्लॉक जुळणाऱ्या <em>Case</em> मध्ये कोड चालवेल."
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr "स्थानांतरण समायोजित करा"
+#~ msgid "adjust transposition"
+#~ msgstr "स्थानांतरण समायोजित करा"
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "प्रकल्प जलद मोडमध्ये चालवण्यासाठी येथे क्लिक करा."
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "प्रकल्प जलद मोडमध्ये चालवण्यासाठी येथे क्लिक करा."
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr "प्रत्येक नोट चालवा"
+#~ msgid "Run note by note"
+#~ msgstr "प्रत्येक नोट चालवा"
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr "आंशिक ब्लॉकला Weighted-partisls ब्लॉकच्या आत वापरले पाहिजे."
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr "आंशिक ब्लॉकला Weighted-partisls ब्लॉकच्या आत वापरले पाहिजे."
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr "Heap length ब्लॉक ढिगाच्या लांबी परत करतो."
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr "Heap length ब्लॉक ढिगाच्या लांबी परत करतो."
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr "शेल"
+#~ msgid "shell"
+#~ msgstr "शेल"
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr "ग्रह बंद करा\","
+#~ msgid "Close Planet\","
+#~ msgstr "ग्रह बंद करा\","
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr "पुढील पृष्ठ"
+#~ msgid "Next page"
+#~ msgstr "पुढील पृष्ठ"
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr "ब्लॉक कॉपी करण्यासाठी दीर्घ दाबा."
+#~ msgid "Long press on blocks to copy."
+#~ msgstr "ब्लॉक कॉपी करण्यासाठी दीर्घ दाबा."
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr "<em>Chorus</em> ब्लॉक कोरस प्रभाव जोडतो."
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr "<em>Chorus</em> ब्लॉक कोरस प्रभाव जोडतो."
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr "<em>Custom mode</em> ब्लॉक एक साधन उघडतो ज्याद्वारे संगीत मोड (स्केलमधील नोट्सची मांडणी) शोधता येईल."
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr "<em>Custom mode</em> ब्लॉक एक साधन उघडतो ज्याद्वारे संगीत मोड (स्केलमधील नोट्सची मांडणी) शोधता येईल."
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr "कृपया नवीन एक उघडण्यापूर्वी वर्तमान मॅट्रिक्स बंद करा."
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr "कृपया नवीन एक उघडण्यापूर्वी वर्तमान मॅट्रिक्स बंद करा."
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr "<em>Wait</em> ब्लॉक दिलेल्या सेकंदांसाठी प्रोग्राम थांबवतो."
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr "<em>Wait</em> ब्लॉक दिलेल्या सेकंदांसाठी प्रोग्राम थांबवतो."
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr "<em>Set drum</em> ब्लॉक कोणत्याही समाविष्ट नोट्सची पिच बदलण्यासाठी ड्रम ध्वनी निवडेल. वरच्या उदाहरणात, <em>sol</em> ऐवजी <em>kick drum</em> ध्वनी वाजवला जाईल."
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr "<em>Set drum</em> ब्लॉक कोणत्याही समाविष्ट नोट्सची पिच बदलण्यासाठी ड्रम ध्वनी निवडेल. वरच्या उदाहरणात, <em>sol</em> ऐवजी <em>kick drum</em> ध्वनी वाजवला जाईल."
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr "<em>Heap length</em> ब्लॉक ढिगाच्या लांबी परत करतो."
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr "<em>Heap length</em> ब्लॉक ढिगाच्या लांबी परत करतो."
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr "ऑफबीटवर करा"
+#~ msgid "on offbeat do"
+#~ msgstr "ऑफबीटवर करा"
 
 #: js/StringHelper.js:17
 
@@ -12301,287 +12301,287 @@ msgstr "हलवा"
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr "डेटा-टूलटिप"
+#~ msgid "data-tooltip"
+#~ msgstr "डेटा-टूलटिप"
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr "थांबा"
+#~ msgid "pause"
+#~ msgstr "थांबा"
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr "निर्दिष्ट नोट मूल्य कालावधीचा आराम <em>Silence</em> ब्लॉक वापरून बांधता येतो."
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr "निर्दिष्ट नोट मूल्य कालावधीचा आराम <em>Silence</em> ब्लॉक वापरून बांधता येतो."
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr "उदा., गिटार, पियानो, व्हायोलिन, किंवा सेलो."
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr "उदा., गिटार, पियानो, व्हायोलिन, किंवा सेलो."
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr "हार्ड स्टॉप"
+#~ msgid "Hard stop"
+#~ msgstr "हार्ड स्टॉप"
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr "<em>Get red</em> ब्लॉक माऊसखालील पिक्सेलचा लाल घटक परत करतो."
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr "<em>Get red</em> ब्लॉक माऊसखालील पिक्सेलचा लाल घटक परत करतो."
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr "मुक्त वेळ"
+#~ msgid "free time"
+#~ msgstr "मुक्त वेळ"
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr "उदा., जर शेवटची वाजवलेली नोट sol असेल तर, Scalar Step 1 ला वाजवेल."
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr "उदा., जर शेवटची वाजवलेली नोट sol असेल तर, Scalar Step 1 ला वाजवेल."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr "पूर्ण-स्वर"
+#~ msgid "whole-tone"
+#~ msgstr "पूर्ण-स्वर"
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr "तुम्ही ब्लॉकच्या स्टॅकची कॉपी करण्यासाठी Alt+C देखील वापरू शकता."
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr "तुम्ही ब्लॉकच्या स्टॅकची कॉपी करण्यासाठी Alt+C देखील वापरू शकता."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr "नैसर्गिक-मायनर"
+#~ msgid "natural-minor"
+#~ msgstr "नैसर्गिक-मायनर"
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr "पेस्ट करण्यासाठी येथे क्लिक करा"
+#~ msgid "Click here to paste"
+#~ msgstr "पेस्ट करण्यासाठी येथे क्लिक करा"
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr "प्राथमिक साधनपट्टी उघडण्यासाठी आणि बंद करण्यासाठी हे बटण दाबा."
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr "प्राथमिक साधनपट्टी उघडण्यासाठी आणि बंद करण्यासाठी हे बटण दाबा."
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr "संगीत पायरी-पायरीने चालवा"
+#~ msgid "Run music step by step"
+#~ msgstr "संगीत पायरी-पायरीने चालवा"
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr "<em>Saveheap</em> ब्लॉक ढिगाला फाइलमध्ये जतन करतो."
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr "<em>Saveheap</em> ब्लॉक ढिगाला फाइलमध्ये जतन करतो."
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr "इथिओपियन"
+#~ msgid "Ethiopian"
+#~ msgstr "इथिओपियन"
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr "हे स्टॅकवर दीर्घ दाबल्यानंतर दिसते."
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr "हे स्टॅकवर दीर्घ दाबल्यानंतर दिसते."
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr "Perfect Block मध्ये इनपुट 1, 4, 5, किंवा 8 असावा."
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr "Perfect Block मध्ये इनपुट 1, 4, 5, किंवा 8 असावा."
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr "टेबल"
+#~ msgid "table"
+#~ msgstr "टेबल"
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ".tb म्हणून जतन करा"
+#~ msgid "Save as .tb"
+#~ msgstr ".tb म्हणून जतन करा"
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr "सीपी"
+#~ msgid "cp"
+#~ msgstr "सीपी"
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr "<em>On-weak-beat</em> ब्लॉक तुम्हाला कमजोर (ऑफ) बीट्सवर घेण्याचे क्रियाकलाप निर्दिष्ट करण्याची परवानगी देतो."
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr "<em>On-weak-beat</em> ब्लॉक तुम्हाला कमजोर (ऑफ) बीट्सवर घेण्याचे क्रियाकलाप निर्दिष्ट करण्याची परवानगी देतो."
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr "सेंद्रिय"
+#~ msgid "sense right"
+#~ msgstr "सेंद्रिय"
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr "<em>Load heap from app</em> ब्लॉक वेब पृष्ठावरून ढिग लोड करतो."
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr "<em>Load heap from app</em> ब्लॉक वेब पृष्ठावरून ढिग लोड करतो."
 
-#~msgid "vspace"
-#~msgstr "व्हीस्पेस"
+#~ msgid "vspace"
+#~ msgstr "व्हीस्पेस"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr "स्पॅनिश-जिप्सी"
+#~ msgid "spanish-gypsy"
+#~ msgstr "स्पॅनिश-जिप्सी"
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr "<em>Color</em> ब्लॉक वर्तमान पेन रंग परत करतो."
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr "<em>Color</em> ब्लॉक वर्तमान पेन रंग परत करतो."
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr "बिबॉप"
+#~ msgid "Bebop"
+#~ msgstr "बिबॉप"
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr "पेस्ट बटण हायलाइट होईल."
+#~ msgid "The Paste Button will highlight."
+#~ msgstr "पेस्ट बटण हायलाइट होईल."
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr "Load heap from app ब्लॉक वेब पृष्ठावरून ढिग लोड करतो."
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr "Load heap from app ब्लॉक वेब पृष्ठावरून ढिग लोड करतो."
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr "Step Pitch ब्लॉक Note ब्लॉकच्या आत वापरला पाहिजे."
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr "Step Pitch ब्लॉक Note ब्लॉकच्या आत वापरला पाहिजे."
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "कॅनव्हासवर ब्लॉकसह सर्व सामग्री काढा."
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "कॅनव्हासवर ब्लॉकसह सर्व सामग्री काढा."
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr "SVG जतन करा"
+#~ msgid "save svg"
+#~ msgstr "SVG जतन करा"
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr "माझ्या डिव्हाइसवर"
+#~ msgid "On my device"
+#~ msgstr "माझ्या डिव्हाइसवर"
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr "<em>No background</em> ब्लॉक जतन केलेल्या SVG आउटपुटमधून पार्श्वभूमी काढून टाकतो."
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr "<em>No background</em> ब्लॉक जतन केलेल्या SVG आउटपुटमधून पार्श्वभूमी काढून टाकतो."
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr "माझे म्युझिक ब्लॉक्स निर्माण"
+#~ msgid "My Music Blocks Creation"
+#~ msgstr "माझे म्युझिक ब्लॉक्स निर्माण"
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr "<em>Open palette</em> ब्लॉक एक पॅलेट उघडतो."
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr "<em>Open palette</em> ब्लॉक एक पॅलेट उघडतो."
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr "<em>Forever</em> ब्लॉक समाविष्ट ब्लॉकला कायमस्वरूपी पुनरावृत्ती करेल. या उदाहरणात, एक साधी ड्रम मशीन, एक किक ड्रम 1/4 नोट्स कायमस्वरूपी वाजवेल."
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr "<em>Forever</em> ब्लॉक समाविष्ट ब्लॉकला कायमस्वरूपी पुनरावृत्ती करेल. या उदाहरणात, एक साधी ड्रम मशीन, एक किक ड्रम 1/4 नोट्स कायमस्वरूपी वाजवेल."
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "Diminished Block मध्ये इनपुट 1, 2, 3, 4, 5, 6, 7, किंवा 8 असावे."
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "Diminished Block मध्ये इनपुट 1, 2, 3, 4, 5, 6, 7, किंवा 8 असावे."
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr "संगीत हळू चालवा"
+#~ msgid "Run music slow"
+#~ msgstr "संगीत हळू चालवा"
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr "स्टॅकला क्लिपबोर्डवर कॉपी करण्यासाठी, स्टॅकवर दीर्घ दाबा."
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr "स्टॅकला क्लिपबोर्डवर कॉपी करण्यासाठी, स्टॅकवर दीर्घ दाबा."
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr "उदा. गिटार, पियानो, व्हायोलिन, किंवा सेलो."
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr "उदा. गिटार, पियानो, व्हायोलिन, किंवा सेलो."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr "मायनर-पेंटाटोनिक"
+#~ msgid "minor-pentatonic"
+#~ msgstr "मायनर-पेंटाटोनिक"
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr "<em>AM synth</em> ब्लॉक एक अॅम्प्लीट्यूड मॉड्युलेटर आहे जो टिंबर परिभाषित करण्यासाठी वापरला जातो."
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr "<em>AM synth</em> ब्लॉक एक अॅम्प्लीट्यूड मॉड्युलेटर आहे जो टिंबर परिभाषित करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr "<em>Right</em> ब्लॉक माऊस उजवीकडे वळवतो."
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr "<em>Right</em> ब्लॉक माऊस उजवीकडे वळवतो."
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr "<em>Harmonic</em> ब्लॉक समाविष्ट नोट्समध्ये हार्मोनिक्स जोडेल."
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr "<em>Harmonic</em> ब्लॉक समाविष्ट नोट्समध्ये हार्मोनिक्स जोडेल."
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr "<em>Staccato</em> ब्लॉक नोट्सच्या निर्दिष्ट तालबद्ध मूल्याचे पालन करताना वास्तविक नोटची लांबी कमी करतो."
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr "<em>Staccato</em> ब्लॉक नोट्सच्या निर्दिष्ट तालबद्ध मूल्याचे पालन करताना वास्तविक नोटची लांबी कमी करतो."
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr "निर्यात करा"
+#~ msgid "export"
+#~ msgstr "निर्यात करा"
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr "<em>Power</em> ब्लॉक एक शक्ती कार्याची गणना करतो."
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr "<em>Power</em> ब्लॉक एक शक्ती कार्याची गणना करतो."
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr "<em>Set heading</em> ब्लॉक माऊसची हेडिंग सेट करतो."
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr "<em>Set heading</em> ब्लॉक माऊसची हेडिंग सेट करतो."
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr "<em>Note</em> ब्लॉक एक किंवा अधिक <em>Pitch</em> ब्लॉक्ससाठी एक कंटेनर आहे. <em>Note</em> ब्लॉक त्याच्या सामग्रीचा कालावधी (नोट मूल्य) निर्दिष्ट करतो."
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr "<em>Note</em> ब्लॉक एक किंवा अधिक <em>Pitch</em> ब्लॉक्ससाठी एक कंटेनर आहे. <em>Note</em> ब्लॉक त्याच्या सामग्रीचा कालावधी (नोट मूल्य) निर्दिष्ट करतो."
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr "<em>Less-than</em> ब्लॉक शीर्ष क्रमांक तळाच्या क्रमांकापेक्षा कमी असल्यास <em>True</em> परत करतो."
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr "<em>Less-than</em> ब्लॉक शीर्ष क्रमांक तळाच्या क्रमांकापेक्षा कमी असल्यास <em>True</em> परत करतो."
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr "<em>बीट काउंट</em> ब्लॉक हा वर्तमान बीटचा क्रमांक आहे, उदा., 1, 2, 3, किंवा 4.\n आकृतीत, प्रत्येक मापनाच्या पहिल्या बीटवर कारवाई करण्यासाठी वापरला जातो."
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr "<em>बीट काउंट</em> ब्लॉक हा वर्तमान बीटचा क्रमांक आहे, उदा., 1, 2, 3, किंवा 4.\n आकृतीत, प्रत्येक मापनाच्या पहिल्या बीटवर कारवाई करण्यासाठी वापरला जातो."
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr "<em>माऊस रंग</em> ब्लॉक निर्दिष्ट माऊसची पेन रंग परत करतो."
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr "<em>माऊस रंग</em> ब्लॉक निर्दिष्ट माऊसची पेन रंग परत करतो."
 
 #: js/turtledefs.js:187
 
@@ -12589,13 +12589,13 @@ msgstr "हलवा"
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr "ABC म्हणून जतन करा"
+#~ msgid "Save as ABC"
+#~ msgstr "ABC म्हणून जतन करा"
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr "सिंथेसायझर"
+#~ msgid "synthesizer"
+#~ msgstr "सिंथेसायझर"
 
 #: js/logo.js:630
 
@@ -12603,86 +12603,86 @@ msgstr "हलवा"
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr "मुख्य"
+#~ msgid "Major"
+#~ msgstr "मुख्य"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr "सेव्हहीप ब्लॉक हिपला फाइलमध्ये जतन करतो."
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr "सेव्हहीप ब्लॉक हिपला फाइलमध्ये जतन करतो."
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr "<em>मास्टर वॉल्यूम सेट करा</em> ब्लॉक सर्व सिंथेसायझरसाठी वॉल्यूम सेट करतो."
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr "<em>मास्टर वॉल्यूम सेट करा</em> ब्लॉक सर्व सिंथेसायझरसाठी वॉल्यूम सेट करतो."
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr "नक्कल नोट्स"
+#~ msgid "duplicate notes"
+#~ msgstr "नक्कल नोट्स"
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr "सेटहीपएंट्री ब्लॉक निर्दिष्ट ठिकाणी हिपमध्ये एक मूल्य सेट करतो."
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr "सेटहीपएंट्री ब्लॉक निर्दिष्ट ठिकाणी हिपमध्ये एक मूल्य सेट करतो."
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr "स्क्रोलिंग अक्षम करा"
+#~ msgid "Disable scrolling"
+#~ msgstr "स्क्रोलिंग अक्षम करा"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr "स्केलर इंटरव्हल ब्लॉक दोन नोट्समधील अंतर अर्धस्वरांमध्ये मोजतो."
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr "स्केलर इंटरव्हल ब्लॉक दोन नोट्समधील अंतर अर्धस्वरांमध्ये मोजतो."
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr "रिदम ब्लॉक: तुम्हाला मॅट्रिक्स ब्लॉक वापरायचा होता का?"
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr "रिदम ब्लॉक: तुम्हाला मॅट्रिक्स ब्लॉक वापरायचा होता का?"
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr "<emवाजवल्या गेलेल्या नोट्स</em> ब्लॉक वाजवल्या गेलेल्या नोट्सची संख्या आहे. (मूलभूतपणे, हे क्वार्टर नोट्स मोजते.)"
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr "<emवाजवल्या गेलेल्या नोट्स</em> ब्लॉक वाजवल्या गेलेल्या नोट्सची संख्या आहे. (मूलभूतपणे, हे क्वार्टर नोट्स मोजते.)"
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr "मूलभूत वॉल्यूम 50 आहे; श्रेणी 0 (शांतता) ते 100 (पूर्ण वॉल्यूम) आहे."
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr "मूलभूत वॉल्यूम 50 आहे; श्रेणी 0 (शांतता) ते 100 (पूर्ण वॉल्यूम) आहे."
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr "प्रत्येक <em>सुरू</em> ब्लॉक एक स्वतंत्र आवाज आहे. <em>प्ले</em> बटण दाबल्यावर सर्व <em>सुरू</em> ब्लॉक एकाच वेळी चालतात."
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr "प्रत्येक <em>सुरू</em> ब्लॉक एक स्वतंत्र आवाज आहे. <em>प्ले</em> बटण दाबल्यावर सर्व <em>सुरू</em> ब्लॉक एकाच वेळी चालतात."
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "उदा. \"do\" नेहमी \"C-नैसर्गिक\" आहे); जेव्हा मूव्हेबल do खरे असते, तेव्हा सोल्फेग नोट नावे स्केल डिग्रीजना दिली जातात (\"do\" नेहमी मोठ्या स्केलची पहिली डिग्री असते)."
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "उदा. \"do\" नेहमी \"C-नैसर्गिक\" आहे); जेव्हा मूव्हेबल do खरे असते, तेव्हा सोल्फेग नोट नावे स्केल डिग्रीजना दिली जातात (\"do\" नेहमी मोठ्या स्केलची पहिली डिग्री असते)."
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr "चालू पीच ऑक्टेव्ह"
+#~ msgid "current pitch octave"
+#~ msgstr "चालू पीच ऑक्टेव्ह"
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr "<em>रिव्हर्सहीप</em> ब्लॉक हिपचा क्रम उलटवतो."
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr "<em>रिव्हर्सहीप</em> ब्लॉक हिपचा क्रम उलटवतो."
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr "हिराजोशी"
+#~ msgid "Hirajoshi"
+#~ msgstr "हिराजोशी"
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr "<em>ब्लॉक तयार करा</em> ब्लॉक एक नवीन ब्लॉक तयार करतो."
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr "<em>ब्लॉक तयार करा</em> ब्लॉक एक नवीन ब्लॉक तयार करतो."
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr "स्पॅनिश"
+#~ msgid "Spanish"
+#~ msgstr "स्पॅनिश"
 

--- a/po/ms.po
+++ b/po/ms.po
@@ -2215,7 +2215,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2296,33 +2296,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2422,7 +2422,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2651,8 +2651,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2821,14 +2821,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2859,7 +2859,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2884,7 +2884,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2893,7 +2893,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2914,7 +2914,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2932,8 +2932,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3035,7 +3035,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3169,14 +3169,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3251,7 +3251,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3287,7 +3287,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3296,7 +3296,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3787,7 +3787,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3799,8 +3799,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3810,7 +3810,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3822,8 +3822,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3833,15 +3833,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3850,14 +3850,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3866,14 +3866,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3923,7 +3923,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3940,7 +3940,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4009,8 +4009,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4032,7 +4032,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4318,7 +4318,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4649,21 +4649,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4672,12 +4672,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4690,62 +4690,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4758,7 +4758,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4767,7 +4767,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4780,7 +4780,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4789,17 +4789,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4808,12 +4808,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4835,17 +4835,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4862,56 +4862,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4927,7 +4927,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4936,7 +4936,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4944,7 +4944,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4953,8 +4953,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4962,7 +4962,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4976,116 +4976,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5104,19 +5104,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5124,61 +5124,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5188,149 +5188,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5339,7 +5339,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5418,22 +5418,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5590,7 +5590,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5612,7 +5612,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5623,7 +5623,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5652,7 +5652,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5661,7 +5661,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5694,7 +5694,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5704,7 +5704,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5713,7 +5713,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5722,7 +5722,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5745,13 +5745,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5760,7 +5760,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5769,7 +5769,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5789,7 +5789,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5814,7 +5814,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5828,7 +5828,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5838,7 +5838,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5876,7 +5876,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5885,7 +5885,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5898,18 +5898,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6030,7 +6030,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6049,7 +6049,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6058,7 +6058,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6075,7 +6075,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6088,7 +6088,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6117,7 +6117,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6140,7 +6140,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6157,7 +6157,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6166,7 +6166,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6183,7 +6183,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6192,7 +6192,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6226,7 +6226,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6235,7 +6235,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6252,7 +6252,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6267,7 +6267,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6301,12 +6301,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6315,12 +6315,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6329,13 +6329,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6353,7 +6353,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6385,8 +6385,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6442,7 +6442,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6599,12 +6599,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6614,8 +6614,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6623,12 +6623,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6637,7 +6637,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6654,7 +6654,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6664,12 +6664,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6679,7 +6679,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6688,7 +6688,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6738,7 +6738,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6771,7 +6771,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6780,12 +6780,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6794,7 +6794,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6803,7 +6803,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6812,7 +6812,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6823,8 +6823,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6834,7 +6834,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6860,7 +6860,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6898,12 +6898,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6915,12 +6915,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6929,7 +6929,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6975,22 +6975,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7012,7 +7012,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7021,47 +7021,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7074,7 +7074,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7083,7 +7083,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7091,7 +7091,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7105,8 +7105,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7135,7 +7135,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7160,14 +7160,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7177,7 +7177,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7196,7 +7196,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7206,7 +7206,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7223,17 +7223,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7242,7 +7242,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7252,7 +7252,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7262,7 +7262,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7274,7 +7274,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7292,7 +7292,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7313,7 +7313,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7328,7 +7328,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7352,7 +7352,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7408,7 +7408,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7586,7 +7586,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7595,7 +7595,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7604,7 +7604,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7613,7 +7613,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7623,13 +7623,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7642,7 +7642,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7651,7 +7651,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7660,7 +7660,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7669,7 +7669,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7678,7 +7678,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7687,7 +7687,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7696,7 +7696,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7705,7 +7705,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7715,17 +7715,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7734,7 +7734,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8161,7 +8161,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8171,7 +8171,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8215,12 +8215,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8229,7 +8229,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8286,7 +8286,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8304,7 +8304,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8317,7 +8317,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8382,7 +8382,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8447,7 +8447,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8456,12 +8456,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8470,7 +8470,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8479,7 +8479,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8488,7 +8488,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8513,7 +8513,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8648,27 +8648,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8694,18 +8694,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8720,7 +8720,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8741,7 +8741,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8758,7 +8758,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8771,7 +8771,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8781,7 +8781,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8795,7 +8795,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8816,7 +8816,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8830,7 +8830,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9017,7 +9017,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9026,7 +9026,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9148,7 +9148,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9231,7 +9231,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9281,7 +9281,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9398,7 +9398,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9477,48 +9477,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9951,38 +9951,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9990,8 +9990,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10001,8 +10001,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10014,35 +10014,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10056,69 +10056,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10138,13 +10138,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10152,58 +10152,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10219,25 +10219,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10247,43 +10247,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10293,190 +10293,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10486,305 +10486,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10794,97 +10794,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10894,144 +10894,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11041,15 +11041,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11059,23 +11059,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11085,8 +11085,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11094,224 +11094,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11327,37 +11327,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11365,28 +11365,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11400,8 +11400,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11411,65 +11411,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11477,8 +11477,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11488,127 +11488,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11616,608 +11616,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12227,165 +12227,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12399,28 +12399,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12428,133 +12428,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12562,136 +12562,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12701,127 +12701,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12829,397 +12829,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13231,196 +13231,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13428,155 +13428,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13584,257 +13584,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13848,223 +13848,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14074,144 +14074,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14219,57 +14219,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14279,30 +14279,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14310,112 +14310,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14423,287 +14423,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14711,13 +14711,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14725,86 +14725,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/mvo.po
+++ b/po/mvo.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -2215,7 +2215,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2296,33 +2296,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2422,7 +2422,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2651,8 +2651,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2821,14 +2821,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2859,7 +2859,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2884,7 +2884,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2893,7 +2893,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2914,7 +2914,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2932,8 +2932,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3035,7 +3035,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3169,14 +3169,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3251,7 +3251,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3287,7 +3287,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3296,7 +3296,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3787,7 +3787,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3799,8 +3799,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3810,7 +3810,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3822,8 +3822,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3833,15 +3833,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3850,14 +3850,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3866,14 +3866,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3923,7 +3923,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3940,7 +3940,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4009,8 +4009,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4032,7 +4032,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4318,7 +4318,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4649,21 +4649,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4672,12 +4672,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4690,62 +4690,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4758,7 +4758,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4767,7 +4767,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4780,7 +4780,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4789,17 +4789,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4808,12 +4808,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4835,17 +4835,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4862,56 +4862,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4927,7 +4927,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4936,7 +4936,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4944,7 +4944,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4953,8 +4953,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4962,7 +4962,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4976,116 +4976,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5104,19 +5104,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5124,61 +5124,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5188,149 +5188,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5339,7 +5339,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5418,22 +5418,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5590,7 +5590,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5612,7 +5612,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5623,7 +5623,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5652,7 +5652,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5661,7 +5661,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5694,7 +5694,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5704,7 +5704,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5713,7 +5713,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5722,7 +5722,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5745,13 +5745,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5760,7 +5760,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "ta av"
 
@@ -5769,7 +5769,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5789,7 +5789,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5814,7 +5814,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5828,7 +5828,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5838,7 +5838,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5876,7 +5876,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5885,7 +5885,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5898,18 +5898,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6030,7 +6030,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6049,7 +6049,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6058,7 +6058,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6075,7 +6075,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6088,7 +6088,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6117,7 +6117,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6140,7 +6140,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6157,7 +6157,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6166,7 +6166,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6183,7 +6183,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6192,7 +6192,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6226,7 +6226,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6235,7 +6235,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6252,7 +6252,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6267,7 +6267,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6301,12 +6301,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6315,12 +6315,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6329,13 +6329,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6353,7 +6353,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6385,8 +6385,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6442,7 +6442,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6599,12 +6599,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6614,8 +6614,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6623,12 +6623,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6637,7 +6637,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6654,7 +6654,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6664,12 +6664,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6679,7 +6679,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6688,7 +6688,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6738,7 +6738,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6771,7 +6771,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6780,12 +6780,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6794,7 +6794,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6803,7 +6803,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6812,7 +6812,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6823,8 +6823,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6834,7 +6834,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6860,7 +6860,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6898,12 +6898,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6915,12 +6915,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6929,7 +6929,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6975,22 +6975,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7012,7 +7012,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7021,47 +7021,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7074,7 +7074,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7083,7 +7083,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7091,7 +7091,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7105,8 +7105,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7135,7 +7135,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7160,14 +7160,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7177,7 +7177,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7196,7 +7196,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7206,7 +7206,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7223,17 +7223,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7242,7 +7242,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7252,7 +7252,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7262,7 +7262,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7274,7 +7274,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7292,7 +7292,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7313,7 +7313,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7328,7 +7328,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7352,7 +7352,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7408,7 +7408,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7586,7 +7586,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7595,7 +7595,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7604,7 +7604,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7613,7 +7613,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7623,13 +7623,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7642,7 +7642,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7651,7 +7651,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7660,7 +7660,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7669,7 +7669,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7678,7 +7678,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7687,7 +7687,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7696,7 +7696,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7705,7 +7705,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7715,17 +7715,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7734,7 +7734,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8161,7 +8161,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8171,7 +8171,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8215,12 +8215,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8229,7 +8229,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8286,7 +8286,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8304,7 +8304,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8317,7 +8317,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8382,7 +8382,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8447,7 +8447,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8456,12 +8456,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "løft penn"
 
@@ -8470,7 +8470,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "trykk ned penn"
 
@@ -8479,7 +8479,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "sett størrelse"
 
@@ -8488,7 +8488,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8513,7 +8513,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8648,27 +8648,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8694,18 +8694,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8720,7 +8720,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8741,7 +8741,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8758,7 +8758,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8771,7 +8771,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8781,7 +8781,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8795,7 +8795,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8816,7 +8816,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8830,7 +8830,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9017,7 +9017,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9026,7 +9026,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9148,7 +9148,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9231,7 +9231,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9281,7 +9281,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9398,7 +9398,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9477,48 +9477,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9951,38 +9951,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9990,8 +9990,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10001,8 +10001,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10014,35 +10014,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10056,69 +10056,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "skjul blokker"
+#~ msgid "hide blocks"
+#~ msgstr "skjul blokker"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10138,13 +10138,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10152,58 +10152,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10219,25 +10219,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10247,43 +10247,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10293,190 +10293,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10486,305 +10486,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10794,97 +10794,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10894,144 +10894,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11041,15 +11041,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11059,23 +11059,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11085,8 +11085,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11094,224 +11094,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11327,37 +11327,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11365,28 +11365,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11400,8 +11400,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11411,65 +11411,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11477,8 +11477,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11488,127 +11488,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11616,608 +11616,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12227,165 +12227,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12399,28 +12399,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12428,133 +12428,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12562,136 +12562,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "Skilpadde"
+#~ msgid "turtle"
+#~ msgstr "Skilpadde"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12701,127 +12701,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12829,397 +12829,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13231,196 +13231,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13428,155 +13428,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13584,257 +13584,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13848,223 +13848,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14074,144 +14074,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14219,57 +14219,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14279,30 +14279,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14310,112 +14310,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14423,287 +14423,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14711,13 +14711,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14725,86 +14725,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/ne.po
+++ b/po/ne.po
@@ -2216,7 +2216,7 @@ msgstr "कार्य"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "मेरो परियोजना"
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "फाइलको नाम"
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "परियोजनाको शीर्षक"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "परियोजनाको लेखक"
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "के  उत्पादनमा MIDI समावेश गर्न चाहनुहुन्छ?"
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "के उत्पादनमा गिटार ट्याब्लेचर समावेश गर्न चाहनुहुन्छ?"
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "लिलिपोण्डको रुपमा बचत गर्नुहोस"
 
@@ -2345,7 +2345,7 @@ msgstr "लिलिपोण्डको रुपमा बचत गर्न
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "मिस्टर माउस"
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "ति ला सोल फा मि रे दो"
 
@@ -2812,7 +2812,7 @@ msgstr "रुलर्र"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "टेम्बर"
 
@@ -2822,14 +2822,14 @@ msgstr "चरण"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "वेग"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "शैली"
 
@@ -2860,7 +2860,7 @@ msgstr "ड्रम"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr "प्रवाह"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr "अधिक"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "खाली थाक"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "पप्"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "धकाल"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "माउस y"
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "turtle y"
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "माउस x"
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "turtle x"
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr "अन्त्यमा भर"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "कलमले नलेख"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "कलमले लेख"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "कलमको परिमाण मिलाऊ"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "मिडिया"
+#~ msgid "media"
+#~ msgstr "मिडिया"
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "देखाउ"
+#~ msgid "show"
+#~ msgstr "देखाउ"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "सफा गर्नुहोस्"
+#~ msgid "Clean"
+#~ msgstr "सफा गर्नुहोस्"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "खण्डहरु लुकाऊ"
+#~ msgid "hide blocks"
+#~ msgstr "खण्डहरु लुकाऊ"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "रोक"
+#~ msgid "stop"
+#~ msgstr "रोक"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "अन्तराल"
+#~ msgid "duration"
+#~ msgstr "अन्तराल"
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr "परियोजना  सुरुवातमा चलाउनुहोस"
+#~ msgid "Run project on startup."
+#~ msgstr "परियोजना  सुरुवातमा चलाउनुहोस"
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr "कोड बल्क सुरुवातमा देखाउनुहोस"
+#~ msgid "Show code blocks on startup."
+#~ msgstr "कोड बल्क सुरुवातमा देखाउनुहोस"
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr "कोड बल्क सुरुवातमा नष्ट गर्नुहोस"
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr "कोड बल्क सुरुवातमा नष्ट गर्नुहोस"
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "छिटो चलाउनुहोस"
+#~ msgid "Run fast"
+#~ msgstr "छिटो चलाउनुहोस"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr "कृपया ब्राउजरको जुम स्तर 100% राख्नुहोस"
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr "कृपया ब्राउजरको जुम स्तर 100% राख्नुहोस"
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "हेलो"
+#~ msgid "hello"
+#~ msgstr "हेलो"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr "संगीत बिस्तारै बजाउन अझै धेरैबेरसम्म थिच्नुहोस"
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr "संगीत बिस्तारै बजाउन अझै धेरैबेरसम्म थिच्नुहोस"
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "कछुवा"
+#~ msgid "turtle"
+#~ msgstr "कछुवा"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr "प्रकाशन गर्नुहोस"
+#~ msgid "Publish"
+#~ msgstr "प्रकाशन गर्नुहोस"
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr "शीर्षक विहिन"
+#~ msgid "untitled"
+#~ msgstr "शीर्षक विहिन"
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr "विश्वव्यापी"
+#~ msgid "Worldwide"
+#~ msgstr "विश्वव्यापी"
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr "बिस्तारै चलाउन धेरैबेरसम्म थिच्नुहोस"
+#~ msgid "long press to run slowly"
+#~ msgstr "बिस्तारै चलाउन धेरैबेरसम्म थिच्नुहोस"
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "खोल"
+#~ msgid "Open"
+#~ msgstr "खोल"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr "ग्रिड लुकाउनुहोस"
+#~ msgid "hide grid"
+#~ msgstr "ग्रिड लुकाउनुहोस"
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr "तपाइको परियोजना बाड्न यो लिङ्क नक्कल/कपी गार्नुहोस"
+#~ msgid "Copy this link to share your project."
+#~ msgstr "तपाइको परियोजना बाड्न यो लिङ्क नक्कल/कपी गार्नुहोस"
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr "पोलार"
+#~ msgid "Polar"
+#~ msgstr "पोलार"
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr "डाउन्लोड"
+#~ msgid "Download"
+#~ msgstr "डाउन्लोड"
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr "ढिक्काहरु"
+#~ msgid "blocks"
+#~ msgstr "ढिक्काहरु"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr "उन्नत विकल्पहरू"
+#~ msgid "Advanced options"
+#~ msgstr "उन्नत विकल्पहरू"
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr "मेरो उपकरणमा"
+#~ msgid "On my device"
+#~ msgstr "मेरो उपकरणमा"
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr "मेरो म्युजिक ब्लक्सको सिर्जना"
+#~ msgid "My Music Blocks Creation"
+#~ msgstr "मेरो म्युजिक ब्लक्सको सिर्जना"
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -2214,7 +2214,7 @@ msgstr "actie"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2281,7 +2281,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2295,33 +2295,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2343,7 +2343,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2650,8 +2650,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2820,14 +2820,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2858,7 +2858,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2883,7 +2883,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2892,7 +2892,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2913,7 +2913,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2931,8 +2931,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3034,7 +3034,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3168,14 +3168,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3250,7 +3250,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3286,7 +3286,7 @@ msgstr "vloeien"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3295,7 +3295,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3786,7 +3786,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3798,8 +3798,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3809,7 +3809,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3821,8 +3821,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3832,15 +3832,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3849,14 +3849,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3865,14 +3865,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3922,7 +3922,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3939,7 +3939,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4008,8 +4008,8 @@ msgstr "extra's"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4031,7 +4031,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4317,7 +4317,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4648,21 +4648,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4671,12 +4671,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4689,62 +4689,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4757,7 +4757,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4766,7 +4766,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4779,7 +4779,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4788,17 +4788,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4807,12 +4807,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4825,7 +4825,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4834,17 +4834,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4861,56 +4861,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4926,7 +4926,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4935,7 +4935,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4943,7 +4943,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4952,8 +4952,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4961,7 +4961,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4975,116 +4975,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5103,19 +5103,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5123,61 +5123,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5187,149 +5187,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5338,7 +5338,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5417,22 +5417,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5589,7 +5589,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5611,7 +5611,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5622,7 +5622,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5651,7 +5651,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5660,7 +5660,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5693,7 +5693,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5703,7 +5703,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "stapel wissen"
 
@@ -5712,7 +5712,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5721,7 +5721,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5744,13 +5744,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5759,7 +5759,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "afnemen"
 
@@ -5768,7 +5768,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "neerleggen"
 
@@ -5788,7 +5788,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5813,7 +5813,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5827,7 +5827,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5837,7 +5837,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5875,7 +5875,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5884,7 +5884,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5897,18 +5897,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6029,7 +6029,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6048,7 +6048,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6057,7 +6057,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6074,7 +6074,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6087,7 +6087,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6116,7 +6116,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6139,7 +6139,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6156,7 +6156,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6165,7 +6165,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6182,7 +6182,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6191,7 +6191,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6225,7 +6225,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6251,7 +6251,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6266,7 +6266,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6300,12 +6300,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6314,12 +6314,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6328,13 +6328,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6352,7 +6352,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6384,8 +6384,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6441,7 +6441,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6598,12 +6598,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6613,8 +6613,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6622,12 +6622,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6636,7 +6636,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6653,7 +6653,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6663,12 +6663,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6678,7 +6678,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6687,7 +6687,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6737,7 +6737,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6770,7 +6770,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6779,12 +6779,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6793,7 +6793,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6802,7 +6802,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6811,7 +6811,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6822,8 +6822,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6833,7 +6833,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6859,7 +6859,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6897,12 +6897,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6914,12 +6914,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6928,7 +6928,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6974,22 +6974,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6998,7 +6998,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7011,7 +7011,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7020,47 +7020,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7073,7 +7073,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7082,7 +7082,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7090,7 +7090,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7104,8 +7104,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7134,7 +7134,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7159,14 +7159,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7176,7 +7176,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7195,7 +7195,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7205,7 +7205,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7222,17 +7222,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7241,7 +7241,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7251,7 +7251,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7261,7 +7261,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7273,7 +7273,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7281,7 +7281,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7291,7 +7291,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7312,7 +7312,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7327,7 +7327,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7337,7 +7337,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7351,7 +7351,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7407,7 +7407,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7585,7 +7585,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7594,7 +7594,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7603,7 +7603,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7612,7 +7612,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7622,13 +7622,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7641,7 +7641,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "muis y"
 
@@ -7650,7 +7650,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "schildpad y"
 
@@ -7659,7 +7659,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "muis x"
 
@@ -7668,7 +7668,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "schildpad x"
 
@@ -7677,7 +7677,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7686,7 +7686,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7695,7 +7695,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7704,7 +7704,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7714,17 +7714,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7733,7 +7733,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8160,7 +8160,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8170,7 +8170,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8214,12 +8214,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8228,7 +8228,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8285,7 +8285,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8303,7 +8303,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8316,7 +8316,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8381,7 +8381,7 @@ msgstr "stop met vullen"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8446,7 +8446,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8455,12 +8455,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "pen omhoog"
 
@@ -8469,7 +8469,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "pen omlaag"
 
@@ -8478,7 +8478,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "zet pen dikte"
 
@@ -8487,7 +8487,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8512,7 +8512,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8647,27 +8647,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8693,18 +8693,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8719,7 +8719,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8740,7 +8740,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8757,7 +8757,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8770,7 +8770,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8780,7 +8780,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8794,7 +8794,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8815,7 +8815,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8829,7 +8829,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9016,7 +9016,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9025,7 +9025,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9147,7 +9147,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9230,7 +9230,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9280,7 +9280,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9397,7 +9397,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9476,48 +9476,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9950,38 +9950,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9989,8 +9989,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10000,8 +10000,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "media"
+#~ msgid "media"
+#~ msgstr "media"
 
 #: js/block-verbose.js:3837
 
@@ -10013,35 +10013,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "toon"
+#~ msgid "show"
+#~ msgstr "toon"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "Rooster"
+#~ msgid "grid"
+#~ msgstr "Rooster"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10055,69 +10055,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Wissen"
+#~ msgid "Clean"
+#~ msgstr "Wissen"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "blokken verbergen"
+#~ msgid "hide blocks"
+#~ msgstr "blokken verbergen"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10137,13 +10137,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "stop"
+#~ msgid "stop"
+#~ msgstr "stop"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10151,58 +10151,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10218,25 +10218,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "duur"
+#~ msgid "duration"
+#~ msgstr "duur"
 
 #: js/widgets/temperament.js:454
 
@@ -10246,43 +10246,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10292,190 +10292,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10485,305 +10485,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10793,97 +10793,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "hallo"
+#~ msgid "hello"
+#~ msgstr "hallo"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10893,144 +10893,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11040,15 +11040,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11058,23 +11058,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11084,8 +11084,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11093,224 +11093,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11326,37 +11326,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11364,28 +11364,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11399,8 +11399,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11410,65 +11410,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11476,8 +11476,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11487,127 +11487,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11615,608 +11615,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12226,165 +12226,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12398,28 +12398,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12427,133 +12427,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12561,136 +12561,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "schildpad"
+#~ msgid "turtle"
+#~ msgstr "schildpad"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12700,127 +12700,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12828,397 +12828,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Open"
+#~ msgid "Open"
+#~ msgstr "Open"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13230,196 +13230,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13427,155 +13427,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13583,257 +13583,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13847,223 +13847,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14073,144 +14073,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr "blokken"
+#~ msgid "blocks"
+#~ msgstr "blokken"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14218,57 +14218,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14278,30 +14278,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14309,112 +14309,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14422,287 +14422,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14710,13 +14710,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14724,86 +14724,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/pap.po
+++ b/po/pap.po
@@ -2216,7 +2216,7 @@ msgstr "akshon"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr "fluho"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr "Èkstranan"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "monton bashi"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "kita"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "pusha"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "raton y"
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "turtuga y"
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "raton x"
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "turtuga x"
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr "stòp yenamentu"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "Pen ariba"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "pen abou"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "instala tamánjo di pen"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "medionan"
+#~ msgid "media"
+#~ msgstr "medionan"
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "Mustra"
+#~ msgid "show"
+#~ msgstr "Mustra"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Limpia"
+#~ msgid "Clean"
+#~ msgstr "Limpia"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "skonde blòkinan"
+#~ msgid "hide blocks"
+#~ msgstr "skonde blòkinan"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "stòp"
+#~ msgid "stop"
+#~ msgstr "stòp"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "durashon"
+#~ msgid "duration"
+#~ msgstr "durashon"
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "haló"
+#~ msgid "hello"
+#~ msgstr "haló"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "turtuga"
+#~ msgid "turtle"
+#~ msgstr "turtuga"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Habri"
+#~ msgid "Open"
+#~ msgstr "Habri"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr "blòki"
+#~ msgid "blocks"
+#~ msgstr "blòki"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/pbs.po
+++ b/po/pbs.po
@@ -2216,7 +2216,7 @@ msgstr "matsjau"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr "maljung se mane'p"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "majáu ne nde'ets kil'e"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "mapuu' ne nde'ets kily'e"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "makeje' ngutue'p"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "nda'u'up"
+#~ msgid "show"
+#~ msgstr "nda'u'up"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Matseiñ'"
+#~ msgid "Clean"
+#~ msgstr "Matseiñ'"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "Ma'aung me'ets kily'e"
+#~ msgid "hide blocks"
+#~ msgstr "Ma'aung me'ets kily'e"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "ndama'ai"
+#~ msgid "stop"
+#~ msgstr "ndama'ai"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "lujuéeu'"
+#~ msgid "duration"
+#~ msgstr "lujuéeu'"
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "hola"
+#~ msgid "hello"
+#~ msgstr "hola"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Maseiñ"
+#~ msgid "Open"
+#~ msgstr "Maseiñ"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -2217,7 +2217,7 @@ msgstr "akcje"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2284,7 +2284,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2298,33 +2298,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2653,8 +2653,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2813,7 +2813,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2823,14 +2823,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2861,7 +2861,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2916,7 +2916,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2934,8 +2934,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3037,7 +3037,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3171,14 +3171,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3789,7 +3789,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3801,8 +3801,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3812,7 +3812,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3824,8 +3824,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3835,15 +3835,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3852,14 +3852,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3868,14 +3868,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3916,7 +3916,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3925,7 +3925,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3942,7 +3942,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4011,8 +4011,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4034,7 +4034,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4320,7 +4320,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4651,21 +4651,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4674,12 +4674,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4692,62 +4692,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4760,7 +4760,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4769,7 +4769,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4782,7 +4782,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4791,17 +4791,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4810,12 +4810,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4828,7 +4828,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4837,17 +4837,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4864,56 +4864,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4921,7 +4921,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4929,7 +4929,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4938,7 +4938,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4946,7 +4946,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4955,8 +4955,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4978,116 +4978,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5106,19 +5106,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5126,61 +5126,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5190,149 +5190,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5341,7 +5341,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5420,22 +5420,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5592,7 +5592,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5614,7 +5614,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5625,7 +5625,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5654,7 +5654,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5663,7 +5663,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5696,7 +5696,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5706,7 +5706,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "opróżnij stos"
 
@@ -5715,7 +5715,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5724,7 +5724,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5747,13 +5747,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "ze stosu"
 
@@ -5771,7 +5771,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "na stos"
 
@@ -5791,7 +5791,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5816,7 +5816,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5830,7 +5830,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5840,7 +5840,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5878,7 +5878,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5887,7 +5887,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5900,18 +5900,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6032,7 +6032,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6051,7 +6051,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6060,7 +6060,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6090,7 +6090,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6119,7 +6119,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6142,7 +6142,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6159,7 +6159,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6168,7 +6168,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6185,7 +6185,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6194,7 +6194,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6228,7 +6228,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6237,7 +6237,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6254,7 +6254,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6269,7 +6269,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6303,12 +6303,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6317,12 +6317,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6331,13 +6331,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6355,7 +6355,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6387,8 +6387,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6444,7 +6444,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6601,12 +6601,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6616,8 +6616,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6625,12 +6625,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6639,7 +6639,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6656,7 +6656,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6666,12 +6666,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6681,7 +6681,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6690,7 +6690,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6740,7 +6740,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6773,7 +6773,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6782,12 +6782,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6796,7 +6796,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6805,7 +6805,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6814,7 +6814,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6825,8 +6825,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6836,7 +6836,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6862,7 +6862,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6900,12 +6900,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6917,12 +6917,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6931,7 +6931,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6977,22 +6977,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7001,7 +7001,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7014,7 +7014,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7023,47 +7023,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7076,7 +7076,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7085,7 +7085,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7093,7 +7093,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7107,8 +7107,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7137,7 +7137,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7162,14 +7162,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7179,7 +7179,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7198,7 +7198,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7208,7 +7208,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7225,17 +7225,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7244,7 +7244,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7254,7 +7254,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7264,7 +7264,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7276,7 +7276,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7284,7 +7284,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7294,7 +7294,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7315,7 +7315,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7330,7 +7330,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7340,7 +7340,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7354,7 +7354,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7410,7 +7410,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7588,7 +7588,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7597,7 +7597,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7606,7 +7606,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7615,7 +7615,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7625,13 +7625,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7644,7 +7644,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "myszka y"
 
@@ -7653,7 +7653,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7662,7 +7662,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "myszka x"
 
@@ -7671,7 +7671,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7680,7 +7680,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7689,7 +7689,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7698,7 +7698,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7707,7 +7707,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7717,17 +7717,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7736,7 +7736,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8163,7 +8163,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8173,7 +8173,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8217,12 +8217,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8231,7 +8231,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8288,7 +8288,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8306,7 +8306,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8319,7 +8319,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8384,7 +8384,7 @@ msgstr "koniec wypełniania"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8449,7 +8449,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8458,12 +8458,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "podnieś pisak"
 
@@ -8472,7 +8472,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "opuść pisak"
 
@@ -8481,7 +8481,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "zmień rozmiar pisaka"
 
@@ -8490,7 +8490,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8515,7 +8515,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8650,27 +8650,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8696,18 +8696,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8722,7 +8722,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8743,7 +8743,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8760,7 +8760,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8773,7 +8773,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8783,7 +8783,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8797,7 +8797,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8818,7 +8818,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8832,7 +8832,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9019,7 +9019,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9028,7 +9028,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9150,7 +9150,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9233,7 +9233,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9283,7 +9283,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9400,7 +9400,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9479,48 +9479,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9953,38 +9953,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9992,8 +9992,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10003,8 +10003,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10016,35 +10016,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "pokaż"
+#~ msgid "show"
+#~ msgstr "pokaż"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "siatka"
+#~ msgid "grid"
+#~ msgstr "siatka"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10058,69 +10058,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Wyczyść"
+#~ msgid "Clean"
+#~ msgstr "Wyczyść"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "schowaj schemat"
+#~ msgid "hide blocks"
+#~ msgstr "schowaj schemat"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10140,13 +10140,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "zatrzymaj"
+#~ msgid "stop"
+#~ msgstr "zatrzymaj"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10154,58 +10154,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10221,25 +10221,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "czas trwania"
+#~ msgid "duration"
+#~ msgstr "czas trwania"
 
 #: js/widgets/temperament.js:454
 
@@ -10249,43 +10249,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10295,190 +10295,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10488,305 +10488,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10796,97 +10796,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "cześć"
+#~ msgid "hello"
+#~ msgstr "cześć"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10896,144 +10896,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11043,15 +11043,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11061,23 +11061,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11087,8 +11087,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11096,224 +11096,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11329,37 +11329,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11367,28 +11367,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11402,8 +11402,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11413,65 +11413,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11479,8 +11479,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11490,127 +11490,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11618,608 +11618,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12229,165 +12229,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12401,28 +12401,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12430,133 +12430,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12564,136 +12564,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "żółw"
+#~ msgid "turtle"
+#~ msgstr "żółw"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12703,127 +12703,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12831,397 +12831,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Otwórz"
+#~ msgid "Open"
+#~ msgstr "Otwórz"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13233,196 +13233,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13430,155 +13430,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13586,257 +13586,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13850,223 +13850,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14076,144 +14076,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14221,57 +14221,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14281,30 +14281,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14312,112 +14312,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14425,287 +14425,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14713,13 +14713,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14727,86 +14727,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -17,10 +17,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Virtaal 0.7.1\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -106,7 +106,7 @@ msgstr "ação"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr "pato"
 
@@ -173,7 +173,7 @@ msgstr "Ocultar"
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "Meu projeto"
 
@@ -187,33 +187,33 @@ msgid "Your recording is in progress."
 msgstr "Sua gravação está em andamento."
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "Nome do arquivo"
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "Título do projeto"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "Autor do projeto"
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "Incluir saida de MIDI?"
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "Incluir saida de tablatura de guitarra?"
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "Salvar como Lilypond"
 
@@ -235,7 +235,7 @@ msgstr "Salvar como Lilypond"
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "Sr. Ratinho"
 
@@ -313,7 +313,7 @@ msgstr "mostrar Cartesiano"
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr "escala de graus"
 
@@ -542,8 +542,8 @@ msgstr "Salvar ajuda do bloco"
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "si la sol fa mi re do"
 
@@ -702,7 +702,7 @@ msgstr "régua"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "timbre"
 
@@ -712,14 +712,14 @@ msgstr "escada"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "tempo"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "modo"
 
@@ -750,7 +750,7 @@ msgstr "bateria"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "criador de ritmo"
 
@@ -775,7 +775,7 @@ msgstr "criador de ritmo"
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "valor de nota"
 
@@ -784,7 +784,7 @@ msgstr "valor de nota"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "intervalo escalar"
 
@@ -805,7 +805,7 @@ msgid "silence"
 msgstr "silêncio"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "abaixo"
 
@@ -823,8 +823,8 @@ msgstr "acima"
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "determinar o tom"
 
@@ -926,7 +926,7 @@ msgstr "tenor"
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "baixo"
 
@@ -1060,14 +1060,14 @@ msgstr "Não há bloco selecionado."
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "avatar"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "amostra"
 
@@ -1142,7 +1142,7 @@ msgstr "iniciar bateria"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "Ritmo"
 
@@ -1178,7 +1178,7 @@ msgstr "seguimento"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr "Sensores"
 
@@ -1187,7 +1187,7 @@ msgstr "Sensores"
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr "Mídia"
 
@@ -1678,7 +1678,7 @@ msgstr "Tocador está pronto"
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "afinação dupla"
 
@@ -1690,8 +1690,8 @@ msgstr "afinação dupla"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "afinado"
 
@@ -1701,7 +1701,7 @@ msgstr "afinado"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "natural"
 
@@ -1713,8 +1713,8 @@ msgstr "natural"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "plano"
 
@@ -1724,15 +1724,15 @@ msgstr "plano"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "plano duplo"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr "unisom"
 
@@ -1741,14 +1741,14 @@ msgstr "unisom"
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "maior"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr "ioniano"
 
@@ -1757,14 +1757,14 @@ msgstr "ioniano"
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "menor"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr "aeoliano"
 
@@ -1805,7 +1805,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr "Você escolheu uma tonalidade para a pré-visualização da melodia."
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "Você deve ter pelo menos um bloco Parcial dentro de um bloco parcial Ponderado"
 
@@ -1814,7 +1814,7 @@ msgid "synth cannot play chords."
 msgstr "sintetizador não pode tocar acordes."
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr "guia url"
 
@@ -1831,7 +1831,7 @@ msgstr "buscar"
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "metro"
 
@@ -1900,8 +1900,8 @@ msgstr "extras"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "programa"
 
@@ -1923,7 +1923,7 @@ msgstr "lógica"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr "Música"
 
@@ -2209,7 +2209,7 @@ msgstr "Ativar/desativar pautas musicais."
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr "Limpar"
 
@@ -2540,21 +2540,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr "Sétima diminuta, mais uma oitava"
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "1º 2º 3º 4º 5º 6º 7º 8º 9º 10º 11º 12º"
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "aumentado"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "diminuído"
 
@@ -2563,12 +2563,12 @@ msgstr "diminuído"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "perfeito"
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "cromático"
 
@@ -2581,62 +2581,62 @@ msgid "spanish"
 msgstr "espanhol"
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr "octatônico"
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "harmônico maior"
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "menor natural"
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "harmônico menor"
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "menor melódico"
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr "doriano"
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr "phrygianiano"
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr "lydiano"
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "mixolydiano"
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr "locriano"
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "jazz menor"
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr "bebop"
 
@@ -2649,7 +2649,7 @@ msgid "byzantine"
 msgstr "bizantino"
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "enigmático"
 
@@ -2658,7 +2658,7 @@ msgid "ethiopian"
 msgstr "etiopiano"
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "geez"
 
@@ -2671,7 +2671,7 @@ msgid "hungarian"
 msgstr "húngaro"
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "romano menor"
 
@@ -2680,17 +2680,17 @@ msgid "spanish gypsy"
 msgstr "espanhol cigano"
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "maqamo"
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "blues menor"
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr "blues maior"
 
@@ -2699,12 +2699,12 @@ msgid "whole tone"
 msgstr "tom inteiro"
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "pentatônico menor"
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "pentatônico maior"
 
@@ -2717,7 +2717,7 @@ msgid "egyptian"
 msgstr "egípcio"
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "hirajoshi"
 
@@ -2726,17 +2726,17 @@ msgid "Japan"
 msgstr "Japão"
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "em"
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "minyo"
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "fibonacci"
 
@@ -2753,56 +2753,56 @@ msgstr "fibonacci"
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr "personalizar"
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr "highpass"
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr "lowpass"
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr "bandpass"
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr "highshelf"
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr "lowshelf"
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr "entalhe"
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr "allpass"
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr "pico"
 
@@ -2810,7 +2810,7 @@ msgstr "pico"
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "sino"
 
@@ -2818,7 +2818,7 @@ msgstr "sino"
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "quadrado"
 
@@ -2827,7 +2827,7 @@ msgstr "quadrado"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "triângulo"
 
@@ -2835,7 +2835,7 @@ msgstr "triângulo"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "dente de serra"
 
@@ -2844,8 +2844,8 @@ msgstr "dente de serra"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr "par"
 
@@ -2853,7 +2853,7 @@ msgstr "par"
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr "ímpar"
 
@@ -2867,116 +2867,116 @@ msgstr "escalar"
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr "piano"
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr "violino"
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr "viola"
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "xilofone"
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "vibrafone"
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr "violoncelo"
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr "contrabaixo"
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr "guitarra"
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr "sitar"
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr "violão acústico"
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr "flauta"
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr "Clarineta"
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr "saxofone"
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr "tuba"
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr "trumpete"
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr "oboé"
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr "trombone"
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr "sintetizador eletrônico"
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "simples 1"
 
@@ -2995,19 +2995,19 @@ msgstr "simples 4"
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr "ruído branco"
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "ruído marrom"
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "ruído rosa"
 
@@ -3015,61 +3015,61 @@ msgstr "ruído rosa"
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr "tarola"
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr "bumbo"
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr "tom tom"
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr "tom baixo"
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr "bumbo"
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "tambor de taça"
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr "tambor de darbuka"
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr "hi hat"
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr "pequeno sino"
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr "sino de vaca"
 
@@ -3079,149 +3079,149 @@ msgstr "tambor japonês"
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr "sino japonês"
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr "sino triângular"
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr "estalar de dedos"
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "carrilhão"
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr "gong"
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr "clang"
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr "bater"
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr "garrafa"
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr "palmas"
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr "tapa"
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr "splash"
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr "bolhas"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr "gota de chuva"
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr "gato"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr "grilo"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr "cachorro"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr "banjo"
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr "koto"
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr "dulcimer"
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr "Guitarra elétrica"
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr "fagote"
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr "celesta"
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr "igual"
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "Pitagórico"
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr "apenas entonação"
 
@@ -3230,7 +3230,7 @@ msgstr "apenas entonação"
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr "Temperamento médio"
 
@@ -3309,22 +3309,22 @@ msgid "previous"
 msgstr "anterior"
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "simples-2"
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "simples-3"
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "simples-4"
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr "taiko"
 
@@ -3473,7 +3473,7 @@ msgstr "O bloco Obter-dict retorna um valor do dicionário para uma chave especi
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "obter valor"
 
@@ -3495,7 +3495,7 @@ msgstr "chave2"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "chave"
 
@@ -3506,7 +3506,7 @@ msgstr "O bloco Definir-dict define um valor no dicionário para uma chave espec
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr "definir valor"
 
@@ -3535,7 +3535,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr "Substituir cada instância de uma altura por um som de bateria."
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "mapear altura para bateria"
 
@@ -3544,7 +3544,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "No exemplo acima, um som de bumbo será reproduzido em vez de sol."
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "definir bateria"
 
@@ -3577,7 +3577,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "O bloco Pilha-vazia? retorna verdadeiro se a pilha está vazia."
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "pilha vazia?"
 
@@ -3587,7 +3587,7 @@ msgstr "O bloco Esvaziar-pilha esvazia a pilha."
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "pilha vazia"
 
@@ -3596,7 +3596,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr "O bloco Pilha-reversa reverte a ordem da pilha."
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr "pilha reversa"
 
@@ -3605,7 +3605,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr "O bloco Índice-pilha retorna um valor na pilha em um local especificado."
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "pilha índice"
 
@@ -3628,13 +3628,13 @@ msgstr "O bloco de entrada Definir-pilha define um valor na pilha na localizaç�
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "definir pilha"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "índice"
 
@@ -3643,7 +3643,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr "O bloco Pop remove o valor do topo da pilha."
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "pop"
 
@@ -3652,7 +3652,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr "O bloco Empurrar adiciona um valor ao topo da pilha."
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "empurrar"
 
@@ -3672,7 +3672,7 @@ msgstr "definir temperamento"
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "oitava"
 
@@ -3697,7 +3697,7 @@ msgid "current interval"
 msgstr "intervalo atual"
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr "medida do intervalo semi-tom"
 
@@ -3711,7 +3711,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr "O bloco de intervalo Escalar mede a distância entre duas notas na tecla e no modo atuais."
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr "medida do intervalo escalar"
 
@@ -3721,7 +3721,7 @@ msgstr "Na figura, adicionamos sol# ao sol."
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr "intervalo semi-tom"
 
@@ -3759,7 +3759,7 @@ msgid "In the figure, we add la to sol."
 msgstr "Na figura, adicionamos la ao sol."
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr "Definir modo"
 
@@ -3768,7 +3768,7 @@ msgid "movable Do"
 msgstr "Do móvel"
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "modo número de notas"
 
@@ -3781,18 +3781,18 @@ msgid "Most Western scales have 7 notes."
 msgstr "A maioria das escalas ocidentais possui 7 notas."
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "modo atual"
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr "chave atual"
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "definir chave"
 
@@ -3913,7 +3913,7 @@ msgstr "fator legato"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr "vizinho"
 
@@ -3932,7 +3932,7 @@ msgstr "legato"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "staccato"
 
@@ -3941,7 +3941,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr "O bloco Carregar-pilha-do-app carrega a pilha de uma página da web."
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr "carregar pilha do aplicativo"
 
@@ -3958,7 +3958,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr "O bloco Salvar-pilha-para-aplicativo salva a pilha em uma página da web."
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr "salvar pilha no aplicativo"
 
@@ -3971,7 +3971,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr "O bloco Carregar-pilha carrega a pilha de um arquivo."
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "carregar pilha"
 
@@ -4000,7 +4000,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr "O bloco Carregar dicionário carrega um dicionário de um arquivo."
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "carregar dicionário"
 
@@ -4023,7 +4023,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr "O bloco Definir dicionário carrega um dicionário."
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr "definir dicionário"
 
@@ -4040,7 +4040,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr "O bloco Salvar dicionário salva um dicionário em um arquivo."
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr "salvar dicionário"
 
@@ -4057,7 +4057,7 @@ msgid "The Delete block block removes a block."
 msgstr "O bloco Excluir bloco remove um bloco."
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr "excluir bloco"
 
@@ -4066,7 +4066,7 @@ msgid "The Move block block moves a block."
 msgstr "O bloco Mover move um bloco."
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr "mover bloco"
 
@@ -4100,7 +4100,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr "executar bloco"
 
@@ -4109,7 +4109,7 @@ msgid "The Dock block block connections two blocks."
 msgstr "O bloco Dock bloco conecta dois blocos."
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr "conectar blocos"
 
@@ -4126,7 +4126,7 @@ msgid "The Make block block creates a new block."
 msgstr "O bloco Fazer bloco criar um novo bloco."
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr "fazer bloco"
 
@@ -4141,7 +4141,7 @@ msgstr "fazer bloco"
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "nota"
 
@@ -4175,12 +4175,12 @@ msgstr "O valor da nota deve ser maior que 0."
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "swing"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "valor do swing"
 
@@ -4189,12 +4189,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr "O bloco Ignorar notas fará com que as notas sejam ignoradas."
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "pular notas"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "multiplicar valor da nota"
 
@@ -4203,13 +4203,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr "O bloco Laço funciona em pares de notas, combinando-as em uma nota."
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "juntar"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "ponto"
 
@@ -4227,7 +4227,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr "Por exemplo, uma semínima pontuada será reproduzida por 3/8 (1/4 + 1/8) de uma batida."
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr "valor da nota da bateria"
 
@@ -4259,8 +4259,8 @@ msgstr "espaço oitava"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "ritmo1"
 
@@ -4316,7 +4316,7 @@ msgstr "nota inteira"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "tuplet"
 
@@ -4473,12 +4473,12 @@ msgid "duplicate factor"
 msgstr "duplicar fator"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr "medidor atual"
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "fator da batida"
 
@@ -4488,8 +4488,8 @@ msgstr "O bloco Batidas por minuto retorna as batidas atuais por minuto."
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "batidas por minuto2"
 
@@ -4497,12 +4497,12 @@ msgstr "batidas por minuto2"
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "batidas por minuto"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr "contador de medida"
 
@@ -4511,7 +4511,7 @@ msgid "The Measure count block returns the current measure."
 msgstr "O bloco Medidor retorna a contagem atual."
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr "contador de batidas"
 
@@ -4528,7 +4528,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr "por exemplo 1, 2, 3, 4."
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr "somar valores das notas"
 
@@ -4538,12 +4538,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr "O bloco Contador de notas pode ser usado para contar o número de notas."
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr "contador de notas"
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr "todas as notas tocadas"
 
@@ -4553,7 +4553,7 @@ msgstr "O bloco Inteiro de notas tocadas retorna o número total de notas inteir
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr "notas tocadas"
 
@@ -4562,7 +4562,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr "O bloco Sem-relógio desacopla as notas do relógio principal."
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "sem relógio"
 
@@ -4608,7 +4608,7 @@ msgstr "O bloco Em-toda-nota permite especificar ações a serem executadas em c
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr "batida mestre por minuto"
 
@@ -4641,7 +4641,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr "O bloco Batidas por minuto define o número de 1/4 notas por minuto."
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr "pegar"
 
@@ -4650,12 +4650,12 @@ msgid "number of beats"
 msgstr "número de batidas"
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "transposição"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr "degrau escalar de baixo"
 
@@ -4664,7 +4664,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr "O bloco Escalar redutor retorna o número de semitons reduzidos até a nota anterior na tecla atual e modo."
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr "degrau escalar de cima"
 
@@ -4673,7 +4673,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr "O bloco Escalar progressivo retorna o número de semitons até a próxima nota na tecla atual e modo."
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr "mudança no tom"
 
@@ -4682,7 +4682,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr "Mudar no bloco de tom é a diferença (em meio passo) entre o tom atual que está sendo tocado e o tom anterior executado."
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr "mudança escalar na altura"
 
@@ -4693,8 +4693,8 @@ msgstr "mudança escalar na altura"
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr "número do tom"
 
@@ -4704,7 +4704,7 @@ msgstr "O bloco Tom número é o valor do tom da nota atualmente sendo reproduzi
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr "tom em hertz"
 
@@ -4730,7 +4730,7 @@ msgid "alphabet"
 msgstr "alfabeto"
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr "classe de letras"
 
@@ -4768,12 +4768,12 @@ msgstr "tom para cor"
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr "MIDI"
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr "definir número do tom"
 
@@ -4785,12 +4785,12 @@ msgstr "O bloco de deslocamento Define número do tom é usado para definir o de
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "nome2"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "número para o tom"
 
@@ -4799,7 +4799,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr "O bloco Número para altura converterá um número de altura para um nome de altura."
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "número para a oitava"
 
@@ -4845,22 +4845,22 @@ msgstr "O bloco Inversor rotaciona todas as notas contidas em torno de uma nota 
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr "Inverter"
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "inverter (ímpar)"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "inverter (par)"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr "registrador"
 
@@ -4869,7 +4869,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr "O bloco Registrador fornece uma maneira fácil de modificar o registro (oitava) das notas que o seguem."
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr "50 cents"
 
@@ -4882,7 +4882,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr "No exemplo acima, sol é deslocado para sol#."
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr "transposição de semi-tom"
 
@@ -4891,47 +4891,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr "O bloco Transpor por razão desloca os tons contidos nos blocos de Nota para cima (ou para baixo) por uma razão."
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr "transpor por razão"
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr "sexta baixa"
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr "terceira baixa"
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr "sétima"
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr "sexta"
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr "quinta"
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr "quarta"
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr "terceira"
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr "segunda"
 
@@ -4944,7 +4944,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr "No exemplo mostrado acima, sol é deslocado até la."
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr "transposição escalar"
 
@@ -4953,7 +4953,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr "O bloco Acidental é usado para criar afinações e planos"
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr "substituição do acidente"
 
@@ -4961,7 +4961,7 @@ msgstr "substituição do acidente"
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr "hertz"
 
@@ -4975,7 +4975,7 @@ msgstr "O bloco Número da altura reproduzirá uma altura associada ao seu núme
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr "enésima altura modal"
 
@@ -5004,7 +5004,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr "O Grau da Escala 1 é sempre a primeira altura em uma determinada escala, independentemente da oitava."
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr "passo escalar"
 
@@ -5029,14 +5029,14 @@ msgstr "Oscilador"
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr "tipo"
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr "parciais"
 
@@ -5046,7 +5046,7 @@ msgstr "Você está adicionando vários blocos do oscilador."
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr "duo sintetizador"
 
@@ -5065,7 +5065,7 @@ msgstr "intensidade de vibrato"
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr "sintetizador AM"
 
@@ -5075,7 +5075,7 @@ msgstr "O bloco sintetizador AM é um modulador de amplitude usado para definir 
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr "sintetizador FM"
 
@@ -5092,17 +5092,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr "O bloco Parcial é usado para especificar um peso para um harmônico parcial específico."
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr "O peso Parcial deve estar entre 0 e 1."
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr "Bloco Parcial deve ser usado dentro de um bloco parcial Ponderado."
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr "parciais ponderadas"
 
@@ -5111,7 +5111,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr "O bloco Harmônico adicionará harmônicos às notas contidas."
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr "harmônico"
 
@@ -5121,7 +5121,7 @@ msgstr "O bloco Distorção adiciona distorção ao tom."
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr "distorção"
 
@@ -5131,7 +5131,7 @@ msgstr "O bloco Tremolo adiciona um efeito de onda."
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr "tremolo"
 
@@ -5143,7 +5143,7 @@ msgstr "tremolo"
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr "taxa"
 
@@ -5151,7 +5151,7 @@ msgstr "taxa"
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr "profundidade"
 
@@ -5161,7 +5161,7 @@ msgstr "O bloco Phaser adiciona um som de varredura."
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr "phaser"
 
@@ -5182,7 +5182,7 @@ msgstr "O bloco Coro adiciona um efeito de coro."
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr "refrão"
 
@@ -5197,7 +5197,7 @@ msgstr "O bloco Vibrato adiciona uma variação rápida e ligeira no tom."
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr "vibrato"
 
@@ -5207,7 +5207,7 @@ msgid "intensity"
 msgstr "intensidade"
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr "difinir sintetizador"
 
@@ -5221,7 +5221,7 @@ msgstr "definir instrumento padrão"
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr "definir instrumento"
 
@@ -5277,7 +5277,7 @@ msgstr "calcular"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr "O bloco Agir é usado para iniciar uma ação."
 
@@ -5455,7 +5455,7 @@ msgid "Cannot find start block"
 msgstr "Não foi possível encontrar o bloco iniciar"
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "cor do ratinho"
 
@@ -5464,7 +5464,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr "O bloco cor do Ratinho retorna a cor da caneta do ratinho especificado."
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "cor da tartaruga"
 
@@ -5473,7 +5473,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr "O bloco Cor da tartaruga retorna a cor da caneta da tartaruga especificada."
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "rumo do ratinho"
 
@@ -5482,7 +5482,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr "O bloco rumo do Ratinho retorna a orientação do ratinho especificado."
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "direção da tartaruga"
 
@@ -5492,13 +5492,13 @@ msgstr "O bloco Direção da tartaruga retorna a direção (como uma bússola) d
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr "Definir ratinho"
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr "definir tartaruga"
 
@@ -5511,7 +5511,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr "O bloco Define tartaruga envia uma pilha de blocos para ser executada pela tartaruga especificada."
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "ratinho y"
 
@@ -5520,7 +5520,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr "O bloco ratinho Y retorna a posição Y do ratinho especificado."
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "tartaruga y"
 
@@ -5529,7 +5529,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr "O bloco Tartaruga Y retorna a posição Y da tartaruga especificada."
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "ratinho x"
 
@@ -5538,7 +5538,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr "O bloco ratinho X retorna a posição X do ratinho especificado"
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "tartaruga x"
 
@@ -5547,7 +5547,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr "O bloco Tartaruga X retorna a posição X da tartaruga especificada."
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "notas de ratinho tocadas"
 
@@ -5556,7 +5556,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr "O bloco de notas de passagem do Ratinho retorna o número de notas executadas pelo ratinho especificado."
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "notas tocadas pela tartaruga"
 
@@ -5565,7 +5565,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr "O bloco Notas tocadas pela tartaruga retorna o número de notas tocadas pela tartaruga especificada."
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "número de tom do ratinho"
 
@@ -5574,7 +5574,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr "O bloco tom do Ratinho retorna o tom atual sendo executado pelo ratinho especificado."
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "número da altura da tartaruga"
 
@@ -5584,17 +5584,17 @@ msgstr "O bloco Altura da tartaruga retorna o número da altura atual sendo toca
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr "valor da nota do ratinho"
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "valor da nota da tartaruga"
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "sincronizar ratinho"
 
@@ -5603,7 +5603,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "O bloco de sincronização do Ratinho alinha a contagem de batimentos entre os ratinho."
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "sincronização da tartaruga"
 
@@ -6030,7 +6030,7 @@ msgid "wrap"
 msgstr "envoltório"
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr "direita (tela)"
 
@@ -6040,7 +6040,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr "O bloco Direita retorna a posição da direita da tela."
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "esquerda"
 
@@ -6084,12 +6084,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr "O bloco Altura retorna a altura da tela."
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "parar de tocar"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr "apagar mídia"
 
@@ -6098,7 +6098,7 @@ msgid "The Erase Media block erases text and images."
 msgstr "O bloco Apagar Mídia apaga textos e imagens."
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "tocar de fundo"
 
@@ -6155,7 +6155,7 @@ msgid "duration (MS)"
 msgstr "duração (MS)"
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "nota para frequência"
 
@@ -6173,7 +6173,7 @@ msgstr "O bloco Avatar é usado para mudar a aparência da tartaruga."
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "tamanho"
 
@@ -6186,7 +6186,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr "O bloco Mostrar é usado para exibir texto ou imagens na tela."
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "mostrar1"
 
@@ -6251,7 +6251,7 @@ msgstr "fim do preenchimento"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "plano de fundo"
 
@@ -6316,7 +6316,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr "O bloco linha Oca cria uma linha com um centro oco."
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "linha oca"
 
@@ -6325,12 +6325,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr "O bloco de Preencher preenche uma forma com uma cor."
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "preencher"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "levantar caneta"
 
@@ -6339,7 +6339,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "O bloco Caneta-erquida levanta a caneta para que ela não desenhe."
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "baixar caneta"
 
@@ -6348,7 +6348,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "O bloco Caneta-para-baixo abaixa a caneta para que ela desenhe."
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "definir largura do traço da caneta"
 
@@ -6357,7 +6357,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr "O bloco Definir-largura-do-traço altera a largura do traço da caneta."
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "definir transparência"
 
@@ -6382,7 +6382,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr "O bloco Definir-sombra muda a cor da caneta de escuro para claro."
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "definir cinza"
 
@@ -6517,27 +6517,27 @@ msgstr "O bloco Teclado retorna o teclado de entrada do computador."
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr "Envelope"
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "iniciar"
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "decair"
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "sustentar"
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "lançar"
 
@@ -6563,18 +6563,18 @@ msgstr "Você está adicionando vários blocos de envelope."
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr "Filtro"
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr "para fora"
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr "O valor de referência deve ser -12, -24, -48 ou -96 decibéis / oitava."
 
@@ -6589,7 +6589,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr "Carregar uma amostra e ajustar seu centro de tom."
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "amostrador"
 
@@ -6610,7 +6610,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr "O bloco do modo Personalizado abre uma ferramenta para explorar o modo musical (o espaçamento das notas em uma escala)."
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "modo personalizado"
 
@@ -6627,7 +6627,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr "A matriz do Tom da bateria é usada para mapear tons dos sons da bateria."
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "mapa do tom de bateria"
 
@@ -6640,7 +6640,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr "A ferramenta de controle deslizante do Tom é usada para gerar tons em freqüências selecionadas."
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "medir tom do slider"
 
@@ -6650,7 +6650,7 @@ msgstr "teclado cromático"
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr "teclado de música"
 
@@ -6664,7 +6664,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr "A ferramenta escada do Tom é usada para gerar tom a partir de uma determinada taxa."
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "medir tom da escala"
 
@@ -6685,7 +6685,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr "O bloco Criar Frases abre uma ferramenta para criar frases musicais."
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "criador de frase"
 
@@ -6699,7 +6699,7 @@ msgstr "O bloco Status abre uma ferramenta para inspecionar o status do Music Bl
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr "Música IA"
 
@@ -6886,7 +6886,7 @@ msgstr "A taxa de vibrato deve ser maior que 0."
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr "A profundidade está fora do limite."
 
@@ -6895,7 +6895,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr "A distorção deve ser de 0 a 100."
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr "Parcial deve ser maior ou igual a 0."
 
@@ -7017,7 +7017,7 @@ msgid "Undo"
 msgstr "Desfazer"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr "Clique no círculo para selecionar notas para o modo."
 
@@ -7100,7 +7100,7 @@ msgid "Save drum machine"
 msgstr "Salvar bateria eletrônica"
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr "Pressiona um ritmo"
 
@@ -7150,7 +7150,7 @@ msgid "Playback"
 msgstr "Reprodução"
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr "tom de referência"
 
@@ -7267,7 +7267,7 @@ msgstr "Sintetizador"
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr "Efeitos"
 
@@ -7346,48 +7346,48 @@ msgid "Cannot connect to server"
 msgstr "Não foi possível conectar ao servidor"
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr "Todos os projetos"
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr "Meus projetos"
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr "Exemplos"
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr "Arte"
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr "Matemática"
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr "Interativo"
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr "Design"
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr "Jogo"
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr "Trecho de Código"
 
@@ -7820,38 +7820,38 @@ msgstr "mover"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr "Nada na lixeira para restaurar."
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr "Nada na lixeira para restaurar."
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr "Slavar o audio do seu projeto como WAV"
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr "Slavar o audio do seu projeto como WAV"
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr "Salvar seu projeto para uma arquivo ABC."
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr "Salvar seu projeto para uma arquivo ABC."
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "Salve seu projeto como um arquivo do Lilypond."
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "Salve seu projeto como um arquivo do Lilypond."
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr "Mostrar ou ocultar uma grade de coordenadas."
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr "Mostrar ou ocultar uma grade de coordenadas."
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr "Expandir/recolher blocos recolhíveis"
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr "Expandir/recolher blocos recolhíveis"
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "Mostrar essas mensagens."
+#~ msgid "Show these messages."
+#~ msgstr "Mostrar essas mensagens."
 
 #: js/rubrics.js:531
 
@@ -7859,8 +7859,8 @@ msgstr "mover"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "sensores"
+#~ msgid "sensors"
+#~ msgstr "sensores"
 
 #: js/rubrics.js:532
 
@@ -7870,8 +7870,8 @@ msgstr "mover"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "mídia"
+#~ msgid "media"
+#~ msgstr "mídia"
 
 #: js/block-verbose.js:3837
 
@@ -7883,35 +7883,35 @@ msgstr "mover"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr "Cartesiano+polar"
+#~ msgid "Cartesian+polar"
+#~ msgstr "Cartesiano+polar"
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "mostrar"
+#~ msgid "show"
+#~ msgstr "mostrar"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr "Mostrar/ocultar bloco"
+#~ msgid "Show/hide block"
+#~ msgstr "Mostrar/ocultar bloco"
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "grade"
+#~ msgid "grid"
+#~ msgstr "grade"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr "Você escolheu a chave "
+#~ msgid "You have chosen key "
+#~ msgstr "Você escolheu a chave "
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr " para sua visualização de tom."
+#~ msgid " for your pitch preview."
+#~ msgstr " para sua visualização de tom."
 
 #: js/toolbar.js:113
 
@@ -7925,69 +7925,69 @@ msgstr "mover"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr "Tela Cheia"
+#~ msgid "Full Screen"
+#~ msgstr "Tela Cheia"
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr "Novo Projeto"
+#~ msgid "New Project"
+#~ msgstr "Novo Projeto"
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr "música"
+#~ msgid "music"
+#~ msgstr "música"
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr "salvar"
+#~ msgid "save"
+#~ msgstr "salvar"
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Limpar"
+#~ msgid "Clean"
+#~ msgstr "Limpar"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "Executar devagar"
+#~ msgid "Run slow"
+#~ msgstr "Executar devagar"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr "Limpar Área de Trabalho"
+#~ msgid "Clear Workspace"
+#~ msgstr "Limpar Área de Trabalho"
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr "Tem certeza que deseja limpar a área de trabalho?"
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr "Tem certeza que deseja limpar a área de trabalho?"
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr "mesotônico"
+#~ msgid "meantone"
+#~ msgstr "mesotônico"
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr "Personalizado"
+#~ msgid "Custom"
+#~ msgstr "Personalizado"
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "ocultar blocos"
+#~ msgid "hide blocks"
+#~ msgstr "ocultar blocos"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr "duplicar"
+#~ msgid "duplicate"
+#~ msgstr "duplicar"
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8007,13 +8007,13 @@ msgstr "mover"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "parar"
+#~ msgid "stop"
+#~ msgstr "parar"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "duração (ms)"
+#~ msgid "duration (ms)"
+#~ msgstr "duração (ms)"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8021,58 +8021,58 @@ msgstr "mover"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "limpar"
+#~ msgid "clear"
+#~ msgstr "limpar"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "inverter"
+#~ msgid "invert"
+#~ msgstr "inverter"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr "O Tom Modal n-ésimo pega o padrão de tons em semitons para um modo e faz cada ponto um grau do modo,"
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr "O Tom Modal n-ésimo pega o padrão de tons em semitons para um modo e faz cada ponto um grau do modo,"
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr "O Tom Modal N-ésimo pega um número como entrada como o n-ésimo grau para o modo dado. 0 é a primeira posição, 1 é a segunda, -1 é a nota antes da primeira etc."
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr "O Tom Modal N-ésimo pega um número como entrada como o n-ésimo grau para o modo dado. 0 é a primeira posição, 1 é a segunda, -1 é a nota antes da primeira etc."
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr "oscilador"
+#~ msgid "oscillator"
+#~ msgstr "oscilador"
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr "atraso"
+#~ msgid "delay"
+#~ msgstr "atraso"
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr "envelope"
+#~ msgid "envelope"
+#~ msgstr "envelope"
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr "filtrar"
+#~ msgid "filter"
+#~ msgstr "filtrar"
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr "aimúsica"
+#~ msgid "aimusic"
+#~ msgstr "aimúsica"
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr "a"
+#~ msgid "a"
+#~ msgstr "a"
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr " abaixo"
+#~ msgid " below"
+#~ msgstr " abaixo"
 
 #: js/widgets/modewidget.js:1017
 
@@ -8088,25 +8088,25 @@ msgstr "mover"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr "Novo bloco de ação gerado!"
+#~ msgid "New action block generated!"
+#~ msgstr "Novo bloco de ação gerado!"
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr "Gravação iniciada..."
+#~ msgid "Recording started..."
+#~ msgstr "Gravação iniciada..."
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr "Gravação completa..."
+#~ msgid "Recording complete..."
+#~ msgstr "Gravação completa..."
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "duração"
+#~ msgid "duration"
+#~ msgstr "duração"
 
 #: js/widgets/temperament.js:454
 
@@ -8116,46 +8116,46 @@ msgstr "mover"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr "fechar"
+#~ msgid "close"
+#~ msgstr "fechar"
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr "Publicar projeto"
+#~ msgid "Publish Project"
+#~ msgstr "Publicar projeto"
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr "tocar"
+#~ msgid "play"
+#~ msgstr "tocar"
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr "Lilypond não pode processar a coleta de"
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr "Lilypond não pode processar a coleta de"
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr "Atualize a página do seu navegador para mudar para o modo avançado."
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr "Atualize a página do seu navegador para mudar para o modo avançado."
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr "Atualize a página do seu navegador para mudar para o modo iniciante."
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr "Atualize a página do seu navegador para mudar para o modo iniciante."
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr "Novos blocos de ação gerados"
+#~ msgid "New action blocks generated"
+#~ msgstr "Novos blocos de ação gerados"
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr "Novo bloco de ação gerado"
+#~ msgid "New action block generated"
+#~ msgstr "Novo bloco de ação gerado"
 
-#~msgid ""Toggle Fullscreen"
-#~msgstr "Alternar tela cheia"
+#~ msgid "Toggle Fullscreen"
+#~ msgstr "Alternar tela cheia"
 
 #: js/toolbar.js:70
 
@@ -8165,190 +8165,190 @@ msgstr "mover"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr "Alternar Editor JavaScript"
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr "Alternar Editor JavaScript"
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr "O bloco Tom da Tartaruga retorna o número do tom atual sendo tocado pela tartaruga especificada."
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr "O bloco Tom da Tartaruga retorna o número do tom atual sendo tocado pela tartaruga especificada."
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr "O Bloco Passo Escalar deve ser usado dentro de um Bloco de Notas."
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr "O Bloco Passo Escalar deve ser usado dentro de um Bloco de Notas."
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr "O Bloco Passo Escalar deve ser precedido de um Bloco de Tom."
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr "O Bloco Passo Escalar deve ser precedido de um Bloco de Tom."
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr "Novos blocos de ação gerados!"
+#~ msgid "New action blocks generated!"
+#~ msgstr "Novos blocos de ação gerados!"
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr "Tela Cheia"
+#~ msgid "FullScreen"
+#~ msgstr "Tela Cheia"
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr "Alternar modo de tela cheia."
+#~ msgid "Toggle full screen mode."
+#~ msgstr "Alternar modo de tela cheia."
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr "O bloco Tuplet é usado para gerar um grupo de notas executadas em uma quantidade de tempo condensada."
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr "O bloco Tuplet é usado para gerar um grupo de notas executadas em uma quantidade de tempo condensada."
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr "O uso de tuplets facilita a criação de grupos de notas que não são baseadas em uma potência de 2."
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr "O uso de tuplets facilita a criação de grupos de notas que não são baseadas em uma potência de 2."
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr "O bloco Definir temperamento é usado para escolher o sistema de afinação usado pelos Music Blocks."
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr "O bloco Definir temperamento é usado para escolher o sistema de afinação usado pelos Music Blocks."
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr "O bloco Número de Intervalo retorna o número de passos escalares no intervalo atual."
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr "O bloco Número de Intervalo retorna o número de passos escalares no intervalo atual."
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr "O bloco de intervalos Semi-tom mede a distância entre duas notas em semi-tons."
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr "O bloco de intervalos Semi-tom mede a distância entre duas notas em semi-tons."
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr "O bloco de intervalos Semi-tom calcula um intervalo relativo baseado em meios tons."
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr "O bloco de intervalos Semi-tom calcula um intervalo relativo baseado em meios tons."
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr "O bloco Arpejo executará cada bloco de nota várias vezes, adicionando uma transposição com base no acorde especificado."
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr "O bloco Arpejo executará cada bloco de nota várias vezes, adicionando uma transposição com base no acorde especificado."
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr "O bloco intervalo Escalar calcula um intervalo relativo baseado no modo atual, pulando todas as notas fora do modo."
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr "O bloco intervalo Escalar calcula um intervalo relativo baseado no modo atual, pulando todas as notas fora do modo."
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr "O bloco do modo Definir permite definir um modo personalizado especificando números de notas."
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr "O bloco do modo Definir permite definir um modo personalizado especificando números de notas."
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr "Quando Móveis é falso, os nomes das notas de solfejo estão sempre ligados a tons específicos,"
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr "Quando Móveis é falso, os nomes das notas de solfejo estão sempre ligados a tons específicos,"
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr "ex.: "dó" é sempre "Dó natural" quando Dó Móvel é verdadeiro, os nomes das notas solfejo são atribuídos aos graus da escala "dó" é sempre o primeiro grau da escala maior."
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr "ex.: \"dó\" é sempre \"Dó natural\" quando Dó Móvel é verdadeiro, os nomes das notas solfejo são atribuídos aos graus da escala \"dó\" é sempre o primeiro grau da escala maior."
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr "O bloco Ação é usado para agrupar blocos para que eles possam ser usados mais de uma vez."
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr "O bloco Ação é usado para agrupar blocos para que eles possam ser usados mais de uma vez."
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr "O bloco Maior-do-que retorna Verdadeiro se o número superior for maior que o número inferior."
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr "O bloco Maior-do-que retorna Verdadeiro se o número superior for maior que o número inferior."
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr "O bloco Menor-do-que retorna Verdadeiro se o número superior for menor que o número inferior."
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr "O bloco Menor-do-que retorna Verdadeiro se o número superior for menor que o número inferior."
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "Neste exemplo, o ratinho se move para a direita até alcançar a borda direita da tela; então reaparece à esquerda da tela."
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "Neste exemplo, o ratinho se move para a direita até alcançar a borda direita da tela; então reaparece à esquerda da tela."
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "Neste exemplo, a tartaruga se move para a direita até atingir a borda direita da tela; então ela reaparece à esquerda da tela."
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "Neste exemplo, a tartaruga se move para a direita até atingir a borda direita da tela; então ela reaparece à esquerda da tela."
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "Neste exemplo, o ratinho se move para cima até alcançar a borda superior da tela; então reaparece na parte de baixo da tela."
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "Neste exemplo, o ratinho se move para cima até alcançar a borda superior da tela; então reaparece na parte de baixo da tela."
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "Neste exemplo, a tartaruga se move para cima até atingir a borda superior da tela; então ela reaparece na parte inferior da tela."
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "Neste exemplo, a tartaruga se move para cima até atingir a borda superior da tela; então ela reaparece na parte inferior da tela."
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr "material de vídeo"
+#~ msgid "video material"
+#~ msgstr "material de vídeo"
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr "O bloco Executar bloco executa um bloco. Ele aceita dois tipos de argumentos: número do bloco ou nome do bloco."
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr "O bloco Executar bloco executa um bloco. Ele aceita dois tipos de argumentos: número do bloco ou nome do bloco."
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr "O bloco Definir bateria selecionará um som de bateria para substituir o tom de todas as notas contidas."
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr "O bloco Definir bateria selecionará um som de bateria para substituir o tom de todas as notas contidas."
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr "O bloco do valor da Nota é o valor da duração da nota atualmente sendo executada."
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr "O bloco do valor da Nota é o valor da duração da nota atualmente sendo executada."
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr "O bloco Milissegundos é semelhante a um bloco de Notas, exceto pelo fato de usar o tempo (em MS) para especificar a duração da nota."
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr "O bloco Milissegundos é semelhante a um bloco de Notas, exceto pelo fato de usar o tempo (em MS) para especificar a duração da nota."
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr "O bloco Swing trabalha em pares de notas (especificadas pelo valor da nota), adicionando alguma duração (especificada pelo valor do swing) à primeira nota e retirando a mesma quantidade da segunda nota."
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr "O bloco Swing trabalha em pares de notas (especificadas pelo valor da nota), adicionando alguma duração (especificada pelo valor do swing) à primeira nota e retirando a mesma quantidade da segunda nota."
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr "O bloco Multiplicar valor da nota altera a duração das notas alterando os valores das notas."
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr "O bloco Multiplicar valor da nota altera a duração das notas alterando os valores das notas."
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr "Um resto da duração do valor da nota especificada pode ser construída usando um bloco Silenciar."
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr "Um resto da duração do valor da nota especificada pode ser construída usando um bloco Silenciar."
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr "O bloco Mostrar-pilha exibe o conteúdo da pilha no topo da tela."
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr "O bloco Mostrar-pilha exibe o conteúdo da pilha no topo da tela."
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr "A saida do exemplo é: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr "A saida do exemplo é: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
 
 #: js/FlowBlocks.js:679
 
@@ -8358,394 +8358,394 @@ msgstr "mover"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr "Condicionais permitem que o seu programa tome ações diferentes dependendo da condição."
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr "Condicionais permitem que o seu programa tome ações diferentes dependendo da condição."
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr "Neste exemplo, se o botão do mouse for pressionado, uma caixa clara tocará, caso contrário, um bumbo tocará."
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr "Neste exemplo, se o botão do mouse for pressionado, uma caixa clara tocará, caso contrário, um bumbo tocará."
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr "Neste exemplo de uma bateria eletrônica, um bumbo toca 1/4 de nota para sempre."
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr "Neste exemplo de uma bateria eletrônica, um bumbo toca 1/4 de nota para sempre."
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr "O bloco Arco move o ratinho em arco."
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr "O bloco Arco move o ratinho em arco."
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr "O bloco Arco move a tartaruga em um arco."
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr "O bloco Arco move a tartaruga em um arco."
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr "O bloco Definir rumo define o rumo do ratinho."
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr "O bloco Definir rumo define o rumo do ratinho."
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr "O bloco Envoltório ativa ou desativa o envolvimento da tela para as ações gráficas dentro dele."
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr "O bloco Envoltório ativa ou desativa o envolvimento da tela para as ações gráficas dentro dele."
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr "O bloco Legato alonga a sustentação das notas enquanto mantém o valor rítmico especificado das notas."
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr "O bloco Legato alonga a sustentação das notas enquanto mantém o valor rítmico especificado das notas."
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr "O bloco Staccato encurta a duração da nota real enquanto mantém o valor rítmico especificado das notas."
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr "O bloco Staccato encurta a duração da nota real enquanto mantém o valor rítmico especificado das notas."
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr "O bloco Decrescendo diminuirá o volume das notas contidas em um valor especificado para cada nota tocada."
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "O bloco Decrescendo diminuirá o volume das notas contidas em um valor especificado para cada nota tocada."
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr "Por exemplo, se você tiver 7 notas em sequência contidas em um bloco Decrescendo com um valor de 5, a nota final será 35% menor que o volume inicial."
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr "Por exemplo, se você tiver 7 notas em sequência contidas em um bloco Decrescendo com um valor de 5, a nota final será 35% menor que o volume inicial."
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr "O bloco Crescendo aumentará o volume das notas contidas em um valor especificado para cada nota tocada."
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "O bloco Crescendo aumentará o volume das notas contidas em um valor especificado para cada nota tocada."
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr "Por exemplo, se você tiver 7 notas em sequência contidas em um bloco Crescendo com um valor de 5, a nota final será 35% maior que o volume inicial."
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr "Por exemplo, se você tiver 7 notas em sequência contidas em um bloco Crescendo com um valor de 5, a nota final será 35% maior que o volume inicial."
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr "O bloco Parcial é usado para especificar um peso para um harmônico parcial específico."
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr "O bloco Parcial é usado para especificar um peso para um harmônico parcial específico."
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr "O bloco parcial Ponderado é usado para especificar os parciais associados a um timbre."
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr "O bloco parcial Ponderado é usado para especificar os parciais associados a um timbre."
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr "O bloco definir instrumento padrão muda o instrumento padrão do sintetizador eletrônico para o instrumento de sua escolha."
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr "O bloco definir instrumento padrão muda o instrumento padrão do sintetizador eletrônico para o instrumento de sua escolha."
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr "O bloco Fator de batida retorna a proporção do valor da nota em relação ao valor da nota do compasso."
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr "O bloco Fator de batida retorna a proporção do valor da nota em relação ao valor da nota do compasso."
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr "Na figura, isso é usado para executar uma ação na primeira batida de cada medida."
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr "Na figura, isso é usado para executar uma ação na primeira batida de cada medida."
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr "(Por padrão, ele conta 1/4 de notas)."
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr "(Por padrão, ele conta 1/4 de notas)."
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr "O bloco Mostrar-dicionário exibe o conteúdo do dicionário na parte superior da tela."
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr "O bloco Mostrar-dicionário exibe o conteúdo do dicionário na parte superior da tela."
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr "O bloco Comentar exibe um comentário no topo da tela quando o programa é executado no modo lento."
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr "O bloco Comentar exibe um comentário no topo da tela quando o programa é executado no modo lento."
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr "O bloco Cursor sobre dispara um evento quando o cursor é movido sobre um mouse."
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr "O bloco Cursor sobre dispara um evento quando o cursor é movido sobre um mouse."
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr "O bloco Cursor sobre dispara um evento quando o cursor é movido sobre uma tartaruga."
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr "O bloco Cursor sobre dispara um evento quando o cursor é movido sobre uma tartaruga."
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr "O bloco Cursor fora dispara um evento quando o cursor é movido para fora de um mouse."
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr "O bloco Cursor fora dispara um evento quando o cursor é movido para fora de um mouse."
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr "O bloco Cursor fora dispara um evento quando o cursor é movido para fora de uma tartaruga."
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr "O bloco Cursor fora dispara um evento quando o cursor é movido para fora de uma tartaruga."
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr "O bloco Botão do cursor pressionado dispara um evento quando o botão do cursor é pressionado sobre um mouse."
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr "O bloco Botão do cursor pressionado dispara um evento quando o botão do cursor é pressionado sobre um mouse."
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr "O bloco Botão do cursor pressionado dispara um evento quando o botão do cursor é pressionado sobre uma tartaruga."
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr "O bloco Botão do cursor pressionado dispara um evento quando o botão do cursor é pressionado sobre uma tartaruga."
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr "O bloco Botão do cursor liberado dispara um evento quando o botão do cursor é liberado sobre um mouse."
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr "O bloco Botão do cursor liberado dispara um evento quando o botão do cursor é liberado sobre um mouse."
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr "O bloco Botão do cursor liberado dispara um evento quando o botão do cursor é liberado sobre uma tartaruga."
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr "O bloco Botão do cursor liberado dispara um evento quando o botão do cursor é liberado sobre uma tartaruga."
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr "O bloco Obtenha azul retorna o componente azul do pixel sob o ratinho."
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr "O bloco Obtenha azul retorna o componente azul do pixel sob o ratinho."
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr "O bloco Obter azul retorna o componente azul do pixel sob a tartaruga."
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr "O bloco Obter azul retorna o componente azul do pixel sob a tartaruga."
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr "O bloco Obtenha verde retorna o componente verde do pixel sob o ratinho."
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr "O bloco Obtenha verde retorna o componente verde do pixel sob o ratinho."
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr "O bloco Obter verde retorna o componente verde do pixel sob a tartaruga."
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr "O bloco Obter verde retorna o componente verde do pixel sob a tartaruga."
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr "O bloco Tempo retorna o número de segundos que o programa está executando."
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr "O bloco Tempo retorna o número de segundos que o programa está executando."
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr "Mais detalhes"
+#~ msgid "More Details"
+#~ msgstr "Mais detalhes"
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr "Compartilhar projeto"
+#~ msgid "Share project"
+#~ msgstr "Compartilhar projeto"
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr "Copiar o link para a área de transferência"
+#~ msgid "Copy link to clipboard"
+#~ msgstr "Copiar o link para a área de transferência"
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr "Executar projeto ao iniciar."
+#~ msgid "Run project on startup."
+#~ msgstr "Executar projeto ao iniciar."
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr "Mostrar blocos de código ao iniciar."
+#~ msgid "Show code blocks on startup."
+#~ msgstr "Mostrar blocos de código ao iniciar."
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr "Recolher blocos de código ao iniciar."
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr "Recolher blocos de código ao iniciar."
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr "Opções avançadas"
+#~ msgid "Advanced Options"
+#~ msgstr "Opções avançadas"
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr "Bloco de Hertz: Você quis usar um Bloco de Notas?"
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr "Bloco de Hertz: Você quis usar um Bloco de Notas?"
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr "Diferente do projeto"
+#~ msgid "Unlike project"
+#~ msgstr "Diferente do projeto"
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr "Curtir projeto"
+#~ msgid "Like project"
+#~ msgstr "Curtir projeto"
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr "Recurso indisponível - não é possível conectar-se ao servidor. Recarregue o Turtle Blocks para tentar novamente."
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr "Recurso indisponível - não é possível conectar-se ao servidor. Recarregue o Turtle Blocks para tentar novamente."
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr "Republicar projeto"
+#~ msgid "Republish Project"
+#~ msgstr "Republicar projeto"
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr "arquivo de áudio1"
+#~ msgid "audio file1"
+#~ msgstr "arquivo de áudio1"
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr "arquivo de áudio2"
+#~ msgid "audio file2"
+#~ msgstr "arquivo de áudio2"
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr "Aviso: Valor da nota maior que 2."
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr "Aviso: Valor da nota maior que 2."
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr "acorde5"
+#~ msgid "chord5"
+#~ msgstr "acorde5"
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr "acorde4"
+#~ msgid "chord4"
+#~ msgstr "acorde4"
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr "acorde1"
+#~ msgid "chord1"
+#~ msgstr "acorde1"
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr "O bloco Cursor Y retorna a posição vertical da tartaruga."
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr "O bloco Cursor Y retorna a posição vertical da tartaruga."
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr "O bloco Cursor X retorna a posição horizontal da tartaruga."
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr "O bloco Cursor X retorna a posição horizontal da tartaruga."
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr "O bloco Nome da N-ésima Tartaruga retorna o nome da n-ésima tartaruga."
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr "O bloco Nome da N-ésima Tartaruga retorna o nome da n-ésima tartaruga."
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "Tocar rápido"
+#~ msgid "Run fast"
+#~ msgstr "Tocar rápido"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "Expandir/recolher blocos recolhíveis"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "Expandir/recolher blocos recolhíveis"
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr "O bloco Nome do N-ésimo Mouse retorna o nome do n-ésimo mouse."
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr "O bloco Nome do N-ésimo Mouse retorna o nome do n-ésimo mouse."
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr "buscar blocos"
+#~ msgid "search for blocks"
+#~ msgstr "buscar blocos"
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr "Por favor, configure o navegador para zoom 100%"
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr "Por favor, configure o navegador para zoom 100%"
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr "Para executar este projeto, abra o Music Blocks em um navegador web e arraste e solte este arquivo na janela do navegador."
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr "Para executar este projeto, abra o Music Blocks em um navegador web e arraste e solte este arquivo na janela do navegador."
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr "Você deve ter sempre ao menos um bloco iniciar."
+#~ msgid "You must always have at least one start block."
+#~ msgstr "Você deve ter sempre ao menos um bloco iniciar."
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr "tom acima"
+#~ msgid "pitch up"
+#~ msgstr "tom acima"
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr "tom abaixo"
+#~ msgid "pitch down"
+#~ msgstr "tom abaixo"
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr "acidente acima"
+#~ msgid "accidental up"
+#~ msgstr "acidente acima"
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr "acidente abaixo"
+#~ msgid "accidental down"
+#~ msgstr "acidente abaixo"
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr "oitava acima"
+#~ msgid "octave up"
+#~ msgstr "oitava acima"
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr "oitava abaixo"
+#~ msgid "octave down"
+#~ msgstr "oitava abaixo"
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "moeda"
+#~ msgid "currency"
+#~ msgstr "moeda"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "de"
+#~ msgid "from"
+#~ msgstr "de"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "preço das ações"
+#~ msgid "stock price"
+#~ msgstr "preço das ações"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "traduzir"
+#~ msgid "translate"
+#~ msgstr "traduzir"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "olá"
+#~ msgid "hello"
+#~ msgstr "olá"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "detectar idioma"
+#~ msgid "detect lang"
+#~ msgstr "detectar idioma"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "definir idioma"
+#~ msgid "set lang"
+#~ msgstr "definir idioma"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "latitude da cidade"
+#~ msgid "city latitude"
+#~ msgstr "latitude da cidade"
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "longitude da cidade"
+#~ msgid "city longitude"
+#~ msgstr "longitude da cidade"
 
 #: plugins/gmap.rtp:71
 
@@ -8755,144 +8755,144 @@ msgstr "mover"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "Dados da coordenada não disponíveis"
+#~ msgid "Coordinate data not available."
+#~ msgstr "Dados da coordenada não disponíveis"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "Mapa do google"
+#~ msgid "Google map"
+#~ msgstr "Mapa do google"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "coordenadas"
+#~ msgid "coordinates"
+#~ msgstr "coordenadas"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "fator de zoom"
+#~ msgid "zoom factor"
+#~ msgstr "fator de zoom"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "zoom"
+#~ msgid "zoom"
+#~ msgstr "zoom"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "latitude"
+#~ msgid "latitude"
+#~ msgstr "latitude"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "longitude"
+#~ msgid "longitude"
+#~ msgstr "longitude"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "graus"
+#~ msgid "degrees"
+#~ msgstr "graus"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "radianos"
+#~ msgid "radians"
+#~ msgstr "radianos"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "definir"
+#~ msgid "define"
+#~ msgstr "definir"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "bitcoin"
+#~ msgid "bitcoin"
+#~ msgstr "bitcoin"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr "Você deve selecionar um arquivo."
+#~ msgid "You need to select a file."
+#~ msgstr "Você deve selecionar um arquivo."
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr "mostrar clave de sol"
+#~ msgid "show treble"
+#~ msgstr "mostrar clave de sol"
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr "ocultar Polar"
+#~ msgid "hide Polar"
+#~ msgstr "ocultar Polar"
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr "mostrar clave de fá"
+#~ msgid "show bass"
+#~ msgstr "mostrar clave de fá"
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr "mostrar mezzo-soprano"
+#~ msgid "show mezzo-soprano"
+#~ msgstr "mostrar mezzo-soprano"
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr "mostrar contralto"
+#~ msgid "show alto"
+#~ msgstr "mostrar contralto"
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr "mostrar tenor"
+#~ msgid "show tenor"
+#~ msgstr "mostrar tenor"
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr "ocultar clave de fá"
+#~ msgid "hide bass"
+#~ msgstr "ocultar clave de fá"
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr "Mostrar Polar"
+#~ msgid "show Polar"
+#~ msgstr "Mostrar Polar"
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr "ocultar Cartesiano"
+#~ msgid "hide Cartesian"
+#~ msgstr "ocultar Cartesiano"
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr "Lilypond não pode processar tempo de "
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr "Lilypond não pode processar tempo de "
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr "Salvar como PDF"
+#~ msgid "Save as PDF"
+#~ msgstr "Salvar como PDF"
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr "Ignorando modo Lilypond"
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr "Ignorando modo Lilypond"
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr "AMPLIAR"
+#~ msgid "ZOOM IN"
+#~ msgstr "AMPLIAR"
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr "REDUZIR"
+#~ msgid "ZOOM OUT"
+#~ msgstr "REDUZIR"
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr "Clique para selecionar um bloco."
+#~ msgid "Click to select a block."
+#~ msgstr "Clique para selecionar um bloco."
 
 #: js/palette.js:1205
 
@@ -8902,15 +8902,15 @@ msgstr "mover"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr "ocultar"
+#~ msgid "hide"
+#~ msgstr "ocultar"
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr "mostrar2"
+#~ msgid "show2"
+#~ msgstr "mostrar2"
 
 #: js/palette.js:1222
 
@@ -8920,23 +8920,23 @@ msgstr "mover"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr "popout"
+#~ msgid "popout"
+#~ msgstr "popout"
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr "meusblocos"
+#~ msgid "myblocks"
+#~ msgstr "meusblocos"
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr "Você deseja salvar o seu projeto?"
+#~ msgid "Do you want to save your project?"
+#~ msgstr "Você deseja salvar o seu projeto?"
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr "Bloco de Bateria: Você quis usar um Bloco de Notas?"
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr "Bloco de Bateria: Você quis usar um Bloco de Notas?"
 
 #: js/pitchtracker.js:181
 
@@ -8946,8 +8946,8 @@ msgstr "mover"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr "Iniciar Gravação"
+#~ msgid "Start Recording"
+#~ msgstr "Iniciar Gravação"
 
 #: js/pitchtracker.js:188
 
@@ -8955,224 +8955,224 @@ msgstr "mover"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr "Parar Gravação"
+#~ msgid "Stop Recording"
+#~ msgstr "Parar Gravação"
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr "salvar ritmos"
+#~ msgid "save rhythms"
+#~ msgstr "salvar ritmos"
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr "arrastar"
+#~ msgid "drag"
+#~ msgstr "arrastar"
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr "Bloco de Tom: Você quis usar um Bloco de Notas?"
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr "Bloco de Tom: Você quis usar um Bloco de Notas?"
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr "Sr. Mouse", 0, 0)]"
+#~ msgid "Mr. Mouse\\\", 0, 0)]"
+#~ msgstr "Sr. Mouse\\\", 0, 0)]"
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr "O bloco Click retorna Verdadeiro se um ratinho tiver sido clicado."
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr "O bloco Click retorna Verdadeiro se um ratinho tiver sido clicado."
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr "O bloco Caixa 2 retorna o valor armazenado na Caixa 2."
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr "O bloco Caixa 2 retorna o valor armazenado na Caixa 2."
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr "O bloco Caixa 1 retorna o valor armazenado na Caixa 1."
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr "O bloco Caixa 1 retorna o valor armazenado na Caixa 1."
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr "Ocultar blocos."
+#~ msgid "Hide blocks."
+#~ msgstr "Ocultar blocos."
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr "Não é possível diminuir mais"
+#~ msgid "Cannot be further decreased"
+#~ msgstr "Não é possível diminuir mais"
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr "Não é possível aumentar mais"
+#~ msgid "Cannot be further increased"
+#~ msgstr "Não é possível aumentar mais"
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr "Erro: Não é possível salvar porque você ficou sem armazenamento local. Tente excluir alguns projetos salvos."
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr "Erro: Não é possível salvar porque você ficou sem armazenamento local. Tente excluir alguns projetos salvos."
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr "Desligando o piscar do ratinho; definição de FPS para 10."
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr "Desligando o piscar do ratinho; definição de FPS para 10."
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr "Desligando o piscar do ratinho; definição de FPS para 30."
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr "Desligando o piscar do ratinho; definição de FPS para 30."
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr "Transposições escalares são iguais a transposições de Semitons para temperamento personalizado."
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr "Transposições escalares são iguais a transposições de Semitons para temperamento personalizado."
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr "Você só pode amarrar notas do mesmo tom. Você quis usar Legato?"
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr "Você só pode amarrar notas do mesmo tom. Você quis usar Legato?"
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr "Aviso: O valor da nota é maior que 2."
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr "Aviso: O valor da nota é maior que 2."
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr "O nome da nota deve ser um de A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr "O nome da nota deve ser um de A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr "Você deseja remover todas as pilhas da sua paleta \"%s"\?"
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr "Você deseja remover todas as pilhas da sua paleta \"%s\"?"
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr "Este botão abre um visualizador para compartilhar projetos e buscar exemplos de projetos."
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr "Este botão abre um visualizador para compartilhar projetos e buscar exemplos de projetos."
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr "Clicar neste botão para expandir ou recolher a barra de ferramentas auxiliar."
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr "Clicar neste botão para expandir ou recolher a barra de ferramentas auxiliar."
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr "A batida da música é determinada pelo bloco Medidor (por padrão, 4 1/4 notas por compasso)."
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr "A batida da música é determinada pelo bloco Medidor (por padrão, 4 1/4 notas por compasso)."
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr "O bloco batidas Mestre por minuto define o número de notas de 1/4 por minuto para cada voz."
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr "O bloco batidas Mestre por minuto define o número de notas de 1/4 por minuto para cada voz."
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr "O bloco Em-cada-nota permite que você especifique ações a serem realizadas em cada nota."
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr "O bloco Em-cada-nota permite que você especifique ações a serem realizadas em cada nota."
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr "O bloco Notas tocadas é o número de notas que foram tocadas."
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr "O bloco Notas tocadas é o número de notas que foram tocadas."
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr "O bloco do Número do Tom reproduzirá um tom associado pelo seu número, por exemplo, 0 para C e 7 para G."
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr "O bloco do Número do Tom reproduzirá um tom associado pelo seu número, por exemplo, 0 para C e 7 para G."
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr "O bloco Pitch-slider abre uma ferramenta para gerar tom arbitrário."
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr "O bloco Pitch-slider abre uma ferramenta para gerar tom arbitrário."
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr "Todos os blocos Iniciar são executados ao mesmo tempo quando o botão Executar é pressionado."
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr "Todos os blocos Iniciar são executados ao mesmo tempo quando o botão Executar é pressionado."
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr "O bloco Armazenar na Caixa 1 é usado para armazenar um valor na Caixa 1."
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr "O bloco Armazenar na Caixa 1 é usado para armazenar um valor na Caixa 1."
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr "O bloco Armazenar na Caixa 2 é usado para armazenar um valor na Caixa 2."
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr "O bloco Armazenar na Caixa 2 é usado para armazenar um valor na Caixa 2."
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr "O bloco Casco é usado para alterar a aparência do ratinho."
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr "O bloco Casco é usado para alterar a aparência do ratinho."
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr "O bloco de Coleta é usado para acomodar todas as notas que vêm antes da batida."
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr "O bloco de Coleta é usado para acomodar todas as notas que vêm antes da batida."
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr "O bloco Batidas por minuto altera as batidas por minuto de quaisquer notas contidas."
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr "O bloco Batidas por minuto altera as batidas por minuto de quaisquer notas contidas."
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr "O bloco Batida-forte permite que você especifique ações para executar batidas especificadas."
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr "O bloco Batida-forte permite que você especifique ações para executar batidas especificadas."
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr "O bloco Batida-fraca permite que você especifique ações para executar batidas fracas (desligadas)."
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr "O bloco Batida-fraca permite que você especifique ações para executar batidas fracas (desligadas)."
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "por exemplo \"do\" é sempre \"C-natural\"); quando Móveis do é verdadeiro, os nomes das notas de solfejo são atribuídos a graus de escala (\"do\" é sempre o primeiro grau da escala maior)."
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "por exemplo \"do\" é sempre \"C-natural\"); quando Móveis do é verdadeiro, os nomes das notas de solfejo são atribuídos a graus de escala (\"do\" é sempre o primeiro grau da escala maior)."
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr "O bloco de volume Nota retorna o volume atual do sintetizador atual."
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr "O bloco de volume Nota retorna o volume atual do sintetizador atual."
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr "O bloco Padrão é usado dentro de um Trocar para definir a ação padrão."
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr "O bloco Padrão é usado dentro de um Trocar para definir a ação padrão."
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr "O bloco nota do Ratinho retorna o atual valor da nota sendo executada pelo ratinho especificado."
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr "O bloco nota do Ratinho retorna o atual valor da nota sendo executada pelo ratinho especificado."
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr "baixo menor"
+#~ msgid "down minor"
+#~ msgstr "baixo menor"
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr "baixo maior"
+#~ msgid "down major"
+#~ msgstr "baixo maior"
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr "eval"
+#~ msgid "eval"
+#~ msgstr "eval"
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr "100"
+#~ msgid "100"
+#~ msgstr "100"
 
 #: js/playback.js:87
 
@@ -9188,37 +9188,37 @@ msgstr "mover"
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr "Arrastar"
+#~ msgid "Drag"
+#~ msgstr "Arrastar"
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr "reproduzir música"
+#~ msgid "playback music"
+#~ msgstr "reproduzir música"
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr "pausar reprodução"
+#~ msgid "pause playback"
+#~ msgstr "pausar reprodução"
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr "reiniciar reprodução"
+#~ msgid "restart playback"
+#~ msgstr "reiniciar reprodução"
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr "preparar música para reprodução"
+#~ msgid "prepare music for playback"
+#~ msgstr "preparar música para reprodução"
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr "Carregar blocos"
+#~ msgid "Load blocks"
+#~ msgstr "Carregar blocos"
 
 #: js/turtledefs.js:304
 
@@ -9226,28 +9226,28 @@ msgstr "mover"
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr "o bloco Definir timbre seleciona uma voz para o sintetizador"
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr "o bloco Definir timbre seleciona uma voz para o sintetizador"
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr "O bloco Executar bloco executa um bloco."
+#~ msgid "The Run block block runs a block."
+#~ msgstr "O bloco Executar bloco executa um bloco."
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr "definir timbre"
+#~ msgid "set timbre"
+#~ msgstr "definir timbre"
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr "direita2"
+#~ msgid "right2"
+#~ msgstr "direita2"
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr "esquerda2"
+#~ msgid "left2"
+#~ msgstr "esquerda2"
 
 #: js/pitchtimematrix.js:323
 
@@ -9261,8 +9261,8 @@ msgstr "mover"
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr "expandir"
+#~ msgid "expand"
+#~ msgstr "expandir"
 
 #: js/pitchtimematrix.js:338
 
@@ -9272,549 +9272,549 @@ msgstr "mover"
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr "recolher"
+#~ msgid "collapse"
+#~ msgstr "recolher"
 
 #: js/musicutils.js:296
 
-#~msgid "japanese"
-#~msgstr "japonês"
+#~ msgid "japanese"
+#~ msgstr "japonês"
 
 #: js/basicblocks.js:3142 js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr "definir volume"
+#~ msgid "set volume"
+#~ msgstr "definir volume"
 
 #: js/pitchstaircase.js:401
 
-#~msgid "play scale"
-#~msgstr "tocar escala"
+#~ msgid "play scale"
+#~ msgstr "tocar escala"
 
 #: js/lilypond.js:19
 
-#~msgid "ml"
-#~msgstr "ml"
+#~ msgid "ml"
+#~ msgstr "ml"
 
 #: js/savebox.js:140
 
-#~msgid "Save block artwork"
-#~msgstr "Salvar bloco de arte"
+#~ msgid "Save block artwork"
+#~ msgstr "Salvar bloco de arte"
 
 #: js/activity.js:2767 js/activity.js:2779
 
-#~msgid "playback"
-#~msgstr "reproduzir"
+#~ msgid "playback"
+#~ msgstr "reproduzir"
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr "O bloco Plano-de-fundo define a cor do plano de fundo."
+#~ msgid "The Background block sets the background color."
+#~ msgstr "O bloco Plano-de-fundo define a cor do plano de fundo."
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr "Página anterior"
+#~ msgid "Previous page"
+#~ msgstr "Página anterior"
 
 #: js/timbre.js:597
 
-#~msgid "effects"
-#~msgstr "efeitos"
+#~ msgid "effects"
+#~ msgstr "efeitos"
 
 #: js/savebox.js:130
 
-#~msgid "Share on Facebook"
-#~msgstr "Compartilhar no Facebook"
+#~ msgid "Share on Facebook"
+#~ msgstr "Compartilhar no Facebook"
 
 #: js/lilypond.js:19
 
-#~msgid "rs"
-#~msgstr "rs"
+#~ msgid "rs"
+#~ msgstr "rs"
 
 #: js/basicblocks.js:821
 
-#~msgid "divide note value"
-#~msgstr "dividir valor da nota"
+#~ msgid "divide note value"
+#~ msgstr "dividir valor da nota"
 
 #: js/rhythmruler.js:1107
 
-#~msgid "save drum machine"
-#~msgstr "salvar máquina de bateria"
+#~ msgid "save drum machine"
+#~ msgstr "salvar máquina de bateria"
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr "volume da nota"
+#~ msgid "note volume"
+#~ msgstr "volume da nota"
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr "topo"
+#~ msgid "top"
+#~ msgstr "topo"
 
 #: js/turtledefs.js:100
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "Abra um painel para configurar o Music Blocks."
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "Abra um painel para configurar o Music Blocks."
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr "O botão salvar-pilha salva uma pilha em uma paleta personalizada."
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr "O botão salvar-pilha salva uma pilha em uma paleta personalizada."
 
 #: js/lilypond.js:19
 
-#~msgid "m"
-#~msgstr "m"
+#~ msgid "m"
+#~ msgstr "m"
 
 #: js/turtledefs.js:104
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "Você pode carregar novos blocos do sistema de arquivos."
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "Você pode carregar novos blocos do sistema de arquivos."
 
 #: js/activity.js:2768 js/activity.js:2780 js/turtledefs.js:100
 
-#~msgid "Settings"
-#~msgstr "Configurações"
+#~ msgid "Settings"
+#~ msgstr "Configurações"
 
 #: js/pitchslider.js:387
 
-#~msgid "move down"
-#~msgstr "mover para baixo"
+#~ msgid "move down"
+#~ msgstr "mover para baixo"
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr "consoante passo acima"
+#~ msgid "consonant step up"
+#~ msgstr "consoante passo acima"
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr "Use o controle deslizante para alterar o tom."
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr "Use o controle deslizante para alterar o tom."
 
 #: js/logo.js:5487 js/logo.js:5511
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr "Bloco de Tuplet: Você quis usar um Bloco de Matriz?"
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr "Bloco de Tuplet: Você quis usar um Bloco de Matriz?"
 
 #: js/activity.js:2769 js/activity.js:2781 js/turtledefs.js:106
 
-#~msgid "Delete all"
-#~msgstr "Excluir tudo"
+#~ msgid "Delete all"
+#~ msgstr "Excluir tudo"
 
 #: js/modewidget.js:84
 
-#~msgid "rotate clockwise"
-#~msgstr "rotacionar sentido horário"
+#~ msgid "rotate clockwise"
+#~ msgstr "rotacionar sentido horário"
 
 #: js/logo.js:4750 js/logo.js:4771
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr "Entrada para Bloco Menor deve ser 2, 3, 6 ou 7"
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr "Entrada para Bloco Menor deve ser 2, 3, 6 ou 7"
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr "rodapé"
+#~ msgid "bottom"
+#~ msgstr "rodapé"
 
 #: js/logo.js:4657 js/logo.js:4678
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "A entrada para o Bloco Aumentado deve ser 1, 2, 3, 4, 5, 6, 7 ou 8"
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "A entrada para o Bloco Aumentado deve ser 1, 2, 3, 4, 5, 6, 7 ou 8"
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr "intervalo relativo"
+#~ msgid "relative interval"
+#~ msgstr "intervalo relativo"
 
 #: js/basicblocks.js:925
 
-#~msgid "on beat"
-#~msgstr "ligar batida"
+#~ msgid "on beat"
+#~ msgstr "ligar batida"
 
 #: js/pitchstaircase.js:396
 
-#~msgid "play chord"
-#~msgstr "tocar acorde"
+#~ msgid "play chord"
+#~ msgstr "tocar acorde"
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr "Clique para executar apenas a música no modo lento."
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr "Clique para executar apenas a música no modo lento."
 
 #: js/playback.js:31 js/playback.js:71 js/rhythmruler.js:771
 
 #: js/rhythmruler.js:1091 js/modewidget.js:60
 
-#~msgid "play all"
-#~msgstr "tocar tudo"
+#~ msgid "play all"
+#~ msgstr "tocar tudo"
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr "passo abaixo consoante"
+#~ msgid "consonant step down"
+#~ msgstr "passo abaixo consoante"
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr "Publicar"
+#~ msgid "Publish"
+#~ msgstr "Publicar"
 
 #: js/samplesviewer.js:577
 
-#~msgid "Worldwide"
-#~msgstr "Mundial"
+#~ msgid "Worldwide"
+#~ msgstr "Mundial"
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr "na batida fraca"
+#~ msgid "on weak beat"
+#~ msgstr "na batida fraca"
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Abrir"
+#~ msgid "Open"
+#~ msgstr "Abrir"
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr "Mais um bumbo vai tocar."
+#~ msgid "Else a kick drum will play."
+#~ msgstr "Mais um bumbo vai tocar."
 
 #: js/lilypond.js:19
 
-#~msgid "ch"
-#~msgstr "ch"
+#~ msgid "ch"
+#~ msgstr "ch"
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run the music note by note."
-#~msgstr "Clique para executar a música nota por nota."
+#~ msgid "Click to run the music note by note."
+#~ msgstr "Clique para executar a música nota por nota."
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr "poly"
+#~ msgid "poly"
+#~ msgstr "poly"
 
 #: js/pitchslider.js:373
 
-#~msgid "move up"
-#~msgstr "mover para cima"
+#~ msgid "move up"
+#~ msgstr "mover para cima"
 
 #: js/clearbox.js:66
 
-#~msgid "confirm"
-#~msgstr "confirmar"
+#~ msgid "confirm"
+#~ msgstr "confirmar"
 
 #: js/turtledefs.js:104 js/utilitybox.js:92
 
-#~msgid "Load plugin from file"
-#~msgstr "Carregar o plugin do arquivo"
+#~ msgid "Load plugin from file"
+#~ msgstr "Carregar o plugin do arquivo"
 
 #: js/savebox.js:97
 
-#~msgid "Save as .svg"
-#~msgstr "Salvar como .svg"
+#~ msgid "Save as .svg"
+#~ msgstr "Salvar como .svg"
 
 #: js/basicblocks.js:2768
 
-#~msgid "save svg"
-#~msgstr "salvar svg"
+#~ msgid "save svg"
+#~ msgstr "salvar svg"
 
 #: js/lilypond.js:19
 
-#~msgid "gs"
-#~msgstr "gs"
+#~ msgid "gs"
+#~ msgstr "gs"
 
 #: js/activity.js:2763 js/activity.js:2775 js/turtledefs.js:92
 
-#~msgid "Load project from files"
-#~msgstr "Carregar projetos de arquivos"
+#~ msgid "Load project from files"
+#~ msgstr "Carregar projetos de arquivos"
 
 #: js/turtledefs.js:85
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "Oculte ou mostre as paletas de bloco."
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "Oculte ou mostre as paletas de bloco."
 
 #: js/activity.js:2688
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr "Executar rápido/ mantenha pressionado para tocar lentamente"
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr "Executar rápido/ mantenha pressionado para tocar lentamente"
 
 #: js/activity.js:539
 
-#~msgid "hide grid"
-#~msgstr "Ocultar grade"
+#~ msgid "hide grid"
+#~ msgstr "Ocultar grade"
 
 #: js/lilypond.js:19
 
-#~msgid "fs"
-#~msgstr "fd"
+#~ msgid "fs"
+#~ msgstr "fd"
 
 #: js/basicblocks.js:727
 
-#~msgid "osctime"
-#~msgstr "osctime"
+#~ msgid "osctime"
+#~ msgstr "osctime"
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr "blues"
+#~ msgid "blues"
+#~ msgstr "blues"
 
 #: js/activity.js:2765
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr "Mantenha os blocos pressionados para copiar. Clique aqui para colar."
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr "Mantenha os blocos pressionados para copiar. Clique aqui para colar."
 
 #: js/basicblocks.js:669
 
-#~msgid "pitch-time matrix"
-#~msgstr "matriz tom-tempo"
+#~ msgid "pitch-time matrix"
+#~ msgstr "matriz tom-tempo"
 
 #: js/turtledefs.js:99
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "Mostrar ou ocultar uma grade de coordenadas polares."
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "Mostrar ou ocultar uma grade de coordenadas polares."
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr "Também pode ser usado com outros blocos, como Cor, largura do traço da caneta."
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr "Também pode ser usado com outros blocos, como Cor, largura do traço da caneta."
 
 #: js/turtledefs.js:84
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "Limpe a tela e devolva as tartarugas às suas posições iniciais."
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "Limpe a tela e devolva as tartarugas às suas posições iniciais."
 
 #: js/logo.js:3355
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr "O Bloco de Meio Tom deve ser usado dentro de um Bloco de Nota."
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr "O Bloco de Meio Tom deve ser usado dentro de um Bloco de Nota."
 
 #: js/basicblocks.js:347
 
-#~msgid "step pitch"
-#~msgstr "passo do tom"
+#~ msgid "step pitch"
+#~ msgstr "passo do tom"
 
 #: js/turtledefs.js:83
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr "Parar a música (e as tartarugas)."
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr "Parar a música (e as tartarugas)."
 
 #: js/lilypond.js:19
 
-#~msgid "bk"
-#~msgstr "bk"
+#~ msgid "bk"
+#~ msgstr "bk"
 
 #: js/lilypond.js:19
 
-#~msgid "bt"
-#~msgstr "bt"
+#~ msgid "bt"
+#~ msgstr "bt"
 
 #: js/lilypond.js:19
 
-#~msgid "br"
-#~msgstr "br"
+#~ msgid "br"
+#~ msgstr "br"
 
 #: js/basicblocks.js:2759
 
-#~msgid "save as lilypond"
-#~msgstr "salvar como lilypond"
+#~ msgid "save as lilypond"
+#~ msgstr "salvar como lilypond"
 
 #: js/modewidget.js:78
 
-#~msgid "rotate counter clockwise"
-#~msgstr "rotacionar no sentido anti-horário"
+#~ msgid "rotate counter clockwise"
+#~ msgstr "rotacionar no sentido anti-horário"
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr "etc."
+#~ msgid "etc."
+#~ msgstr "etc."
 
 #: js/pitchtimematrix.js:189
 
-#~msgid "sort"
-#~msgstr "ordenar"
+#~ msgid "sort"
+#~ msgstr "ordenar"
 
 #: js/activity.js:552 js/activity.js:559 js/activity.js:2766
 
 #: js/activity.js:2778 js/turtledefs.js:98 js/turtledefs.js:99
 
-#~msgid "Polar"
-#~msgstr "Polar"
+#~ msgid "Polar"
+#~ msgstr "Polar"
 
 #: js/lilypond.js:19
 
-#~msgid "gp"
-#~msgstr "gp"
+#~ msgid "gp"
+#~ msgstr "gp"
 
 #: js/savebox.js:105
 
-#~msgid "Save as .png"
-#~msgstr "Salvar como .png"
+#~ msgid "Save as .png"
+#~ msgstr "Salvar como .png"
 
 #: js/savebox.js:113
 
-#~msgid "Upload to Planet"
-#~msgstr "Enviar para o Planeta"
+#~ msgid "Upload to Planet"
+#~ msgstr "Enviar para o Planeta"
 
 #: js/samplesviewer.js:84 js/samplesviewer.js:100
 
-#~msgid "Download"
-#~msgstr "Baixar"
+#~ msgid "Download"
+#~ msgstr "Baixar"
 
 #: js/timbre.js:640
 
-#~msgid "add filter"
-#~msgstr "adicionar filtro"
+#~ msgid "add filter"
+#~ msgstr "adicionar filtro"
 
 #: js/logo.js:2643
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr "turtleHeaps não contém uma pilha válida para"
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr "turtleHeaps não contém uma pilha válida para"
 
 #: js/activity.js:2680 js/turtledefs.js:85
 
-#~msgid "Show/hide palettes"
-#~msgstr "Mostrar/ocultar\t palhetas"
+#~ msgid "Show/hide palettes"
+#~ msgstr "Mostrar/ocultar\t palhetas"
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr "pentatônico"
+#~ msgid "pentatonic"
+#~ msgstr "pentatônico"
 
 #: js/basicblocks.js:652 js/basicblocks.js:661
 
-#~msgid "rhythm ruler"
-#~msgstr "régua de ritmo"
+#~ msgid "rhythm ruler"
+#~ msgstr "régua de ritmo"
 
 #: js/logo.js:4703 js/logo.js:4725
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr "A entrada para o Bloco Maior deve ser 2, 3, 6 ou 7"
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr "A entrada para o Bloco Maior deve ser 2, 3, 6 ou 7"
 
 #: js/timbre.js:656 js/rhythmruler.js:1137 js/modewidget.js:96
 
 #: js/pitchstaircase.js:455
 
-#~msgid "undo"
-#~msgstr "desfazer"
+#~ msgid "undo"
+#~ msgstr "desfazer"
 
 #: js/turtledefs.js:94 js/savebox.js:122
 
-#~msgid "Save sheet music"
-#~msgstr "Salvar partitura"
+#~ msgid "Save sheet music"
+#~ msgstr "Salvar partitura"
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr "ajustar transposição"
+#~ msgid "adjust transposition"
+#~ msgstr "ajustar transposição"
 
 #: js/turtledefs.js:78
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "Clique para executar o projeto no modo rápido."
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "Clique para executar o projeto no modo rápido."
 
 #: js/activity.js:2677 js/turtledefs.js:82
 
-#~msgid "Run note by note"
-#~msgstr "Rodar nota a nota"
+#~ msgid "Run note by note"
+#~ msgstr "Rodar nota a nota"
 
 #: js/basicblocks.js:2539
 
-#~msgid "shell"
-#~msgstr "casco"
+#~ msgid "shell"
+#~ msgstr "casco"
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr "Próxima página"
+#~ msgid "Next page"
+#~ msgstr "Próxima página"
 
 #: js/basicblocks.js:915
 
-#~msgid "on offbeat do"
-#~msgstr "ligar desligar batida"
+#~ msgid "on offbeat do"
+#~ msgstr "ligar desligar batida"
 
 #: js/playback.js:28 js/tempo.js:212 js/tempo.js:217 js/rhythmruler.js:801
 
 #: js/rhythmruler.js:1318
 
-#~msgid "pause"
-#~msgstr "pausar"
+#~ msgid "pause"
+#~ msgstr "pausar"
 
-#~msgid "free time"
-#~msgstr "tempo livre"
+#~ msgid "free time"
+#~ msgstr "tempo livre"
 
 #: js/lilypond.js:19
 
-#~msgid "cb"
-#~msgstr "cb"
+#~ msgid "cb"
+#~ msgstr "cb"
 
 #: js/turtledefs.js:97
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr "Aparece após um longo pressionar em uma pilha."
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr "Aparece após um longo pressionar em uma pilha."
 
 #: js/logo.js:4565 js/logo.js:4586
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr "Entrada para o Bloco Perfeito deve ser 1, 4, 5 ou 8"
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr "Entrada para o Bloco Perfeito deve ser 1, 4, 5 ou 8"
 
 #: js/savebox.js:89
 
-#~msgid "Save as .tb"
-#~msgstr "Salvar como .tb"
+#~ msgid "Save as .tb"
+#~ msgstr "Salvar como .tb"
 
 #: js/lilypond.js:19
 
-#~msgid "cp"
-#~msgstr "cp"
+#~ msgid "cp"
+#~ msgstr "cp"
 
 #: js/turtledefs.js:95
 
-#~msgid "The Paste Button will highlight."
-#~msgstr "O Botão Colar irá exibir destaque."
+#~ msgid "The Paste Button will highlight."
+#~ msgstr "O Botão Colar irá exibir destaque."
 
 #: js/turtledefs.js:106
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "Remova todo o conteúdo da tela, incluindo os blocos."
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "Remova todo o conteúdo da tela, incluindo os blocos."
 
 #: js/samplesviewer.js:576
 
-#~msgid "On my device"
-#~msgstr "No meu dispositivo"
+#~ msgid "On my device"
+#~ msgstr "No meu dispositivo"
 
 #: js/logo.js:4611 js/logo.js:4632
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "A entrada para o Bloco Diminuído deve ser 1, 2, 3, 4, 5, 6, 7 ou 8"
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "A entrada para o Bloco Diminuído deve ser 1, 2, 3, 4, 5, 6, 7 ou 8"
 
 #: js/turtledefs.js:80
 
-#~msgid "Run music slow"
-#~msgstr "Executar música devagar"
+#~ msgid "Run music slow"
+#~ msgstr "Executar música devagar"
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr "Para copiar uma pilha para a área de transferência, pressione longamente na pilha"
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr "Para copiar uma pilha para a área de transferência, pressione longamente na pilha"
 
 #: js/pitchtimematrix.js:184
 
-#~msgid "export"
-#~msgstr "exportar"
+#~ msgid "export"
+#~ msgstr "exportar"
 
 #: js/timbre.js:510
 
-#~msgid "synthesizer"
-#~msgstr "sintetizador"
+#~ msgid "synthesizer"
+#~ msgstr "sintetizador"
 
 #: js/utilitybox.js:109
 
-#~msgid "Disable scrolling"
-#~msgstr "Desativar rolagem"
+#~ msgid "Disable scrolling"
+#~ msgstr "Desativar rolagem"
 
 #: js/logo.js:3939
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr "Bloco de Ritmo: Você quis usar um Bloco Matriz?"
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr "Bloco de Ritmo: Você quis usar um Bloco Matriz?"
 

--- a/po/quz.po
+++ b/po/quz.po
@@ -439,7 +439,7 @@ msgstr ""
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
 #: js/languagebox.js:208
-#.TRANS: Actualice su navegador para cambiar su preferencia de idioma.
+#. TRANS: Actualice su navegador para cambiar su preferencia de idioma.
 msgid "Refresh your browser to change your language preference."
 msgstr ""
 
@@ -448,7 +448,7 @@ msgid "Music Blocks is already set to this language."
 msgstr "Music Blocks ya está configurado en este idioma."
 
 #: js/planetInterface.js:131
-#.TRANS: El proyecto no está definido.
+#. TRANS: El proyecto no está definido.
 msgid "project undefined"
 msgstr ""
 
@@ -501,15 +501,15 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2501
 #: js/widgets/rhythmruler.js:2508
 #: js/widgets/phrasemaker.js:4996
-#.TRANS: acción
+#. TRANS: acción
 msgid "action"
 msgstr "ruway"
 
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
-#.TRANS: pato
+#. TRANS: animal sound effect
+#. TRANS: pato
 msgid "duck"
 msgstr "Waswa"
 
@@ -520,60 +520,60 @@ msgstr ""
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
-#.TRANS: Proyecto de Bloques de Música
+#. TRANS: Proyecto de Bloques de Música
 msgid "Music Blocks Project"
 msgstr ""
 
 #: js/SaveInterface.js:63
-#.TRANS: Este proyecto fue creado en Bloques de Música
+#. TRANS: Este proyecto fue creado en Bloques de Música
 msgid "This project was created in Music Blocks"
 msgstr ""
 
 #: js/SaveInterface.js:67
-#.TRANS: Bloques de Música es una aplicación de Software Libre
+#. TRANS: Bloques de Música es una aplicación de Software Libre
 msgid "Music Blocks is a Free/Libre Software application."
 msgstr ""
 
 #: js/SaveInterface.js:69
-#.TRANS: Se puede acceder al código fuente en
+#. TRANS: Se puede acceder al código fuente en
 msgid "The source code can be accessed at"
 msgstr ""
 
 #: js/SaveInterface.js:72
-#.TRANS: Para más información, consulte el
+#. TRANS: Para más información, consulte el
 msgid "For more information, please consult the"
 msgstr ""
 
 #: js/SaveInterface.js:76
 #: js/turtledefs.js:489
-#.TRANS: Guía de Bloques de Música
+#. TRANS: Guía de Bloques de Música
 msgid "Music Blocks Guide"
 msgstr ""
 
 #: js/SaveInterface.js:83
-#.TRANS: Alternativamente, abra el archivo en Bloques de Música usando el botón Cargar proyecto.
+#. TRANS: Alternativamente, abra el archivo en Bloques de Música usando el botón Cargar proyecto.
 msgid "Alternatively, open the file in Music Blocks using the Load project button."
 msgstr ""
 
 #: js/SaveInterface.js:85
-#.TRANS: Código de proyecto
+#. TRANS: Código de proyecto
 msgid "Project Code"
 msgstr ""
 
 #: js/SaveInterface.js:87
-#.TRANS: Este código almacena datos sobre los bloques en un proyecto.
+#. TRANS: Este código almacena datos sobre los bloques en un proyecto.
 msgid "This code stores data about the blocks in a project."
 msgstr ""
 
 #: js/SaveInterface.js:89
 #: js/blocks.js:5091
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: Mostrar
+#. TRANS: Mostrar
 msgid "Show"
 msgstr ""
 
 #: js/SaveInterface.js:91
-#.TRANS: Ocultar
+#. TRANS: Ocultar
 msgid "Hide"
 msgstr ""
 
@@ -587,56 +587,56 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
-#.TRANS: Mi proyecto
+#. TRANS: default project title when saving as Lilypond
+#. TRANS: Mi proyecto
 msgid "My Project"
 msgstr "hatun llamk’anay"
 
 #: js/SaveInterface.js:197
 #: planet/js/SaveInterface.js:58
-#.TRANS: Ninguna descripción provista
+#. TRANS: Ninguna descripción provista
 msgid "No description provided"
 msgstr "Mana mayqin willakuypas kamasqachu"
 
 #: js/SaveInterface.js:346
-#.TRANS: Tu grabación está en curso.
+#. TRANS: Tu grabación está en curso.
 msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
-#.TRANS: Nombre del archivo
+#. TRANS: File name prompt for save as Lilypond
+#. TRANS: Nombre del archivo
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
-#.TRANS: Título del proyecto
+#. TRANS: Project title prompt for save as Lilypond
+#. TRANS: Título del proyecto
 msgid "Project title"
 msgstr "Título del proyecto"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
-#.TRANS: Autor del Proyecto
+#. TRANS: Project title prompt for save as Lilypond
+#. TRANS: Autor del Proyecto
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
-#.TRANS: Incluye MIDI?
+#. TRANS: MIDI prompt for save as Lilypond
+#. TRANS: Incluye MIDI?
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
-#.TRANS: Incluye tablatura de guitarra
+#. TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Incluye tablatura de guitarra
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
-#.TRANS: Guardar como lilypond
+#. TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Guardar como lilypond
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -658,19 +658,19 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
-#.TRANS: Sr. Ratón
+#. TRANS: default project author when saving as Lilypond
+#. TRANS: Sr. Ratón
 msgid "Mr. Mouse"
 msgstr "Sr. Ratón"
 
 #: js/SaveInterface.js:589
-#.TRANS: El código de Lilypond se copia al portapapeles. Puedes pegarlo aquí:
+#. TRANS: El código de Lilypond se copia al portapapeles. Puedes pegarlo aquí:
 msgid "The Lilypond code is copied to clipboard. You can paste it here: "
 msgstr ""
 
 #: js/activity.js:411
 #: js/activity.js:416
-#.TRANS: Buscar bloques
+#. TRANS: Buscar bloques
 msgid "Search for blocks"
 msgstr ""
 
@@ -691,57 +691,57 @@ msgid "Click on stop saving"
 msgstr ""
 
 #: js/activity.js:1882
-#.TRANS: atrapar ratones
+#. TRANS: atrapar ratones
 msgid "Catching mice"
 msgstr ""
 
 #: js/activity.js:1883
-#.TRANS: limpiar los instrumentos
+#. TRANS: limpiar los instrumentos
 msgid "Cleaning the instruments"
 msgstr ""
 
 #: js/activity.js:1884
-#.TRANS: probando piezas clave
+#. TRANS: probando piezas clave
 msgid "Testing key pieces"
 msgstr ""
 
 #: js/activity.js:1885
-#.TRANS: lectura a primera vista
+#. TRANS: lectura a primera vista
 msgid "Sight-reading"
 msgstr ""
 
 #: js/activity.js:1886
-#.TRANS: combinando matemáticas y música
+#. TRANS: combinando matemáticas y música
 msgid "Combining math and music"
 msgstr ""
 
 #: js/activity.js:1887
-#.TRANS: generando más bloques
+#. TRANS: generando más bloques
 msgid "Generating more blocks"
 msgstr ""
 
 #: js/activity.js:1888
-#.TRANS: Do Re Mi Fa Sol La Si Do
+#. TRANS: Do Re Mi Fa Sol La Si Do
 msgid "Do Re Mi Fa Sol La Ti Do"
 msgstr ""
 
 #: js/activity.js:1889
-#.TRANS: afinar instrumentos de cuerda
+#. TRANS: afinar instrumentos de cuerda
 msgid "Tuning string instruments"
 msgstr ""
 
 #: js/activity.js:1890
-#.TRANS: presionando teclas aleatorias
+#. TRANS: presionando teclas aleatorias
 msgid "Pressing random keys"
 msgstr ""
 
 #: js/activity.js:2072
-#.TRANS: los plugins se eliminarán al reiniciar.
+#. TRANS: los plugins se eliminarán al reiniciar.
 msgid "plugins will be removed upon restart."
 msgstr ""
 
 #: js/activity.js:2081
-#.TRANS: Mostrar Cartesiano
+#. TRANS: Mostrar Cartesiano
 msgid "show Cartesian"
 msgstr ""
 
@@ -750,144 +750,144 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: grado de escala
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: grado de escala
 msgid "scale degree"
 msgstr ""
 
 #: js/activity.js:2606
 #: js/palette.js:681
-#.TRANS: nombre de voz
+#. TRANS: nombre de voz
 msgid "voice name"
 msgstr ""
 
 #: js/activity.js:2609
 #: js/palette.js:678
-#.TRANS: modo invertido
+#. TRANS: modo invertido
 msgid "invert mode"
 msgstr ""
 
 #: js/activity.js:2612
-#.TRANS: herramientas de producción
+#. TRANS: herramientas de producción
 msgid "output tools"
 msgstr ""
 
 #: js/activity.js:2615
-#.TRANS: nota personalizada
+#. TRANS: nota personalizada
 msgid "custom note"
 msgstr ""
 
 #: js/activity.js:2618
-#.TRANS: nombre accidental
+#. TRANS: nombre accidental
 msgid "accidental name"
 msgstr ""
 
 #: js/activity.js:2621
 #: js/blocks/PitchBlocks.js:855
-#.TRANS: 
+#. TRANS: 
 msgid "east indian solfege"
 msgstr ""
 
 #: js/activity.js:2624
 #: js/blocks/PitchBlocks.js:869
-#.TRANS: nombre de la nota
+#. TRANS: nombre de la nota
 msgid "note name"
 msgstr ""
 
 #: js/activity.js:2627
 #: js/blocks/IntervalsBlocks.js:94
-#.TRANS: nombre de temperamento
+#. TRANS: nombre de temperamento
 msgid "temperament name"
 msgstr ""
 
 #: js/activity.js:2630
 #: js/palette.js:675
-#.TRANS: nombre de modo
+#. TRANS: nombre de modo
 msgid "mode name"
 msgstr ""
 
 #: js/activity.js:2633
-#.TRANS: nombre de achorde
+#. TRANS: nombre de achorde
 msgid "chord name"
 msgstr ""
 
 #: js/activity.js:2636
 #: js/palette.js:698
-#.TRANS: nombre de intervalo
+#. TRANS: nombre de intervalo
 msgid "interval name"
 msgstr ""
 
 #: js/activity.js:2639
-#.TRANS: tipo de filtro
+#. TRANS: tipo de filtro
 msgid "filter type"
 msgstr ""
 
 #: js/activity.js:2642
-#.TRANS: tipo de oscilador
+#. TRANS: tipo de oscilador
 msgid "oscillator type"
 msgstr ""
 
 #: js/activity.js:2645
 #: js/blocks.js:2479
 #: js/blocks.js:2487
-#.TRANS: archivo de audio
+#. TRANS: archivo de audio
 msgid "audio file"
 msgstr ""
 
 #: js/activity.js:2648
 #: js/blocks/DrumBlocks.js:32
-#.TRANS: nombre de ruido
+#. TRANS: nombre de ruido
 msgid "noise name"
 msgstr ""
 
 #: js/activity.js:2651
 #: js/blocks/DrumBlocks.js:75
-#.TRANS: nombre del tambor
+#. TRANS: nombre del tambor
 msgid "drum name"
 msgstr ""
 
 #: js/activity.js:2654
 #: js/blocks/DrumBlocks.js:119
-#.TRANS: nombre de efectos
+#. TRANS: nombre de efectos
 msgid "effects name"
 msgstr ""
 
 #: js/activity.js:2657
-#.TRANS: modo de envoltura
+#. TRANS: modo de envoltura
 msgid "wrap mode"
 msgstr ""
 
 #: js/activity.js:2660
-#.TRANS: cargar archivo
+#. TRANS: cargar archivo
 msgid "load file"
 msgstr ""
 
 #: js/activity.js:2830
 #: js/activity.js:6368
-#.TRANS: Este bloque está en desuso.
+#. TRANS: Este bloque está en desuso.
 msgid "This block is deprecated."
 msgstr ""
 
 #: js/activity.js:2832
 #: js/activity.js:6370
-#.TRANS: Este bloque no se puede encontrar.
+#. TRANS: Este bloque no se puede encontrar.
 msgid "Block cannot be found."
 msgstr ""
 
 #: js/activity.js:3041
-#.TRANS: Guardar ilustraciones de bloques
+#. TRANS: Guardar ilustraciones de bloques
 msgid "Saving block artwork"
 msgstr ""
 
 #: js/activity.js:3045
 #: js/turtledefs.js:708
 #: planet/js/LocalCard.js:31
-#.TRANS: Copiar
+#. TRANS: Copiar
 msgid "Copy"
 msgstr "Kikinchay"
 
 #: js/activity.js:3052
-#.TRANS: Borrar
+#. TRANS: Borrar
 msgid "Erase"
 msgstr ""
 
@@ -954,7 +954,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:4608
 #: js/widgets/phrasemaker.js:4722
 #: plugins/rodi.rtp:191
-#.TRANS: Tocar
+#. TRANS: Tocar
 msgid "Play"
 msgstr "waqachiy"
 
@@ -986,18 +986,18 @@ msgstr "waqachiy"
 #: plugins/rodi.rtp:29
 #: plugins/rodi.rtp:73
 #: plugins/rodi.rtp:413
-#.TRANS: Detener
+#. TRANS: Detener
 msgid "Stop"
 msgstr "Sayachiy"
 
 #: js/activity.js:3084
 #: js/activity.js:3106
-#.TRANS: Pegar
+#. TRANS: Pegar
 msgid "Paste"
 msgstr ""
 
 #: js/activity.js:3088
-#.TRANS: Guardar ayuda de bloque
+#. TRANS: Guardar ayuda de bloque
 msgid "Save block help"
 msgstr ""
 
@@ -1008,60 +1008,60 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: si la sol fa mi re do
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: si la sol fa mi re do
 msgid "ti la sol fa mi re do"
 msgstr "si la sol fa mi re do"
 
 #: js/activity.js:3173
-#.TRANS: Saltando al final de la página
+#. TRANS: Saltando al final de la página
 msgid "Jumping to the bottom of the page."
 msgstr ""
 
 #: js/activity.js:3179
-#.TRANS: Desplazarse hacia arriba
+#. TRANS: Desplazarse hacia arriba
 msgid "Scrolling up."
 msgstr ""
 
 #: js/activity.js:3184
-#.TRANS: Desplazarse hacia abajo
+#. TRANS: Desplazarse hacia abajo
 msgid "Scrolling down."
 msgstr ""
 
 #: js/activity.js:3189
-#.TRANS: Bloque de extracción
+#. TRANS: Bloque de extracción
 msgid "Extracting block"
 msgstr ""
 
 #: js/activity.js:3197
-#.TRANS: Mover bloque hacia arriba
+#. TRANS: Mover bloque hacia arriba
 msgid "Moving block up."
 msgstr ""
 
 #: js/activity.js:3218
-#.TRANS: Mover bloque hacia abajo
+#. TRANS: Mover bloque hacia abajo
 msgid "Moving block down."
 msgstr ""
 
 #: js/activity.js:3239
-#.TRANS: Mover bloque a la izquierda
+#. TRANS: Mover bloque a la izquierda
 msgid "Moving block left."
 msgstr ""
 
 #: js/activity.js:3256
-#.TRANS: Mover bloque a la derecha
+#. TRANS: Mover bloque a la derecha
 msgid "Moving block right."
 msgstr ""
 
 #: js/activity.js:3271
-#.TRANS: Saltar a la posición inicial
+#. TRANS: Saltar a la posición inicial
 msgid "Jump to home position."
 msgstr ""
 
 #: js/activity.js:3298
 #: js/blocks/ExtrasBlocks.js:274
-#.TRANS: Ocultar bloques
+#. TRANS: Ocultar bloques
 msgid "Hide blocks"
 msgstr ""
 
@@ -1072,7 +1072,7 @@ msgstr ""
 
 #: js/activity.js:3679
 #: js/activity.js:3760
-#.TRANS: Objeto recuperado de la basura.
+#. TRANS: Objeto recuperado de la basura.
 msgid "Item restored from the trash."
 msgstr ""
 
@@ -1085,69 +1085,69 @@ msgid "Restore all items"
 msgstr ""
 
 #: js/activity.js:5016
-#.TRANS: Haga clic en el botón ejecutar para ejecutar el proyecto.
+#. TRANS: Haga clic en el botón ejecutar para ejecutar el proyecto.
 msgid "Click the run button to run the project."
 msgstr ""
 
 #: js/activity.js:6201
 #: js/turtledefs.js:756
-#.TRANS: Casa
+#. TRANS: Casa
 msgid "Home"
 msgstr ""
 
 #: js/activity.js:6209
 #: js/turtledefs.js:762
-#.TRANS: Mostrar u ocultar los bloques.
+#. TRANS: Mostrar u ocultar los bloques.
 msgid "Show/hide blocks"
 msgstr ""
 
 #: js/activity.js:6215
 #: js/turtledefs.js:768
-#.TRANS: Expandir / Contraer bloques
+#. TRANS: Expandir / Contraer bloques
 msgid "Expand/collapse blocks"
 msgstr ""
 
 #: js/activity.js:6221
 #: js/turtledefs.js:776
-#.TRANS: Disminuir el tamaño de los bloques
+#. TRANS: Disminuir el tamaño de los bloques
 msgid "Decrease block size"
 msgstr ""
 
 #: js/activity.js:6227
 #: js/turtledefs.js:782
-#.TRANS: Incrementar tamaño de bloques
+#. TRANS: Incrementar tamaño de bloques
 msgid "Increase block size"
 msgstr ""
 
 #: js/activity.js:6493
-#.TRANS: No se pudo analizar la entrada de JSON.
+#. TRANS: No se pudo analizar la entrada de JSON.
 msgid "Could not parse JSON input."
 msgstr ""
 
 #: js/activity.js:6624
-#.TRANS: Seleccionar está habilitado.
+#. TRANS: Seleccionar está habilitado.
 msgid "Select is enabled."
 msgstr ""
 
 #: js/activity.js:6624
-#.TRANS: Seleccionar está deshabilitado.
+#. TRANS: Seleccionar está deshabilitado.
 msgid "Select is disabled."
 msgstr ""
 
 #: js/activity.js:7005
 #: js/activity.js:7111
 #: js/activity.js:7162
-#.TRANS: No se puede cargar el proyecto desde el archivo. Compruebe el tipo de archivo.
+#. TRANS: No se puede cargar el proyecto desde el archivo. Compruebe el tipo de archivo.
 msgid "Cannot load project from the file. Please check the file type."
 msgstr ""
 
 #: js/activity.js:7448
-#.TRANS: El parametro es invalido.
+#. TRANS: El parametro es invalido.
 msgid "Invalid parameters"
 msgstr ""
 
 #: js/activity.js:7599
-#.TRANS: Error al regenerar las paletas. Actualice la página.
+#. TRANS: Error al regenerar las paletas. Actualice la página.
 msgid "Error regenerating palettes. Please refresh the page."
 msgstr ""
 
@@ -1156,7 +1156,7 @@ msgstr ""
 #: js/palette.js:688
 #: js/blocks/IntervalsBlocks.js:63
 #: js/blocks/WidgetBlocks.js:259
-#.TRANS: temperamento
+#. TRANS: temperamento
 msgid "temperament"
 msgstr "munasqanman tikrakuq"
 
@@ -1170,67 +1170,67 @@ msgstr "munasqanman tikrakuq"
 #: js/turtles.js:119
 #: js/blocks/ProgramBlocks.js:1267
 #: js/blocks/ActionBlocks.js:1223
-#.TRANS: iniciar
+#. TRANS: iniciar
 msgid "start"
 msgstr "qallari"
 
 #: js/block.js:1590
-#.TRANS: matriz
+#. TRANS: matriz
 msgid "matrix"
 msgstr ""
 
 #: js/block.js:1597
 #: js/blocks/WidgetBlocks.js:1510
 #: plugins/rodi.rtp:324
-#.TRANS: estatus
+#. TRANS: estatus
 msgid "status"
 msgstr "kakusqan"
 
 #: js/block.js:1604
-#.TRANS: mapa del tambor
+#. TRANS: mapa del tambor
 msgid "drum mapper"
 msgstr ""
 
 #: js/block.js:1611
-#.TRANS: regla
+#. TRANS: regla
 msgid "ruler"
 msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
-#.TRANS: timbre
+#. TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre
 msgid "timbre"
 msgstr "kunkariq"
 
 #: js/block.js:1625
-#.TRANS: escalera
+#. TRANS: escalera
 msgid "stair"
 msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
-#.TRANS: tempo
+#. TRANS: the speed at music is should be played.
+#. TRANS: tempo
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
-#.TRANS: modo
+#. TRANS: mode, e.g., Major in C Major
+#. TRANS: modo
 msgid "mode"
 msgstr "Tupasqa kunkakuna"
 
 #: js/block.js:1646
-#.TRANS: deslizador
+#. TRANS: deslizador
 msgid "slider"
 msgstr ""
 
 #: js/block.js:1653
 #: js/blocks/SensorsBlocks.js:1002
-#.TRANS: teclado
+#. TRANS: teclado
 msgid "keyboard"
 msgstr "ñup’una taqi"
 
@@ -1246,15 +1246,15 @@ msgstr "ñup’una taqi"
 #: js/blocks/RhythmBlocks.js:766
 #: js/blocks/VolumeBlocks.js:502
 #: js/widgets/phrasemaker.js:1124
-#.TRANS: tambor
+#. TRANS: tambor
 msgid "drum"
 msgstr "tankar"
 
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
-#.TRANS: hacer un ritmo
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: hacer un ritmo
 msgid "rhythm maker"
 msgstr " kunka ruray"
 
@@ -1279,8 +1279,8 @@ msgstr " kunka ruray"
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
-#.TRANS: valor de la nota
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: valor de la nota
 msgid "note value"
 msgstr "T’uyaq yupaynin"
 
@@ -1289,14 +1289,14 @@ msgstr "T’uyaq yupaynin"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
-#.TRANS: intervalo escalar
+#. TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: intervalo escalar
 msgid "scalar interval"
 msgstr "intervalo escalar"
 
 #: js/block.js:1688
 #: js/blocks/RhythmBlocks.js:148
-#.TRANS: milisegundos
+#. TRANS: milisegundos
 msgid "milliseconds"
 msgstr "k’ata tip"
 
@@ -1308,18 +1308,18 @@ msgstr "k’ata tip"
 #: js/blocks/RhythmBlocks.js:712
 #: js/widgets/rhythmruler.js:1177
 #: js/widgets/rhythmruler.js:1323
-#.TRANS: silencio
+#. TRANS: silencio
 msgid "silence"
 msgstr "ch’in"
 
 #: js/block.js:2542
-#.TRANS: scalar step
-#.TRANS: abajo
+#. TRANS: scalar step
+#. TRANS: abajo
 msgid "down"
 msgstr ""
 
 #: js/block.js:2543
-#.TRANS: arriba
+#. TRANS: arriba
 msgid "up"
 msgstr ""
 
@@ -1333,20 +1333,20 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
-#.TRANS: tono
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: tono
 msgid "pitch"
 msgstr "kunka"
 
 #: js/block.js:2963
-#.TRANS: El bloqueo de silencio no se puede eliminar.
+#. TRANS: El bloqueo de silencio no se puede eliminar.
 msgid "Silence block cannot be removed."
 msgstr ""
 
 #: js/block.js:3135
 #: js/piemenus.js:3457
-#.TRANS: Puedes restaurar bloques eliminados de la papelera con el botón Restaurar desde la papelera.
+#. TRANS: Puedes restaurar bloques eliminados de la papelera con el botón Restaurar desde la papelera.
 msgid "You can restore deleted blocks from the trash with the Restore From Trash button."
 msgstr ""
 
@@ -1366,7 +1366,7 @@ msgstr ""
 #: js/blocks/BooleanBlocks.js:948
 #: js/blocks/BooleanBlocks.js:1033
 #: js/blocks/SensorsBlocks.js:911
-#.TRANS: verdadero
+#. TRANS: verdadero
 msgid "true"
 msgstr "chiqaq"
 
@@ -1384,65 +1384,65 @@ msgstr "chiqaq"
 #: js/blocks/BooleanBlocks.js:849
 #: js/blocks/BooleanBlocks.js:950
 #: js/blocks/SensorsBlocks.js:913
-#.TRANS: falso
+#. TRANS: falso
 msgid "false"
 msgstr "llulla"
 
 #: js/block.js:3776
 #: js/block.js:3789
 #: js/blocks/ExtrasBlocks.js:618
-#.TRANS: Cartesiano
+#. TRANS: Cartesiano
 msgid "Cartesian"
 msgstr ""
 
 #: js/block.js:3777
 #: js/block.js:3790
 #: js/blocks/ExtrasBlocks.js:622
-#.TRANS: polar
+#. TRANS: polar
 msgid "polar"
 msgstr ""
 
 #: js/block.js:3778
 #: js/block.js:3791
 #: js/blocks/ExtrasBlocks.js:626
-#.TRANS: Cartesiano/Polar
+#. TRANS: Cartesiano/Polar
 msgid "Cartesian/Polar"
 msgstr ""
 
 #: js/block.js:3779
 #: js/block.js:3798
 #: js/blocks/ExtrasBlocks.js:655
-#.TRANS: ninguno
+#. TRANS: ninguno
 msgid "none"
 msgstr ""
 
 #: js/block.js:3792
 #: js/blocks/ExtrasBlocks.js:631
-#.TRANS: agudos
+#. TRANS: agudos
 msgid "treble"
 msgstr ""
 
 #: js/block.js:3793
 #: js/blocks/ExtrasBlocks.js:635
-#.TRANS: staff grande
+#. TRANS: staff grande
 msgid "grand staff"
 msgstr ""
 
 #: js/block.js:3794
 #: js/blocks/ExtrasBlocks.js:639
-#.TRANS: mezzo-soprano
+#. TRANS: mezzo-soprano
 msgid "mezzo-soprano"
 msgstr ""
 
 #: js/block.js:3795
 #: js/blocks/ExtrasBlocks.js:643
-#.TRANS: alto
+#. TRANS: alto
 msgid "alto"
 msgstr ""
 
 #: js/block.js:3796
 #: js/blocks/ExtrasBlocks.js:647
-#.TRANS: tenor
+#. TRANS: tenor
 msgid "tenor"
 msgstr ""
 
@@ -1450,37 +1450,37 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
-#.TRANS: bass
+#. TRANS: musical instrument
+#. TRANS: bass
 msgid "bass"
 msgstr ""
 
 #: js/block.js:3842
 #: js/blocks.js:2600
 #: js/blocks.js:3211
-#.TRANS: encendido
+#. TRANS: encendido
 msgid "on2"
 msgstr ""
 
 #: js/block.js:3844
 #: js/blocks.js:2602
 #: js/blocks.js:3213
-#.TRANS: apagado
+#. TRANS: apagado
 msgid "off"
 msgstr ""
 
 #: js/block.js:4411
-#.TRANS: no es un número
+#. TRANS: no es un número
 msgid "Not a number"
 msgstr ""
 
 #: js/block.js:4418
-#.TRANS: El valor de octava debe estar entre 1 y 8.
+#. TRANS: El valor de octava debe estar entre 1 y 8.
 msgid "Octave value must be between 1 and 8."
 msgstr ""
 
 #: js/block.js:4426
-#.TRANS: El bloqueo de silencio no se puede eliminar.
+#. TRANS: El bloqueo de silencio no se puede eliminar.
 msgid "Numbers can have at most 10 digits."
 msgstr ""
 
@@ -1498,19 +1498,19 @@ msgstr ""
 #: js/blocks/BoxesBlocks.js:285
 #: js/blocks/BoxesBlocks.js:405
 #: js/blocks/BoxesBlocks.js:594
-#.TRANS: caja
+#. TRANS: caja
 msgid "box"
 msgstr "tawa k'uchu"
 
 #: js/blocks.js:1713
-#.TRANS: Considera dividir esta pila en partes.
+#. TRANS: Considera dividir esta pila en partes.
 msgid "Consider breaking this stack into parts."
 msgstr ""
 
 #: js/blocks.js:2472
 #: js/palette.js:736
 #: js/blocks/MediaBlocks.js:602
-#.TRANS: abrir archivo
+#. TRANS: abrir archivo
 msgid "open file"
 msgstr ""
 
@@ -1518,7 +1518,7 @@ msgstr ""
 #: js/palette.js:657
 #: js/blocks/MediaBlocks.js:892
 #: js/blocks/MediaBlocks.js:963
-#.TRANS: texto
+#. TRANS: texto
 msgid "text"
 msgstr "qillqa"
 
@@ -1526,7 +1526,7 @@ msgstr "qillqa"
 #: js/palette.js:724
 #: js/palette.js:725
 #: js/blocks/BoxesBlocks.js:514
-#.TRANS: guardar en caja
+#. TRANS: guardar en caja
 msgid "store in box"
 msgstr "tawa k’uchupi waqaychay"
 
@@ -1537,7 +1537,7 @@ msgstr "tawa k’uchupi waqaychay"
 #: js/blocks.js:5862
 #: js/blocks.js:5883
 #: js/blocks/BoxesBlocks.js:772
-#.TRANS: caja1
+#. TRANS: caja1
 msgid "box1"
 msgstr "1 tawa k’uchu"
 
@@ -1548,7 +1548,7 @@ msgstr "1 tawa k’uchu"
 #: js/blocks.js:5864
 #: js/blocks.js:5885
 #: js/blocks/BoxesBlocks.js:663
-#.TRANS: caja2
+#. TRANS: caja2
 msgid "box2"
 msgstr "2 tawa k’uchu"
 
@@ -1557,9 +1557,9 @@ msgstr "2 tawa k’uchu"
 #: js/palette.js:727
 #: js/palette.js:1127
 #: js/blocks/BoxesBlocks.js:591
-#.TRANS: guardar en
+#. TRANS: guardar en
 msgid "store in"
-msgstr "imapi waqaychanki" "maypi waqaychanki"
+msgstr "imapi waqaychanki maypi waqaychanki"
 
 #: js/blocks.js:4122
 #: js/blocks/BoxesBlocks.js:595
@@ -1575,7 +1575,7 @@ msgstr "imapi waqaychanki" "maypi waqaychanki"
 #: js/blocks/EnsembleBlocks.js:393
 #: js/blocks/EnsembleBlocks.js:404
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: nombre
+#. TRANS: nombre
 msgid "name"
 msgstr "nombre"
 
@@ -1586,32 +1586,32 @@ msgstr "nombre"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/RhythmBlocks.js:1130
-#.TRANS: valor
+#. TRANS: valor
 msgid "value"
 msgstr "tupu"
 
 #: js/blocks.js:4465
-#.TRANS: Se detectó un bucle indefinido dentro de un bloque de valor de nota. Pueden ocurrir cosas inesperadas.
+#. TRANS: Se detectó un bucle indefinido dentro de un bloque de valor de nota. Pueden ocurrir cosas inesperadas.
 msgid "Forever loop detected inside a note value block. Unexpected things may happen."
 msgstr ""
 
 #: js/blocks.js:4988
-#.TRANS: No hay bloque seleccionado.
+#. TRANS: No hay bloque seleccionado.
 msgid "There is no block selected."
 msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
-#.TRANS: avatar
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: avatar
 msgid "avatar"
 msgstr "siq’isqa"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
-#.TRANS: muestra de audio
+#. TRANS: The sound sample that the user uploads.
+#. TRANS: muestra de audio
 msgid "sample"
 msgstr ""
 
@@ -1620,62 +1620,62 @@ msgstr ""
 #: js/lilypond.js:910
 #: js/lilypond.js:948
 #: js/rubrics.js:526
-#.TRANS: ratón
+#. TRANS: ratón
 msgid "mouse"
 msgstr ""
 
 #: js/lilypond.js:606
-#.TRANS: rata marrón
+#. TRANS: rata marrón
 msgid "brown rat"
 msgstr ""
 
 #: js/lilypond.js:607
-#.TRANS: topo
+#. TRANS: topo
 msgid "mole"
 msgstr ""
 
 #: js/lilypond.js:608
-#.TRANS: ardilla
+#. TRANS: ardilla
 msgid "chipmunk"
 msgstr ""
 
 #: js/lilypond.js:609
-#.TRANS: ardilla roja
+#. TRANS: ardilla roja
 msgid "red squirrel"
 msgstr ""
 
 #: js/lilypond.js:610
-#.TRANS: conejillo de indias
+#. TRANS: conejillo de indias
 msgid "guinea pig"
 msgstr ""
 
 #: js/lilypond.js:611
-#.TRANS: capybara
+#. TRANS: capybara
 msgid "capybara"
 msgstr ""
 
 #: js/lilypond.js:612
-#.TRANS: coypu
+#. TRANS: coypu
 msgid "coypu"
 msgstr ""
 
 #: js/lilypond.js:613
-#.TRANS: rata negra
+#. TRANS: rata negra
 msgid "black rat"
 msgstr ""
 
 #: js/lilypond.js:614
-#.TRANS: ardilla gris
+#. TRANS: ardilla gris
 msgid "grey squirrel"
 msgstr ""
 
 #: js/lilypond.js:615
-#.TRANS: ardilla voladora
+#. TRANS: ardilla voladora
 msgid "flying squirrel"
 msgstr ""
 
 #: js/lilypond.js:616
-#.TRANS: murciélago
+#. TRANS: murciélago
 msgid "bat"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 #: js/lilypond.js:951
 #: js/blocks/ActionBlocks.js:1256
 #: js/blocks/ExtrasBlocks.js:559
-#.TRANS: iniciar tambor
+#. TRANS: iniciar tambor
 msgid "start drum"
 msgstr "iniciar tambor"
 
@@ -1699,15 +1699,15 @@ msgstr "iniciar tambor"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
-#.TRANS: ritmo
+#. TRANS: an arrangement of notes based on duration
+#. TRANS: ritmo
 msgid "rhythm"
 msgstr "taki muyuchik"
 
 #: js/rubrics.js:525
 #: js/turtledefs.js:126
 #: js/turtledefs.js:227
-#.TRANS: tono
+#. TRANS: tono
 msgid "tone"
 msgstr ""
 
@@ -1715,7 +1715,7 @@ msgstr ""
 #: js/turtledefs.js:135
 #: js/turtledefs.js:236
 #: js/widgets/phrasemaker.js:1126
-#.TRANS: pluma
+#. TRANS: pluma
 msgid "pen"
 msgstr "qillqana"
 
@@ -1725,14 +1725,14 @@ msgstr "qillqana"
 #: js/blocks/NumberBlocks.js:981
 #: js/blocks/PitchBlocks.js:1717
 #: js/blocks/PitchBlocks.js:1758
-#.TRANS: número
+#. TRANS: número
 msgid "number"
 msgstr "yupana"
 
 #: js/rubrics.js:529
 #: js/turtledefs.js:130
 #: js/turtledefs.js:231
-#.TRANS: flujo
+#. TRANS: flujo
 msgid "flow"
 msgstr ""
 
@@ -1740,8 +1740,8 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: sensores
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: sensores
 msgid "Sensors"
 msgstr "musyapakuq"
 
@@ -1750,19 +1750,19 @@ msgstr "musyapakuq"
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: medios
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: medios
 msgid "Media"
 msgstr "imayna llamk’anapaq"
 
 #: js/rubrics.js:533
-#.TRANS: ratón
+#. TRANS: ratón
 msgid "mice"
 msgstr ""
 
 #: js/toolbar.js:48
 #: js/toolbar.js:114
-#.TRANS: Acerca de los Bloques de Música
+#. TRANS: Acerca de los Bloques de Música
 msgid "About Music Blocks"
 msgstr ""
 
@@ -1771,7 +1771,7 @@ msgstr ""
 #: js/toolbar.js:188
 #: js/toolbar.js:249
 #: js/turtledefs.js:509
-#.TRANS: Grabar
+#. TRANS: Grabar
 msgid "Record"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 #: js/toolbar.js:190
 #: js/toolbar.js:250
 #: js/toolbar.js:251
-#.TRANS: Pantalla completa
+#. TRANS: Pantalla completa
 msgid "Full screen"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 #: js/toolbar.js:191
 #: js/toolbar.js:252
 #: js/turtledefs.js:516
-#.TRANS: Alternar pantalla completa
+#. TRANS: Alternar pantalla completa
 msgid "Toggle Fullscreen"
 msgstr ""
 
@@ -1803,7 +1803,7 @@ msgstr ""
 #: js/toolbar.js:1118
 #: js/turtledefs.js:522
 #: planet/js/StringHelper.js:33
-#.TRANS: Nuevo proyecto
+#. TRANS: Nuevo proyecto
 msgid "New project"
 msgstr "Nuevo proyecto"
 
@@ -1812,7 +1812,7 @@ msgstr "Nuevo proyecto"
 #: js/toolbar.js:193
 #: js/toolbar.js:254
 #: js/turtledefs.js:528
-#.TRANS: Cargar proyecto de archivo
+#. TRANS: Cargar proyecto de archivo
 msgid "Load project from file"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 #: js/turtledefs.js:535
 #: js/turtledefs.js:546
 #: js/turtledefs.js:566
-#.TRANS: Guardar proyecto
+#. TRANS: Guardar proyecto
 msgid "Save project"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 #: js/toolbar.js:279
 #: js/turtledefs.js:536
 #: js/turtledefs.js:567
-#.TRANS: Guardar como HTML
+#. TRANS: Guardar como HTML
 msgid "Save project as HTML"
 msgstr ""
 
@@ -1850,7 +1850,7 @@ msgstr ""
 #: js/toolbar.js:125
 #: js/toolbar.js:196
 #: js/toolbar.js:257
-#.TRANS: Encuentra y comparte proyectos
+#. TRANS: Encuentra y comparte proyectos
 msgid "Find and share projects"
 msgstr ""
 
@@ -1858,7 +1858,7 @@ msgstr ""
 #: js/toolbar.js:126
 #: js/toolbar.js:197
 #: js/toolbar.js:258
-#.TRANS: Desconectado. Compartir no está disponible.
+#. TRANS: Desconectado. Compartir no está disponible.
 msgid "Offline. Sharing is unavailable"
 msgstr ""
 
@@ -1866,7 +1866,7 @@ msgstr ""
 #: js/toolbar.js:127
 #: js/toolbar.js:198
 #: js/toolbar.js:259
-#.TRANS: Menú auxiliar
+#. TRANS: Menú auxiliar
 msgid "Auxiliary menu"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 #: js/toolbar.js:260
 #: js/piemenus.js:3386
 #: js/turtledefs.js:592
-#.TRANS: Ayuda
+#. TRANS: Ayuda
 msgid "Help"
 msgstr ""
 
@@ -1885,7 +1885,7 @@ msgstr ""
 #: js/toolbar.js:200
 #: js/toolbar.js:261
 #: js/turtledefs.js:598
-#.TRANS: Tocar lentamente
+#. TRANS: Tocar lentamente
 msgid "Run slowly"
 msgstr ""
 
@@ -1894,7 +1894,7 @@ msgstr ""
 #: js/toolbar.js:201
 #: js/toolbar.js:262
 #: js/turtledefs.js:604
-#.TRANS: Ejecutar paso a paso
+#. TRANS: Ejecutar paso a paso
 msgid "Run step by step"
 msgstr ""
 
@@ -1903,7 +1903,7 @@ msgstr ""
 #: js/toolbar.js:202
 #: js/toolbar.js:263
 #: js/turtledefs.js:611
-#.TRANS: Analizar
+#. TRANS: Analizar
 msgid "Display statistics"
 msgstr ""
 
@@ -1912,7 +1912,7 @@ msgstr ""
 #: js/toolbar.js:203
 #: js/toolbar.js:264
 #: js/turtledefs.js:617
-#.TRANS: Cargar plugin
+#. TRANS: Cargar plugin
 msgid "Load plugin"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgstr ""
 #: js/toolbar.js:204
 #: js/toolbar.js:265
 #: js/turtledefs.js:625
-#.TRANS: Eliminar plugin
+#. TRANS: Eliminar plugin
 msgid "Delete plugin"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 #: js/toolbar.js:134
 #: js/toolbar.js:205
 #: js/toolbar.js:266
-#.TRANS: Habilitar desplazamiento horizontal
+#. TRANS: Habilitar desplazamiento horizontal
 msgid "Enable horizontal scrolling"
 msgstr ""
 
@@ -1937,7 +1937,7 @@ msgstr ""
 #: js/toolbar.js:135
 #: js/toolbar.js:206
 #: js/toolbar.js:267
-#.TRANS: Deshabilitar desplazamiento horizontal
+#. TRANS: Deshabilitar desplazamiento horizontal
 msgid "Disable horizontal scrolling"
 msgstr ""
 
@@ -1970,14 +1970,14 @@ msgstr ""
 #: js/turtledefs.js:648
 #: planet/js/LocalCard.js:54
 #: planet/js/StringHelper.js:71
-#.TRANS: Unir con el proyecto actual
+#. TRANS: Unir con el proyecto actual
 msgid "Merge with current project"
 msgstr "Unir con el proyecto actual"
 
 #: js/toolbar.js:74
 #: js/toolbar.js:140
 #: js/turtledefs.js:662
-#.TRANS: Establecer vista previa de tono
+#. TRANS: Establecer vista previa de tono
 msgid "Set Pitch Preview"
 msgstr ""
 
@@ -1986,7 +1986,7 @@ msgstr ""
 #: js/toolbar.js:211
 #: js/toolbar.js:272
 #: js/turtledefs.js:669
-#.TRANS: Editor de Javascript
+#. TRANS: Editor de Javascript
 msgid "JavaScript Editor"
 msgstr "JavaScript Llamk'apusqa"
 
@@ -1995,7 +1995,7 @@ msgstr "JavaScript Llamk'apusqa"
 #: js/toolbar.js:212
 #: js/toolbar.js:273
 #: js/turtledefs.js:676
-#.TRANS: Restaurar
+#. TRANS: Restaurar
 msgid "Restore"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 #: js/toolbar.js:143
 #: js/toolbar.js:213
 #: js/toolbar.js:274
-#.TRANS: Cambiar al modo principiante
+#. TRANS: Cambiar al modo principiante
 msgid "Switch to beginner mode"
 msgstr ""
 
@@ -2011,7 +2011,7 @@ msgstr ""
 #: js/toolbar.js:144
 #: js/toolbar.js:214
 #: js/toolbar.js:275
-#.TRANS: Cambiar a modo avanzado
+#. TRANS: Cambiar a modo avanzado
 msgid "Switch to advanced mode"
 msgstr ""
 
@@ -2021,7 +2021,7 @@ msgstr ""
 #: js/toolbar.js:215
 #: js/toolbar.js:276
 #: js/turtledefs.js:690
-#.TRANS: Seleccione el idioma
+#. TRANS: Seleccione el idioma
 msgid "Select language"
 msgstr ""
 
@@ -2029,37 +2029,37 @@ msgstr ""
 #: js/toolbar.js:84
 #: js/toolbar.js:148
 #: js/turtledefs.js:538
-#.TRANS: Guardar ilustraciones del ratón como PNG
+#. TRANS: Guardar ilustraciones del ratón como PNG
 msgid "Save mouse artwork as PNG"
 msgstr ""
 
 #: js/toolbar.js:83
 #: js/toolbar.js:147
-#.TRANS: Guardar ilustraciones del ratón como SVG
+#. TRANS: Guardar ilustraciones del ratón como SVG
 msgid "Save mouse artwork as SVG"
 msgstr ""
 
 #: js/toolbar.js:85
 #: js/toolbar.js:149
 #: js/turtledefs.js:569
-#.TRANS: Guarda música como WAV
+#. TRANS: Guarda música como WAV
 msgid "Save music as WAV"
 msgstr ""
 
 #: js/toolbar.js:86
 #: js/toolbar.js:150
-#.TRANS: Guardar partituras como ABC
+#. TRANS: Guardar partituras como ABC
 msgid "Save sheet music as ABC"
 msgstr ""
 
 #: js/toolbar.js:87
 #: js/toolbar.js:151
-#.TRANS: Guardar partituras como Lilypond.
+#. TRANS: Guardar partituras como Lilypond.
 msgid "Save sheet music as Lilypond"
 msgstr ""
 
 #: js/toolbar.js:88
-#.TRANS: Guardar partituras como MusicXML
+#. TRANS: Guardar partituras como MusicXML
 msgid "Save sheet music as MusicXML"
 msgstr ""
 
@@ -2069,7 +2069,7 @@ msgstr ""
 #: js/toolbar.js:221
 #: js/toolbar.js:282
 #: js/turtledefs.js:558
-#.TRANS: Guardar bloque de ilustraciones como SVG
+#. TRANS: Guardar bloque de ilustraciones como SVG
 msgid "Save block artwork as SVG"
 msgstr ""
 
@@ -2087,7 +2087,7 @@ msgstr ""
 #: js/toolbar.js:223
 #: js/toolbar.js:284
 #: js/toolbar.js:1134
-#.TRANS: Confirmar
+#. TRANS: Confirmar
 msgid "Confirm"
 msgstr ""
 
@@ -2095,7 +2095,7 @@ msgstr ""
 #: js/toolbar.js:164
 #: js/toolbar.js:224
 #: js/toolbar.js:285
-#.TRANS: 
+#. TRANS: 
 msgid "English (United States)"
 msgstr ""
 
@@ -2103,7 +2103,7 @@ msgstr ""
 #: js/toolbar.js:165
 #: js/toolbar.js:225
 #: js/toolbar.js:286
-#.TRANS: 
+#. TRANS: 
 msgid "English (United Kingdom)"
 msgstr ""
 
@@ -2111,12 +2111,12 @@ msgstr ""
 #: js/toolbar.js:166
 #: js/toolbar.js:226
 #: js/toolbar.js:287
-#.TRANS: 
+#. TRANS: 
 msgid "日本語"
 msgstr ""
 
 #: js/toolbar.js:95
-#.TRANS: 
+#. TRANS: 
 msgid "한국어"
 msgstr ""
 
@@ -2124,7 +2124,7 @@ msgstr ""
 #: js/toolbar.js:168
 #: js/toolbar.js:228
 #: js/toolbar.js:289
-#.TRANS: 
+#. TRANS: 
 msgid "español"
 msgstr ""
 
@@ -2132,7 +2132,7 @@ msgstr ""
 #: js/toolbar.js:169
 #: js/toolbar.js:229
 #: js/toolbar.js:290
-#.TRANS: 
+#. TRANS: 
 msgid "português"
 msgstr ""
 
@@ -2140,7 +2140,7 @@ msgstr ""
 #: js/toolbar.js:170
 #: js/toolbar.js:230
 #: js/toolbar.js:291
-#.TRANS: 
+#. TRANS: 
 msgid "にほんご"
 msgstr ""
 
@@ -2148,7 +2148,7 @@ msgstr ""
 #: js/toolbar.js:171
 #: js/toolbar.js:231
 #: js/toolbar.js:292
-#.TRANS: 
+#. TRANS: 
 msgid "中文"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 #: js/toolbar.js:172
 #: js/toolbar.js:232
 #: js/toolbar.js:293
-#.TRANS: 
+#. TRANS: 
 msgid "ภาษาไทย"
 msgstr ""
 
@@ -2164,7 +2164,7 @@ msgstr ""
 #: js/toolbar.js:173
 #: js/toolbar.js:233
 #: js/toolbar.js:294
-#.TRANS: 
+#. TRANS: 
 msgid "aymara"
 msgstr ""
 
@@ -2172,7 +2172,7 @@ msgstr ""
 #: js/toolbar.js:174
 #: js/toolbar.js:234
 #: js/toolbar.js:295
-#.TRANS: 
+#. TRANS: 
 msgid "quechua"
 msgstr ""
 
@@ -2180,7 +2180,7 @@ msgstr ""
 #: js/toolbar.js:175
 #: js/toolbar.js:235
 #: js/toolbar.js:296
-#.TRANS: 
+#. TRANS: 
 msgid "guarani"
 msgstr ""
 
@@ -2188,7 +2188,7 @@ msgstr ""
 #: js/toolbar.js:176
 #: js/toolbar.js:236
 #: js/toolbar.js:297
-#.TRANS: 
+#. TRANS: 
 msgid "हिंदी"
 msgstr ""
 
@@ -2196,7 +2196,7 @@ msgstr ""
 #: js/toolbar.js:178
 #: js/toolbar.js:237
 #: js/toolbar.js:299
-#.TRANS: 
+#. TRANS: 
 msgid "igbo"
 msgstr ""
 
@@ -2204,7 +2204,7 @@ msgstr ""
 #: js/toolbar.js:179
 #: js/toolbar.js:238
 #: js/toolbar.js:300
-#.TRANS: 
+#. TRANS: 
 msgid "عربى"
 msgstr ""
 
@@ -2212,7 +2212,7 @@ msgstr ""
 #: js/toolbar.js:177
 #: js/toolbar.js:239
 #: js/toolbar.js:298
-#.TRANS: 
+#. TRANS: 
 msgid "తెలుగు"
 msgstr ""
 
@@ -2220,7 +2220,7 @@ msgstr ""
 #: js/toolbar.js:180
 #: js/toolbar.js:240
 #: js/toolbar.js:301
-#.TRANS: 
+#. TRANS: 
 msgid "עִברִית"
 msgstr ""
 
@@ -2238,7 +2238,7 @@ msgstr ""
 #: js/toolbar.js:278
 #: js/toolbar.js:281
 #: js/turtledefs.js:554
-#.TRANS: Guardar la ilustración de la tortuga como PNG
+#. TRANS: Guardar la ilustración de la tortuga como PNG
 msgid "Save turtle artwork as PNG"
 msgstr ""
 
@@ -2246,55 +2246,55 @@ msgstr ""
 #: js/toolbar.js:219
 #: js/toolbar.js:280
 #: js/turtledefs.js:550
-#.TRANS: Guardar la ilustración de la tortuga como SVG
+#. TRANS: Guardar la ilustración de la tortuga como SVG
 msgid "Save turtle artwork as SVG"
 msgstr ""
 
 #: js/toolbar.js:167
 #: js/toolbar.js:227
 #: js/toolbar.js:288
-#.TRANS: 
+#. TRANS: 
 msgid "한국인"
 msgstr ""
 
 #: js/toolbar.js:185
 #: js/toolbar.js:246
-#.TRANS: Sobre TortuBloques
+#. TRANS: Sobre TortuBloques
 msgid "About Turtle Blocks"
 msgstr ""
 
 #: js/toolbar.js:494
 #: js/toolbar.js:505
 #: js/toolbar.js:545
-#.TRANS: No Envolver
+#. TRANS: No Envolver
 msgid "Turtle Wrap Off"
 msgstr ""
 
 #: js/toolbar.js:514
 #: js/toolbar.js:554
-#.TRANS: Envolver
+#. TRANS: Envolver
 msgid "Turtle Wrap On"
 msgstr ""
 
 #: js/toolbar.js:1121
-#.TRANS: Â¿Estás seguro de que deseas crear un nuevo proyecto?
+#. TRANS: Â¿Estás seguro de que deseas crear un nuevo proyecto?
 msgid "Are you sure you want to create a new project?"
 msgstr ""
 
 #: js/logo.js:61
-#.TRANS: No es un nombre de tono válido.
+#. TRANS: No es un nombre de tono válido.
 msgid "Not a valid pitch name"
 msgstr ""
 
 #: js/logo.js:507
 #: js/blocks/ProgramBlocks.js:258
 #: js/blocks/ProgramBlocks.js:427
-#.TRANS: Debe seleccionar un archivo.
+#. TRANS: Debe seleccionar un archivo.
 msgid "You must select a file."
 msgstr "Huk waqaychasqata ch’ikuy"
 
 #: js/logo.js:1688
-#.TRANS: La reproducción está preparada.
+#. TRANS: La reproducción está preparada.
 msgid "Playback is ready."
 msgstr ""
 
@@ -2304,8 +2304,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
-#.TRANS: doble agudas
+#. TRANS: double sharp is a music term related to pitch
+#. TRANS: doble agudas
 msgid "double sharp"
 msgstr "iskay ñañu kunka"
 
@@ -2317,9 +2317,9 @@ msgstr "iskay ñañu kunka"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
-#.TRANS: agudas
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
+#. TRANS: agudas
 msgid "sharp"
 msgstr "allin uyarikuy"
 
@@ -2329,8 +2329,8 @@ msgstr "allin uyarikuy"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
-#.TRANS: normal
+#. TRANS: natural is a music term related to pitch
+#. TRANS: normal
 msgid "natural"
 msgstr "purum"
 
@@ -2342,9 +2342,9 @@ msgstr "purum"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
-#.TRANS: planas
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
+#. TRANS: planas
 msgid "flat"
 msgstr "pampa"
 
@@ -2354,17 +2354,17 @@ msgstr "pampa"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
-#.TRANS: doble planas
+#. TRANS: double flat is a music term related to pitch
+#. TRANS: doble planas
 msgid "double flat"
 msgstr "iskay t’aqlla"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
-#.TRANS: unísono
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
+#. TRANS: unísono
 msgid "unison"
 msgstr "unísono"
 
@@ -2373,16 +2373,16 @@ msgstr "unísono"
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
-#.TRANS: mayor
+#. TRANS: major is a music term related to intervals and mode
+#. TRANS: mayor
 msgid "major"
 msgstr "kuraq"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
-#.TRANS: ionian
+#. TRANS: modal scale for music
+#. TRANS: ionian
 msgid "ionian"
 msgstr ""
 
@@ -2391,33 +2391,33 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
-#.TRANS: menor
+#. TRANS: minor is a music term related to intervals and mode
+#. TRANS: menor
 msgid "minor"
 msgstr "sullk’a"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
-#.TRANS: aeolian
+#. TRANS: modal scale for music
+#. TRANS: aeolian
 msgid "aeolian"
 msgstr ""
 
 #: js/piemenus.js:3373
 #: js/blocks/FlowBlocks.js:136
-#.TRANS: Duplicar
+#. TRANS: Duplicar
 msgid "Duplicate"
 msgstr ""
 
 #: js/piemenus.js:3374
 #: js/turtledefs.js:714
-#.TRANS: Extraer
+#. TRANS: Extraer
 msgid "Extract"
 msgstr ""
 
 #: js/piemenus.js:3375
-#.TRANS: Mover para recargar
+#. TRANS: Mover para recargar
 msgid "Move to trash"
 msgstr ""
 
@@ -2428,50 +2428,50 @@ msgstr ""
 #: js/widgets/temperament.js:1441
 #: js/widgets/timbre.js:962
 #: planet/js/StringHelper.js:69
-#.TRANS: Cerrar
+#. TRANS: Cerrar
 msgid "Close"
 msgstr "wisq’ay"
 
 #: js/piemenus.js:3382
-#.TRANS: Guardar pila
+#. TRANS: Guardar pila
 msgid "Save stack"
 msgstr ""
 
 #: js/piemenus.js:3412
-#.TRANS: Se detectó un bucle indefinido dentro de un bloque de valor de nota. Pueden ocurrir cosas inesperadas.
+#. TRANS: Se detectó un bucle indefinido dentro de un bloque de valor de nota. Pueden ocurrir cosas inesperadas.
 msgid "In order to copy a sample, you must reload the widget, import the sample again, and export it."
 msgstr ""
 
 #: js/piemenus.js:3801
-#.TRANS: Ha elegido la tecla para la vista previa de su tono.
+#. TRANS: Ha elegido la tecla para la vista previa de su tono.
 msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
-#.TRANS: Debe tener al menos un bloque parcial dentro de un bloque parcial ponderado.
+#. TRANS: partials are weighted components in a harmonic series
+#. TRANS: Debe tener al menos un bloque parcial dentro de un bloque parcial ponderado.
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
 #: js/turtle-singer.js:2078
-#.TRANS: Synth no puede tocar acordes.
+#. TRANS: Synth no puede tocar acordes.
 msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
-#.TRANS: https://github.com/sugarlabs/musicblocks/tree/master/guide-es/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: https://github.com/sugarlabs/musicblocks/tree/master/guide-es/README.md
 msgid "guide url"
 msgstr ""
 
 #: js/turtledefs.js:88
-#.TRANS: TortuBloques
+#. TRANS: TortuBloques
 msgid "Turtle Blocks"
 msgstr ""
 
 #: js/turtledefs.js:121
 #: js/turtledefs.js:222
-#.TRANS: buscar
+#. TRANS: buscar
 msgid "search"
 msgstr ""
 
@@ -2479,20 +2479,20 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
-#.TRANS: metro
+#. TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: metro
 msgid "meter"
 msgstr "tupuna"
 
 #: js/turtledefs.js:125
 #: js/turtledefs.js:226
-#.TRANS: intervalos
+#. TRANS: intervalos
 msgid "intervals"
 msgstr ""
 
 #: js/turtledefs.js:127
 #: js/turtledefs.js:228
-#.TRANS: ornamento
+#. TRANS: ornamento
 msgid "ornament"
 msgstr ""
 
@@ -2501,32 +2501,32 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:362
 #: js/blocks/VolumeBlocks.js:502
 #: js/blocks/VolumeBlocks.js:545
-#.TRANS: volumen
+#. TRANS: volumen
 msgid "volume"
 msgstr "volumen"
 
 #: js/turtledefs.js:132
 #: js/turtledefs.js:233
-#.TRANS: cajas
+#. TRANS: cajas
 msgid "boxes"
 msgstr ""
 
 #: js/turtledefs.js:133
 #: js/turtledefs.js:234
-#.TRANS: aparatos
+#. TRANS: aparatos
 msgid "widgets"
 msgstr ""
 
 #: js/turtledefs.js:134
 #: js/turtledefs.js:235
 #: js/widgets/phrasemaker.js:1125
-#.TRANS: gráficos
+#. TRANS: gráficos
 msgid "graphics"
 msgstr "siq’ikuna"
 
 #: js/turtledefs.js:137
 #: js/turtledefs.js:238
-#.TRANS: booleano
+#. TRANS: booleano
 msgid "boolean"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 #: js/turtledefs.js:241
 #: js/blocks/HeapBlocks.js:59
 #: js/widgets/status.js:143
-#.TRANS: pila
+#. TRANS: pila
 msgid "heap"
 msgstr ""
 
@@ -2542,68 +2542,68 @@ msgstr ""
 #: js/turtledefs.js:242
 #: js/blocks/DictBlocks.js:142
 #: js/blocks/ProgramBlocks.js:495
-#.TRANS: diccionario
+#. TRANS: diccionario
 msgid "dictionary"
 msgstr ""
 
 #: js/turtledefs.js:142
 #: js/turtledefs.js:243
-#.TRANS: conjunto
+#. TRANS: conjunto
 msgid "ensemble"
 msgstr ""
 
 #: js/turtledefs.js:143
 #: js/turtledefs.js:244
-#.TRANS: extras
+#. TRANS: extras
 msgid "extras"
 msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
-#.TRANS: programa
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: programa
 msgid "program"
 msgstr ""
 
 #: js/turtledefs.js:146
 #: js/turtledefs.js:247
-#.TRANS: mis bloques
+#. TRANS: mis bloques
 msgid "my blocks"
 msgstr ""
 
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
-#.TRANS: arte
+#. TRANS: arte
 msgid "artwork"
 msgstr ""
 
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
-#.TRANS: lógica
+#. TRANS: lógica
 msgid "logic"
 msgstr ""
 
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: música
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: música
 msgid "Music"
 msgstr "taki"
 
 #: js/turtledefs.js:190
-#.TRANS: Bloques de Música
+#. TRANS: Bloques de Música
 msgid "Music Blocks"
 msgstr ""
 
 #: js/turtledefs.js:438
-#.TRANS: Bienvenidos a TortuBloques
+#. TRANS: Bienvenidos a TortuBloques
 msgid "Welcome to Turtle Blocks"
 msgstr ""
 
 #: js/turtledefs.js:439
-#.TRANS: TortuBloques es una tortuga basada en Logo que dibuja imÃÂÃÂ¡genes coloridas programable de una forma visual con bloques encastrables.
+#. TRANS: TortuBloques es una tortuga basada en Logo que dibuja imÃÂÃÂ¡genes coloridas programable de una forma visual con bloques encastrables.
 msgid "Turtle Blocks is a Logo-inspired turtle that draws colorful pictures with snap-together visual-programming blocks."
 msgstr ""
 
@@ -2611,93 +2611,93 @@ msgstr ""
 #: js/turtledefs.js:467
 #: js/turtledefs.js:822
 #: js/turtledefs.js:845
-#.TRANS: La versión actual es
+#. TRANS: La versión actual es
 msgid "The current version is"
 msgstr ""
 
 #: js/turtledefs.js:448
 #: js/turtledefs.js:493
-#.TRANS: Haga clic para ejecutar el proyecto en modo rápido.
+#. TRANS: Haga clic para ejecutar el proyecto en modo rápido.
 msgid "Click the run button to run the project in fast mode."
 msgstr ""
 
 #: js/turtledefs.js:454
-#.TRANS: Detener la tortuga.
+#. TRANS: Detener la tortuga.
 msgid "Stop the turtle."
 msgstr ""
 
 #: js/turtledefs.js:456
 #: js/turtledefs.js:501
-#.TRANS: También puede escribir Alt-S para detenerse.
+#. TRANS: También puede escribir Alt-S para detenerse.
 msgid "You can also type Alt-S to stop."
 msgstr ""
 
 #: js/turtledefs.js:464
 #: js/widgets/help.js:335
-#.TRANS: Bienvenido a Bloques de Música
+#. TRANS: Bienvenido a Bloques de Música
 msgid "Welcome to Music Blocks"
 msgstr "Takiy t’aqaman allin hamunki"
 
 #: js/turtledefs.js:465
-#.TRANS: Bloques de Música es una colección de herramientas de manipulación para explorar conceptos musicales fundamentales de una manera integradora y divertido.
+#. TRANS: Bloques de Música es una colección de herramientas de manipulación para explorar conceptos musicales fundamentales de una manera integradora y divertido.
 msgid "Music Blocks is a collection of tools for exploring fundamental musical concepts in a fun way."
 msgstr ""
 
 #: js/turtledefs.js:474
 #: js/widgets/help.js:336
-#.TRANS: Conoce Sr. Ratón
+#. TRANS: Conoce Sr. Ratón
 msgid "Meet Mr. Mouse!"
 msgstr "Wiraqucha huk’uchata riqsinki"
 
 #: js/turtledefs.js:475
-#.TRANS: Sr. Ratón es nuestro conductor de Bloques de Música.
+#. TRANS: Sr. Ratón es nuestro conductor de Bloques de Música.
 msgid "Mr Mouse is our Music Blocks conductor."
 msgstr ""
 
 #: js/turtledefs.js:477
-#.TRANS: Sr. Ratón le anima a explorar los Bloques de Música.
+#. TRANS: Sr. Ratón le anima a explorar los Bloques de Música.
 msgid "Mr Mouse encourages you to explore Music Blocks."
 msgstr ""
 
 #: js/turtledefs.js:479
-#.TRANS: Vamos a empezar nuestro recorrido!
+#. TRANS: Vamos a empezar nuestro recorrido!
 msgid "Let us start our tour!"
 msgstr ""
 
 #: js/turtledefs.js:484
 #: js/turtledefs.js:807
 #: js/widgets/help.js:337
-#.TRANS: Guía
+#. TRANS: Guía
 msgid "Guide"
 msgstr "pusaq"
 
 #: js/turtledefs.js:485
-#.TRANS: Una guía detallada de Bloques de Música está disponible.
+#. TRANS: Una guía detallada de Bloques de Música está disponible.
 msgid "A detailed guide to Music Blocks is available."
 msgstr ""
 
 #: js/turtledefs.js:499
-#.TRANS: Detener la música (y los ratones)
+#. TRANS: Detener la música (y los ratones)
 msgid "Stop the music (and the mice)."
 msgstr ""
 
 #: js/turtledefs.js:510
-#.TRANS: Grabe su proyecto como video.
+#. TRANS: Grabe su proyecto como video.
 msgid "Record your project as video."
 msgstr ""
 
 #: js/turtledefs.js:517
-#.TRANS: Alternar el modo de pantalla completa
+#. TRANS: Alternar el modo de pantalla completa
 msgid "Toggle Fullscreen mode."
 msgstr ""
 
 #: js/turtledefs.js:523
-#.TRANS: Inicializar un nuevo proyecto.
+#. TRANS: Inicializar un nuevo proyecto.
 msgid "Initialize a new project."
 msgstr ""
 
 #: js/turtledefs.js:529
-#.TRANS: También puede cargar proyectos desde el sistema de archivos.
+#. TRANS: También puede cargar proyectos desde el sistema de archivos.
 msgid "You can also load projects from the file system."
 msgstr ""
 
@@ -2712,27 +2712,27 @@ msgstr ""
 #: js/widgets/temperament.js:2173
 #: js/widgets/timbre.js:750
 #: js/widgets/phrasemaker.js:561
-#.TRANS: Guardar
+#. TRANS: Guardar
 msgid "Save"
 msgstr "waqaychay"
 
 #: js/turtledefs.js:548
-#.TRANS: Guarde proyecto en archivo
+#. TRANS: Guarde proyecto en archivo
 msgid "Save your project to a file."
 msgstr ""
 
 #: js/turtledefs.js:552
-#.TRANS: Guardar gráficos de su proyecto como SVG
+#. TRANS: Guardar gráficos de su proyecto como SVG
 msgid "Save graphics from your project to as SVG."
 msgstr ""
 
 #: js/turtledefs.js:556
-#.TRANS: Guardar gráficos de su proyecto como PNG
+#. TRANS: Guardar gráficos de su proyecto como PNG
 msgid "Save graphics from your project as PNG."
 msgstr ""
 
 #: js/turtledefs.js:560
-#.TRANS: Guardar bloque de ilustraciones como un archivo de SVG
+#. TRANS: Guardar bloque de ilustraciones como un archivo de SVG
 msgid "Save block artwork as an SVG file."
 msgstr ""
 
@@ -2745,22 +2745,22 @@ msgid "Save block artwork as SVG or PNG"
 msgstr ""
 
 #: js/turtledefs.js:580
-#.TRANS: Cargar ejemplos desde el servidor
+#. TRANS: Cargar ejemplos desde el servidor
 msgid "Load samples from server"
 msgstr ""
 
 #: js/turtledefs.js:581
-#.TRANS: Este botón abre la pantalla de carga de proyectos de ejemplo.
+#. TRANS: Este botón abre la pantalla de carga de proyectos de ejemplo.
 msgid "This button opens a viewer for loading example projects."
 msgstr ""
 
 #: js/turtledefs.js:586
-#.TRANS: Expandir/colapsar la barra de opciones.
+#. TRANS: Expandir/colapsar la barra de opciones.
 msgid "Expand/collapse option toolbar"
 msgstr ""
 
 #: js/turtledefs.js:587
-#.TRANS: Haga clic en este botón para expandir o contraer la barra de herramientas auxiliar.
+#. TRANS: Haga clic en este botón para expandir o contraer la barra de herramientas auxiliar.
 msgid "Click this button to expand or collapse the auxillary toolbar."
 msgstr ""
 
@@ -2769,17 +2769,17 @@ msgid "Displays help messages for the main and auxiliary toolbar, right-click co
 msgstr ""
 
 #: js/turtledefs.js:599
-#.TRANS: Haz click para ejecutar el proyecto en modo lento.
+#. TRANS: Haz click para ejecutar el proyecto en modo lento.
 msgid "Click to run the project in slow mode."
 msgstr ""
 
 #: js/turtledefs.js:605
-#.TRANS: Haz click para ejecutar el proyecto en modo paso a paso.
+#. TRANS: Haz click para ejecutar el proyecto en modo paso a paso.
 msgid "Click to run the project step by step."
 msgstr ""
 
 #: js/turtledefs.js:612
-#.TRANS: Analizar los tipos de bloques usados.
+#. TRANS: Analizar los tipos de bloques usados.
 msgid "Display statistics about your Music project."
 msgstr ""
 
@@ -2788,17 +2788,17 @@ msgid "Load a selected plugin."
 msgstr ""
 
 #: js/turtledefs.js:626
-#.TRANS: Eliminar un plugin seleccionado.
+#. TRANS: Eliminar un plugin seleccionado.
 msgid "Delete a selected plugin."
 msgstr ""
 
 #: js/turtledefs.js:633
-#.TRANS: Activar scroll
+#. TRANS: Activar scroll
 msgid "Enable scrolling"
 msgstr ""
 
 #: js/turtledefs.js:634
-#.TRANS: Puedes mover los bloques por el área de trabajo
+#. TRANS: Puedes mover los bloques por el área de trabajo
 msgid "You can scroll the blocks on the canvas."
 msgstr ""
 
@@ -2811,12 +2811,12 @@ msgid "Click to add another project into the current one."
 msgstr ""
 
 #: js/turtledefs.js:654
-#.TRANS: Envolver tortuga
+#. TRANS: Envolver tortuga
 msgid "Wrap Turtle"
 msgstr ""
 
 #: js/turtledefs.js:655
-#.TRANS: Encender / apagar la envoltura de tortugas
+#. TRANS: Encender / apagar la envoltura de tortugas
 msgid "Turn Turtle wrapping On or Off."
 msgstr ""
 
@@ -2829,22 +2829,22 @@ msgid "Converts Music Block programs to JavaScript."
 msgstr ""
 
 #: js/turtledefs.js:677
-#.TRANS: Restaurar bloques de la papelera.
+#. TRANS: Restaurar bloques de la papelera.
 msgid "Restore blocks from the trash."
 msgstr ""
 
 #: js/turtledefs.js:684
-#.TRANS: Cambiar el modo
+#. TRANS: Cambiar el modo
 msgid "Switch mode"
 msgstr ""
 
 #: js/turtledefs.js:685
-#.TRANS: Cambia entre los modos principiante y avanzado.
+#. TRANS: Cambia entre los modos principiante y avanzado.
 msgid "Switch between beginner and advance modes."
 msgstr ""
 
 #: js/turtledefs.js:691
-#.TRANS: Seleccione su preferencia de idioma.
+#. TRANS: Seleccione su preferencia de idioma.
 msgid "Select your language preference."
 msgstr ""
 
@@ -2858,32 +2858,32 @@ msgstr ""
 
 #: js/turtledefs.js:702
 #: planet/js/StringHelper.js:46
-#.TRANS: Borrar
+#. TRANS: Borrar
 msgid "Delete"
 msgstr "Borrar"
 
 #: js/turtledefs.js:703
-#.TRANS: Para eliminar un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de eliminar.
+#. TRANS: Para eliminar un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de eliminar.
 msgid "To delete a block, right-click on it. You will see the delete option."
 msgstr ""
 
 #: js/turtledefs.js:709
-#.TRANS: Para copiar un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de copiar.
+#. TRANS: Para copiar un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de copiar.
 msgid "To copy a block, right-click on it. You will see the copy option."
 msgstr ""
 
 #: js/turtledefs.js:715
-#.TRANS: Para extraer un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de extracción.
+#. TRANS: Para extraer un bloque, simplemente haz clic derecho sobre él, luego podrás ver la opción de extracción.
 msgid "To extract a block, right-click on it. You will see the extract option."
 msgstr ""
 
 #: js/turtledefs.js:721
-#.TRANS: Atajos de teclado
+#. TRANS: Atajos de teclado
 msgid "Keyboard shortcuts"
 msgstr ""
 
 #: js/turtledefs.js:722
-#.TRANS: Puede escribir \"d\" para crear un bloque \"do\", \"r\" para crear un bloque \"re\", etc.
+#. TRANS: Puede escribir \"d\" para crear un bloque \"do\", \"r\" para crear un bloque \"re\", etc.
 msgid "You can type d to create a do block and r to create a re block etc."
 msgstr ""
 
@@ -2898,7 +2898,7 @@ msgstr ""
 #: js/turtledefs.js:736
 #: js/turtles.js:940
 #: js/palette.js:654
-#.TRANS: Cuadrícula
+#. TRANS: Cuadrícula
 msgid "Grid"
 msgstr ""
 
@@ -2922,49 +2922,49 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
-#.TRANS: Borrar
+#. TRANS: clear all subdivisions from the ruler.
+#. TRANS: Borrar
 msgid "Clear"
 msgstr "pichay"
 
 #: js/turtledefs.js:745
-#.TRANS: Borre la pantalla y devuelva los ratones a sus posiciones iniciales.
+#. TRANS: Borre la pantalla y devuelva los ratones a sus posiciones iniciales.
 msgid "Clear the screen and return the mice to their initial positions."
 msgstr ""
 
 #: js/turtledefs.js:750
 #: js/turtles.js:980
-#.TRANS: Contraer
+#. TRANS: Contraer
 msgid "Collapse"
 msgstr ""
 
 #: js/turtledefs.js:751
-#.TRANS: Contraer la ventana de gráficos.
+#. TRANS: Contraer la ventana de gráficos.
 msgid "Collapse the graphics window."
 msgstr ""
 
 #: js/turtledefs.js:757
-#.TRANS: Devolver todos los bloques para el centro de la pantalla.
+#. TRANS: Devolver todos los bloques para el centro de la pantalla.
 msgid "Return all blocks to the center of the screen."
 msgstr ""
 
 #: js/turtledefs.js:763
-#.TRANS: Ocultar o mostrar los bloques y las paletas.
+#. TRANS: Ocultar o mostrar los bloques y las paletas.
 msgid "Hide or show the blocks and the palettes."
 msgstr ""
 
 #: js/turtledefs.js:769
-#.TRANS: Expandir o colapsar los bloques colapsables, cómo por ejemplo los bloques de empezar y los de acción.
+#. TRANS: Expandir o colapsar los bloques colapsables, cómo por ejemplo los bloques de empezar y los de acción.
 msgid "Expand or collapse start and action stacks."
 msgstr ""
 
 #: js/turtledefs.js:777
-#.TRANS: Disminuye el tamaño de los bloques
+#. TRANS: Disminuye el tamaño de los bloques
 msgid "Decrease the size of the blocks."
 msgstr ""
 
 #: js/turtledefs.js:783
-#.TRANS: Incrementa el tamaño de los bloques.
+#. TRANS: Incrementa el tamaño de los bloques.
 msgid "Increase the size of the blocks."
 msgstr ""
 
@@ -2977,86 +2977,86 @@ msgid "Left-click and drag on workspace to select multiple blocks."
 msgstr ""
 
 #: js/turtledefs.js:797
-#.TRANS: Botones de paleta
+#. TRANS: Botones de paleta
 msgid "Palette buttons"
 msgstr ""
 
 #: js/turtledefs.js:798
-#.TRANS: Esta barra de herramientas contiene los botones de la paleta de Ritmo, Tono, Tortuga, y más.
+#. TRANS: Esta barra de herramientas contiene los botones de la paleta de Ritmo, Tono, Tortuga, y más.
 msgid "This toolbar contains the palette buttons including Rhythm Pitch Tone Action and more."
 msgstr ""
 
 #: js/turtledefs.js:800
-#.TRANS: Haga clic para mostrar las paletas de bloques y bloques de arrastre de las gamas de colores en el lienzo para usarlos.
+#. TRANS: Haga clic para mostrar las paletas de bloques y bloques de arrastre de las gamas de colores en el lienzo para usarlos.
 msgid "Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
 msgstr ""
 
 #: js/turtledefs.js:808
-#.TRANS: Se encuentra disponible una guía detallada de TortuBloques.
+#. TRANS: Se encuentra disponible una guía detallada de TortuBloques.
 msgid "A detailed guide to Turtle Blocks is available."
 msgstr ""
 
 #: js/turtledefs.js:812
-#.TRANS: Guía de TortuBloques
+#. TRANS: Guía de TortuBloques
 msgid "Turtle Blocks Guide"
 msgstr ""
 
 #: js/turtledefs.js:815
 #: js/turtledefs.js:838
 #: js/widgets/help.js:338
-#.TRANS: Acerca
+#. TRANS: Acerca
 msgid "About"
 msgstr "qayllampi"
 
 #: js/turtledefs.js:816
-#.TRANS: TortuBloques es una colección de herramientas de Software Libre para explorar conceptos musicales. 
+#. TRANS: TortuBloques es una colección de herramientas de Software Libre para explorar conceptos musicales. 
 msgid "Turtle Blocks is an open source collection of tools for exploring musical concepts."
 msgstr ""
 
 #: js/turtledefs.js:818
-#.TRANS: Se puede encontrar una lista completa de colaboradores en el repositorio GitHub de TortuBloques.
+#. TRANS: Se puede encontrar una lista completa de colaboradores en el repositorio GitHub de TortuBloques.
 msgid "A full list of contributors can be found in the Turtle Blocks GitHub repository."
 msgstr ""
 
 #: js/turtledefs.js:820
-#.TRANS: TortuBloques está licenciado bajo el AGPL.
+#. TRANS: TortuBloques está licenciado bajo el AGPL.
 msgid "Turtle Blocks is licensed under the AGPL."
 msgstr ""
 
 #: js/turtledefs.js:828
-#.TRANS: El repositorio de GitHub de TortuBloques
+#. TRANS: El repositorio de GitHub de TortuBloques
 msgid "Turtle Blocks GitHub repository"
 msgstr ""
 
 #: js/turtledefs.js:831
 #: js/widgets/help.js:339
 #: js/widgets/help.js:361
-#.TRANS: Felicitaciones.
+#. TRANS: Felicitaciones.
 msgid "Congratulations."
 msgstr "Felicitaciones."
 
 #: js/turtledefs.js:832
-#.TRANS: Ha terminado la gira. Por favor, disfrutar de TortuBloques
+#. TRANS: Ha terminado la gira. Por favor, disfrutar de TortuBloques
 msgid "You have finished the tour. Please enjoy Turtle Blocks!"
 msgstr ""
 
 #: js/turtledefs.js:839
-#.TRANS: Bloques de Música es una colección de herramientas de Software Libre para explorar conceptos musicales.
+#. TRANS: Bloques de Música es una colección de herramientas de Software Libre para explorar conceptos musicales.
 msgid "Music Blocks is an open source collection of tools for exploring musical concepts."
 msgstr ""
 
 #: js/turtledefs.js:841
-#.TRANS: Se puede encontrar una lista completa de colaboradores en el repositorio GitHub de Bloques de Música.
+#. TRANS: Se puede encontrar una lista completa de colaboradores en el repositorio GitHub de Bloques de Música.
 msgid "A full list of contributors can be found in the Music Blocks GitHub repository."
 msgstr ""
 
 #: js/turtledefs.js:843
-#.TRANS: Bloques de Música está licenciado bajo el AGPL.
+#. TRANS: Bloques de Música está licenciado bajo el AGPL.
 msgid "Music Blocks is licensed under the AGPL."
 msgstr ""
 
 #: js/turtledefs.js:851
-#.TRANS: El repositorio de GitHub de Bloques de Música
+#. TRANS: El repositorio de GitHub de Bloques de Música
 msgid "Music Blocks GitHub repository"
 msgstr ""
 
@@ -3065,39 +3065,39 @@ msgid "Congratulations!"
 msgstr ""
 
 #: js/turtledefs.js:855
-#.TRANS: Ha terminado la gira. Por favor, disfrutar de Bloques de Música!
+#. TRANS: Ha terminado la gira. Por favor, disfrutar de Bloques de Música!
 msgid "You have finished the tour. Please enjoy Music Blocks!"
 msgstr ""
 
 #: js/turtles.js:1052
-#.TRANS: Expandir
+#. TRANS: Expandir
 msgid "Expand"
 msgstr ""
 
 #: js/palette.js:663
-#.TRANS: efecto
+#. TRANS: efecto
 msgid "effect"
 msgstr ""
 
 #: js/palette.js:669
-#.TRANS: 
+#. TRANS: 
 msgid "sargam"
 msgstr ""
 
 #: js/palette.js:684
 #: js/blocks/PitchBlocks.js:1209
-#.TRANS: personalizado tono
+#. TRANS: personalizado tono
 msgid "custom pitch"
 msgstr "sapallanpa kunka"
 
 #: js/palette.js:692
-#.TRANS: accidental
+#. TRANS: accidental
 msgid "accidental"
 msgstr "yanapaqnin"
 
 #: js/palette.js:716
 #: js/blocks/PitchBlocks.js:405
-#.TRANS: convertidor de tono
+#. TRANS: convertidor de tono
 msgid "pitch converter"
 msgstr ""
 
@@ -3105,249 +3105,249 @@ msgstr ""
 #: js/utils/musicutils.js:644
 #: js/widgets/musickeyboard.js:2906
 #: js/widgets/pitchdrummatrix.js:228
-#.TRANS: descanso
+#. TRANS: descanso
 msgid "rest"
 msgstr "samay"
 
 #: js/utils/musicutils.js:687
-#.TRANS: Unísono perfecto
+#. TRANS: Unísono perfecto
 msgid "Perfect unison"
 msgstr ""
 
 #: js/utils/musicutils.js:687
-#.TRANS: Segundo disminuido
+#. TRANS: Segundo disminuido
 msgid "Diminished second"
 msgstr ""
 
 #: js/utils/musicutils.js:688
-#.TRANS: Segundo menor
+#. TRANS: Segundo menor
 msgid "Minor second"
 msgstr ""
 
 #: js/utils/musicutils.js:688
-#.TRANS: Unísono aumentado
+#. TRANS: Unísono aumentado
 msgid "Augmented unison"
 msgstr ""
 
 #: js/utils/musicutils.js:689
-#.TRANS: Segundo mayor
+#. TRANS: Segundo mayor
 msgid "Major second"
 msgstr ""
 
 #: js/utils/musicutils.js:689
-#.TRANS: Tercio disminuido
+#. TRANS: Tercio disminuido
 msgid "Diminished third"
 msgstr ""
 
 #: js/utils/musicutils.js:690
-#.TRANS: Tercio menor
+#. TRANS: Tercio menor
 msgid "Minor third"
 msgstr ""
 
 #: js/utils/musicutils.js:690
-#.TRANS: Segundo aumentado
+#. TRANS: Segundo aumentado
 msgid "Augmented second"
 msgstr ""
 
 #: js/utils/musicutils.js:691
-#.TRANS: Tercio mayor
+#. TRANS: Tercio mayor
 msgid "Major third"
 msgstr ""
 
 #: js/utils/musicutils.js:691
-#.TRANS: Cuarta disminuida
+#. TRANS: Cuarta disminuida
 msgid "Diminished fourth"
 msgstr ""
 
 #: js/utils/musicutils.js:692
-#.TRANS: Cuarta perfecta
+#. TRANS: Cuarta perfecta
 msgid "Perfect fourth"
 msgstr ""
 
 #: js/utils/musicutils.js:692
-#.TRANS: Tercio aumentado
+#. TRANS: Tercio aumentado
 msgid "Augmented third"
 msgstr ""
 
 #: js/utils/musicutils.js:693
-#.TRANS: Quinta disminuida
+#. TRANS: Quinta disminuida
 msgid "Diminished fifth"
 msgstr ""
 
 #: js/utils/musicutils.js:693
-#.TRANS: Cuarta aumentada
+#. TRANS: Cuarta aumentada
 msgid "Augmented fourth"
 msgstr ""
 
 #: js/utils/musicutils.js:694
-#.TRANS: Quinta perfecta
+#. TRANS: Quinta perfecta
 msgid "Perfect fifth"
 msgstr ""
 
 #: js/utils/musicutils.js:694
-#.TRANS: Sexto disminuido
+#. TRANS: Sexto disminuido
 msgid "Diminished sixth"
 msgstr ""
 
 #: js/utils/musicutils.js:695
-#.TRANS: Sexto menor
+#. TRANS: Sexto menor
 msgid "Minor sixth"
 msgstr ""
 
 #: js/utils/musicutils.js:695
-#.TRANS: Quinta aumentada
+#. TRANS: Quinta aumentada
 msgid "Augmented fifth"
 msgstr ""
 
 #: js/utils/musicutils.js:696
-#.TRANS: Sexto mayor
+#. TRANS: Sexto mayor
 msgid "Major sixth"
 msgstr ""
 
 #: js/utils/musicutils.js:696
-#.TRANS: Séptimo disminuido
+#. TRANS: Séptimo disminuido
 msgid "Diminished seventh"
 msgstr ""
 
 #: js/utils/musicutils.js:697
-#.TRANS: Séptimo menor
+#. TRANS: Séptimo menor
 msgid "Minor seventh"
 msgstr ""
 
 #: js/utils/musicutils.js:697
-#.TRANS: Sexto aumentado
+#. TRANS: Sexto aumentado
 msgid "Augmented sixth"
 msgstr ""
 
 #: js/utils/musicutils.js:698
-#.TRANS: Séptimo mayor
+#. TRANS: Séptimo mayor
 msgid "Major seventh"
 msgstr ""
 
 #: js/utils/musicutils.js:698
-#.TRANS: Octavo disminuido
+#. TRANS: Octavo disminuido
 msgid "Diminished octave"
 msgstr ""
 
 #: js/utils/musicutils.js:699
-#.TRANS: Octavo perfecto
+#. TRANS: Octavo perfecto
 msgid "Perfect octave"
 msgstr ""
 
 #: js/utils/musicutils.js:699
-#.TRANS: Séptimo aumentado
+#. TRANS: Séptimo aumentado
 msgid "Augmented seventh"
 msgstr ""
 
 #: js/utils/musicutils.js:700
-#.TRANS: Novena menor
+#. TRANS: Novena menor
 msgid "Minor ninth"
 msgstr ""
 
 #: js/utils/musicutils.js:700
-#.TRANS: Octavo aumentado
+#. TRANS: Octavo aumentado
 msgid "Augmented octave"
 msgstr ""
 
 #: js/utils/musicutils.js:701
-#.TRANS: Novena mayor
+#. TRANS: Novena mayor
 msgid "Major ninth"
 msgstr ""
 
 #: js/utils/musicutils.js:701
-#.TRANS: Décima disminuida
+#. TRANS: Décima disminuida
 msgid "Diminished tenth"
 msgstr ""
 
 #: js/utils/musicutils.js:702
-#.TRANS: Décima menor
+#. TRANS: Décima menor
 msgid "Minor tenth"
 msgstr ""
 
 #: js/utils/musicutils.js:702
-#.TRANS: Novena aumentada
+#. TRANS: Novena aumentada
 msgid "Augmented ninth"
 msgstr ""
 
 #: js/utils/musicutils.js:703
-#.TRANS: Décima mayor
+#. TRANS: Décima mayor
 msgid "Major tenth"
 msgstr ""
 
 #: js/utils/musicutils.js:703
-#.TRANS: Undécimo disminuido
+#. TRANS: Undécimo disminuido
 msgid "Diminished eleventh"
 msgstr ""
 
 #: js/utils/musicutils.js:704
-#.TRANS: Undécimo perfecto
+#. TRANS: Undécimo perfecto
 msgid "Perfect eleventh"
 msgstr ""
 
 #: js/utils/musicutils.js:704
-#.TRANS: Décima aumentada
+#. TRANS: Décima aumentada
 msgid "Augmented tenth"
 msgstr ""
 
 #: js/utils/musicutils.js:705
-#.TRANS: Doce disminuido
+#. TRANS: Doce disminuido
 msgid "Diminished twelfth"
 msgstr ""
 
 #: js/utils/musicutils.js:705
-#.TRANS: Undécimo aumentado
+#. TRANS: Undécimo aumentado
 msgid "Augmented eleventh"
 msgstr ""
 
 #: js/utils/musicutils.js:706
-#.TRANS: Doce perfecto
+#. TRANS: Doce perfecto
 msgid "Perfect twelfth"
 msgstr ""
 
 #: js/utils/musicutils.js:706
-#.TRANS: Decimotercero disminuido
+#. TRANS: Decimotercero disminuido
 msgid "Diminished thirteenth"
 msgstr ""
 
 #: js/utils/musicutils.js:707
-#.TRANS: Doce menor
+#. TRANS: Doce menor
 msgid "Minor thirteenth"
 msgstr ""
 
 #: js/utils/musicutils.js:707
-#.TRANS: Quinta aumentada, más una octava
+#. TRANS: Quinta aumentada, más una octava
 msgid "Augmented fifth, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:708
-#.TRANS: Decimotercero mayor
+#. TRANS: Decimotercero mayor
 msgid "Major thirteenth"
 msgstr ""
 
 #: js/utils/musicutils.js:708
-#.TRANS: Séptimo disminuido, más una octava
+#. TRANS: Séptimo disminuido, más una octava
 msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
-#.TRANS: 1ÃÂº 2ÃÂº 3ÃÂº 4ÃÂº 5ÃÂº 6ÃÂº 7ÃÂº 8ÃÂº 9ÃÂº 10ÃÂº 11ÃÂº 12ÃÂº
+#. TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: 1ÃÂº 2ÃÂº 3ÃÂº 4ÃÂº 5ÃÂº 6ÃÂº 7ÃÂº 8ÃÂº 9ÃÂº 10ÃÂº 11ÃÂº 12ÃÂº
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "1ñ (huk ñiqi) 2ñ (iskay ñiqi) 3ñ (kimsa ñiqi) 4ñ(kimsa ñiqi) 5ñ (phisqa ñiqi)6ñ (suqta ñiqi) 7ñ qanchik ñiqi) 8ñ (pusaq ñiqi)9ñ (isqun ñiqi) 10ñ (chunka ñiqi) 11ñ (chunka hukniyuq ñuqi) 12ñ (chunka iskayniyuq ñiqi"
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
-#.TRANS: aumentado
+#. TRANS: augmented is a music term related to intervals
+#. TRANS: aumentado
 msgid "augmented"
 msgstr "yapaspa"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
-#.TRANS: disminuido
+#. TRANS: diminished is a music term related to intervals and mode
+#. TRANS: disminuido
 msgid "diminished"
 msgstr "pisiyachiy"
 
@@ -3356,218 +3356,218 @@ msgstr "pisiyachiy"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
-#.TRANS: perfecto
+#. TRANS: perfect is a music term related to intervals
+#. TRANS: perfecto
 msgid "perfect"
 msgstr "allinpuni"
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
-#.TRANS: cromático
+#. TRANS: twelve semi-tone scale for music
+#. TRANS: cromático
 msgid "chromatic"
 msgstr "llimp’I sapa"
 
 #: js/utils/musicutils.js:1013
-#.TRANS: argelino
+#. TRANS: argelino
 msgid "algerian"
 msgstr "alhiriyan"
 
 #: js/utils/musicutils.js:1014
-#.TRANS: español
+#. TRANS: español
 msgid "spanish"
 msgstr "ispañul"
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
-#.TRANS: octatonic
+#. TRANS: modal scale in music
+#. TRANS: octatonic
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
-#.TRANS: armónico mayor
+#. TRANS: harmonic major scale in music
+#. TRANS: armónico mayor
 msgid "harmonic major"
 msgstr "kuraq muyurichiq"
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
-#.TRANS: natural menor
+#. TRANS: natural minor scales in music
+#. TRANS: natural menor
 msgid "natural minor"
 msgstr "sullk’a kikin"
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
-#.TRANS: armónico menor
+#. TRANS: harmonic minor scale in music
+#. TRANS: armónico menor
 msgid "harmonic minor"
 msgstr "Sullk’a muyurichiq"
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
-#.TRANS: melódico menor
+#. TRANS: melodic minor scale in music
+#. TRANS: melódico menor
 msgid "melodic minor"
 msgstr "sullk’a sumaq kunka "
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
-#.TRANS: dorio
+#. TRANS: modal scale for music
+#. TRANS: dorio
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
-#.TRANS: frigio
+#. TRANS: modal scale for music
+#. TRANS: frigio
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
-#.TRANS: lidio
+#. TRANS: modal scale for music
+#. TRANS: lidio
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
-#.TRANS: mixolidio
+#. TRANS: modal scale for music
+#. TRANS: mixolidio
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
-#.TRANS: locrian
+#. TRANS: modal scale for music
+#. TRANS: locrian
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
-#.TRANS: jazz menor
+#. TRANS: minor jazz scale for music
+#. TRANS: jazz menor
 msgid "jazz minor"
 msgstr "jazz menor"
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
-#.TRANS: bebop
+#. TRANS: bebop scale for music
+#. TRANS: bebop
 msgid "bebop"
 msgstr ""
 
 #: js/utils/musicutils.js:1043
-#.TRANS: arábica
+#. TRANS: arábica
 msgid "arabic"
 msgstr "arábica"
 
 #: js/utils/musicutils.js:1044
-#.TRANS: bizantino
+#. TRANS: bizantino
 msgid "byzantine"
 msgstr "bizantino"
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
-#.TRANS: enigmático
+#. TRANS: musical scale for music by Verdi
+#. TRANS: enigmático
 msgid "enigmatic"
 msgstr "mana riqsichikuq"
 
 #: js/utils/musicutils.js:1047
-#.TRANS: etíope
+#. TRANS: etíope
 msgid "ethiopian"
 msgstr "etíope"
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
-#.TRANS: geez
+#. TRANS: Ethiopic scale for music
+#. TRANS: geez
 msgid "geez"
 msgstr ""
 
 #: js/utils/musicutils.js:1050
-#.TRANS: hindú
+#. TRANS: hindú
 msgid "hindu"
 msgstr "hindú"
 
 #: js/utils/musicutils.js:1051
-#.TRANS: húngaro
+#. TRANS: húngaro
 msgid "hungarian"
 msgstr "húngaro"
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
-#.TRANS: romano menor
+#. TRANS: minor Romanian scale for music
+#. TRANS: romano menor
 msgid "romanian minor"
 msgstr "sullqa romanian"
 
 #: js/utils/musicutils.js:1054
-#.TRANS: gitana española
+#. TRANS: gitana española
 msgid "spanish gypsy"
 msgstr "ispaña guitarra"
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
-#.TRANS: maqam
+#. TRANS: musical scale for Mid-Eastern music
+#. TRANS: maqam
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
-#.TRANS: blues menor
+#. TRANS: minor blues scale for music
+#. TRANS: blues menor
 msgid "minor blues"
 msgstr "Sullqa anqaskuna"
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
-#.TRANS: blues mayor
+#. TRANS: major blues scale for music
+#. TRANS: blues mayor
 msgid "major blues"
 msgstr "kuraq anqas"
 
 #: js/utils/musicutils.js:1061
-#.TRANS: tono completo
+#. TRANS: tono completo
 msgid "whole tone"
 msgstr "tono completo"
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
-#.TRANS: pentatonic minor
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic minor
 msgid "minor pentatonic"
 msgstr "pentatonic minor"
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
-#.TRANS: pentatonic mayor
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic mayor
 msgid "major pentatonic"
 msgstr "pentatonic mayor"
 
 #: js/utils/musicutils.js:1066
-#.TRANS: chino
+#. TRANS: chino
 msgid "chinese"
 msgstr "chino"
 
 #: js/utils/musicutils.js:1067
-#.TRANS: egipcio
+#. TRANS: egipcio
 msgid "egyptian"
 msgstr "egipcio"
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
-#.TRANS: hirajoshi
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: hirajoshi
 msgid "hirajoshi"
 msgstr ""
 
 #: js/utils/musicutils.js:1070
-#.TRANS: Japón
+#. TRANS: Japón
 msgid "Japan"
 msgstr "Japón"
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
-#.TRANS: in
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: in
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
-#.TRANS: minyo
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: minyo
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
-#.TRANS: fibonacci
+#. TRANS: Italian mathematician
+#. TRANS: fibonacci
 msgid "fibonacci"
 msgstr ""
 
@@ -3584,65 +3584,65 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
-#.TRANS: personalizado
+#. TRANS: customize voice
+#. TRANS: personalizado
 msgid "custom"
 msgstr "Runachasqa"
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
-#.TRANS: highpass
+#. TRANS: highpass filter
+#. TRANS: highpass
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
-#.TRANS: 
+#. TRANS: lowpass filter
+#. TRANS: 
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
-#.TRANS: 
+#. TRANS: bandpass filter
+#. TRANS: 
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
-#.TRANS: 
+#. TRANS: high-shelf filter
+#. TRANS: 
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
-#.TRANS: 
+#. TRANS: low-shelf filter
+#. TRANS: 
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
-#.TRANS: 
+#. TRANS: notch-shelf filter
+#. TRANS: 
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
-#.TRANS: 
+#. TRANS: all-pass filter
+#. TRANS: 
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
-#.TRANS: 
+#. TRANS: peaking filter
+#. TRANS: 
 msgid "peaking"
 msgstr ""
 
@@ -3650,8 +3650,8 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
-#.TRANS: sine
+#. TRANS: sine wave
+#. TRANS: sine
 msgid "sine"
 msgstr ""
 
@@ -3659,8 +3659,8 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
-#.TRANS: cuadrado
+#. TRANS: square wave
+#. TRANS: cuadrado
 msgid "square"
 msgstr "tawa k’uchu"
 
@@ -3669,8 +3669,8 @@ msgstr "tawa k’uchu"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
-#.TRANS: triángulo
+#. TRANS: triangle wave
+#. TRANS: triángulo
 msgid "triangle"
 msgstr "kimsa k’uchu"
 
@@ -3678,8 +3678,8 @@ msgstr "kimsa k’uchu"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
-#.TRANS: diente de sierra
+#. TRANS: sawtooth wave
+#. TRANS: diente de sierra
 msgid "sawtooth"
 msgstr ""
 
@@ -3688,9 +3688,9 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
-#.TRANS: par
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
+#. TRANS: par
 msgid "even"
 msgstr "masa"
 
@@ -3698,8 +3698,8 @@ msgstr "masa"
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
-#.TRANS: impar
+#. TRANS: odd numbers
+#. TRANS: impar
 msgid "odd"
 msgstr "sapallan"
 
@@ -3707,178 +3707,178 @@ msgstr "sapallan"
 #: js/utils/musicutils.js:1357
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:473
-#.TRANS: escalar
+#. TRANS: escalar
 msgid "scalar"
 msgstr "siqay"
 
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
-#.TRANS: piano
+#. TRANS: musical instrument
+#. TRANS: piano
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
-#.TRANS: violín
+#. TRANS: musical instrument
+#. TRANS: violín
 msgid "violin"
 msgstr "violin"
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
-#.TRANS: viola
+#. TRANS: viola musical instrument
+#. TRANS: viola
 msgid "viola"
 msgstr "viola"
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
-#.TRANS: xilófono
+#. TRANS: xylophone musical instrument
+#. TRANS: xilófono
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
-#.TRANS: vibráfono
+#. TRANS: vibraphone musical instrument
+#. TRANS: vibráfono
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
-#.TRANS: violonchelo
+#. TRANS: musical instrument
+#. TRANS: violonchelo
 msgid "cello"
 msgstr "violonchelo"
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
-#.TRANS: contrabajo
+#. TRANS: viola musical instrument
+#. TRANS: contrabajo
 msgid "double bass"
 msgstr "Viola takina waqachina"
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
-#.TRANS: guitarra
+#. TRANS: musical instrument
+#. TRANS: guitarra
 msgid "guitar"
 msgstr "guitarra"
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
-#.TRANS: guitarra acustica
+#. TRANS: musical instrument
+#. TRANS: guitarra acustica
 msgid "acoustic guitar"
 msgstr "aswan kunkayuq guitarra"
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
-#.TRANS: flauta
+#. TRANS: musical instrument
+#. TRANS: flauta
 msgid "flute"
 msgstr "flauta"
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
-#.TRANS: clarinete
+#. TRANS: musical instrument
+#. TRANS: clarinete
 msgid "clarinet"
 msgstr "clarinete"
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
-#.TRANS: saxofón
+#. TRANS: musical instrument
+#. TRANS: saxofón
 msgid "saxophone"
 msgstr "saxofón"
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
-#.TRANS: tuba
+#. TRANS: musical instrument
+#. TRANS: tuba
 msgid "tuba"
 msgstr "tuba"
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
-#.TRANS: trompeta
+#. TRANS: musical instrument
+#. TRANS: trompeta
 msgid "trumpet"
 msgstr "trompeta"
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
-#.TRANS: oboe
+#. TRANS: musical instrument
+#. TRANS: oboe
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
-#.TRANS: trombón
+#. TRANS: musical instrument
+#. TRANS: trombón
 msgid "trombone"
 msgstr "trombón"
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
-#.TRANS: sintetizador electronico
+#. TRANS: polytone synthesizer
+#. TRANS: sintetizador electronico
 msgid "electronic synth"
 msgstr "sintetizador electronico"
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
-#.TRANS: simple-1
+#. TRANS: simple monotone synthesizer
+#. TRANS: simple-1
 msgid "simple 1"
 msgstr "qasi-1"
 
 #: js/utils/musicutils.js:1123
-#.TRANS: simple 2
+#. TRANS: simple 2
 msgid "simple 2"
 msgstr ""
 
 #: js/utils/musicutils.js:1124
-#.TRANS: simple 3
+#. TRANS: simple 3
 msgid "simple 3"
 msgstr ""
 
 #: js/utils/musicutils.js:1125
-#.TRANS: simple 4
+#. TRANS: simple 4
 msgid "simple 4"
 msgstr ""
 
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
-#.TRANS: ruido blanco
+#. TRANS: white noise synthesizer
+#. TRANS: ruido blanco
 msgid "white noise"
 msgstr "Yuraq rakhaqaqaq"
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
-#.TRANS: ruido marrón
+#. TRANS: brown noise synthesizer
+#. TRANS: ruido marrón
 msgid "brown noise"
 msgstr "ch’umpi chanraray"
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
-#.TRANS: ruido rosa
+#. TRANS: pink noise synthesizer
+#. TRANS: ruido rosa
 msgid "pink noise"
 msgstr "rosa chanraray"
 
@@ -3886,249 +3886,249 @@ msgstr "rosa chanraray"
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
-#.TRANS: tambor militar pequeño
+#. TRANS: musical instrument
+#. TRANS: tambor militar pequeño
 msgid "snare drum"
 msgstr "wankar"
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
-#.TRANS: tambor de patada
+#. TRANS: musical instrument
+#. TRANS: tambor de patada
 msgid "kick drum"
 msgstr "Hayt’ana wankar"
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
-#.TRANS: tom tom
+#. TRANS: musical instrument
+#. TRANS: tom tom
 msgid "tom tom"
 msgstr "tum tum"
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
-#.TRANS: piso tom
+#. TRANS: musical instrument
+#. TRANS: piso tom
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
-#.TRANS: tambor de bajo
+#. TRANS: musical instrument
+#. TRANS: tambor de bajo
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
-#.TRANS: taza de tambor
+#. TRANS: a drum made from an inverted cup
+#. TRANS: taza de tambor
 msgid "cup drum"
 msgstr "qiru wankar"
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
-#.TRANS: darbuka
+#. TRANS: musical instrument
+#. TRANS: darbuka
 msgid "darbuka drum"
 msgstr "wankar darbuka"
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
-#.TRANS: 
+#. TRANS: musical instrument
+#. TRANS: 
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
-#.TRANS: campana de paseo
+#. TRANS: a small metal bell
+#. TRANS: campana de paseo
 msgid "ride bell"
 msgstr "puriq kampana/kalanka"
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
-#.TRANS: campana de vaca
+#. TRANS: musical instrument
+#. TRANS: campana de vaca
 msgid "cow bell"
 msgstr "waka kampana/kalanka"
 
 #: js/utils/musicutils.js:1140
-#.TRANS: tambor japonés
+#. TRANS: tambor japonés
 msgid "japanese drum"
 msgstr "tambor japonés"
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
-#.TRANS: campana japonesa
+#. TRANS: musical instrument
+#. TRANS: campana japonesa
 msgid "japanese bell"
 msgstr "campana japonesa"
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
-#.TRANS: campana triangular
+#. TRANS: musical instrument
+#. TRANS: campana triangular
 msgid "triangle bell"
 msgstr "kimsa k’uchu kampana/kalanka"
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
-#.TRANS: castañuelas
+#. TRANS: musical instrument
+#. TRANS: castañuelas
 msgid "finger cymbals"
 msgstr "kastañuylas"
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
-#.TRANS: campaneo
+#. TRANS: a musically tuned set of bells
+#. TRANS: campaneo
 msgid "chime"
 msgstr "campaneo"
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
-#.TRANS: gong
+#. TRANS: a musical instrument
+#. TRANS: gong
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
-#.TRANS: estruendo
+#. TRANS: sound effect
+#. TRANS: estruendo
 msgid "clang"
 msgstr "raqhaqaqay"
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
-#.TRANS: choque
+#. TRANS: sound effect
+#. TRANS: choque
 msgid "crash"
 msgstr "Takanakuy"
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
-#.TRANS: botella
+#. TRANS: sound effect
+#. TRANS: botella
 msgid "bottle"
 msgstr "wutilla"
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
-#.TRANS: palmada
+#. TRANS: sound effect
+#. TRANS: palmada
 msgid "clap"
 msgstr "T’aklla"
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
-#.TRANS: bofetada
+#. TRANS: sound effect
+#. TRANS: bofetada
 msgid "slap"
 msgstr "ch’aqllay"
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
-#.TRANS: salpicadura
+#. TRANS: sound effect
+#. TRANS: salpicadura
 msgid "splash"
 msgstr "ch’iqiy"
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
-#.TRANS: burbujas
+#. TRANS: sound effect
+#. TRANS: burbujas
 msgid "bubbles"
 msgstr "phullpu"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
-#.TRANS: gota de agua
+#. TRANS: sound effect
+#. TRANS: gota de agua
 msgid "raindrop"
 msgstr " unu sut’u"
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
-#.TRANS: gato
+#. TRANS: animal sound effect
+#. TRANS: gato
 msgid "cat"
 msgstr "Misi"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
-#.TRANS: grillo
+#. TRANS: animal sound effect
+#. TRANS: grillo
 msgid "cricket"
 msgstr "ch’illiku"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
-#.TRANS: perro
+#. TRANS: animal sound effect
+#. TRANS: perro
 msgid "dog"
 msgstr "Allqu"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
-#.TRANS: banjo
+#. TRANS: musical instrument
+#. TRANS: banjo
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
-#.TRANS: koto
+#. TRANS: musical instrument
+#. TRANS: koto
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
-#.TRANS: dulcimer
+#. TRANS: musical instrument
+#. TRANS: dulcimer
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
-#.TRANS: guitarra electrica
+#. TRANS: musical instrument
+#. TRANS: guitarra electrica
 msgid "electric guitar"
 msgstr "tawtinku phinchikilla"
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
-#.TRANS: fagot
+#. TRANS: musical instrument
+#. TRANS: fagot
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
-#.TRANS: celeste
+#. TRANS: musical instrument
+#. TRANS: celeste
 msgid "celeste"
 msgstr "yuraq anqhas"
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
-#.TRANS: igual
+#. TRANS: musical temperament
+#. TRANS: igual
 msgid "equal"
 msgstr "igual"
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
-#.TRANS: Pitagórico
+#. TRANS: musical temperament
+#. TRANS: Pitagórico
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
-#.TRANS: solo entonación
+#. TRANS: musical temperament
+#. TRANS: solo entonación
 msgid "just intonation"
 msgstr "solo entonación"
 
@@ -4137,285 +4137,285 @@ msgstr "solo entonación"
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
-#.TRANS: 
+#. TRANS: musical temperament
+#. TRANS: 
 msgid "Meantone"
 msgstr ""
 
 #: js/utils/musicutils.js:1188
-#.TRANS: 7mo mayor
+#. TRANS: 7mo mayor
 msgid "major 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1189
-#.TRANS: 7mo menor
+#. TRANS: 7mo menor
 msgid "minor 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1190
-#.TRANS: 7ma dominante
+#. TRANS: 7ma dominante
 msgid "dominant 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1191
-#.TRANS: 7mo menor-mayor
+#. TRANS: 7mo menor-mayor
 msgid "minor-major 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1192
-#.TRANS: 7ÃÂº completamente disminuido
+#. TRANS: 7ÃÂº completamente disminuido
 msgid "fully-diminished 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1193
-#.TRANS: 7ÃÂº medio disminuido
+#. TRANS: 7ÃÂº medio disminuido
 msgid "half-diminished 7th"
 msgstr ""
 
 #: js/utils/musicutils.js:1600
 #: js/utils/musicutils.js:1616
-#.TRANS: Igual (12EDO)
+#. TRANS: Igual (12EDO)
 msgid "Equal (12EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1601
 #: js/utils/musicutils.js:1617
-#.TRANS: Igual (5EDO)
+#. TRANS: Igual (5EDO)
 msgid "Equal (5EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1602
 #: js/utils/musicutils.js:1618
-#.TRANS: Igual (7EDO)
+#. TRANS: Igual (7EDO)
 msgid "Equal (7EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1603
 #: js/utils/musicutils.js:1619
-#.TRANS: Igual (19EDO)
+#. TRANS: Igual (19EDO)
 msgid "Equal (19EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1604
 #: js/utils/musicutils.js:1620
-#.TRANS: Igual (31EDO)
+#. TRANS: Igual (31EDO)
 msgid "Equal (31EDO)"
 msgstr ""
 
 #: js/utils/musicutils.js:1605
 #: js/utils/musicutils.js:1621
-#.TRANS: 5-Límite de entonación justa
+#. TRANS: 5-Límite de entonación justa
 msgid "5-limit Just Intonation"
 msgstr ""
 
 #: js/utils/musicutils.js:1606
 #: js/utils/musicutils.js:1622
-#.TRANS: Pythagorean (3-limite EJ)
+#. TRANS: Pythagorean (3-limite EJ)
 msgid "Pythagorean (3-limit JI)"
 msgstr ""
 
 #: js/utils/musicutils.js:5631
 #: js/utils/musicutils.js:5674
-#.TRANS: actuales
+#. TRANS: actuales
 msgid "current"
 msgstr "actuales"
 
 #: js/utils/musicutils.js:5634
 #: js/utils/musicutils.js:5665
-#.TRANS: próximo
+#. TRANS: próximo
 msgid "next"
 msgstr "próximo"
 
 #: js/utils/musicutils.js:5637
 #: js/utils/musicutils.js:5670
-#.TRANS: anterior
+#. TRANS: anterior
 msgid "previous"
 msgstr "anterior"
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
-#.TRANS: simple-2
+#. TRANS: simple monotone synthesizer
+#. TRANS: simple-2
 msgid "simple-2"
 msgstr "qasi-2"
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
-#.TRANS: simple-3
+#. TRANS: simple monotone synthesizer
+#. TRANS: simple-3
 msgid "simple-3"
 msgstr "qasi-3"
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
-#.TRANS: simple-4
+#. TRANS: simple monotone synthesizer
+#. TRANS: simple-4
 msgid "simple-4"
 msgstr "qasi-4"
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
-#.TRANS: taiko
+#. TRANS: musical instrument
+#. TRANS: taiko
 msgid "taiko"
 msgstr "chakiyuq wankar"
 
 #: js/blocks/BooleanBlocks.js:44
-#.TRANS: El bloque No es el operador lógico no.
+#. TRANS: El bloque No es el operador lógico no.
 msgid "The Not block is the logical not operator."
 msgstr "El bloque No es el operador lógico no."
 
 #: js/blocks/BooleanBlocks.js:62
-#.TRANS: no
+#. TRANS: no
 msgid "not"
 msgstr "mana"
 
 #: js/blocks/BooleanBlocks.js:134
-#.TRANS: El bloque Y es el lógico y el operador.
+#. TRANS: El bloque Y es el lógico y el operador.
 msgid "The And block is the logical and operator."
 msgstr "El bloque Y es el lógico y el operador."
 
 #: js/blocks/BooleanBlocks.js:152
-#.TRANS: y
+#. TRANS: y
 msgid "and"
 msgstr "hinallataq"
 
 #: js/blocks/BooleanBlocks.js:218
-#.TRANS: El bloque O es el lógico o el operador.
+#. TRANS: El bloque O es el lógico o el operador.
 msgid "The Or block is the logical or operator."
 msgstr "El bloque O es el lógico o el operador."
 
 #: js/blocks/BooleanBlocks.js:236
-#.TRANS: o
+#. TRANS: o
 msgid "or"
 msgstr "utaq"
 
 #: js/blocks/BooleanBlocks.js:302
-#.TRANS: El bloque XOR es el lógico XOR el operador.
+#. TRANS: El bloque XOR es el lógico XOR el operador.
 msgid "The XOR block is the logical XOR operator."
 msgstr "El bloque XOR es el lógico XOR el operador."
 
 #: js/blocks/BooleanBlocks.js:320
-#.TRANS: xor
+#. TRANS: xor
 msgid "xor"
 msgstr ""
 
 #: js/blocks/BooleanBlocks.js:808
-#.TRANS: El bloque Igual devuelve verdadero si los dos números son iguales.
+#. TRANS: El bloque Igual devuelve verdadero si los dos números son iguales.
 msgid "The Equal block returns True if the two numbers are equal."
 msgstr "El bloque Igual devuelve verdadero si los dos números son iguales."
 
 #: js/blocks/BooleanBlocks.js:909
-#.TRANS: El bloque No igual a devuelve Verdadero si los dos números no son iguales entre sí.
+#. TRANS: El bloque No igual a devuelve Verdadero si los dos números no son iguales entre sí.
 msgid "The Not-equal-to block returns True if the two numbers are not equal to each other."
 msgstr ""
 
 #: js/blocks/BooleanBlocks.js:1008
-#.TRANS: El bloque Booleano se utiliza para especificar verdadero o falso.
+#. TRANS: El bloque Booleano se utiliza para especificar verdadero o falso.
 msgid "The Boolean block is used to specify true or false."
 msgstr "El bloque Booleano se utiliza para especificar verdadero o falso."
 
 #: js/blocks/BoxesBlocks.js:53
 #: js/blocks/BoxesBlocks.js:59
-#.TRANS: El bloque Agregar a se usa para agregar al valor almacenado en un cuadro.
+#. TRANS: El bloque Agregar a se usa para agregar al valor almacenado en un cuadro.
 msgid "The Add-to block is used to add to the value stored in a box."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:61
-#.TRANS: También se puede utilizar con otros bloques, como el color, el tamaño de la pluma.
+#. TRANS: También se puede utilizar con otros bloques, como el color, el tamaño de la pluma.
 msgid "It can also be used with other blocks such as Color and Pen size."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:73
-#.TRANS: sumar
+#. TRANS: sumar
 msgid "add"
 msgstr "yapay"
 
 #: js/blocks/BoxesBlocks.js:75
 #: js/widgets/temperament.js:825
-#.TRANS: para
+#. TRANS: para
 msgid "to"
 msgstr "sayay"
 
 #: js/blocks/BoxesBlocks.js:75
 #: js/blocks/BoxesBlocks.js:595
 #: js/blocks/HeapBlocks.js:544
-#.TRANS: valor
+#. TRANS: valor
 msgid "value1"
 msgstr "chanin"
 
 #: js/blocks/BoxesBlocks.js:118
-#.TRANS: Bloque no soporta incremento.
+#. TRANS: Bloque no soporta incremento.
 msgid "Block does not support incrementing."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:152
-#.TRANS: El bloque Sumar-1-a agrega uno al valor almacenado en un cuadro.
+#. TRANS: El bloque Sumar-1-a agrega uno al valor almacenado en un cuadro.
 msgid "The Add-1-to block adds one to the value stored in a box."
 msgstr "Yapay-1 t’aqa hukta tawa k’uchu wayqaychasqaman yapan"
 
 #: js/blocks/BoxesBlocks.js:163
-#.TRANS: sumar 1 a
+#. TRANS: sumar 1 a
 msgid "add 1 to"
-msgstr "1 yapay" "hukta yapay"
+msgstr "1 yapay hukta yapay"
 
 #: js/blocks/BoxesBlocks.js:211
-#.TRANS: El bloque restar-1-de resta uno al valor almacenado en un cuadro.
+#. TRANS: El bloque restar-1-de resta uno al valor almacenado en un cuadro.
 msgid "The Subtract-1-from block subtracts one from the value stored in a box."
 msgstr "El bloque restar-1-de resta uno al valor almacenado en un cuadro."
 
 #: js/blocks/BoxesBlocks.js:222
-#.TRANS: restar 1 de
+#. TRANS: restar 1 de
 msgid "subtract 1 from"
-msgstr "1 qichuy" "hukta qichuy"
+msgstr "1 qichuy hukta qichuy"
 
 #: js/blocks/BoxesBlocks.js:270
 #: js/blocks/BoxesBlocks.js:387
-#.TRANS: El bloque Caja devuelve el valor almacenado en una caja .
+#. TRANS: El bloque Caja devuelve el valor almacenado en una caja .
 msgid "The Box block returns the value stored in a box."
 msgstr "El bloque Caja devuelve el valor almacenado en una caja."
 
 #: js/blocks/BoxesBlocks.js:500
 #: js/blocks/BoxesBlocks.js:576
-#.TRANS: El bloque Guardar en caja se utiliza para almacenar un valor en una caja.
+#. TRANS: El bloque Guardar en caja se utiliza para almacenar un valor en una caja.
 msgid "The Store in block will store a value in a box."
 msgstr "El bloque Guardar en caja se utiliza para almacenar un valor en una caja."
 
 #: js/blocks/BoxesBlocks.js:595
 #: js/blocks/EnsembleBlocks.js:393
 #: js/blocks/EnsembleBlocks.js:404
-#.TRANS: nombre
+#. TRANS: nombre
 msgid "name1"
 msgstr "Suti"
 
 #: js/blocks/BoxesBlocks.js:652
-#.TRANS: El bloque Caja 2 devuelve el valor almacenado en caja 2.
+#. TRANS: El bloque Caja 2 devuelve el valor almacenado en caja 2.
 msgid "The Box2 block returns the value stored in Box2."
 msgstr "El bloque Caja 2 devuelve el valor almacenado en caja 2."
 
 #: js/blocks/BoxesBlocks.js:703
-#.TRANS: El bloque Guardar en caja2 se utiliza para almacenar un valor en caja2.
+#. TRANS: El bloque Guardar en caja2 se utiliza para almacenar un valor en caja2.
 msgid "The Store in Box2 block is used to store a value in Box2."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:715
-#.TRANS: guardar en caja 2
+#. TRANS: guardar en caja 2
 msgid "store in box2"
 msgstr "2 tawa k’uchupi waqaychay"
 
 #: js/blocks/BoxesBlocks.js:761
-#.TRANS: El bloque Caja 1 devuelve el valor almacenado en caja 1.
+#. TRANS: El bloque Caja 1 devuelve el valor almacenado en caja 1.
 msgid "The Box1 block returns the value stored in Box1."
 msgstr "El bloque Caja 1 devuelve el valor almacenado en caja 1."
 
 #: js/blocks/BoxesBlocks.js:812
-#.TRANS: El bloque Guardar en caja1 se utiliza para almacenar un valor en caja1.
+#. TRANS: El bloque Guardar en caja1 se utiliza para almacenar un valor en caja1.
 msgid "The Store in Box1 block is used to store a value in Box1."
 msgstr ""
 
 #: js/blocks/BoxesBlocks.js:826
-#.TRANS: guardar en caja 1
+#. TRANS: guardar en caja 1
 msgid "store in box1"
 msgstr "1 tawa k’uchupi waqaychay"
 
 #: js/blocks/DictBlocks.js:77
-#.TRANS: mostrar diccionario
+#. TRANS: mostrar diccionario
 msgid "show dictionary"
 msgstr ""
 
@@ -4426,25 +4426,25 @@ msgstr ""
 #: js/blocks/ProgramBlocks.js:396
 #: js/blocks/ProgramBlocks.js:501
 #: js/blocks/ProgramBlocks.js:664
-#.TRANS: mi diccionario
+#. TRANS: mi diccionario
 msgid "My Dictionary"
 msgstr ""
 
 #: js/blocks/DictBlocks.js:129
-#.TRANS: El bloque Diccionario devuelve un diccionario.
+#. TRANS: El bloque Diccionario devuelve un diccionario.
 msgid "The Dictionary block returns a dictionary."
 msgstr ""
 
 #: js/blocks/DictBlocks.js:197
 #: js/blocks/DictBlocks.js:339
-#.TRANS: El bloque obtener-valor devuelve un valor en el diccionario para una clave especificada.
+#. TRANS: El bloque obtener-valor devuelve un valor en el diccionario para una clave especificada.
 msgid "The Get-dict block returns a value in the dictionary for a specified key."
 msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
-#.TRANS: obtener valor
+#. TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: obtener valor
 msgid "get value"
 msgstr ""
 
@@ -4455,7 +4455,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:357
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
-#.TRANS: clave
+#. TRANS: clave
 msgid "key2"
 msgstr ""
 
@@ -4467,143 +4467,143 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
-#.TRANS: clave
+#. TRANS: key, e.g., C in C Major
+#. TRANS: clave
 msgid "key"
 msgstr "kichanapaq"
 
 #: js/blocks/DictBlocks.js:271
 #: js/blocks/DictBlocks.js:411
-#.TRANS: El bloque valor-adjusto establece un valor en el diccionario para una clave específica.
+#. TRANS: El bloque valor-adjusto establece un valor en el diccionario para una clave específica.
 msgid "The Set-dict block sets a value in the dictionary for a specified key."
 msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
-#.TRANS: valor ajustado
+#. TRANS: set a value in the dictionary for a given key
+#. TRANS: valor ajustado
 msgid "set value"
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:59
-#.TRANS: El bloque Nombre de ruido se utiliza para seleccionar un sintetizador de ruido.
+#. TRANS: El bloque Nombre de ruido se utiliza para seleccionar un sintetizador de ruido.
 msgid "The Noise name block is used to select a noise synthesizer."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:102
-#.TRANS: El bloque nombre del tambor se utiliza para seleccionar un tambor.
+#. TRANS: El bloque nombre del tambor se utiliza para seleccionar un tambor.
 msgid "The Drum name block is used to select a drum."
 msgstr "Tambor sayaq sutinqa, tambor akllanapaqmi"
 
 #: js/blocks/DrumBlocks.js:146
-#.TRANS: El bloque nombre de efectos se utiliza para seleccionar un efecto de sonido.
+#. TRANS: El bloque nombre de efectos se utiliza para seleccionar un efecto de sonido.
 msgid "The Effects name block is used to select a sound effect."
 msgstr "Pantanchina Sayaqa, pantachina akllanapaqmi "
 
 #: js/blocks/DrumBlocks.js:163
-#.TRANS: ruido
+#. TRANS: ruido
 msgid "noise"
 msgstr "rakhaqaqaq"
 
 #: js/blocks/DrumBlocks.js:177
-#.TRANS: El bloque Ruido de reproducción generará ruido blanco, rosa o marrón.
+#. TRANS: El bloque Ruido de reproducción generará ruido blanco, rosa o marrón.
 msgid "The Play noise block will generate white, pink, or brown noise."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:317
-#.TRANS: Reemplace cada instancia de un tono con un sonido de tambor.
+#. TRANS: Reemplace cada instancia de un tono con un sonido de tambor.
 msgid "Replace every instance of a pitch with a drum sound."
 msgstr "Reemplace cada instancia de un tono con un sonido de tambor."
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
-#.TRANS: mapa de tono al tambor
+#. TRANS: map a pitch to a drum sound
+#. TRANS: mapa de tono al tambor
 msgid "map pitch to drum"
 msgstr "saywa"
 
 #: js/blocks/DrumBlocks.js:395
-#.TRANS: En el ejemplo anterior, se reproducirá un sonido de bombo en lugar de sol.
+#. TRANS: En el ejemplo anterior, se reproducirá un sonido de bombo en lugar de sol.
 msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
-#.TRANS: fijar tambor
+#. TRANS: set the current drum sound for playback
+#. TRANS: fijar tambor
 msgid "set drum"
 msgstr "tankar takyachiy"
 
 #: js/blocks/DrumBlocks.js:451
-#.TRANS: efecto de sonido
+#. TRANS: efecto de sonido
 msgid "sound effect"
 msgstr "t’uqyaq pantachiq"
 
 #: js/blocks/DrumBlocks.js:489
-#.TRANS: Puede utilizar varios bloques de percusión dentro de un bloque de notas.
+#. TRANS: Puede utilizar varios bloques de percusión dentro de un bloque de notas.
 msgid "You can use multiple Drum blocks within a Note block."
 msgstr "Sayaq uhpi atiwaqmi achka kunkakunaq takaykunanpi"
 
 #: js/blocks/HeapBlocks.js:49
-#.TRANS: El bloque Pila devuelve la pila.
+#. TRANS: El bloque Pila devuelve la pila.
 msgid "The Heap block returns the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:133
-#.TRANS: mostrar pila
+#. TRANS: mostrar pila
 msgid "show heap"
 msgstr "qutu rikuchiy"
 
 #: js/blocks/HeapBlocks.js:181
-#.TRANS: El bloque Longitud de la pila devuelve la longitud de la pila.
+#. TRANS: El bloque Longitud de la pila devuelve la longitud de la pila.
 msgid "The Heap-length block returns the length of the heap."
 msgstr "El bloque Longitud de la pila devuelve la longitud de la pila."
 
 #: js/blocks/HeapBlocks.js:195
-#.TRANS: tamaño de la pila
+#. TRANS: tamaño de la pila
 msgid "heap length"
 msgstr "qutuq sunin"
 
 #: js/blocks/HeapBlocks.js:254
-#.TRANS: El bloque Pila-vacío? devuelve verdadero si la pila está vacío.
+#. TRANS: El bloque Pila-vacío? devuelve verdadero si la pila está vacío.
 msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "El bloque Pila-vacío? devuelve verdadero si la pila está vacío."
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
-#.TRANS: ÃÂ¿pila vacía?
+#. TRANS: Is the heap empty?
+#. TRANS: ÃÂ¿pila vacía?
 msgid "heap empty?"
 msgstr "Llapan qutupi mana kanchu?"
 
 #: js/blocks/HeapBlocks.js:317
-#.TRANS: El bloque Vacío pila vacía la pila.
+#. TRANS: El bloque Vacío pila vacía la pila.
 msgid "The Empty-heap block empties the heap."
 msgstr "El bloque Vacío pila vacía la pila."
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
-#.TRANS: vaciar pila
+#. TRANS: empty the heap
+#. TRANS: vaciar pila
 msgid "empty heap"
 msgstr "ch’usaq qutu"
 
 #: js/blocks/HeapBlocks.js:371
-#.TRANS: El bloque Pila inversa invierte el orden de la pila.
+#. TRANS: El bloque Pila inversa invierte el orden de la pila.
 msgid "The Reverse-heap block reverses the order of the heap."
 msgstr "El bloque Pila inversa invierte el orden de la pila."
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
-#.TRANS: revertir la pila
+#. TRANS: reverse the order of the heap
+#. TRANS: revertir la pila
 msgid "reverse heap"
 msgstr "Qutu tikray"
 
 #: js/blocks/HeapBlocks.js:428
-#.TRANS: El bloque ÃÂndice de pila devuelve un valor en la pila en una ubicación especificada.
+#. TRANS: El bloque ÃÂndice de pila devuelve un valor en la pila en una ubicación especificada.
 msgid "The Index-heap block returns a value in the heap at a specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
-#.TRANS: valor en la pila
+#. TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: valor en la pila
 msgid "index heap"
 msgstr "valor en la pila"
 
@@ -4611,60 +4611,60 @@ msgstr "valor en la pila"
 #: js/blocks/HeapBlocks.js:572
 #: js/blocks/EnsembleBlocks.js:124
 #: js/blocks/EnsembleBlocks.js:1200
-#.TRANS: El índice debe ser > 0.
+#. TRANS: El índice debe ser > 0.
 msgid "Index must be > 0."
 msgstr "El índice debe ser > 0."
 
 #: js/blocks/HeapBlocks.js:479
 #: js/blocks/HeapBlocks.js:577
 #: js/blocks/EnsembleBlocks.js:129
-#.TRANS: El tamaño máximo de pilas es 1000.
+#. TRANS: El tamaño máximo de pilas es 1000.
 msgid "Maximum heap size is 1000."
 msgstr "El tamaño máximo de pilas es 1000."
 
 #: js/blocks/HeapBlocks.js:523
-#.TRANS: El bloque Fijar entrada de pila establece un valor en la pila en la ubicación especificada.
+#. TRANS: El bloque Fijar entrada de pila establece un valor en la pila en la ubicación especificada.
 msgid "The Set-heap entry block sets a value in he heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
-#.TRANS: fijar pila
+#. TRANS: load the heap from a JSON encoding
+#. TRANS: fijar pila
 msgid "set heap"
 msgstr "Qutu kutichiy"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
-#.TRANS: posición en la pila
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: posición en la pila
 msgid "index"
 msgstr "posición"
 
 #: js/blocks/HeapBlocks.js:619
-#.TRANS: El bloque Pop elimina el valor en la parte superior del pila.
+#. TRANS: El bloque Pop elimina el valor en la parte superior del pila.
 msgid "The Pop block removes the value at the top of the heap."
 msgstr "El bloque Pop elimina el valor en la parte superior del pila."
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
-#.TRANS: sacar
+#. TRANS: pop a value off the top of the heap
+#. TRANS: sacar
 msgid "pop"
 msgstr "hurquy"
 
 #: js/blocks/HeapBlocks.js:680
-#.TRANS: El bloque Push agrega un valor a la parte superior del pila.
+#. TRANS: El bloque Push agrega un valor a la parte superior del pila.
 msgid "The Push block adds a value to the top of the heap."
 msgstr "El bloque Push agrega un valor a la parte superior del pila."
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
-#.TRANS: apilar
+#. TRANS: push a value onto the top of the heap
+#. TRANS: apilar
 msgid "push"
 msgstr "tawqay"
 
 #: js/blocks/IntervalsBlocks.js:45
-#.TRANS: fijar temperamento
+#. TRANS: fijar temperamento
 msgid "set temperament"
 msgstr "q’uñipi k’askachiy"
 
@@ -4680,510 +4680,510 @@ msgstr "q’uñipi k’askachiy"
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
-#.TRANS: octava
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: octava
 msgid "octave"
 msgstr "pusaq pata"
 
 #: js/blocks/IntervalsBlocks.js:99
-#.TRANS: El bloque Nombre Temperamento se utiliza para seleccionar un método de ajuste.
+#. TRANS: El bloque Nombre Temperamento se utiliza para seleccionar un método de ajuste.
 msgid "The Temperament name block is used to select a tuning method."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:161
-#.TRANS: doble
+#. TRANS: doble
 msgid "doubly"
 msgstr "iskaycha"
 
 #: js/blocks/IntervalsBlocks.js:166
-#.TRANS: El bloque doble duplicará el tamaño de un intervalo.
+#. TRANS: El bloque doble duplicará el tamaño de un intervalo.
 msgid "The Doubly block will double the size of an interval."
 msgstr "iskaycha t’aqata iskaychanqa sayayninta unaymanta"
 
 #: js/blocks/IntervalsBlocks.js:262
-#.TRANS: número de intervalo
+#. TRANS: número de intervalo
 msgid "interval number"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:317
-#.TRANS: intervalo actua
+#. TRANS: intervalo actua
 msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
-#.TRANS: medida de intervalo semitono
+#. TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: medida de intervalo semitono
 msgid "semi-tone interval measure"
 msgstr "tupuy unaymanta kuskan kunka"
 
 #: js/blocks/IntervalsBlocks.js:454
 #: js/blocks/IntervalsBlocks.js:570
-#.TRANS: Debe usar dos bloques de tono cuando mida un intervalo.
+#. TRANS: Debe usar dos bloques de tono cuando mida un intervalo.
 msgid "You must use two pitch blocks when measuring an interval."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:496
-#.TRANS: El bloque Intervalo escalar mide la distancia entre dos notas en la clave y el modo actuales.
+#. TRANS: El bloque Intervalo escalar mide la distancia entre dos notas en la clave y el modo actuales.
 msgid "The Scalar interval block measures the distance between two notes in the current key and mode."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
-#.TRANS: medida de intervalo escalar
+#. TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: medida de intervalo escalar
 msgid "scalar interval measure"
 msgstr "tupuy unaymanta siqaq"
 
 #: js/blocks/IntervalsBlocks.js:678
-#.TRANS: En la figura, agregamos sol# a sol.
+#. TRANS: En la figura, agregamos sol# a sol.
 msgid "In the figure, we add sol# to sol."
 msgstr "En la figura, agregamos sol# a sol."
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
-#.TRANS: intervalo semitono
+#. TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: intervalo semitono
 msgid "semi-tone interval"
 msgstr "intervalo semitono"
 
 #: js/blocks/IntervalsBlocks.js:733
-#.TRANS: La salida del ejemplo es: do, mi, sol, sol, ti, mi
+#. TRANS: La salida del ejemplo es: do, mi, sol, sol, ti, mi
 msgid "The output of the example is: do, mi, sol, sol, ti, mi"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:740
 #: js/blocks/WidgetBlocks.js:768
-#.TRANS: arpegio
+#. TRANS: arpegio
 msgid "arpeggio"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:931
-#.TRANS: El bloque Acordes calcula acordes comunes.
+#. TRANS: El bloque Acordes calcula acordes comunes.
 msgid "The Chord block calculates common chords."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:933
-#.TRANS: En la figura generamos un acorde de C-mayor.
+#. TRANS: En la figura generamos un acorde de C-mayor.
 msgid "In the figure, we generate a C-major chord."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:938
-#.TRANS: acorde
+#. TRANS: acorde
 msgid "chord"
 msgstr "tinkuq kunka"
 
 #: js/blocks/IntervalsBlocks.js:990
-#.TRANS: El bloque intervalo de razón calcula un intervalo basado en una razón
+#. TRANS: El bloque intervalo de razón calcula un intervalo basado en una razón
 msgid "The Ratio Interval block calculates an interval based on a ratio."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:995
-#.TRANS: intervalo de razón
+#. TRANS: intervalo de razón
 msgid "ratio interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1064
-#.TRANS: En la figura, sumamos la a sol.
+#. TRANS: En la figura, sumamos la a sol.
 msgid "In the figure, we add la to sol."
 msgstr "En la figura, sumamos la a sol."
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
-#.TRANS: definir el modo
+#. TRANS: define a custom mode
+#. TRANS: definir el modo
 msgid "define mode"
 msgstr "definir el modo"
 
 #: js/blocks/IntervalsBlocks.js:1173
-#.TRANS: movible Do
+#. TRANS: movible Do
 msgid "movable Do"
 msgstr "movible Do"
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
-#.TRANS: longitud de modo
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: longitud de modo
 msgid "mode length"
 msgstr "Hina kay sunin"
 
 #: js/blocks/IntervalsBlocks.js:1233
-#.TRANS: El bloque Longitud de modo es el número de notas en la escala actual.
+#. TRANS: El bloque Longitud de modo es el número de notas en la escala actual.
 msgid "The Mode length block is the number of notes in the current scale."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1235
-#.TRANS: La mayoría de las escalas occidentales tienen 7 notas.
+#. TRANS: La mayoría de las escalas occidentales tienen 7 notas.
 msgid "Most Western scales have 7 notes."
 msgstr "La mayoría de las escalas occidentales tienen 7 notas."
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
-#.TRANS: modo actual
+#. TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: modo actual
 msgid "current mode"
 msgstr "Chaynalla kunka"
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
-#.TRANS: clave actual
+#. TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: clave actual
 msgid "current key"
 msgstr "kunan kichaq"
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
-#.TRANS: fijar clave
+#. TRANS: set the key and mode, e.g. C Major
+#. TRANS: fijar clave
 msgid "set key"
 msgstr "kichananta takyachiy"
 
 #: js/blocks/IntervalsBlocks.js:1443
 #: js/blocks/IntervalsBlocks.js:1449
-#.TRANS: El bloque Fijar tecla se usa para configurar la tecla y el modo,
+#. TRANS: El bloque Fijar tecla se usa para configurar la tecla y el modo,
 msgid "The Set key block is used to set the key and mode,"
 msgstr "El bloque Fijar tecla se usa para configurar la tecla y el modo."
 
 #: js/blocks/IntervalsBlocks.js:1449
-#.TRANS: por ejemplo, C Mayor
+#. TRANS: por ejemplo, C Mayor
 msgid "eg C Major"
 msgstr "C kuraq"
 
 #: js/blocks/NumberBlocks.js:28
-#.TRANS: El bloque Int devuelve un entero.
+#. TRANS: El bloque Int devuelve un entero.
 msgid "The Int block returns an integer."
 msgstr "El bloque Int devuelve un entero."
 
 #: js/blocks/NumberBlocks.js:34
-#.TRANS: int
+#. TRANS: int
 msgid "int"
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:73
-#.TRANS: El bloque Mod devuelve el resto de una división.
+#. TRANS: El bloque Mod devuelve el resto de una división.
 msgid "The Mod block returns the remainder from a division."
 msgstr "El bloque Mod devuelve el resto de una división."
 
 #: js/blocks/NumberBlocks.js:79
-#.TRANS: módulo
+#. TRANS: módulo
 msgid "mod"
 msgstr "kunka tupachiy"
 
 #: js/blocks/NumberBlocks.js:141
-#.TRANS: El bloque de potencia calcula una función de potencia.
+#. TRANS: El bloque de potencia calcula una función de potencia.
 msgid "The Power block calculates a power function."
 msgstr "El bloque de potencia calcula una función de potencia."
 
 #: js/blocks/NumberBlocks.js:196
-#.TRANS: El bloque Sqrt devuelve la raíz cuadrada.
+#. TRANS: El bloque Sqrt devuelve la raíz cuadrada.
 msgid "The Sqrt block returns the square root."
 msgstr "El bloque Sqrt devuelve la raíz cuadrada."
 
 #: js/blocks/NumberBlocks.js:202
-#.TRANS: raíz
+#. TRANS: raíz
 msgid "sqrt"
 msgstr "saphi"
 
 #: js/blocks/NumberBlocks.js:248
-#.TRANS: El bloque Abs devuelve el valor absoluto.
+#. TRANS: El bloque Abs devuelve el valor absoluto.
 msgid "The Abs block returns the absolute value."
 msgstr "El bloque Abs devuelve el valor absoluto."
 
 #: js/blocks/NumberBlocks.js:254
-#.TRANS: abs
+#. TRANS: abs
 msgid "abs"
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:295
-#.TRANS: El bloque Distancia devuelve la distancia entre dos puntos. Por ejemplo, entre el ratón y el centro de la pantalla.
+#. TRANS: El bloque Distancia devuelve la distancia entre dos puntos. Por ejemplo, entre el ratón y el centro de la pantalla.
 msgid "The Distance block returns the distance between two points. For example, between the mouse and the center of the screen."
 msgstr ""
 
 #: js/blocks/NumberBlocks.js:301
 #: plugins/rodi.rtp:310
-#.TRANS: distancia
+#. TRANS: distancia
 msgid "distance"
 msgstr "karukay"
 
 #: js/blocks/NumberBlocks.js:361
-#.TRANS: El bloque División se usa para dividir.
+#. TRANS: El bloque División se usa para dividir.
 msgid "The Divide block is used to divide."
 msgstr "rakiy t’aqaqa rakinapaq apaykachakun"
 
 #: js/blocks/NumberBlocks.js:441
-#.TRANS: El bloque Multiplicar se usa para multiplicar.
+#. TRANS: El bloque Multiplicar se usa para multiplicar.
 msgid "The Multiply block is used to multiply."
 msgstr "Mirachiy t’aqaqa mirachinapaq apaykachay"
 
 #: js/blocks/NumberBlocks.js:612
-#.TRANS: El bloque Minus se usa para restar.
+#. TRANS: El bloque Minus se usa para restar.
 msgid "The Minus block is used to subtract."
 msgstr "Qichuy/minus t’aqaqa qichunapaq apaykachakun"
 
 #: js/blocks/NumberBlocks.js:723
-#.TRANS: El bloque Plus se utiliza para agregar.
+#. TRANS: El bloque Plus se utiliza para agregar.
 msgid "The Plus block is used to add."
 msgstr "Plus t’aqaqa yapanapaq apaykachakun"
 
 #: js/blocks/NumberBlocks.js:849
-#.TRANS: El bloque Uno de estos devuelve una de dos opciones.
+#. TRANS: El bloque Uno de estos devuelve una de dos opciones.
 msgid "The One-of block returns one of two choices."
 msgstr "El bloque Uno de estos devuelve una de dos opciones."
 
 #: js/blocks/NumberBlocks.js:856
 #: js/blocks/PitchBlocks.js:616
-#.TRANS: uno de estos
+#. TRANS: uno de estos
 msgid "one of"
 msgstr "huk kaykunamanta"
 
 #: js/blocks/NumberBlocks.js:858
-#.TRANS: éste
+#. TRANS: éste
 msgid "this"
 msgstr "kay"
 
 #: js/blocks/NumberBlocks.js:858
-#.TRANS: ése
+#. TRANS: ése
 msgid "that"
 msgstr "chay"
 
 #: js/blocks/NumberBlocks.js:913
-#.TRANS: El bloque Aleatorio devuelve un número aleatorio.
+#. TRANS: El bloque Aleatorio devuelve un número aleatorio.
 msgid "The Random block returns a random number."
 msgstr "El bloque Aleatorio devuelve un número aleatorio."
 
 #: js/blocks/NumberBlocks.js:920
-#.TRANS: aleatorio
+#. TRANS: aleatorio
 msgid "random"
 msgstr "chaqrusqa"
 
 #: js/blocks/NumberBlocks.js:922
-#.TRANS: min
+#. TRANS: min
 msgid "min"
 msgstr "pisi"
 
 #: js/blocks/NumberBlocks.js:922
-#.TRANS: max
+#. TRANS: max
 msgid "max"
 msgstr "achkha"
 
 #: js/blocks/NumberBlocks.js:986
-#.TRANS: El bloque Numérico contiene un número.
+#. TRANS: El bloque Numérico contiene un número.
 msgid "The Number block holds a number."
 msgstr "Yupay t’aqaqa huk yupayniyuq"
 
 #: js/blocks/OrnamentBlocks.js:32
-#.TRANS: factor de staccato
+#. TRANS: factor de staccato
 msgid "staccato factor"
 msgstr "factor de staccato"
 
 #: js/blocks/OrnamentBlocks.js:108
-#.TRANS: factor de legato
+#. TRANS: factor de legato
 msgid "slur factor"
 msgstr "factor de legato"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
-#.TRANS: vecino
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: vecino
 msgid "neighbor"
 msgstr "wasimasi"
 
 #: js/blocks/OrnamentBlocks.js:293
-#.TRANS: El bloque Vecino cambia rápidamente entre los tonos vecinos.
+#. TRANS: El bloque Vecino cambia rápidamente entre los tonos vecinos.
 msgid "The Neighbor block rapidly switches between neighboring pitches."
 msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:364
-#.TRANS: deslizarse
+#. TRANS: deslizarse
 msgid "glide"
 msgstr "deslizarse"
 
 #: js/blocks/OrnamentBlocks.js:479
 #: js/blocks/OrnamentBlocks.js:643
-#.TRANS: legato
+#. TRANS: legato
 msgid "slur"
 msgstr "legato"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
-#.TRANS: staccato
+#. TRANS: play each note sharply detached from the others
+#. TRANS: staccato
 msgid "staccato"
 msgstr "staccato"
 
 #: js/blocks/ProgramBlocks.js:33
-#.TRANS: El bloque Cargar-pila-en-app carga la pila en una página web.
+#. TRANS: El bloque Cargar-pila-en-app carga la pila en una página web.
 msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
-#.TRANS: cargar pila desde aplicación
+#. TRANS: load the heap contents from a URL
+#. TRANS: cargar pila desde aplicación
 msgid "load heap from App"
 msgstr "cargar pila desde aplicación"
 
 #: js/blocks/ProgramBlocks.js:95
-#.TRANS: Error de análisis de datos JSON.
+#. TRANS: Error de análisis de datos JSON.
 msgid "Error parsing JSON data:"
 msgstr "Error de análisis de datos JSON."
 
 #: js/blocks/ProgramBlocks.js:100
-#.TRANS: 404: Página no encontrada.
+#. TRANS: 404: Página no encontrada.
 msgid "404: Page not found"
 msgstr "mana tarisqa p’anqa"
 
 #: js/blocks/ProgramBlocks.js:133
-#.TRANS: El bloque Guardar-pila-en-app guarda la pila en una página web.
+#. TRANS: El bloque Guardar-pila-en-app guarda la pila en una página web.
 msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr "El bloque Guardar-pila-en-app guarda la pila en una página web."
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
-#.TRANS: guardar pila a aplicación
+#. TRANS: save the heap contents to a URL
+#. TRANS: guardar pila a aplicación
 msgid "save heap to App"
 msgstr "Llapanta kay qutupi waqaychana"
 
 #: js/blocks/ProgramBlocks.js:189
-#.TRANS: Pilas tortuga no contiene un montón válida para
+#. TRANS: Pilas tortuga no contiene un montón válida para
 msgid "Cannot find a valid heap for"
 msgstr "Manam llapan qutupi tarikunchu"
 
 #: js/blocks/ProgramBlocks.js:206
-#.TRANS: El bloque Cargar pila carga la pila de un archivo.
+#. TRANS: El bloque Cargar pila carga la pila de un archivo.
 msgid "The Load-heap block loads the heap from a file."
 msgstr "El bloque Cargar pila carga la pila de un archivo."
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
-#.TRANS: cargar pila
+#. TRANS: load the heap from a file
+#. TRANS: cargar pila
 msgid "load heap"
 msgstr "Qututa apachiy"
 
 #: js/blocks/ProgramBlocks.js:270
-#.TRANS: El archivo seleccionado no contiene un pila válida.
+#. TRANS: El archivo seleccionado no contiene un pila válida.
 msgid "The file you selected does not contain a valid heap."
 msgstr "El archivo seleccionado no contiene un pila válida."
 
 #: js/blocks/ProgramBlocks.js:275
-#.TRANS: El bloque Pila de carga necesita un bloque de archivo de carga.
+#. TRANS: El bloque Pila de carga necesita un bloque de archivo de carga.
 msgid "The loadHeap block needs a loadFile block."
 msgstr "El bloque Pila de carga necesita un bloque de archivo de carga."
 
 #: js/blocks/ProgramBlocks.js:291
-#.TRANS: El bloque fijar pila carga la pila.
+#. TRANS: El bloque fijar pila carga la pila.
 msgid "The Set-heap block loads the heap."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:340
-#.TRANS: El bloque que seleccionó no contiene una pila válido.
+#. TRANS: El bloque que seleccionó no contiene una pila válido.
 msgid "The block you selected does not contain a valid heap."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:343
-#.TRANS: El bloque fija pila necesita una pila.
+#. TRANS: El bloque fija pila necesita una pila.
 msgid "The Set heap block needs a heap."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:360
-#.TRANS: El bloque Carga-diccionario carga un diccionario desde un archivo.
+#. TRANS: El bloque Carga-diccionario carga un diccionario desde un archivo.
 msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
-#.TRANS: carga diccionario
+#. TRANS: load a dictionary from a file
+#. TRANS: carga diccionario
 msgid "load dictionary"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:390
 #: js/blocks/ProgramBlocks.js:658
 #: js/blocks/ToneBlocks.js:1025
-#.TRANS: archivo
+#. TRANS: archivo
 msgid "file"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:444
-#.TRANS: El archivo que seleccionó no contiene un diccionario válido.
+#. TRANS: El archivo que seleccionó no contiene un diccionario válido.
 msgid "The file you selected does not contain a valid dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:449
-#.TRANS: El bloque de diccionario de carga necesita un bloque de archivo
+#. TRANS: El bloque de diccionario de carga necesita un bloque de archivo
 msgid "The load dictionary block needs a load file block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:466
-#.TRANS: El bloque fijar diccionario carga un diccionario.
+#. TRANS: El bloque fijar diccionario carga un diccionario.
 msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
-#.TRANS: fijar diccionario
+#. TRANS: load a dictionary from a JSON
+#. TRANS: fijar diccionario
 msgid "set dictionary"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:546
-#.TRANS: El bloque que seleccionó no contiene un diccionario válido.
+#. TRANS: El bloque que seleccionó no contiene un diccionario válido.
 msgid "The block you selected does not contain a valid dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:550
-#.TRANS: El bloque Fijar dictionario necesita un diccionario.
+#. TRANS: El bloque Fijar dictionario necesita un diccionario.
 msgid "The set dictionary block needs a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:567
-#.TRANS: El bloque Guardar pila guarda la pila en un archivo.
+#. TRANS: El bloque Guardar pila guarda la pila en un archivo.
 msgid "The Save-heap block saves the heap to a file."
 msgstr "El bloque Guardar pila guarda la pila en un archivo."
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
-#.TRANS: guardar pila
+#. TRANS: save the heap to a file
+#. TRANS: guardar pila
 msgid "save heap"
 msgstr "Qutupi waqaychay"
 
 #: js/blocks/ProgramBlocks.js:629
-#.TRANS: El bloque Guardar diccionario guarda el diccionario en un archivo
+#. TRANS: El bloque Guardar diccionario guarda el diccionario en un archivo
 msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
-#.TRANS: guardar diccionario
+#. TRANS: save a dictionary to a file
+#. TRANS: guardar diccionario
 msgid "save dictionary"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:720
-#.TRANS: El bloque abrir la paleta abre una paleta
+#. TRANS: El bloque abrir la paleta abre una paleta
 msgid "The Open palette block opens a palette."
-msgstr "El bloque abrir la paleta abre una paleta""
+msgstr "El bloque abrir la paleta abre una paleta"
 
 #: js/blocks/ProgramBlocks.js:727
-#.TRANS: abrir la paleta
+#. TRANS: abrir la paleta
 msgid "open palette"
 msgstr "llimp’ipa taqinta kichay"
 
 #: js/blocks/ProgramBlocks.js:785
-#.TRANS: El bloque eliminar bloque elimina un bloque
+#. TRANS: El bloque eliminar bloque elimina un bloque
 msgid "The Delete block block removes a block."
 msgstr "El bloque eliminar bloque elimina un bloque"
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
-#.TRANS: eliminar bloque
+#. TRANS: Move this block to the trash.
+#. TRANS: eliminar bloque
 msgid "delete block"
 msgstr "kay chiqasta chanqapuy"
 
 #: js/blocks/ProgramBlocks.js:861
-#.TRANS: El bloque mover bloque mueve un bloque.
+#. TRANS: El bloque mover bloque mueve un bloque.
 msgid "The Move block block moves a block."
 msgstr "El bloque mover bloque mueve un bloque."
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
-#.TRANS: mover bloque
+#. TRANS: Move the position of a block on the screen.
+#. TRANS: mover bloque
 msgid "move block"
 msgstr "kay chiqasta kuyuchiy"
 
 #: js/blocks/ProgramBlocks.js:881
 #: js/blocks/ProgramBlocks.js:1048
-#.TRANS: número de bloque
+#. TRANS: número de bloque
 msgid "block number"
 msgstr "kay chiqaspa payupaynin"
 
@@ -5196,7 +5196,7 @@ msgstr "kay chiqaspa payupaynin"
 #: js/blocks/GraphicsBlocks.js:478
 #: js/blocks/GraphicsBlocks.js:525
 #: js/blocks/GraphicsBlocks.js:741
-#.TRANS: x
+#. TRANS: x
 msgid "x"
 msgstr "x"
 
@@ -5209,45 +5209,45 @@ msgstr "x"
 #: js/blocks/GraphicsBlocks.js:478
 #: js/blocks/GraphicsBlocks.js:525
 #: js/blocks/GraphicsBlocks.js:741
-#.TRANS: y
+#. TRANS: y
 msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
-#.TRANS: ejecutar bloque
+#. TRANS: Run program beginning at this block.
+#. TRANS: ejecutar bloque
 msgid "run block"
 msgstr "kay chiqasta ruray"
 
 #: js/blocks/ProgramBlocks.js:1025
-#.TRANS: El bloque connectar conecta dos bloques
+#. TRANS: El bloque connectar conecta dos bloques
 msgid "The Dock block block connections two blocks."
 msgstr "El bloque connectar conecta dos bloques"
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
-#.TRANS: connectar block
+#. TRANS: We can connect a block to another block.
+#. TRANS: connectar block
 msgid "connect blocks"
 msgstr "chiqasta hap’ichiy"
 
 #: js/blocks/ProgramBlocks.js:1048
-#.TRANS: bloque de destino
+#. TRANS: bloque de destino
 msgid "target block"
 msgstr "mayman chiqas riq "
 
 #: js/blocks/ProgramBlocks.js:1048
-#.TRANS: número de conexion
+#. TRANS: número de conexion
 msgid "connection number"
-msgstr "hap’ichiypa yupaynin""
+msgstr "hap’ichiypa yupaynin"
 
 #: js/blocks/ProgramBlocks.js:1140
-#.TRANS: El bloque crear bloque crea un bloque.
+#. TRANS: El bloque crear bloque crea un bloque.
 msgid "The Make block block creates a new block."
 msgstr "El bloque crear bloque crea un bloque."
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
-#.TRANS: crear bloque
+#. TRANS: Create a new block
+#. TRANS: crear bloque
 msgid "make block"
 msgstr " chiqasta paqarichiy"
 
@@ -5262,152 +5262,152 @@ msgstr " chiqasta paqarichiy"
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
-#.TRANS: nota
+#. TRANS: a musical note consisting of pitch and duration
+#. TRANS: nota
 msgid "note"
 msgstr "kunka"
 
 #: js/blocks/ProgramBlocks.js:1285
-#.TRANS: No se puede encontrar el bloque.
+#. TRANS: No se puede encontrar el bloque.
 msgid "Cannot find block"
 msgstr "Manam chiqas tarikunchu"
 
 #: js/blocks/ProgramBlocks.js:1304
 #: js/blocks/ProgramBlocks.js:1313
-#.TRANS: Advertencia: el tipo de argumento de bloque no coincide
+#. TRANS: Advertencia: el tipo de argumento de bloque no coincide
 msgid "Warning: block argument type mismatch"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1347
-#.TRANS: El bloque Abrir proyecto se utiliza para abrir un proyecto desde una página web.
+#. TRANS: El bloque Abrir proyecto se utiliza para abrir un proyecto desde una página web.
 msgid "The Open project block is used to open a project from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1357
-#.TRANS: abierto proyecto
+#. TRANS: abierto proyecto
 msgid "open project"
 msgstr "rurana kichasqa"
 
 #: js/blocks/ProgramBlocks.js:1410
-#.TRANS: Por favor introduzca un URL válido.
+#. TRANS: Por favor introduzca un URL válido.
 msgid "Please enter a valid URL."
 msgstr "Ama hina waliq URLta haykuchiy"
 
 #: js/blocks/RhythmBlocks.js:182
 #: js/blocks/RhythmBlocks.js:1086
 #: js/blocks/RhythmBlocks.js:1162
-#.TRANS: Valor de la nota debe ser mayor que 0.
+#. TRANS: Valor de la nota debe ser mayor que 0.
 msgid "Note value must be greater than 0."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
-#.TRANS: swing
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
-#.TRANS: valor de swing
+#. TRANS: the amount to shift to the offbeat note
+#. TRANS: valor de swing
 msgid "swing value"
 msgstr "valor de swing"
 
 #: js/blocks/RhythmBlocks.js:419
-#.TRANS: El bloque Omitir notas hará que las notas se omitan.
+#. TRANS: El bloque Omitir notas hará que las notas se omitan.
 msgid "The Skip notes block will cause notes to be skipped."
 msgstr "El bloque Omitir notas hará que las notas se omitan."
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
-#.TRANS: saltar notas
+#. TRANS: substitute rests on notes being skipped
+#. TRANS: saltar notas
 msgid "skip notes"
 msgstr "kunkakuna p’itay"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
-#.TRANS: ritmo multiplican
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: ritmo multiplican
 msgid "multiply note value"
 msgstr "Muyuq miracchiq"
 
 #: js/blocks/RhythmBlocks.js:542
-#.TRANS: El bloque Atar funciona en pares de notas, combinándolas en una sola nota.
+#. TRANS: El bloque Atar funciona en pares de notas, combinándolas en una sola nota.
 msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
-#.TRANS: atar
+#. TRANS: tie notes together into one longer note
+#. TRANS: atar
 msgid "tie"
 msgstr "Watay"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
-#.TRANS: punto
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: punto
 msgid "dot"
 msgstr "Ch’iku)"
 
 #: js/blocks/RhythmBlocks.js:619
 #: js/turtleactions/RhythmActions.js:221
-#.TRANS: Un argumento de -1 da como resultado un valor de nota de 0.
+#. TRANS: Un argumento de -1 da como resultado un valor de nota de 0.
 msgid "An argument of -1 results in a note value of 0."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:661
-#.TRANS: El bloque Punto extiende la duración de una nota en un 50%.
+#. TRANS: El bloque Punto extiende la duración de una nota en un 50%.
 msgid "The Dot block extends the duration of a note by 50%."
 msgstr "El bloque Punto extiende la duración de una nota en un 50%."
 
 #: js/blocks/RhythmBlocks.js:663
-#.TRANS: Por ejemplo, una nota de un cuarto de puntos se reproducirá a 3/8 (1/4 + 1/8) de un tiempo.
+#. TRANS: Por ejemplo, una nota de un cuarto de puntos se reproducirá a 3/8 (1/4 + 1/8) de un tiempo.
 msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
-#.TRANS: Valor de nota tambor
+#. TRANS: Japanese only: note value block for drum
+#. TRANS: Valor de nota tambor
 msgid "note value drum"
 msgstr "Valor de nota tambor"
 
 #: js/blocks/RhythmBlocks.js:829
-#.TRANS: 392 hertz
+#. TRANS: 392 hertz
 msgid "392 hertz"
 msgstr "392 kaparina"
 
 #: js/blocks/RhythmBlocks.js:1119
-#.TRANS: El bloque Nota es un contenedor para uno o más bloques de tono.
+#. TRANS: El bloque Nota es un contenedor para uno o más bloques de tono.
 msgid "The Note block is a container for one or more Pitch blocks."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:1121
-#.TRANS: El bloque Notas especifica la duración (valor de la nota) de su contenido.
+#. TRANS: El bloque Notas especifica la duración (valor de la nota) de su contenido.
 msgid "The Note block specifies the duration (note value) of its contents."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:1130
-#.TRANS: valor
+#. TRANS: valor
 msgid "value2"
 msgstr "tupu"
 
 #: js/blocks/RhythmBlocks.js:1200
-#.TRANS: definir frecuencia
+#. TRANS: definir frecuencia
 msgid "define frequency"
 msgstr "definir frecuencia"
 
 #: js/blocks/RhythmBlocks.js:1218
 #: js/widgets/temperament.js:757
 #: js/widgets/temperament.js:1522
-#.TRANS: espacio de octava
+#. TRANS: espacio de octava
 msgid "octave space"
 msgstr "pusaqpa pachan"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
-#.TRANS: ritmo
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
+#. TRANS: ritmo
 msgid "rhythm1"
 msgstr "taki muyuchik"
 
@@ -5416,177 +5416,177 @@ msgstr "taki muyuchik"
 #: js/blocks/RhythmBlockPaletteBlocks.js:517
 #: js/blocks/RhythmBlockPaletteBlocks.js:586
 #: js/blocks/RhythmBlockPaletteBlocks.js:907
-#.TRANS: número de notas
+#. TRANS: número de notas
 msgid "number of notes"
 msgstr "Yupay waqaykuna"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:126
-#.TRANS: ritmo polifónico
+#. TRANS: ritmo polifónico
 msgid "polyphonic rhythm"
 msgstr "Achka waqaykunap Munay muyuchik"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:219
-#.TRANS: El bloque Ritmo se utiliza para generar patrones de ritmo.
+#. TRANS: El bloque Ritmo se utiliza para generar patrones de ritmo.
 msgid "The Rhythm block is used to generate rhythm patterns."
 msgstr "Munay purichiqa kinkinman hina qatipaq"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:281
 #: js/blocks/RhythmBlockPaletteBlocks.js:286
-#.TRANS: 1/64 nota
+#. TRANS: 1/64 nota
 msgid "1/64 note"
 msgstr "1/64 kunka"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:312
 #: js/blocks/RhythmBlockPaletteBlocks.js:317
-#.TRANS: 1/32 nota
+#. TRANS: 1/32 nota
 msgid "1/32 note"
 msgstr "Kunkaq tahasqan"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:346
 #: js/blocks/RhythmBlockPaletteBlocks.js:351
-#.TRANS: 1/16 nota
+#. TRANS: 1/16 nota
 msgid "1/16 note"
 msgstr "1/6 kunka"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:380
-#.TRANS: 1/8 nota
+#. TRANS: 1/8 nota
 msgid "eighth note"
 msgstr "1/8 kunka"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:408
-#.TRANS: 1/4 nota
+#. TRANS: 1/4 nota
 msgid "quarter note"
 msgstr "1/4 kunka"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:436
 #: js/blocks/RhythmBlockPaletteBlocks.js:441
-#.TRANS: 1/2 nota
+#. TRANS: 1/2 nota
 msgid "half note"
 msgstr "1/2 kunka"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:470
 #: js/blocks/RhythmBlockPaletteBlocks.js:475
-#.TRANS: nota completa
+#. TRANS: nota completa
 msgid "whole note"
 msgstr "hunt’asqa kunka"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
-#.TRANS: tuplet
+#. TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: tuplet
 msgid "tuplet"
 msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:800
-#.TRANS: septeto
+#. TRANS: septeto
 msgid "septuplet"
 msgstr "Qanchikmanta"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:828
-#.TRANS: quinteto
+#. TRANS: quinteto
 msgid "quintuplet"
 msgstr "Phisqamanta"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:856
-#.TRANS: trillizo
+#. TRANS: trillizo
 msgid "triplet"
 msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:883
-#.TRANS: tuplet simple
+#. TRANS: tuplet simple
 msgid "simple tuplet"
 msgstr "tuplet simple"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:893
-#.TRANS: Tuplets son una colección de notas que se escalan a una duración específica.
+#. TRANS: Tuplets son una colección de notas que se escalan a una duración específica.
 msgid "Tuplets are a collection of notes that get scaled to a specific duration."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:41
-#.TRANS: El bloque Atrás ejecuta el código en orden inverso (retrógrado en la música).
+#. TRANS: El bloque Atrás ejecuta el código en orden inverso (retrógrado en la música).
 msgid "The Backward block runs code in reverse order (Musical retrograde)."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:48
-#.TRANS: hacia atrás
+#. TRANS: hacia atrás
 msgid "backward"
 msgstr "Qhipaman"
 
 #: js/blocks/FlowBlocks.js:124
-#.TRANS: El bloque Duplicado ejecutará cada bloque varias veces.
+#. TRANS: El bloque Duplicado ejecutará cada bloque varias veces.
 msgid "The Duplicate block will run each block multiple times."
 msgstr "Iskay kikinyachiq sayaq, ruranqa sapanka sayaqta achka kutita"
 
 #: js/blocks/FlowBlocks.js:334
-#.TRANS: El bloque predeterminado se usa dentro de un bloque de switch para definir la acción predeterminada.
+#. TRANS: El bloque predeterminado se usa dentro de un bloque de switch para definir la acción predeterminada.
 msgid "The Default block is used inside of a Switch to define the default action."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:342
-#.TRANS: el caso de forma predeterminada
+#. TRANS: el caso de forma predeterminada
 msgid "default"
 msgstr "Chhaynapaq rurasqa"
 
 #: js/blocks/FlowBlocks.js:361
 #: js/blocks/FlowBlocks.js:418
-#.TRANS: El bloque Caso debe utilizarse dentro de un bloque de switch.
+#. TRANS: El bloque Caso debe utilizarse dentro de un bloque de switch.
 msgid "The Case Block must be used inside of a Switch Block."
 msgstr "El bloque Caso debe utilizarse dentro de un bloque de switch."
 
 #: js/blocks/FlowBlocks.js:389
-#.TRANS: El bloque Caso se utiliza dentro de un interruptor para definir coincidencias.
+#. TRANS: El bloque Caso se utiliza dentro de un interruptor para definir coincidencias.
 msgid "The Case block is used inside of a Switch to define matches."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:397
-#.TRANS: caso
+#. TRANS: caso
 msgid "case"
 msgstr "caso"
 
 #: js/blocks/FlowBlocks.js:446
-#.TRANS: El bloque Switch ejecutará el código en el caso correspondiente.
+#. TRANS: El bloque Switch ejecutará el código en el caso correspondiente.
 msgid "The Switch block will run the code in the matching Case."
 msgstr "El bloque Switch ejecutará el código en el caso correspondiente."
 
 #: js/blocks/FlowBlocks.js:454
-#.TRANS: switch
+#. TRANS: switch
 msgid "switch"
 msgstr "tinkuchiy"
 
 #: js/blocks/FlowBlocks.js:595
-#.TRANS: El bloque Parar detendrá un bucle.
+#. TRANS: El bloque Parar detendrá un bucle.
 msgid "The Stop block will stop a loop"
 msgstr "El bloque Parar detendrá un bucle."
 
 #: js/blocks/FlowBlocks.js:597
-#.TRANS: Por siempre, Repetir, Mientras o Hasta.
+#. TRANS: Por siempre, Repetir, Mientras o Hasta.
 msgid "Forever, Repeat, While, or Until."
 msgstr "Por siempre, Repetir, Mientras o Hasta."
 
 #: js/blocks/FlowBlocks.js:653
-#.TRANS: El bloque Esperar esperará hasta que la condición sea verdadera.
+#. TRANS: El bloque Esperar esperará hasta que la condición sea verdadera.
 msgid "The Waitfor block will wait until the condition is true."
 msgstr "El bloque Esperar esperará hasta que la condición sea verdadera."
 
 #: js/blocks/FlowBlocks.js:661
-#.TRANS: esperar hasta
+#. TRANS: esperar hasta
 msgid "wait for"
 msgstr "esperar hasta"
 
 #: js/blocks/FlowBlocks.js:732
-#.TRANS: El bloque Hasta se repetirá hasta que la condición sea verdadera.
+#. TRANS: El bloque Hasta se repetirá hasta que la condición sea verdadera.
 msgid "The Until block will repeat until the condition is true."
 msgstr "El bloque Hasta se repetirá hasta que la condición sea verdadera."
 
 #: js/blocks/FlowBlocks.js:740
-#.TRANS: hasta
+#. TRANS: hasta
 msgid "until"
 msgstr "kay kama"
 
 #: js/blocks/FlowBlocks.js:742
 #: js/blocks/FlowBlocks.js:822
-#.TRANS: hacer
+#. TRANS: hacer
 msgid "do2"
 msgstr "ruray"
 
@@ -5597,96 +5597,96 @@ msgstr "ruray"
 #: js/blocks/ActionBlocks.js:610
 #: js/blocks/ActionBlocks.js:959
 #: js/blocks/ActionBlocks.js:1048
-#.TRANS: hacer
+#. TRANS: hacer
 msgid "do"
 msgstr "Ruray"
 
 #: js/blocks/FlowBlocks.js:812
-#.TRANS: El bloque Mientras se repetirá mientras la condición sea verdadera.
+#. TRANS: El bloque Mientras se repetirá mientras la condición sea verdadera.
 msgid "The While block will repeat while the condition is true."
 msgstr "El bloque Mientras se repetirá mientras la condición sea verdadera."
 
 #: js/blocks/FlowBlocks.js:820
-#.TRANS: mientras
+#. TRANS: mientras
 msgid "while"
 msgstr "chaykamataq"
 
 #: js/blocks/FlowBlocks.js:903
 #: js/blocks/FlowBlocks.js:968
 #: js/blocks/FlowBlocks.js:979
-#.TRANS: En este ejemplo, si se presiona el botón del mouse, se reproducirá una caja.
+#. TRANS: En este ejemplo, si se presiona el botón del mouse, se reproducirá una caja.
 msgid "In this example if the mouse button is pressed a snare drum will play."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:925
 #: js/blocks/FlowBlocks.js:988
-#.TRANS: si
+#. TRANS: si
 msgid "if"
 msgstr "arí"
 
 #: js/blocks/FlowBlocks.js:927
 #: js/blocks/FlowBlocks.js:990
-#.TRANS: entonces
+#. TRANS: entonces
 msgid "then"
 msgstr "chaynaqa"
 
 #: js/blocks/FlowBlocks.js:927
-#.TRANS: sino
+#. TRANS: sino
 msgid "else"
 msgstr "mana chayqa"
 
 #: js/blocks/FlowBlocks.js:1025
-#.TRANS: El bloque Por siempre repetirá los bloques contenidos para siempre.
+#. TRANS: El bloque Por siempre repetirá los bloques contenidos para siempre.
 msgid "The Forever block will repeat the contained blocks forever."
 msgstr ""
 
 #: js/blocks/FlowBlocks.js:1037
-#.TRANS: por siempre
+#. TRANS: por siempre
 msgid "forever"
 msgstr "wiñaypaq"
 
 #: js/blocks/FlowBlocks.js:1073
-#.TRANS: El bloque Repetir repetirá los bloques contenidos.
+#. TRANS: El bloque Repetir repetirá los bloques contenidos.
 msgid "The Repeat block will repeat the contained blocks."
 msgstr "El bloque Repetir repetirá los bloques contenidos."
 
 #: js/blocks/FlowBlocks.js:1075
-#.TRANS: En este ejemplo la nota se tocará 4 veces.
+#. TRANS: En este ejemplo la nota se tocará 4 veces.
 msgid "In this example the note will be played 4 times."
 msgstr "En este ejemplo la nota se tocará 4 veces."
 
 #: js/blocks/FlowBlocks.js:1083
-#.TRANS: repetir
+#. TRANS: repetir
 msgid "repeat"
 msgstr "huktawan"
 
 #: js/blocks/FlowBlocks.js:1123
-#.TRANS: duplicar factor
+#. TRANS: duplicar factor
 msgid "duplicate factor"
 msgstr "factor de duplicar"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
-#.TRANS: meter actuale
+#. TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: meter actuale
 msgid "current meter"
 msgstr "actualita haykuchiy"
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
-#.TRANS: factor de ritmo
+#. TRANS: number of beats per minute
+#. TRANS: factor de ritmo
 msgid "beat factor"
 msgstr "p’ullpuqiy"
 
 #: js/blocks/MeterBlocks.js:161
-#.TRANS: El bloque de latidos por minuto devuelve los latidos actuales por minuto.
+#. TRANS: El bloque de latidos por minuto devuelve los latidos actuales por minuto.
 msgid "The Beats per minute block returns the current beats per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
-#.TRANS: pulsaciones por minuto
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: pulsaciones por minuto
 msgid "beats per minute2"
 msgstr "minutupi p’ullpuqiy"
 
@@ -5694,25 +5694,25 @@ msgstr "minutupi p’ullpuqiy"
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
-#.TRANS: pulsaciones por minuto
+#. TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: pulsaciones por minuto
 msgid "beats per minute"
 msgstr "minutupi p’ullpuqiy"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
-#.TRANS: cuenta de medidas
+#. TRANS: count of current musical measure in meter
+#. TRANS: cuenta de medidas
 msgid "measure count"
 msgstr "tupusqakunapa yupaynin"
 
 #: js/blocks/MeterBlocks.js:242
-#.TRANS: El bloque de conteo de medidas devuelve la medida actual.
+#. TRANS: El bloque de conteo de medidas devuelve la medida actual.
 msgid "The Measure count block returns the current measure."
 msgstr "tupunakuna yupay chiqasqa kunan tupunata kutichipun"
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
-#.TRANS: cuenta de latidos
+#. TRANS: count of current beat in the meter
+#. TRANS: cuenta de latidos
 msgid "beat count"
 msgstr "p’ullpuqiyta yupay"
 
@@ -5720,85 +5720,85 @@ msgstr "p’ullpuqiyta yupay"
 #: js/blocks/MeterBlocks.js:312
 #: js/blocks/MeterBlocks.js:566
 #: js/blocks/MeterBlocks.js:577
-#.TRANS: El bloque Conteo de tiempos es el número del tiempo actual,
+#. TRANS: El bloque Conteo de tiempos es el número del tiempo actual,
 msgid "The Beat count block is the number of the current beat,"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:314
 #: js/blocks/MeterBlocks.js:579
-#.TRANS: por ejemplo, 1, 2, 3, o 4.
+#. TRANS: por ejemplo, 1, 2, 3, o 4.
 msgid "eg 1, 2, 3, or 4."
 msgstr "kanman huk, iskay, kimsa, kallanmantaq tawa"
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
-#.TRANS: cuenta las notas
+#. TRANS: count the number of notes
+#. TRANS: cuenta las notas
 msgid "sum note values"
 msgstr "nota yupay"
 
 #: js/blocks/MeterBlocks.js:377
 #: js/blocks/MeterBlocks.js:441
-#.TRANS: El bloque Contador de notas se puede usar para contar el número de notas contenidas.
+#. TRANS: El bloque Contador de notas se puede usar para contar el número de notas contenidas.
 msgid "The Note counter block can be used to count the number of contained notes."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
-#.TRANS: cuenta las notas
+#. TRANS: count the number of notes
+#. TRANS: cuenta las notas
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
-#.TRANS: notas completa jugadas
+#. TRANS: number of whole notes that have been played
+#. TRANS: notas completa jugadas
 msgid "whole notes played"
 msgstr "hunt’asqa nota pukllasqakuna"
 
 #: js/blocks/MeterBlocks.js:506
-#.TRANS: El bloque Nota completa reproducidas devuelve el número total de notas completas reproducidas.
+#. TRANS: El bloque Nota completa reproducidas devuelve el número total de notas completas reproducidas.
 msgid "The Whole notes played block returns the total number of whole notes played."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
-#.TRANS: notas jugadas
+#. TRANS: number of notes that have been played
+#. TRANS: notas jugadas
 msgid "notes played"
 msgstr "notakuna pukllasqakuna"
 
 #: js/blocks/MeterBlocks.js:654
-#.TRANS: El bloque Sin reloj desacopla las notas del reloj maestro.
+#. TRANS: El bloque Sin reloj desacopla las notas del reloj maestro.
 msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
-#.TRANS: sin reloj
+#. TRANS: don't lock notes to master clock
+#. TRANS: sin reloj
 msgid "no clock"
 msgstr "mana intiwatanayuq"
 
 #: js/blocks/MeterBlocks.js:701
-#.TRANS: en latido débil hacer
+#. TRANS: en latido débil hacer
 msgid "on weak beat do"
 msgstr "mana kallpayuq p’ullpuqiypi rurana"
 
 #: js/blocks/MeterBlocks.js:706
-#.TRANS: El bloque En-latido-débil-hacer te permite especificar acciones a realizar en latido débiles.
+#. TRANS: El bloque En-latido-débil-hacer te permite especificar acciones a realizar en latido débiles.
 msgid "The On-weak-beat block lets you specify actions to take on weak (off) beats."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:751
-#.TRANS: en latido fuerte hacer
+#. TRANS: en latido fuerte hacer
 msgid "on strong beat"
 msgstr "kallpayuq p’ullpuqiypi rurana"
 
 #: js/blocks/MeterBlocks.js:759
-#.TRANS: El bloque En-latido-fuerte-hacer le permite especificar acciones a realizar en latido específicos.
+#. TRANS: El bloque En-latido-fuerte-hacer le permite especificar acciones a realizar en latido específicos.
 msgid "The On-strong-beat block lets you specify actions to take on specified beats."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:770
-#.TRANS: latidos
+#. TRANS: latidos
 msgid "beat"
 msgstr "p’ullpuqiy"
 
@@ -5807,123 +5807,123 @@ msgstr "p’ullpuqiy"
 #: js/blocks/ActionBlocks.js:610
 #: js/blocks/ActionBlocks.js:959
 #: js/blocks/ActionBlocks.js:1048
-#.TRANS: do
+#. TRANS: do
 msgid "do1"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:814
-#.TRANS: en cado latodo hacer
+#. TRANS: en cado latodo hacer
 msgid "on every beat do"
 msgstr "en cada latodo hacer"
 
 #: js/blocks/MeterBlocks.js:822
-#.TRANS: El bloque En-cado-latido-hacer le permite especificar acciones a realizar en cado latado.
+#. TRANS: El bloque En-cado-latido-hacer le permite especificar acciones a realizar en cado latado.
 msgid "The On-every-beat block lets you specify actions to take on every beat."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:875
-#.TRANS: en cada nota hacer
+#. TRANS: en cada nota hacer
 msgid "on every note do"
 msgstr "en cada nota hacer"
 
 #: js/blocks/MeterBlocks.js:883
-#.TRANS: El bloque En-cada-nota-hacer le permite especificar acciones a realizar en cada nota.
+#. TRANS: El bloque En-cada-nota-hacer le permite especificar acciones a realizar en cada nota.
 msgid "The On-every-note block lets you specify actions to take on every note."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
-#.TRANS: latidos por minuto de dominar
+#. TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: latidos por minuto de dominar
 msgid "master beats per minute"
 msgstr "minutupi p’ullpuqiy hap’iy"
 
 #: js/blocks/MeterBlocks.js:953
 #: js/blocks/MeterBlocks.js:1079
 #: js/blocks/MeterBlocks.js:1136
-#.TRANS: lpm
+#. TRANS: lpm
 msgid "bpm"
 msgstr "bmp"
 
 #: js/blocks/MeterBlocks.js:953
 #: js/blocks/MeterBlocks.js:1079
 #: js/blocks/MeterBlocks.js:1136
-#.TRANS: valor de latidos
+#. TRANS: valor de latidos
 msgid "beat value"
 msgstr "p’ullpuqiypa kaqnin"
 
 #: js/blocks/MeterBlocks.js:1025
 #: js/blocks/MeterBlocks.js:1168
 #: js/blocks/MeterBlocks.js:1242
-#.TRANS: Latidos por minuto debe ser > 30.
+#. TRANS: Latidos por minuto debe ser > 30.
 msgid "Beats per minute must be > 30."
 msgstr "minutupi p’ullpuqiyniqa 30 kurakmi kanan"
 
 #: js/blocks/MeterBlocks.js:1028
 #: js/blocks/MeterBlocks.js:1171
 #: js/blocks/MeterBlocks.js:1245
-#.TRANS: Los latidos por minuto como máximo es de 1000.
+#. TRANS: Los latidos por minuto como máximo es de 1000.
 msgid "Maximum beats per minute is 1000."
 msgstr " minutupi p’ullpuqiyniqa may tukupunankamaqa waranqan (1000) kanan"
 
 #: js/blocks/MeterBlocks.js:1069
-#.TRANS: El bloque Pulsaciones por minuto establece el número de 1/4 notas por minuto.
+#. TRANS: El bloque Pulsaciones por minuto establece el número de 1/4 notas por minuto.
 msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
-#.TRANS: 
+#. TRANS: anacrusis
+#. TRANS: 
 msgid "pickup"
 msgstr "pallay"
 
 #: js/blocks/MeterBlocks.js:1368
-#.TRANS: número de latidos
+#. TRANS: número de latidos
 msgid "number of beats"
 msgstr "p’ullpuqiypa yupanan"
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
-#.TRANS: transposición
+#. TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: transposición
 msgid "transposition"
 msgstr "haywapuynin"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
-#.TRANS: escalar bajar
+#. TRANS: step down one note in current musical scale
+#. TRANS: escalar bajar
 msgid "scalar step down"
 msgstr "wichay uraqay"
 
 #: js/blocks/PitchBlocks.js:172
-#.TRANS: El bloque Escalar bajar devuelve el número de semitonos a la nota anterior en la tecla y modo actuales.
+#. TRANS: El bloque Escalar bajar devuelve el número de semitonos a la nota anterior en la tecla y modo actuales.
 msgid "The Scalar step down block returns the number of semi-tones down to the previous note in the current key and mode."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
-#.TRANS: escalar aumentar
+#. TRANS: step up one note in current musical scale
+#. TRANS: escalar aumentar
 msgid "scalar step up"
 msgstr "wichay yapaykuy"
 
 #: js/blocks/PitchBlocks.js:194
-#.TRANS: El bloque Escalar aumentar devuelve el número de semitonos hasta la siguiente nota en la tecla y modo actuales.
+#. TRANS: El bloque Escalar aumentar devuelve el número de semitonos hasta la siguiente nota en la tecla y modo actuales.
 msgid "The Scalar step up block returns the number of semi-tones up to the next note in the current key and mode."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
-#.TRANS: cambio en tono
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: cambio en tono
 msgid "change in pitch"
 msgstr "kunkan t’ikrasqa"
 
 #: js/blocks/PitchBlocks.js:216
-#.TRANS: El cambio en el bloque de tono es la diferencia (en medio pasos) entre el tono actual que se está reproduciendo y el tono anterior.
+#. TRANS: El cambio en el bloque de tono es la diferencia (en medio pasos) entre el tono actual que se está reproduciendo y el tono anterior.
 msgid "The Change in pitch block is the difference (in half steps) between the current pitch being played and the previous pitch played."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
-#.TRANS: cambio en tono escalar
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: cambio en tono escalar
 msgid "scalar change in pitch"
 msgstr "cambio en tono escalar"
 
@@ -5934,111 +5934,111 @@ msgstr "cambio en tono escalar"
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
-#.TRANS: número de tono
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: número de tono
 msgid "pitch number"
 msgstr "kunkapa yupaynin"
 
 #: js/blocks/PitchBlocks.js:256
-#.TRANS: El bloque Número de tono es el valor del tono de la nota que se está reproduciendo actualmente.
+#. TRANS: El bloque Número de tono es el valor del tono de la nota que se está reproduciendo actualmente.
 msgid "The Pitch number block is the value of the pitch of the note currently being played."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
-#.TRANS: tono en hertz
+#. TRANS: the current pitch expressed in Hertz
+#. TRANS: tono en hertz
 msgid "pitch in hertz"
 msgstr "hertzpi kunkan"
 
 #: js/blocks/PitchBlocks.js:334
-#.TRANS: El bloque Tono en Hertz es el valor en hercios del tono de la nota que se está reproduciendo actualmente.
+#. TRANS: El bloque Tono en Hertz es el valor en hercios del tono de la nota que se está reproduciendo actualmente.
 msgid "The Pitch in Hertz block is the value in Hertz of the pitch of the note currently being played."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:367
 #: js/turtleactions/DictActions.js:87
-#.TRANS: tono actual
+#. TRANS: tono actual
 msgid "current pitch"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:373
-#.TRANS: El bloque de tono actual se utiliza con el bloque convertidor de tono. En el ejemplo anterior, el tono actual, sol 4, se muestra como 392 hercios.
+#. TRANS: El bloque de tono actual se utiliza con el bloque convertidor de tono. En el ejemplo anterior, el tono actual, sol 4, se muestra como 392 hercios.
 msgid "The Current Pitch block is used with the Pitch Converter block. In the example above, current pitch, sol 4, is displayed as 392 hertz."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:410
-#.TRANS: Este bloque convierte el valor de tono de la última nota tocada en diferentes formatos como hertz, nombre de letra, número de tono, etc.
+#. TRANS: Este bloque convierte el valor de tono de la última nota tocada en diferentes formatos como hertz, nombre de letra, número de tono, etc.
 msgid "This block converts the pitch value of the last note played into different formats such as hertz, letter name, pitch number, et al."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:434
-#.TRANS: alfabeto
+#. TRANS: alfabeto
 msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
-#.TRANS: clase de alfabeto
+#. TRANS: Translate as "alphabet class"
+#. TRANS: clase de alfabeto
 msgid "letter class"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:437
-#.TRANS: clase de solfege
+#. TRANS: clase de solfege
 msgid "solfege class"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:438
-#.TRANS: musical y
+#. TRANS: musical y
 msgid "staff y"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:439
-#.TRANS: sílaba solfege
+#. TRANS: sílaba solfege
 msgid "solfege syllable"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:440
-#.TRANS: clase de tono
+#. TRANS: clase de tono
 msgid "pitch class"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:441
-#.TRANS: clase de escala
+#. TRANS: clase de escala
 msgid "scalar class"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:443
-#.TRANS: nth grado
+#. TRANS: nth grado
 msgid "nth degree"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:444
-#.TRANS: tono a la sombra
+#. TRANS: tono a la sombra
 msgid "pitch to shade"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:445
-#.TRANS: tono a color
+#. TRANS: tono a color
 msgid "pitch to color"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
-#.TRANS: MIDI
+#. TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI
 msgid "MIDI"
 msgstr "MIDI"
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
-#.TRANS: fijar offset del número de tono
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: fijar offset del número de tono
 msgid "set pitch number offset"
 msgstr "kunkapa yupayninta watapuna "
 
 #: js/blocks/PitchBlocks.js:645
-#.TRANS: El bloque Fijar del número de tono establecido se usa para establecer el desplazamiento para asignar números de tono a tono y octava.
+#. TRANS: El bloque Fijar del número de tono establecido se usa para establecer el desplazamiento para asignar números de tono a tono y octava.
 msgid "The Set pitch number offset block is used to set the offset for mapping pitch numbers to pitch and octave."
 msgstr ""
 
@@ -6046,213 +6046,213 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
-#.TRANS: nombre
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: nombre
 msgid "name2"
 msgstr "suti"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
-#.TRANS: número a tono
+#. TRANS: convert piano key number (1-88) to pitch
+#. TRANS: número a tono
 msgid "number to pitch"
 msgstr "yupay kunkaman"
 
 #: js/blocks/PitchBlocks.js:682
-#.TRANS: El bloque Número a tono convertirá un número de tono en un nombre pich.
+#. TRANS: El bloque Número a tono convertirá un número de tono en un nombre pich.
 msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
-#.TRANS: número a octava
+#. TRANS: convert piano key number (1-88) to octave
+#. TRANS: número a octava
 msgid "number to octave"
 msgstr "yupay pusaq pataman"
 
 #: js/blocks/PitchBlocks.js:717
-#.TRANS: El bloque Número a octava convertirá un número de tono en una octava.
+#. TRANS: El bloque Número a octava convertirá un número de tono en una octava.
 msgid "The Number to octave block will convert a pitch number to an octave."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:726
-#.TRANS: y para tono
+#. TRANS: y para tono
 msgid "y to pitch"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:729
-#.TRANS: El bloque Y a tono convertirá una posición de pentagrama y a la notación de tono correspondiente.
+#. TRANS: El bloque Y a tono convertirá una posición de pentagrama y a la notación de tono correspondiente.
 msgid "Y to pitch block will convert a staff y position to corresponding pitch notation."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:841
-#.TRANS: selector accidental
+#. TRANS: selector accidental
 msgid "accidental selector"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:844
-#.TRANS: El bloque Selector de accidental se usa para elegir entre doble filo, agudo, natural, plano y doble plano.
+#. TRANS: El bloque Selector de accidental se usa para elegir entre doble filo, agudo, natural, plano y doble plano.
 msgid "The Accidental selector block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:858
-#.TRANS: El tono puede especificarse en términos de ni dha pa ma ga re sa.
+#. TRANS: El tono puede especificarse en términos de ni dha pa ma ga re sa.
 msgid "Pitch can be specified in terms of ni dha pa ma ga re sa."
 msgstr "kunkaqa kay tukuykunapi ni dha pa ma ga re sa alayrichikun "
 
 #: js/blocks/PitchBlocks.js:872
-#.TRANS: El tono puede especificarse en términos de C D E F G A B.
+#. TRANS: El tono puede especificarse en términos de C D E F G A B.
 msgid "Pitch can be specified in terms of C D E F G A B."
 msgstr " kunkaqa kay tukuykunapi C D E F G A B alayrichikun "
 
 #: js/blocks/PitchBlocks.js:884
-#.TRANS: 
+#. TRANS: 
 msgid "solfege"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:887
-#.TRANS: El tono puede especificarse en términos de do re mi fa sol la si.
+#. TRANS: El tono puede especificarse en términos de do re mi fa sol la si.
 msgid "Pitch can be specified in terms of do re mi fa sol la ti."
 msgstr " kunkaqa kay tukuykunapi do re mi fa sol la si alayrichikun "
 
 #: js/blocks/PitchBlocks.js:922
-#.TRANS: El bloque Invertir gira cualquier nota contenida alrededor de una nota de destino.
+#. TRANS: El bloque Invertir gira cualquier nota contenida alrededor de una nota de destino.
 msgid "The Invert block rotates any contained notes around a target note."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
-#.TRANS: Invertir
+#. TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: Invertir
 msgid "Invert"
 msgstr "Tikray"
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
-#.TRANS: invertir (impar)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: invertir (impar)
 msgid "invert (odd)"
 msgstr "t’ikray (sapallan"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
-#.TRANS: invertir (par)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: invertir (par)
 msgid "invert (even)"
 msgstr "t’ikray (masantin)"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
-#.TRANS: registro
+#. TRANS: register is the octave of the current pitch
+#. TRANS: registro
 msgid "register"
 msgstr "waqaychasqa"
 
 #: js/blocks/PitchBlocks.js:1026
-#.TRANS: El bloque Registro proporciona una manera fácil de modificar el registro (octava) de las notas que lo siguen.
+#. TRANS: El bloque Registro proporciona una manera fácil de modificar el registro (octava) de las notas que lo siguen.
 msgid "The Register block provides an easy way to modify the register (octave) of the notes that follow it."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
-#.TRANS: 50 centavos
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: 50 centavos
 msgid "50 cents"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1102
-#.TRANS: El bloque de transposición de semitono desplazará los pasos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) medio pasos.
+#. TRANS: El bloque de transposición de semitono desplazará los pasos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) medio pasos.
 msgid "The Semi-tone transposition block will shift the pitches contained inside Note blocks up (or down) by half steps."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1104
-#.TRANS: En el ejemplo que se muestra arriba, sol se desplaza hasta sol#.
+#. TRANS: En el ejemplo que se muestra arriba, sol se desplaza hasta sol#.
 msgid "In the example shown above, sol is shifted up to sol#."
 msgstr "wichaypi qhawachisqapi hina, solqa solkama purin"
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
-#.TRANS: transposición semitono
+#. TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: transposición semitono
 msgid "semi-tone transpose"
 msgstr "kuskan kunka Haywapuynin"
 
 #: js/blocks/PitchBlocks.js:1143
-#.TRANS: El bloque transponer por razón cambiará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) en una proporción
+#. TRANS: El bloque transponer por razón cambiará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) en una proporción
 msgid "The Transpose by Ratio block will shift the pitches contained inside Note blocks up (or down) by a ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
-#.TRANS: transponer por razón
+#. TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: transponer por razón
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
-#.TRANS: sexto abajo
+#. TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: sexto abajo
 msgid "down sixth"
 msgstr "uraypi suqta pata"
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
-#.TRANS: tercero abajo
+#. TRANS: down third means the note is two scale degrees below current note
+#. TRANS: tercero abajo
 msgid "down third"
 msgstr "uraypi kimsa pata"
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
-#.TRANS: séptimo
+#. TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: séptimo
 msgid "seventh"
 msgstr "qanchis pata"
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
-#.TRANS: sexto
+#. TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sexto
 msgid "sixth"
 msgstr "suqta pata"
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
-#.TRANS: quinto
+#. TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: quinto
 msgid "fifth"
 msgstr "phichqa pata"
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
-#.TRANS: cuarto
+#. TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: cuarto
 msgid "fourth"
 msgstr "tawa pata"
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
-#.TRANS: tercio
+#. TRANS: third means the note is two scale degrees above current note
+#. TRANS: tercio
 msgid "third"
 msgstr "kimsa pata"
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
-#.TRANS: segundo
+#. TRANS: second means the note is one scale degree above current note
+#. TRANS: segundo
 msgid "second"
 msgstr "iskay pata"
 
 #: js/blocks/PitchBlocks.js:1407
-#.TRANS: El bloque Transposición escalar desplazará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) de la escala.
+#. TRANS: El bloque Transposición escalar desplazará los tonos contenidos dentro de los bloques de notas hacia arriba (o hacia abajo) de la escala.
 msgid "The Scalar transposition block will shift the pitches contained inside Note blocks up (or down) the scale."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1409
-#.TRANS: En el ejemplo que se muestra arriba, el sol se desplaza hacia arriba a la.
+#. TRANS: En el ejemplo que se muestra arriba, el sol se desplaza hacia arriba a la.
 msgid "In the example shown above, sol is shifted up to la."
 msgstr "En el ejemplo que se muestra arriba, el sol se desplaza hacia arriba a la."
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
-#.TRANS: transposición escalar
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: transposición escalar
 msgid "scalar transpose"
 msgstr "sayayninta  tupachiy haywapuynin"
 
 #: js/blocks/PitchBlocks.js:1451
-#.TRANS: El bloque Accidental se utiliza para crear objetos punzantes y pisos.
+#. TRANS: El bloque Accidental se utiliza para crear objetos punzantes y pisos.
 msgid "The Accidental block is used to create sharps and flats"
 msgstr "Yanapaqnin chiqasqa chhukuna hinallataq saruna imakunapas paqarichiy llamk’anam"
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
-#.TRANS: anular accidental
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: anular accidental
 msgid "accidental override"
 msgstr ""
 
@@ -6260,83 +6260,83 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
-#.TRANS: hertz
+#. TRANS: a measure of frequency: one cycle per second
+#. TRANS: hertz
 msgid "hertz"
 msgstr "hertz"
 
 #: js/blocks/PitchBlocks.js:1581
-#.TRANS: El bloque Hertz (en combinación con un bloque numérico) reproducirá un sonido a la frecuencia especificada.
+#. TRANS: El bloque Hertz (en combinación con un bloque numérico) reproducirá un sonido a la frecuencia especificada.
 msgid "The Hertz block (in combination with a Number block) will play a sound at the specified frequency."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1671
-#.TRANS: El bloque de número de tono reproducirá un tono asociado por su número, p. 0 para C y 7 para G.
+#. TRANS: El bloque de número de tono reproducirá un tono asociado por su número, p. 0 para C y 7 para G.
 msgid "The Pitch Number block will play a pitch associated by its number, e.g. 0 for C and 7 for G."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: nth tono modal
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: nth tono modal
 msgid "nth modal pitch"
 msgstr "nth tono modal"
 
 #: js/blocks/PitchBlocks.js:1706
-#.TRANS: Nth Modal Pitch toma el patrón de tonos en semitonos para un modo y hace que cada punto sea un grado del modo,
+#. TRANS: Nth Modal Pitch toma el patrón de tonos en semitonos para un modo y hace que cada punto sea un grado del modo,
 msgid "nth Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1708
-#.TRANS: comenzando desde 1 e independientemente del marco tonal (es decir, no siempre 8 notas en la octava)
+#. TRANS: comenzando desde 1 e independientemente del marco tonal (es decir, no siempre 8 notas en la octava)
 msgid "starting from 1 and regardless of tonal framework (i.e. not always 8 notes in the octave)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
-#.TRANS: Nth modal tono un número como entrada como el nth grado para el modo dado. 0 es la primera posición, 1 es la segunda, -1 es la nota anterior a la primera, etc.
+#. TRANS: Nth modal tono un número como entrada como el nth grado para el modo dado. 0 es la primera posición, 1 es la segunda, -1 es la nota anterior a la primera, etc.
 msgid "Nth Modal Pitch takes a number as an input as the nth degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1751
-#.TRANS: Los tonos cambian según el modo especificado sin necesidad de grafías.
+#. TRANS: Los tonos cambian según el modo especificado sin necesidad de grafías.
 msgid "The pitches change according to the mode specified without any need for respellings."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1790
-#.TRANS: El grado de escala es una convención común en la música. El grado de ecala ofrece siete posiciones posibles en la escala (1-7) y puede modificarse mediante alteraciones.
+#. TRANS: El grado de escala es una convención común en la música. El grado de ecala ofrece siete posiciones posibles en la escala (1-7) y puede modificarse mediante alteraciones.
 msgid "Scale Degree is a common convention in music. Scale Degree offers seven possible positions in the scale (1-7) and can be modified via accidentals."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1792
-#.TRANS: El grado de la escala de 1 es siempre el primer tono de una escala determinada, independientemente de la octava.
+#. TRANS: El grado de la escala de 1 es siempre el primer tono de una escala determinada, independientemente de la octava.
 msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of octave."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
-#.TRANS: paso escalar
+#. TRANS: step some number of notes in current musical scale
+#. TRANS: paso escalar
 msgid "scalar step"
 msgstr "wichayman challqa"
 
 #: js/blocks/PitchBlocks.js:1819
-#.TRANS: El bloque Paso escalar (en combinación con un bloque numérico) reproducirá el siguiente tono en una escala,
+#. TRANS: El bloque Paso escalar (en combinación con un bloque numérico) reproducirá el siguiente tono en una escala,
 msgid "The Scalar Step block (in combination with a Number block) will play the next pitch in a scale,"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1821
-#.TRANS: por ejemplo, si la última nota tocada fue sol, el paso escalar 1 tocará la.
+#. TRANS: por ejemplo, si la última nota tocada fue sol, el paso escalar 1 tocará la.
 msgid "eg if the last note played was sol, Scalar Step 1 will play la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1857
-#.TRANS: The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note.
+#. TRANS: The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note.
 msgid "The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 #: js/widgets/timbre.js:783
-#.TRANS: Oscilador
+#. TRANS: Oscilador
 msgid "Oscillator"
 msgstr "Tikraq"
 
@@ -6344,131 +6344,131 @@ msgstr "Tikraq"
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
-#.TRANS: typo
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: typo
 msgid "type"
 msgstr "typo"
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
-#.TRANS: parciales
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: parciales
 msgid "partials"
 msgstr "chawakuna"
 
 #: js/blocks/ToneBlocks.js:76
-#.TRANS: Está agregando varios bloques de oscilador.
+#. TRANS: Está agregando varios bloques de oscilador.
 msgid "You are adding multiple oscillator blocks."
 msgstr "maymikuqmanmi achka chiqasta yapachkan"
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
-#.TRANS: duo sintetizador
+#. TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: duo sintetizador
 msgid "duo synth"
 msgstr "iskayman pisiyachiqnin"
 
 #: js/blocks/ToneBlocks.js:149
-#.TRANS: El bloque Sintetizador Duo es un modulador de frecuencia doble usado para definir un timbre.
+#. TRANS: El bloque Sintetizador Duo es un modulador de frecuencia doble usado para definir un timbre.
 msgid "The Duo synth block is a duo-frequency modulator used to define a timbre."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:157
 #: js/widgets/timbre.js:1468
-#.TRANS: velocidad del vibrato
+#. TRANS: velocidad del vibrato
 msgid "vibrato rate"
 msgstr "vibratupa usqhachiq"
 
 #: js/blocks/ToneBlocks.js:157
-#.TRANS: intensidad de vibrato
+#. TRANS: intensidad de vibrato
 msgid "vibrato intensity"
 msgstr "vibratupa kallpachaynin"
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
-#.TRANS: AM sintetizador
+#. TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM sintetizador
 msgid "AM synth"
 msgstr "AM pisiyachiqnin"
 
 #: js/blocks/ToneBlocks.js:189
-#.TRANS: El bloque Sintetizador AM es un modulador de amplitud usado para definir un timbre.
+#. TRANS: El bloque Sintetizador AM es un modulador de amplitud usado para definir un timbre.
 msgid "The AM synth block is an amplitude modulator used to define a timbre."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
-#.TRANS: FM sintetizador
+#. TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM sintetizador
 msgid "FM synth"
 msgstr "FM pisiyachiqnin "
 
 #: js/blocks/ToneBlocks.js:228
-#.TRANS: El bloque Sintetizador de FM es un modulador de frecuencia utilizado para definir un timbre.
+#. TRANS: El bloque Sintetizador de FM es un modulador de frecuencia utilizado para definir un timbre.
 msgid "The FM synth block is a frequency modulator used to define a timbre."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:262
-#.TRANS: parcial
+#. TRANS: parcial
 msgid "partial"
 msgstr "chawa"
 
 #: js/blocks/ToneBlocks.js:265
-#.TRANS: El bloque Parcial se utiliza para especificar un peso para un armónico parcial específico.
+#. TRANS: El bloque Parcial se utiliza para especificar un peso para un armónico parcial específico.
 msgid "The Partial block is used to specify a weight for a specific partial harmonic."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
-#.TRANS: El peso parcial debe estar entre 0 y 1.
+#. TRANS: partials are weighted components in a harmonic series
+#. TRANS: El peso parcial debe estar entre 0 y 1.
 msgid "Partial weight must be between 0 and 1."
 msgstr "chawapa llasayninqa chúsaqpi hinallataq huk chawpipin kanan"
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
-#.TRANS: El bloque Parcial debe usarse dentro de un bloque de parciales ponderados.
+#. TRANS: partials are weighted components in a harmonic series
+#. TRANS: El bloque Parcial debe usarse dentro de un bloque de parciales ponderados.
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
-#.TRANS: parcial ponderada
+#. TRANS: partials are weighted components in a harmonic series
+#. TRANS: parcial ponderada
 msgid "weighted partials"
 msgstr "chawa chaninchasqa"
 
 #: js/blocks/ToneBlocks.js:383
-#.TRANS: El bloque Armónicos agregará armónicos a las notas contenidas.
+#. TRANS: El bloque Armónicos agregará armónicos a las notas contenidas.
 msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
-#.TRANS: armónico
+#. TRANS: A harmonic is an overtone.
+#. TRANS: armónico
 msgid "harmonic"
 msgstr "armónico"
 
 #: js/blocks/ToneBlocks.js:431
-#.TRANS: El bloque Distorsión agrega distorsión al tono.
+#. TRANS: El bloque Distorsión agrega distorsión al tono.
 msgid "The Distortion block adds distortion to the pitch."
 msgstr "q’iwiy chiqasqa kunkaman q’iwiyninta yapam"
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
-#.TRANS: distorsión
+#. TRANS: distortion is an alteration in the sound
+#. TRANS: distorsión
 msgid "distortion"
 msgstr "q’íwiy"
 
 #: js/blocks/ToneBlocks.js:487
-#.TRANS: El bloque Tremolo añade un efecto de vacilación.
+#. TRANS: El bloque Tremolo añade un efecto de vacilación.
 msgid "The Tremolo block adds a wavering effect."
 msgstr "Thalay chiqasqa iskayananpaq yapaykun"
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
-#.TRANS: tremolo
+#. TRANS: a wavering effect in a musical tone
+#. TRANS: tremolo
 msgid "tremolo"
 msgstr "Thalay"
 
@@ -6480,8 +6480,8 @@ msgstr "Thalay"
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
-#.TRANS: velocidad
+#. TRANS: rate at which tremolo wavers
+#. TRANS: velocidad
 msgid "rate"
 msgstr "utqay"
 
@@ -6489,135 +6489,135 @@ msgstr "utqay"
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
-#.TRANS: intensidad
+#. TRANS: amplitude of tremolo waver
+#. TRANS: intensidad
 msgid "depth"
 msgstr "kallpa"
 
 #: js/blocks/ToneBlocks.js:559
-#.TRANS: El bloque Phaser añade un sonido de barrido.
+#. TRANS: El bloque Phaser añade un sonido de barrido.
 msgid "The Phaser block adds a sweeping sound."
 msgstr "Phaser chiqasqa pichana kunkatan yapan"
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
-#.TRANS: phaser
+#. TRANS: alter the phase of the sound
+#. TRANS: phaser
 msgid "phaser"
 msgstr "phaser"
 
 #: js/blocks/ToneBlocks.js:569
 #: js/turtleactions/IntervalsActions.js:114
 #: js/widgets/timbre.js:2410
-#.TRANS: octavas
+#. TRANS: octavas
 msgid "octaves"
 msgstr "pusaq patakuna"
 
 #: js/blocks/ToneBlocks.js:569
 #: js/widgets/timbre.js:2413
-#.TRANS: frecuencia de base
+#. TRANS: frecuencia de base
 msgid "base frequency"
 msgstr "tiyananpi sapakuti ruranan "
 
 #: js/blocks/ToneBlocks.js:619
-#.TRANS: El bloque Chorus añade un efecto chorus.
+#. TRANS: El bloque Chorus añade un efecto chorus.
 msgid "The Chorus block adds a chorus effect."
 msgstr "takich’unku chiqasqa takich’unku kayninta yapan"
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
-#.TRANS: coro
+#. TRANS: musical effect to simulate a choral sound
+#. TRANS: coro
 msgid "chorus"
 msgstr "takich’unku"
 
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2310
-#.TRANS: retraso (MS)
+#. TRANS: retraso (MS)
 msgid "delay (MS)"
 msgstr "qhipariy"
 
 #: js/blocks/ToneBlocks.js:678
-#.TRANS: El bloque Vibrato agrega una variación rápida y leve en el tono.
+#. TRANS: El bloque Vibrato agrega una variación rápida y leve en el tono.
 msgid "The Vibrato block adds a rapid, slight variation in pitch."
 msgstr "Khatatay chiqasqa utqay chaninchayninta hinallataq pisi kunkanta yapan"
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
-#.TRANS: vibrato
+#. TRANS: a rapid, slight variation in pitch
+#. TRANS: vibrato
 msgid "vibrato"
 msgstr "khatatay"
 
 #: js/blocks/ToneBlocks.js:689
 #: js/widgets/timbre.js:2209
-#.TRANS: intensidad
+#. TRANS: intensidad
 msgid "intensity"
 msgstr "kallpa"
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
-#.TRANS: fijar synth
+#. TRANS: select synthesizer
+#. TRANS: fijar synth
 msgid "set synth"
 msgstr "synth watay"
 
 #: js/blocks/ToneBlocks.js:804
-#.TRANS: nombre del sintetizador
+#. TRANS: nombre del sintetizador
 msgid "synth name"
 msgstr " pisiyachiqninpa sutin"
 
 #: js/blocks/ToneBlocks.js:842
-#.TRANS: fijar instrumento predeterminado
+#. TRANS: fijar instrumento predeterminado
 msgid "set default instrument"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
-#.TRANS: fijar instrumento
+#. TRANS: set the characteristics of a custom instrument
+#. TRANS: fijar instrumento
 msgid "set instrument"
 msgstr "ruk’awita churana"
 
 #: js/blocks/ToneBlocks.js:898
 #: js/blocks/ToneBlocks.js:926
 #: js/blocks/ToneBlocks.js:932
-#.TRANS: El bloque Fijar Instrumentos selecciona una voz para el sintetizador,
+#. TRANS: El bloque Fijar Instrumentos selecciona una voz para el sintetizador,
 msgid "The Set instrument block selects a voice for the synthesizer,"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:900
 #: js/blocks/ToneBlocks.js:934
-#.TRANS: Por ejemplo, guitarra, piano, violín o cello
+#. TRANS: Por ejemplo, guitarra, piano, violín o cello
 msgid "eg guitar piano violin or cello."
 msgstr "kitara, piyanu, wiyulin kallamanta wiyula hina"
 
 #: js/blocks/ToneBlocks.js:1015
-#.TRANS: Importe un archivo de sonido para usarlo como instrumento y establezca su centro de tono.
+#. TRANS: Importe un archivo de sonido para usarlo como instrumento y establezca su centro de tono.
 msgid "Import a sound file to use as an instrument and set its pitch center."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:1110
-#.TRANS: Cargue un archivo de sonido para conectarlo con el bloque de muestra.
+#. TRANS: Cargue un archivo de sonido para conectarlo con el bloque de muestra.
 msgid "Upload a sound file to connect with the sample block."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:58
-#.TRANS: El bloque Volver (Return) devolverá un valor de una acción.
+#. TRANS: El bloque Volver (Return) devolverá un valor de una acción.
 msgid "The Return block will return a value from an action."
 msgstr "Kutiq Saya, kutichinqa huk  rurayta "
 
 #: js/blocks/ActionBlocks.js:75
-#.TRANS: retorno
+#. TRANS: retorno
 msgid "return"
 msgstr "kuti"
 
 #: js/blocks/ActionBlocks.js:128
-#.TRANS: El bloque Volver a URL devolverá un valor a una página web.
+#. TRANS: El bloque Volver a URL devolverá un valor a una página web.
 msgid "The Return to URL block will return a value to a webpage."
 msgstr "Kutichiq Saya URLman qupunqa huk chaninta web qhawanaman"
 
 #: js/blocks/ActionBlocks.js:145
-#.TRANS: retorno a URL
+#. TRANS: retorno a URL
 msgid "return to URL"
 msgstr "Kutichimuy URLman"
 
@@ -6625,14 +6625,14 @@ msgstr "Kutichimuy URLman"
 #: js/blocks/ActionBlocks.js:290
 #: js/blocks/ActionBlocks.js:501
 #: js/blocks/ActionBlocks.js:688
-#.TRANS: El bloque Calcular devuelve un valor calculado por una acción.
+#. TRANS: El bloque Calcular devuelve un valor calculado por una acción.
 msgid "The Calculate block returns a value calculated by an action."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:251
 #: js/blocks/ActionBlocks.js:517
 #: js/blocks/ActionBlocks.js:707
-#.TRANS: calcular
+#. TRANS: calcular
 msgid "calculate"
 msgstr "Yuyakukuy"
 
@@ -6640,100 +6640,100 @@ msgstr "Yuyakukuy"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
-#.TRANS: El bloque Hacer se utiliza para iniciar una acción.
+#. TRANS: do is the do something or take an action.
+#. TRANS: El bloque Hacer se utiliza para iniciar una acción.
 msgid "The Do block is used to initiate an action."
 msgstr "El bloque Hacer se utiliza para iniciar una acción."
 
 #: js/blocks/ActionBlocks.js:791
 #: js/blocks/ActionBlocks.js:865
-#.TRANS: El bloque Arg contiene el valor de un argumento pasado a una acción.
+#. TRANS: El bloque Arg contiene el valor de un argumento pasado a una acción.
 msgid "The Arg block contains the value of an argument passed to an action."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:806
 #: js/blocks/ActionBlocks.js:878
-#.TRANS: arg
+#. TRANS: arg
 msgid "arg"
 msgstr "ruray"
 
 #: js/blocks/ActionBlocks.js:836
 #: js/blocks/ActionBlocks.js:900
 #: js/blocks/ActionBlocks.js:908
-#.TRANS: argumento no válido
+#. TRANS: argumento no válido
 msgid "Invalid argument"
 msgstr "Mana chaninniyuq rimay"
 
 #: js/blocks/ActionBlocks.js:944
-#.TRANS: En el ejemplo, se usa con el bloque Uno para elegir una fase aleatoria.
+#. TRANS: En el ejemplo, se usa con el bloque Uno para elegir una fase aleatoria.
 msgid "In the example, it is used with the One of block to choose a random phase."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:1019
 #: js/blocks/ActionBlocks.js:1026
-#.TRANS: El bloque de escucha se usa para escuchar un evento como un clic del ratón.
+#. TRANS: El bloque de escucha se usa para escuchar un evento como un clic del ratón.
 msgid "The Listen block is used to listen for an event such as a mouse click."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:1028
-#.TRANS: Cuando ocurre el evento, se realiza una acción.
+#. TRANS: Cuando ocurre el evento, se realiza una acción.
 msgid "When the event happens, an action is taken."
 msgstr "Sichus kanqa ruray, chayqa kuyukachay kanqa"
 
 #: js/blocks/ActionBlocks.js:1045
-#.TRANS: cuando
+#. TRANS: cuando
 msgid "on"
 msgstr "hayk’aq"
 
 #: js/blocks/ActionBlocks.js:1048
 #: js/blocks/ActionBlocks.js:1049
 #: js/blocks/ActionBlocks.js:1153
-#.TRANS: señal
+#. TRANS: señal
 msgid "event"
 msgstr "riqsichi"
 
 #: js/blocks/ActionBlocks.js:1133
-#.TRANS: El bloque Emitir se utiliza para desencadenar un evento.
+#. TRANS: El bloque Emitir se utiliza para desencadenar un evento.
 msgid "The Broadcast block is used to trigger an event."
 msgstr "El bloque Emitir se utiliza para desencadenar un evento."
 
 #: js/blocks/ActionBlocks.js:1151
-#.TRANS: emitir
+#. TRANS: emitir
 msgid "broadcast"
 msgstr "lluqsichiy"
 
 #: js/blocks/ActionBlocks.js:1208
-#.TRANS: Cada bloque de inicio es una voz separada.
+#. TRANS: Cada bloque de inicio es una voz separada.
 msgid "Each Start block is a separate voice."
 msgstr "Cada bloque de inicio es una voz separada."
 
 #: js/blocks/ActionBlocks.js:1304
-#.TRANS: A menudo se utiliza para almacenar una frase de música que se repite.
+#. TRANS: A menudo se utiliza para almacenar una frase de música que se repite.
 msgid "It is often used for storing a phrase of music that is repeated."
 msgstr ""
 
 #: js/blocks/ActionBlocks.js:1495
-#.TRANS: definir el temperamento
+#. TRANS: definir el temperamento
 msgid "define temperament"
 msgstr "akllay"
 
 #: js/blocks/EnsembleBlocks.js:87
-#.TRANS: valor en la pila de ratón
+#. TRANS: valor en la pila de ratón
 msgid "mouse index heap"
 msgstr "Huk’ucha /qillqa purichina"
 
 #: js/blocks/EnsembleBlocks.js:87
-#.TRANS: valor en la pila de tortuga
+#. TRANS: valor en la pila de tortuga
 msgid "turtle index heap"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:89
-#.TRANS: El bloque de valor en la pila de ratón devuelve un valor en el almacenamiento dinámico en una ubicación específica para un mouse específico.
+#. TRANS: El bloque de valor en la pila de ratón devuelve un valor en el almacenamiento dinámico en una ubicación específica para un mouse específico.
 msgid "The Mouse index heap block returns a value in the heap at a specified location for a specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:90
-#.TRANS: El bloque de valor en la pila de tortuga devuelve un valor en el almacenamiento dinámico en una ubicación específica para un mouse específico.
+#. TRANS: El bloque de valor en la pila de tortuga devuelve un valor en el almacenamiento dinámico en una ubicación específica para un mouse específico.
 msgid "The Turtle index heap block returns a value in the heap at a specified location for a specified turtle."
 msgstr ""
 
@@ -6754,39 +6754,39 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:957
 #: js/blocks/EnsembleBlocks.js:1222
 #: js/blocks/EnsembleBlocks.js:1296
-#.TRANS: 
+#. TRANS: 
 msgid "Yertle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:96
 #: js/blocks/EnsembleBlocks.js:1083
-#.TRANS: renombrar ratón
+#. TRANS: renombrar ratón
 msgid "mouse name"
 msgstr "Sutichay huk’uchata"
 
 #: js/blocks/EnsembleBlocks.js:96
 #: js/blocks/EnsembleBlocks.js:1092
-#.TRANS: renombrar tortuga
+#. TRANS: renombrar tortuga
 msgid "turtle name"
 msgstr "renombrar tortuga"
 
 #: js/blocks/EnsembleBlocks.js:147
-#.TRANS: parar ratón
+#. TRANS: parar ratón
 msgid "stop mouse"
 msgstr "parar ratón"
 
 #: js/blocks/EnsembleBlocks.js:149
-#.TRANS: El bloque parar ratón parar el ratón especificado.
+#. TRANS: El bloque parar ratón parar el ratón especificado.
 msgid "The Stop mouse block stops the specified mouse."
 msgstr "El bloque parar ratón parar el ratón especificado."
 
 #: js/blocks/EnsembleBlocks.js:160
-#.TRANS: detener tortuga
+#. TRANS: detener tortuga
 msgid "stop turtle"
 msgstr "detener tortuga"
 
 #: js/blocks/EnsembleBlocks.js:162
-#.TRANS: El bloque parar tortuga parar el ratón especificado.
+#. TRANS: El bloque parar tortuga parar el ratón especificado.
 msgid "The Stop turtle block stops the specified turtle."
 msgstr ""
 
@@ -6799,7 +6799,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:872
 #: js/blocks/EnsembleBlocks.js:1193
 #: js/blocks/EnsembleBlocks.js:1256
-#.TRANS: No se puede encontrar ratón
+#. TRANS: No se puede encontrar ratón
 msgid "Cannot find mouse"
 msgstr "Manan huk’uchata tarikunchu"
 
@@ -6812,470 +6812,470 @@ msgstr "Manan huk’uchata tarikunchu"
 #: js/blocks/EnsembleBlocks.js:874
 #: js/blocks/EnsembleBlocks.js:1195
 #: js/blocks/EnsembleBlocks.js:1258
-#.TRANS: No se puede encontrar tortuga.
+#. TRANS: No se puede encontrar tortuga.
 msgid "Cannot find turtle"
 msgstr "No se puede encontrar tortuga."
 
 #: js/blocks/EnsembleBlocks.js:208
-#.TRANS: comenzar ratón
+#. TRANS: comenzar ratón
 msgid "start mouse"
 msgstr "comenzar ratón"
 
 #: js/blocks/EnsembleBlocks.js:211
-#.TRANS: El bloque comenzar ratón inicia el ratón especificado.
+#. TRANS: El bloque comenzar ratón inicia el ratón especificado.
 msgid "The Start mouse block starts the specified mouse."
 msgstr "El bloque comenzar ratón inicia el ratón especificado."
 
 #: js/blocks/EnsembleBlocks.js:222
-#.TRANS: iniciar tortuga
+#. TRANS: iniciar tortuga
 msgid "start turtle"
 msgstr "iniciar tortuga"
 
 #: js/blocks/EnsembleBlocks.js:225
-#.TRANS: El bloque comenzar tortuga inicia el ratón especificado.
+#. TRANS: El bloque comenzar tortuga inicia el ratón especificado.
 msgid "The Start turtle block starts the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:258
-#.TRANS: Ratón ya ha comenzado.
+#. TRANS: Ratón ya ha comenzado.
 msgid "Mouse is already running."
 msgstr "Huk’ucha qallarinña"
 
 #: js/blocks/EnsembleBlocks.js:260
-#.TRANS: Tortuga ya ha comenzado.
+#. TRANS: Tortuga ya ha comenzado.
 msgid "Turtle is already running."
 msgstr "Tortuga ya ha comenzado."
 
 #: js/blocks/EnsembleBlocks.js:284
-#.TRANS: No se puede encontrar el bloque de inicar.
+#. TRANS: No se puede encontrar el bloque de inicar.
 msgid "Cannot find start block"
 msgstr "Manan qallariq saya tarikunchu"
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
-#.TRANS: color de ratón
+#. TRANS: pen color for this mouse
+#. TRANS: color de ratón
 msgid "mouse color"
 msgstr "Llimp’iyniyuq huk’ucha"
 
 #: js/blocks/EnsembleBlocks.js:296
-#.TRANS: El bloque de color del ratón devuelve el color del lápiz del ratón especificado.
+#. TRANS: El bloque de color del ratón devuelve el color del lápiz del ratón especificado.
 msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
-#.TRANS: color de tortuga
+#. TRANS: pen color for this turtle
+#. TRANS: color de tortuga
 msgid "turtle color"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:310
-#.TRANS: El bloque de color de la tortuga devuelve el color del lápiz de la tortuga especificado.
+#. TRANS: El bloque de color de la tortuga devuelve el color del lápiz de la tortuga especificado.
 msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
-#.TRANS: rumbo de ratón
+#. TRANS: heading (compass direction) for this mouse
+#. TRANS: rumbo de ratón
 msgid "mouse heading"
 msgstr "rumbo de ratón"
 
 #: js/blocks/EnsembleBlocks.js:342
-#.TRANS: El bloque de rumbo del ratón devuelve el rumbo del lápiz del ratón especificado.
+#. TRANS: El bloque de rumbo del ratón devuelve el rumbo del lápiz del ratón especificado.
 msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
-#.TRANS: rumbo de tortuga
+#. TRANS: heading (compass direction) for this turtle
+#. TRANS: rumbo de tortuga
 msgid "turtle heading"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:356
-#.TRANS: El bloque de rumbo de la tortuga devuelve el rumbo del lápiz de la tortuga especificado.
+#. TRANS: El bloque de rumbo de la tortuga devuelve el rumbo del lápiz de la tortuga especificado.
 msgid "The Turtle heading block returns the heading of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
-#.TRANS: fijar ratón
+#. TRANS: set xy position for this mouse
+#. TRANS: fijar ratón
 msgid "set mouse"
 msgstr "fijar ratón"
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
-#.TRANS: fijar tortuga
+#. TRANS: set xy position for this turtle
+#. TRANS: fijar tortuga
 msgid "set turtle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:435
-#.TRANS: El bloque de ratón establecer envía una pila de bloques para que los ejecute el ratón especificado.
+#. TRANS: El bloque de ratón establecer envía una pila de bloques para que los ejecute el ratón especificado.
 msgid "The Set mouse block sends a stack of blocks to be run by the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:448
-#.TRANS: El bloque de tortuga establecer envía una pila de bloques para que los ejecute el tortuga especificado.
+#. TRANS: El bloque de tortuga establecer envía una pila de bloques para que los ejecute el tortuga especificado.
 msgid "The Set turtle block sends a stack of blocks to be run by the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
-#.TRANS: ratón y
+#. TRANS: y position for this mouse
+#. TRANS: ratón y
 msgid "mouse y"
 msgstr "puripaq Y"
 
 #: js/blocks/EnsembleBlocks.js:484
-#.TRANS: El bloque del ratón Y devuelve la posición Y del ratón especificado.
+#. TRANS: El bloque del ratón Y devuelve la posición Y del ratón especificado.
 msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
-#.TRANS: tortuga y
+#. TRANS: y position for this turtle
+#. TRANS: tortuga y
 msgid "turtle y"
 msgstr "tortuga y"
 
 #: js/blocks/EnsembleBlocks.js:498
-#.TRANS: El bloque de la tortuga Y devuelve la posición Y de la tortuga especificado.
+#. TRANS: El bloque de la tortuga Y devuelve la posición Y de la tortuga especificado.
 msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
-#.TRANS: ratón x
+#. TRANS: x position for this mouse
+#. TRANS: ratón x
 msgid "mouse x"
 msgstr "puripaq X"
 
 #: js/blocks/EnsembleBlocks.js:530
-#.TRANS: El bloque del ratón X devuelve la posición X del ratón especificado.
+#. TRANS: El bloque del ratón X devuelve la posición X del ratón especificado.
 msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
-#.TRANS: tortuga x
+#. TRANS: x position for this turtle
+#. TRANS: tortuga x
 msgid "turtle x"
 msgstr "tortuga x"
 
 #: js/blocks/EnsembleBlocks.js:544
-#.TRANS: El bloque de la tortuga X devuelve la posición X de la tortuga especificado.
+#. TRANS: El bloque de la tortuga X devuelve la posición X de la tortuga especificado.
 msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
-#.TRANS: notas jugadas de ratón
+#. TRANS: notes played by this mouse
+#. TRANS: notas jugadas de ratón
 msgid "mouse notes played"
 msgstr "notas jugadas de ratón"
 
 #: js/blocks/EnsembleBlocks.js:577
-#.TRANS: El bloque de notas jugadas del ratón devuelve el número de notas tocadas por el ratón especificado.
+#. TRANS: El bloque de notas jugadas del ratón devuelve el número de notas tocadas por el ratón especificado.
 msgid "The Mouse elapse notes block returns the number of notes played by the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
-#.TRANS: notas jugadas de tortuga
+#. TRANS: notes played by this turtle
+#. TRANS: notas jugadas de tortuga
 msgid "turtle notes played"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:591
-#.TRANS: El bloque de notas jugadas de la tortuga devuelve el número de notas tocadas por la tortuga especificado.
+#. TRANS: El bloque de notas jugadas de la tortuga devuelve el número de notas tocadas por la tortuga especificado.
 msgid "The Turtle elapse notes block returns the number of notes played by the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
-#.TRANS: número de tono de ratón
+#. TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: número de tono de ratón
 msgid "mouse pitch number"
 msgstr "número de tono de ratón"
 
 #: js/blocks/EnsembleBlocks.js:631
-#.TRANS: El bloque de tono del ratón devuelve el número de tono actual que está reproduciendo el ratón especificado.
+#. TRANS: El bloque de tono del ratón devuelve el número de tono actual que está reproduciendo el ratón especificado.
 msgid "The Mouse pitch block returns the current pitch number being played by the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
-#.TRANS: número de tono de tortuga
+#. TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: número de tono de tortuga
 msgid "turtle pitch number"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:645
-#.TRANS: El bloque de tono de la tortuga devuelve el número de tono actual que está reproduciendo la tortuga especificado.
+#. TRANS: El bloque de tono de la tortuga devuelve el número de tono actual que está reproduciendo la tortuga especificado.
 msgid "The Turtle pitch block returns the current pitch number being played by the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
-#.TRANS: valor de la nota del ratón
+#. TRANS: note value is the duration of the note played by this mouse
+#. TRANS: valor de la nota del ratón
 msgid "mouse note value"
 msgstr "valor de la nota del ratón"
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
-#.TRANS: valor de la nota de la tortuga
+#. TRANS: note value is the duration of the note played by this turtle
+#. TRANS: valor de la nota de la tortuga
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
-#.TRANS: sincronizar
+#. TRANS: sync is short for synchronization
+#. TRANS: sincronizar
 msgid "mouse sync"
 msgstr "sincronizar"
 
 #: js/blocks/EnsembleBlocks.js:834
-#.TRANS: El bloque sincronizar alinea el conteo de latidos entre ratones.
+#. TRANS: El bloque sincronizar alinea el conteo de latidos entre ratones.
 msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "El bloque sincronizar alinea el conteo de latidos entre ratones."
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
-#.TRANS: sincronizar
+#. TRANS: sync is short for synchronization
+#. TRANS: sincronizar
 msgid "turtle sync"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:848
-#.TRANS: El bloque sincronizar alinea el conteo de latidos entre tortugas.
+#. TRANS: El bloque sincronizar alinea el conteo de latidos entre tortugas.
 msgid "The Turtle sync block aligns the beat count between turtles."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:889
-#.TRANS: El bloque de ratón encontrado devolverá verdadero si se puede encontrar el ratón especificado.
+#. TRANS: El bloque de ratón encontrado devolverá verdadero si se puede encontrar el ratón especificado.
 msgid "The Found mouse block will return true if the specified mouse can be found."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:895
-#.TRANS: encontré el raton
+#. TRANS: encontré el raton
 msgid "found mouse"
 msgstr "Huk’uchata tarini"
 
 #: js/blocks/EnsembleBlocks.js:905
-#.TRANS: El bloque de tortuga encontrado devolverá verdadero si se puede encontrar el tortuga especificado.
+#. TRANS: El bloque de tortuga encontrado devolverá verdadero si se puede encontrar el tortuga especificado.
 msgid "The Found turtle block will return true if the specified turtle can be found."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:911
-#.TRANS: encontré la tortuga
+#. TRANS: encontré la tortuga
 msgid "found turtle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:934
-#.TRANS: nuevo ratón
+#. TRANS: nuevo ratón
 msgid "new mouse"
 msgstr "Musuq huk’ucha"
 
 #: js/blocks/EnsembleBlocks.js:936
-#.TRANS: El bloque nuevo ratón crea un nuevo ratón.
+#. TRANS: El bloque nuevo ratón crea un nuevo ratón.
 msgid "The New mouse block will create a new mouse."
 msgstr "El bloque nuevo ratón crea un nuevo ratón."
 
 #: js/blocks/EnsembleBlocks.js:947
-#.TRANS: nuevo tortuga
+#. TRANS: nuevo tortuga
 msgid "new turtle"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:949
-#.TRANS: El bloque nuevo ratón crea un nuevo tortuga.
+#. TRANS: El bloque nuevo ratón crea un nuevo tortuga.
 msgid "The New turtle block will create a new turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1013
-#.TRANS: fijar color del ratón
+#. TRANS: fijar color del ratón
 msgid "set mouse color"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1016
-#.TRANS: El bloque fijar color del ratón se usa para fijar el color de un ratón.
+#. TRANS: El bloque fijar color del ratón se usa para fijar el color de un ratón.
 msgid "The Set-mouse-color block is used to set the color of a mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1022
-#.TRANS: fijar color de la tortuga
+#. TRANS: fijar color de la tortuga
 msgid "set turtle color"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1025
-#.TRANS: El bloque fijar color de la tortuga se usa para fijar el color de una tortuga.
+#. TRANS: El bloque fijar color de la tortuga se usa para fijar el color de una tortuga.
 msgid "The Set-turtle-color block is used to set the color of a turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1086
-#.TRANS: El bloque Nombre del ratón devuelve el nombre de un ratón.
+#. TRANS: El bloque Nombre del ratón devuelve el nombre de un ratón.
 msgid "The Mouse-name block returns the name of a mouse."
 msgstr "Huk’uha sayaq kutichin huk’ucha  sutiman"
 
 #: js/blocks/EnsembleBlocks.js:1095
-#.TRANS: El bloque Nombre de la tortuga devuelve el nombre de una tortuga.
+#. TRANS: El bloque Nombre de la tortuga devuelve el nombre de una tortuga.
 msgid "The Turtle-name block returns the name of a turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1118
-#.TRANS: recuento de ratones
+#. TRANS: recuento de ratones
 msgid "mouse count"
 msgstr "recuento de ratones"
 
 #: js/blocks/EnsembleBlocks.js:1121
-#.TRANS: El bloque recuento de ratones devuelve el número de ratones.
+#. TRANS: El bloque recuento de ratones devuelve el número de ratones.
 msgid "The Mouse-count block returns the number of mice."
 msgstr "El bloque recuento de ratones devuelve el número de ratones."
 
 #: js/blocks/EnsembleBlocks.js:1127
-#.TRANS: recuento de tortuga
+#. TRANS: recuento de tortuga
 msgid "turtle count"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1130
-#.TRANS: El bloque recuento de tortugas devuelve el número de tortugas.
+#. TRANS: El bloque recuento de tortugas devuelve el número de tortugas.
 msgid "The Turtle-count block returns the number of turtles."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1152
-#.TRANS: nombre de nth ratón
+#. TRANS: nombre de nth ratón
 msgid "nth mouse name"
 msgstr "nombre de nth ratón"
 
 #: js/blocks/EnsembleBlocks.js:1155
-#.TRANS: El bloque de nombre Nth-ratón devuelve el nombre del enésimo ratón.
+#. TRANS: El bloque de nombre Nth-ratón devuelve el nombre del enésimo ratón.
 msgid "The Nth-Mouse name block returns the name of the nth mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1161
-#.TRANS: nombre de nth tortuga
+#. TRANS: nombre de nth tortuga
 msgid "nth turtle name"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1164
-#.TRANS: El bloque de nombre Nth-tortuga devuelve el nombre del enésimo tortuga.
+#. TRANS: El bloque de nombre Nth-tortuga devuelve el nombre del enésimo tortuga.
 msgid "The Nth-Turtle name block returns the name of the nth turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:1208
 #: js/blocks/EnsembleBlocks.js:1268
-#.TRANS: fijar nombre
+#. TRANS: fijar nombre
 msgid "set name"
 msgstr "Sutita tahachik"
 
 #: js/blocks/EnsembleBlocks.js:1217
 #: js/blocks/EnsembleBlocks.js:1224
-#.TRANS: origen
+#. TRANS: origen
 msgid "source"
 msgstr "paqarina"
 
 #: js/blocks/EnsembleBlocks.js:1217
 #: js/blocks/EnsembleBlocks.js:1224
-#.TRANS: destino
+#. TRANS: destino
 msgid "target"
 msgstr "chayana"
 
 #: js/blocks/EnsembleBlocks.js:1274
-#.TRANS: El bloque Fijar nombre se usa para nombrar un ratón.
+#. TRANS: El bloque Fijar nombre se usa para nombrar un ratón.
 msgid "The Set-name block is used to name a mouse."
 msgstr "El bloque Fijar nombre se usa para nombrar un ratón."
 
 #: js/blocks/EnsembleBlocks.js:1287
-#.TRANS: El bloque Fijar nombre se usa para nombrar una tortuga.
+#. TRANS: El bloque Fijar nombre se usa para nombrar una tortuga.
 msgid "The Set-name block is used to name a turtle."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:33
-#.TRANS: fracción
+#. TRANS: fracción
 msgid "fraction"
 msgstr "phatmi"
 
 #: js/blocks/ExtrasBlocks.js:36
-#.TRANS: convertir un número racional en fracción
+#. TRANS: convertir un número racional en fracción
 msgid "Convert a float to a fraction"
-msgstr "convertir un número racional en fracción""
+msgstr "convertir un número racional en fracción"
 
 #: js/blocks/ExtrasBlocks.js:93
-#.TRANS: guardar como ABC
+#. TRANS: guardar como ABC
 msgid "save as ABC"
 msgstr "ABC hinaman waqaychay"
 
 #: js/blocks/ExtrasBlocks.js:96
 #: js/blocks/ExtrasBlocks.js:132
 #: js/blocks/ExtrasBlocks.js:168
-#.TRANS: título
+#. TRANS: título
 msgid "title"
 msgstr "umalliq suti"
 
 #: js/blocks/ExtrasBlocks.js:129
-#.TRANS: guardar como Lilypond
+#. TRANS: guardar como Lilypond
 msgid "save as Lilypond"
 msgstr "Lilypondtahina waqaychay"
 
 #: js/blocks/ExtrasBlocks.js:165
-#.TRANS: guardar como SVG
+#. TRANS: guardar como SVG
 msgid "save as SVG"
 msgstr "SVGtahina waqaychay"
 
 #: js/blocks/ExtrasBlocks.js:216
-#.TRANS: sin fondo
+#. TRANS: sin fondo
 msgid "no background"
 msgstr "Mana imayuq"
 
 #: js/blocks/ExtrasBlocks.js:219
-#.TRANS: El bloque Sin fondo elimina el fondo de la salida SVG guardada.
+#. TRANS: El bloque Sin fondo elimina el fondo de la salida SVG guardada.
 msgid "The No background block eliminates the background from the saved SVG output."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:247
-#.TRANS: mostrar bloques
+#. TRANS: mostrar bloques
 msgid "show blocks"
 msgstr " chiqaskunata qhawachiy"
 
 #: js/blocks/ExtrasBlocks.js:249
-#.TRANS: El bloque mostrar bloques muestra los bloques.
+#. TRANS: El bloque mostrar bloques muestra los bloques.
 msgid "The Show blocks block shows the blocks."
 msgstr "El bloque mostrar bloques muestra los bloques."
 
 #: js/blocks/ExtrasBlocks.js:276
-#.TRANS: El bloque ocultar esconde los bloques.
+#. TRANS: El bloque ocultar esconde los bloques.
 msgid "The Hide blocks block hides the blocks."
 msgstr "El bloque ocultar esconde los bloques."
 
 #: js/blocks/ExtrasBlocks.js:305
 #: js/blocks/ExtrasBlocks.js:338
-#.TRANS: El bloque Espacio se utiliza para agregar espacio entre bloques.
+#. TRANS: El bloque Espacio se utiliza para agregar espacio entre bloques.
 msgid "The Space block is used to add space between blocks."
 msgstr " Qaylla chiqasqa chiqaspurakuna qayllayuq kanankupaq yapaq yapanapaq"
 
 #: js/blocks/ExtrasBlocks.js:376
-#.TRANS: esperar
+#. TRANS: esperar
 msgid "wait"
 msgstr "suyay"
 
 #: js/blocks/ExtrasBlocks.js:379
-#.TRANS: El bloque Espera detiene el programa durante un número específico de segundos.
+#. TRANS: El bloque Espera detiene el programa durante un número específico de segundos.
 msgid "The Wait block pauses the program for a specified number of seconds."
 msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:433
 #: plugins/facebook.rtp:30
-#.TRANS: comentar
+#. TRANS: comentar
 msgid "comment"
 msgstr "rimariy"
 
 #: js/blocks/ExtrasBlocks.js:469
-#.TRANS: imprimir
+#. TRANS: imprimir
 msgid "print"
 msgstr "ñit'iy"
 
 #: js/blocks/ExtrasBlocks.js:476
-#.TRANS: El bloque Imprimir muestra texto en la parte superior de la pantalla.
+#. TRANS: El bloque Imprimir muestra texto en la parte superior de la pantalla.
 msgid "The Print block displays text at the top of the screen."
 msgstr "Nit’iy chiqasqa pantallapa hawanpi qillqata qhawachikun"
 
 #: js/blocks/ExtrasBlocks.js:585
-#.TRANS: mostrar cuadrícula
+#. TRANS: mostrar cuadrícula
 msgid "display grid"
 msgstr "mostrar cuadrícula"
 
 #: js/blocks/ExtrasBlocks.js:590
-#.TRANS: Mostrar el bloque de cuadrícula cambia el tipo de cuadrícula
+#. TRANS: Mostrar el bloque de cuadrícula cambia el tipo de cuadrícula
 msgid "The Display Grid Block changes the grid type"
 msgstr "Mostrar el bloque de cuadrícula cambia el tipo de cuadrícula"
 
@@ -7287,7 +7287,7 @@ msgstr "Mostrar el bloque de cuadrícula cambia el tipo de cuadrícula"
 #: js/blocks/ExtrasBlocks.js:794
 #: js/blocks/ExtrasBlocks.js:813
 #: js/blocks/ExtrasBlocks.js:832
-#.TRANS: desconocido
+#. TRANS: desconocido
 msgid "unknown"
 msgstr "Mana riqsisqa"
 
@@ -7295,77 +7295,77 @@ msgstr "Mana riqsisqa"
 #: js/turtleactions/DictActions.js:77
 #: js/turtleactions/DictActions.js:144
 #: js/turtleactions/DictActions.js:173
-#.TRANS: rumbo
+#. TRANS: rumbo
 msgid "heading"
 msgstr "mayman"
 
 #: js/blocks/GraphicsBlocks.js:56
-#.TRANS: El bloque rumbo devuelve la orientación del ratón.
+#. TRANS: El bloque rumbo devuelve la orientación del ratón.
 msgid "The Heading block returns the orientation of the mouse."
 msgstr "El bloque rumbo devuelve la orientación del ratón."
 
 #: js/blocks/GraphicsBlocks.js:62
-#.TRANS: El bloque rumbo devuelve la orientación de la tortuga.
+#. TRANS: El bloque rumbo devuelve la orientación de la tortuga.
 msgid "The Heading block returns the orientation of the turtle."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:133
-#.TRANS: El bloque Y devuelve la posición horizontal del ratón.
+#. TRANS: El bloque Y devuelve la posición horizontal del ratón.
 msgid "The Y block returns the vertical position of the mouse."
 msgstr "chiqasqa huk’ucha pampallanpi kasqanta kutichipun"
 
 #: js/blocks/GraphicsBlocks.js:140
-#.TRANS: El bloque Y devuelve la posición horizontal de la tortuga.
+#. TRANS: El bloque Y devuelve la posición horizontal de la tortuga.
 msgid "The Y block returns the vertical position of the turtle."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:149
-#.TRANS: y
+#. TRANS: y
 msgid "y3"
 msgstr "y3"
 
 #: js/blocks/GraphicsBlocks.js:219
-#.TRANS: El bloque X devuelve la posición horizontal del ratón.
+#. TRANS: El bloque X devuelve la posición horizontal del ratón.
 msgid "The X block returns the horizontal position of the mouse."
 msgstr "X chiqasqa huk’ucha pampallanpi kasqanta kutichipun"
 
 #: js/blocks/GraphicsBlocks.js:226
-#.TRANS: El bloque X devuelve la posición horizontal de la tortuga.
+#. TRANS: El bloque X devuelve la posición horizontal de la tortuga.
 msgid "The X block returns the horizontal position of the turtle."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:235
-#.TRANS: x
+#. TRANS: x
 msgid "x3"
 msgstr "x3"
 
 #: js/blocks/GraphicsBlocks.js:295
-#.TRANS: desplazar xy
+#. TRANS: desplazar xy
 msgid "scroll xy"
 msgstr "xy purichiy"
 
 #: js/blocks/GraphicsBlocks.js:303
-#.TRANS: El bloque Desplazar XY mueve el lienzo.
+#. TRANS: El bloque Desplazar XY mueve el lienzo.
 msgid "The Scroll XY block moves the canvas."
 msgstr "Purichiy chiqasqa XY llikata kuyuchin"
 
 #: js/blocks/GraphicsBlocks.js:313
-#.TRANS: x
+#. TRANS: x
 msgid "x2"
 msgstr "x2"
 
 #: js/blocks/GraphicsBlocks.js:313
-#.TRANS: y
+#. TRANS: y
 msgid "y2"
 msgstr "y2"
 
 #: js/blocks/GraphicsBlocks.js:417
-#.TRANS: El bloque Control-point 2 establece el segundo punto de control para la curva Bezier.
+#. TRANS: El bloque Control-point 2 establece el segundo punto de control para la curva Bezier.
 msgid "The Control-point 2 block sets the second control point for the Bezier curve."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:424
-#.TRANS: punto de control 2
+#. TRANS: punto de control 2
 msgid "control point 2"
 msgstr "arariwaq 2"
 
@@ -7373,7 +7373,7 @@ msgstr "arariwaq 2"
 #: js/blocks/GraphicsBlocks.js:478
 #: js/blocks/GraphicsBlocks.js:525
 #: js/blocks/GraphicsBlocks.js:741
-#.TRANS: x
+#. TRANS: x
 msgid "x1"
 msgstr "x1"
 
@@ -7381,47 +7381,47 @@ msgstr "x1"
 #: js/blocks/GraphicsBlocks.js:478
 #: js/blocks/GraphicsBlocks.js:525
 #: js/blocks/GraphicsBlocks.js:741
-#.TRANS: y
+#. TRANS: y
 msgid "y1"
 msgstr "y1"
 
 #: js/blocks/GraphicsBlocks.js:468
-#.TRANS: El bloque Control-point 1 establece el segundo punto de control para la curva Bezier.
+#. TRANS: El bloque Control-point 1 establece el segundo punto de control para la curva Bezier.
 msgid "The Control-point 1 block sets the first control point for the Bezier curve."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:475
-#.TRANS: punto de control 1
+#. TRANS: punto de control 1
 msgid "control point 1"
 msgstr "arariwaq 1"
 
 #: js/blocks/GraphicsBlocks.js:518
-#.TRANS: El bloque bezier dibuja una curva bezier.
+#. TRANS: El bloque bezier dibuja una curva bezier.
 msgid "The Bezier block draws a Bezier curve."
 msgstr "El bloque bezier dibuja una curva bezier."
 
 #: js/blocks/GraphicsBlocks.js:522
-#.TRANS: bezier
+#. TRANS: bezier
 msgid "bezier"
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:583
-#.TRANS: El bloque Arco mueve la tortuga en un arco.
+#. TRANS: El bloque Arco mueve la tortuga en un arco.
 msgid "The Arc block moves the turtle in an arc."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:591
-#.TRANS: arco
+#. TRANS: arco
 msgid "arc"
 msgstr "k’umu"
 
 #: js/blocks/GraphicsBlocks.js:594
-#.TRANS: ángulo
+#. TRANS: ángulo
 msgid "angle"
 msgstr "k'uchu"
 
 #: js/blocks/GraphicsBlocks.js:594
-#.TRANS: radio
+#. TRANS: radio
 msgid "radius"
 msgstr "illwa"
 
@@ -7429,7 +7429,7 @@ msgstr "illwa"
 #: js/blocks/GraphicsBlocks.js:758
 #: js/blocks/GraphicsBlocks.js:1001
 #: js/blocks/GraphicsBlocks.js:1084
-#.TRANS: El valor debe estar entre -5000 y 5000 cuando el modo Wrap está desactivado.
+#. TRANS: El valor debe estar entre -5000 y 5000 cuando el modo Wrap está desactivado.
 msgid "Value must be within -5000 to 5000 when Wrap Mode is off."
 msgstr ""
 
@@ -7437,47 +7437,47 @@ msgstr ""
 #: js/blocks/GraphicsBlocks.js:760
 #: js/blocks/GraphicsBlocks.js:1003
 #: js/blocks/GraphicsBlocks.js:1086
-#.TRANS: El valor debe estar entre -20000 y 20000 cuando el modo Wrap está activado.
+#. TRANS: El valor debe estar entre -20000 y 20000 cuando el modo Wrap está activado.
 msgid "Value must be within -20000 to 20000 when Wrap Mode is on."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:651
-#.TRANS: fijar rumbo
+#. TRANS: fijar rumbo
 msgid "set heading"
 msgstr "mayman rinantam churay"
 
 #: js/blocks/GraphicsBlocks.js:664
-#.TRANS: El bloque fijar rumbo establece el rumbo de la tortuga.
+#. TRANS: El bloque fijar rumbo establece el rumbo de la tortuga.
 msgid "The Set heading block sets the heading of the turtle."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:724
-#.TRANS: El bloque Fijar XY mueve el ratón a una posición específica en la pantalla.
+#. TRANS: El bloque Fijar XY mueve el ratón a una posición específica en la pantalla.
 msgid "The Set XY block moves the mouse to a specific position on the screen."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:730
-#.TRANS: El bloque Fijar XY mueve la tortuga a una posición específica en la pantalla.
+#. TRANS: El bloque Fijar XY mueve la tortuga a una posición específica en la pantalla.
 msgid "The Set XY block moves the turtle to a specific position on the screen."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:738
-#.TRANS: fijar xy
+#. TRANS: fijar xy
 msgid "set xy"
-msgstr "xy nisqata churay" "xy k’askachiy"
+msgstr "xy nisqata churay xy k’askachiy"
 
 #: js/blocks/GraphicsBlocks.js:810
-#.TRANS: El bloque Derecha gira el ratón hacia la derecha.
+#. TRANS: El bloque Derecha gira el ratón hacia la derecha.
 msgid "The Right block turns the mouse to the right."
 msgstr "El bloque Derecha gira el ratón hacia la derecha."
 
 #: js/blocks/GraphicsBlocks.js:817
-#.TRANS: El bloque Derecha gira la tortuga hacia la derecha.
+#. TRANS: El bloque Derecha gira la tortuga hacia la derecha.
 msgid "The Right block turns the turtle to the right."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:826
-#.TRANS: derecha
+#. TRANS: derecha
 msgid "right1"
 msgstr "paña"
 
@@ -7485,22 +7485,22 @@ msgstr "paña"
 #: plugins/rodi.rtp:77
 #: plugins/rodi.rtp:340
 #: plugins/rodi.rtp:375
-#.TRANS: derecha
+#. TRANS: derecha
 msgid "right"
 msgstr "paña"
 
 #: js/blocks/GraphicsBlocks.js:890
-#.TRANS: El bloque izquierdo gira el ratón hacia la izquierda.
+#. TRANS: El bloque izquierdo gira el ratón hacia la izquierda.
 msgid "The Left block turns the mouse to the left."
 msgstr "lluq’i t’aqa huk’uchawan lluq’iman muyun"
 
 #: js/blocks/GraphicsBlocks.js:897
-#.TRANS: El bloque izquierdo gira la tortuga hacia la izquierda.
+#. TRANS: El bloque izquierdo gira la tortuga hacia la izquierda.
 msgid "The Left block turns the turtle to the left."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:906
-#.TRANS: izquierda
+#. TRANS: izquierda
 msgid "left1"
 msgstr "lluq’i"
 
@@ -7508,7 +7508,7 @@ msgstr "lluq’i"
 #: plugins/rodi.rtp:79
 #: plugins/rodi.rtp:339
 #: plugins/rodi.rtp:362
-#.TRANS: izquierda
+#. TRANS: izquierda
 msgid "left"
 msgstr "lluq’i"
 
@@ -7517,174 +7517,174 @@ msgstr "lluq’i"
 #: js/widgets/temperament.js:1033
 #: plugins/rodi.rtp:69
 #: plugins/rodi.rtp:387
-#.TRANS: atrás
+#. TRANS: atrás
 msgid "back"
 msgstr "qhipa"
 
 #: js/blocks/GraphicsBlocks.js:967
-#.TRANS: El bloque Atrás mueve el ratón hacia atrás.
+#. TRANS: El bloque Atrás mueve el ratón hacia atrás.
 msgid "The Back block moves the mouse backward."
 msgstr "qhipa t’aqa huk’uchawan qhipaman muyun"
 
 #: js/blocks/GraphicsBlocks.js:974
-#.TRANS: El bloque Atrás mueve la tortuga hacia atrás.
+#. TRANS: El bloque Atrás mueve la tortuga hacia atrás.
 msgid "The Back block moves the turtle backward."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:1041
 #: plugins/rodi.rtp:71
 #: plugins/rodi.rtp:400
-#.TRANS: adelante
+#. TRANS: adelante
 msgid "forward"
 msgstr "ñawpaq"
 
 #: js/blocks/GraphicsBlocks.js:1050
-#.TRANS: El bloque Adelante mueve el ratón hacia adelante.
+#. TRANS: El bloque Adelante mueve el ratón hacia adelante.
 msgid "The Forward block moves the mouse forward."
 msgstr "ñawpaq t’aqa huk’uchawan ñawpaqman muyun"
 
 #: js/blocks/GraphicsBlocks.js:1057
-#.TRANS: El bloque Adelante mueve la tortuga hacia adelante.
+#. TRANS: El bloque Adelante mueve la tortuga hacia adelante.
 msgid "The Forward block moves the turtle forward."
 msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:1145
 #: js/blocks/GraphicsBlocks.js:1163
-#.TRANS: envolver
+#. TRANS: envolver
 msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
-#.TRANS: derecha
+#. TRANS: right side of the screen
+#. TRANS: derecha
 msgid "right (screen)"
 msgstr "pantallapa pañanpi"
 
 #: js/blocks/MediaBlocks.js:45
 #: js/blocks/MediaBlocks.js:56
-#.TRANS: El bloque Derecha devuelve la posición de la derecha del lienzo.
+#. TRANS: El bloque Derecha devuelve la posición de la derecha del lienzo.
 msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
-#.TRANS: izquierdo
+#. TRANS: left side of the screen
+#. TRANS: izquierdo
 msgid "left (screen)"
 msgstr "pantallapa lluq’ínpi"
 
 #: js/blocks/MediaBlocks.js:107
 #: js/blocks/MediaBlocks.js:118
-#.TRANS: El bloque Izquierdo devuelve la posición de la izquierda del lienzo.
+#. TRANS: El bloque Izquierdo devuelve la posición de la izquierda del lienzo.
 msgid "The Left block returns the position of the left of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:158
-#.TRANS: superior
+#. TRANS: superior
 msgid "top (screen)"
 msgstr "hanan"
 
 #: js/blocks/MediaBlocks.js:168
 #: js/blocks/MediaBlocks.js:179
-#.TRANS: El bloque superior devuelve la posición de la parte superior del lienzo.
+#. TRANS: El bloque superior devuelve la posición de la parte superior del lienzo.
 msgid "The Top block returns the position of the top of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:219
-#.TRANS: inferior
+#. TRANS: inferior
 msgid "bottom (screen)"
 msgstr "uran"
 
 #: js/blocks/MediaBlocks.js:229
 #: js/blocks/MediaBlocks.js:240
-#.TRANS: El bloque Inferior devuelve la posición de la parte inferior del lienzo.
+#. TRANS: El bloque Inferior devuelve la posición de la parte inferior del lienzo.
 msgid "The Bottom block returns the position of the bottom of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:282
-#.TRANS: anchura
+#. TRANS: anchura
 msgid "width"
 msgstr "chutariynin"
 
 #: js/blocks/MediaBlocks.js:291
-#.TRANS: El bloque ancho devuelve el ancho del lienzo.
+#. TRANS: El bloque ancho devuelve el ancho del lienzo.
 msgid "The Width block returns the width of the canvas."
 msgstr "chutariynin chiqasqa qillqana llikapa chutariyninta kutichin"
 
 #: js/blocks/MediaBlocks.js:325
-#.TRANS: altura
+#. TRANS: altura
 msgid "height"
 msgstr "sayaynin"
 
 #: js/blocks/MediaBlocks.js:334
-#.TRANS: El bloque altura devuelve la altura del lienzo.
+#. TRANS: El bloque altura devuelve la altura del lienzo.
 msgid "The Height block returns the height of the canvas."
 msgstr "sayaynin chiqasqa qillqana llikapa sayayninta kutichin"
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
-#.TRANS: detener
+#. TRANS: stops playback of an audio recording
+#. TRANS: detener
 msgid "stop play"
 msgstr "sayachiy"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
-#.TRANS: borrar medios
+#. TRANS: Erases the images and text
+#. TRANS: borrar medios
 msgid "erase media"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:409
-#.TRANS: El bloque Erase Media borra texto e imágenes.
+#. TRANS: El bloque Erase Media borra texto e imágenes.
 msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
-#.TRANS: reproducir
+#. TRANS: play an audio recording
+#. TRANS: reproducir
 msgid "play back"
 msgstr "puririchiy"
 
 #: js/blocks/MediaBlocks.js:487
-#.TRANS: hablar
+#. TRANS: hablar
 msgid "speak"
 msgstr "rimay"
 
 #: js/blocks/MediaBlocks.js:495
-#.TRANS: El bloque Habla emite al sintetizador de texto a voz.
+#. TRANS: El bloque Habla emite al sintetizador de texto a voz.
 msgid "The Speak block outputs to the text-to-speech synthesizer"
 msgstr "Rimay chiqasqa kunkawan rimasqa pisiyachisqanmanta riman "
 
 #: js/blocks/MediaBlocks.js:546
-#.TRANS: 
+#. TRANS: 
 msgid "camera"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:551
-#.TRANS: El bloque cámara conecta una cámara web al bloque mostrar.
+#. TRANS: El bloque cámara conecta una cámara web al bloque mostrar.
 msgid "The Camera block connects a webcam to the Show block."
 msgstr "Cámarata webman hap’ichiy"
 
 #: js/blocks/MediaBlocks.js:574
-#.TRANS: 
+#. TRANS: 
 msgid "video"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:579
-#.TRANS: El bloque video selecciona video para al bloque mostrar.
+#. TRANS: El bloque video selecciona video para al bloque mostrar.
 msgid "The Video block selects video for use with the Show block."
 msgstr "El bloque video selecciona video para al bloque mostrar."
 
 #: js/blocks/MediaBlocks.js:607
-#.TRANS: El bloque Abrir archivo abre un archivo para usar con el bloque Mostrar.
+#. TRANS: El bloque Abrir archivo abre un archivo para usar con el bloque Mostrar.
 msgid "The Open file block opens a file for use with the Show block."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:645
-#.TRANS: detener medios
+#. TRANS: detener medios
 msgid "stop media"
 msgstr "ruranakunata sayachiy"
 
 #: js/blocks/MediaBlocks.js:650
-#.TRANS: El bloque detener medios detiene la reproducción de audio o video.
+#. TRANS: El bloque detener medios detiene la reproducción de audio o video.
 msgid "The Stop media block stops audio or video playback."
 msgstr "El bloque detener medios detiene la reproducción de audio o video."
 
@@ -7696,136 +7696,136 @@ msgstr "El bloque detener medios detiene la reproducción de audio o video."
 #: js/widgets/temperament.js:590
 #: js/widgets/temperament.js:1446
 #: js/widgets/timbre.js:1834
-#.TRANS: frecuencia
+#. TRANS: frecuencia
 msgid "frequency"
 msgstr "Kutipayaq"
 
 #: js/blocks/MediaBlocks.js:692
 #: plugins/rodi.rtp:193
-#.TRANS: 
+#. TRANS: 
 msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
-#.TRANS: nota a frecuencia
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: nota a frecuencia
 msgid "note to frequency"
 msgstr "kuti kuti ruranaman huch’uy willakuy"
 
 #: js/blocks/MediaBlocks.js:736
-#.TRANS: El bloque A frecuencia convierte un nombre de tono y una octava a Hertz.
+#. TRANS: El bloque A frecuencia convierte un nombre de tono y una octava a Hertz.
 msgid "The To frequency block converts a pitch name and octave to Hertz."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:812
-#.TRANS: El bloque Avatar se usa para cambiar la apariencia del ratón.
+#. TRANS: El bloque Avatar se usa para cambiar la apariencia del ratón.
 msgid "The Avatar block is used to change the appearance of the mouse."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:819
-#.TRANS: El bloque Avatar se usa para cambiar la apariencia de la tortuga.
+#. TRANS: El bloque Avatar se usa para cambiar la apariencia de la tortuga.
 msgid "The Avatar block is used to change the appearance of the turtle."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
-#.TRANS: tamaño
+#. TRANS: a media object
+#. TRANS: tamaño
 msgid "size"
 msgstr "sayay"
 
 #: js/blocks/MediaBlocks.js:831
-#.TRANS: imagen
+#. TRANS: imagen
 msgid "image"
 msgstr "rikch’aynin"
 
 #: js/blocks/MediaBlocks.js:880
-#.TRANS: El bloque Mostrar se utiliza para mostrar texto o imágenes en el lienzo.
+#. TRANS: El bloque Mostrar se utiliza para mostrar texto o imágenes en el lienzo.
 msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
-#.TRANS: mostrar
+#. TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: mostrar
 msgid "show1"
 msgstr "qhawachiy"
 
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: objeto
+#. TRANS: objeto
 msgid "obj"
 msgstr "ima"
 
 #: js/blocks/MediaBlocks.js:938
-#.TRANS: El bloque Medios se utiliza para importar una imagen.
+#. TRANS: El bloque Medios se utiliza para importar una imagen.
 msgid "The Media block is used to import an image."
 msgstr "Kaqkuna chiqastaqa llimp’ita apamunapaq hap’ikun"
 
 #: js/blocks/MediaBlocks.js:973
-#.TRANS: El bloque Texto contiene una cadena de texto.
+#. TRANS: El bloque Texto contiene una cadena de texto.
 msgid "The Text block holds a text string."
 msgstr "Qillqa t’aqaqa watuchasqa qillqakuna kaqniyuqmi"
 
 #: js/blocks/PenBlocks.js:30
-#.TRANS: morado
+#. TRANS: morado
 msgid "purple"
 msgstr "Kulli"
 
 #: js/blocks/PenBlocks.js:48
 #: js/blocks/SensorsBlocks.js:521
 #: plugins/rodi.rtp:219
-#.TRANS: azur
+#. TRANS: azur
 msgid "blue"
 msgstr "Anqas"
 
 #: js/blocks/PenBlocks.js:64
 #: js/blocks/SensorsBlocks.js:577
 #: plugins/rodi.rtp:218
-#.TRANS: verde
+#. TRANS: verde
 msgid "green"
 msgstr "Qunir"
 
 #: js/blocks/PenBlocks.js:80
-#.TRANS: amarillo
+#. TRANS: amarillo
 msgid "yellow"
 msgstr "Q’illu"
 
 #: js/blocks/PenBlocks.js:96
 #: plugins/nutrition.rtp:164
-#.TRANS: naranja
+#. TRANS: naranja
 msgid "orange"
 msgstr "q'illmu"
 
 #: js/blocks/PenBlocks.js:112
 #: js/blocks/SensorsBlocks.js:633
 #: plugins/rodi.rtp:217
-#.TRANS: rojo
+#. TRANS: rojo
 msgid "red"
 msgstr "Puka"
 
 #: js/blocks/PenBlocks.js:128
-#.TRANS: blanco
+#. TRANS: blanco
 msgid "white"
 msgstr "Yuraq"
 
 #: js/blocks/PenBlocks.js:144
-#.TRANS: negro
+#. TRANS: negro
 msgid "black"
 msgstr "Yana"
 
 #: js/blocks/PenBlocks.js:163
-#.TRANS: iniciar relleno
+#. TRANS: iniciar relleno
 msgid "begin fill"
 msgstr "Hunt’achiyta qallariy"
 
 #: js/blocks/PenBlocks.js:188
-#.TRANS: Cargar proyecto desde archivo
+#. TRANS: Cargar proyecto desde archivo
 msgid "end fill"
 msgstr "pusariqta waqaychanamanta hunt’achimuy"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
-#.TRANS: rellenar pantalla
+#. TRANS: set the background color
+#. TRANS: rellenar pantalla
 msgid "background"
 msgstr " qhawanata hunt’achiy"
 
@@ -7833,12 +7833,12 @@ msgstr " qhawanata hunt’achiy"
 #: js/turtleactions/DictActions.js:71
 #: js/turtleactions/DictActions.js:138
 #: js/turtleactions/DictActions.js:170
-#.TRANS: gris
+#. TRANS: gris
 msgid "grey"
 msgstr "uqi"
 
 #: js/blocks/PenBlocks.js:261
-#.TRANS: El bloque gris devuelve el valor gris actual de la pluma.
+#. TRANS: El bloque gris devuelve el valor gris actual de la pluma.
 msgid "The Grey block returns the current pen grey value."
 msgstr "El bloque gris devuelve el valor gris actual de la pluma."
 
@@ -7846,12 +7846,12 @@ msgstr "El bloque gris devuelve el valor gris actual de la pluma."
 #: js/turtleactions/DictActions.js:69
 #: js/turtleactions/DictActions.js:136
 #: js/turtleactions/DictActions.js:169
-#.TRANS: sombra
+#. TRANS: sombra
 msgid "shade"
 msgstr "llanthu"
 
 #: js/blocks/PenBlocks.js:326
-#.TRANS: El bloque sombra devuelve la sombra actual de la pluma.
+#. TRANS: El bloque sombra devuelve la sombra actual de la pluma.
 msgid "The Shade block returns the current pen shade value."
 msgstr "El bloque sombra devuelve la sombra actual de la pluma."
 
@@ -7859,12 +7859,12 @@ msgstr "El bloque sombra devuelve la sombra actual de la pluma."
 #: js/turtleactions/DictActions.js:67
 #: js/turtleactions/DictActions.js:134
 #: js/turtleactions/DictActions.js:168
-#.TRANS: color
+#. TRANS: color
 msgid "color"
 msgstr "llimp'i"
 
 #: js/blocks/PenBlocks.js:394
-#.TRANS: El bloque color devuelve el color actual de la pluma.
+#. TRANS: El bloque color devuelve el color actual de la pluma.
 msgid "The Color block returns the current pen color."
 msgstr "sayaq llimp’i kutichin llimp’ita kunan llimp’qman"
 
@@ -7872,541 +7872,541 @@ msgstr "sayaq llimp’i kutichin llimp’ita kunan llimp’qman"
 #: js/turtleactions/DictActions.js:73
 #: js/turtleactions/DictActions.js:140
 #: js/turtleactions/DictActions.js:171
-#.TRANS: tamaño de la pluma
+#. TRANS: tamaño de la pluma
 msgid "pen size"
 msgstr "Qillqanq sayayanin"
 
 #: js/blocks/PenBlocks.js:453
-#.TRANS: El bloque tamaño de la pluma devuelve el tamaño actual de la pluma.
+#. TRANS: El bloque tamaño de la pluma devuelve el tamaño actual de la pluma.
 msgid "The Pen size block returns the current pen size value."
 msgstr "El bloque tamaño de la pluma devuelve el tamaño actual de la pluma."
 
 #: js/blocks/PenBlocks.js:492
-#.TRANS: fijar font
+#. TRANS: fijar font
 msgid "set font"
 msgstr "tahachiy font"
 
 #: js/blocks/PenBlocks.js:497
-#.TRANS: El bloque fijar font establece el font utilizada por el bloque mostrar.
+#. TRANS: El bloque fijar font establece el font utilizada por el bloque mostrar.
 msgid "The Set font block sets the font used by the Show block."
 msgstr "El bloque fijar font establece el font utilizada por el bloque mostrar."
 
 #: js/blocks/PenBlocks.js:544
-#.TRANS: El bloque Fondo establece el color de fondo de la ventana.
+#. TRANS: El bloque Fondo establece el color de fondo de la ventana.
 msgid "The Background block sets the window background color."
 msgstr "El bloque Fondo establece el color de fondo de la ventana."
 
 #: js/blocks/PenBlocks.js:575
-#.TRANS: El bloque de línea sin relleno crea una línea con un centro hueco.
+#. TRANS: El bloque de línea sin relleno crea una línea con un centro hueco.
 msgid "The Hollow line block creates a line with a hollow center."
 msgstr "El bloque de línea sin relleno crea una línea con un centro hueco."
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
-#.TRANS: linea sin relleno
+#. TRANS: draw a line logo has a hollow space down its center
+#. TRANS: linea sin relleno
 msgid "hollow line"
 msgstr "Hunt’achina siq’i"
 
 #: js/blocks/PenBlocks.js:652
-#.TRANS: El bloque relleno rellena una forma con un color.
+#. TRANS: El bloque relleno rellena una forma con un color.
 msgid "The Fill block fills in a shape with a color."
 msgstr "El bloque relleno rellena una forma con un color."
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
-#.TRANS: relleno
+#. TRANS: fill in as a solid color
+#. TRANS: relleno
 msgid "fill"
 msgstr "Hunt’achina"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
-#.TRANS: subir pluma
+#. TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: subir pluma
 msgid "pen up"
 msgstr "qillqanata uqariy"
 
 #: js/blocks/PenBlocks.js:745
-#.TRANS: El bloque Subir pluma levanta la pluma para que no dibuje.
+#. TRANS: El bloque Subir pluma levanta la pluma para que no dibuje.
 msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "Sayaqpi, qillqanata uqariy mana siq’inanpaq"
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
-#.TRANS: bajar pluma
+#. TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: bajar pluma
 msgid "pen down"
 msgstr "qillqanata urayachiy"
 
 #: js/blocks/PenBlocks.js:787
-#.TRANS: El bloque de Haciar pluma abajo baja la pluma para que dibuje.
+#. TRANS: El bloque de Haciar pluma abajo baja la pluma para que dibuje.
 msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "El bloque Subir pluma levanta la pluma para que no dibuje."
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
-#.TRANS: fijar pluma
+#. TRANS: set the width of the line drawn by the pen
+#. TRANS: fijar pluma
 msgid "set pen size"
 msgstr "Qillqanata tahachiy"
 
 #: js/blocks/PenBlocks.js:831
-#.TRANS: El bloque Fijar tamaño de la pluma de ajuste cambia el tamaño de la pluma.
+#. TRANS: El bloque Fijar tamaño de la pluma de ajuste cambia el tamaño de la pluma.
 msgid "The Set-pen-size block changes the size of the pen."
 msgstr "Sayaq, qillqanaq tahachinanmi kutichin qillqaqa rakhuyanata, ñañuyachinata"
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
-#.TRANS: fijar translucidez
+#. TRANS: set degree of translucence of the pen color
+#. TRANS: fijar translucidez
 msgid "set translucency"
 msgstr "K’anchayninta tahachiy "
 
 #: js/blocks/PenBlocks.js:898
-#.TRANS: El bloque fijar translucidez cambia la opacidad de la pluma.
+#. TRANS: El bloque fijar translucidez cambia la opacidad de la pluma.
 msgid "The Set translucency block changes the opacity of the pen."
 msgstr "El bloque fijar translucidez cambia la opacidad de la pluma."
 
 #: js/blocks/PenBlocks.js:958
-#.TRANS: fijar matiz
+#. TRANS: fijar matiz
 msgid "set hue"
 msgstr "Llimp’inta tahachiy "
 
 #: js/blocks/PenBlocks.js:966
-#.TRANS: El bloque fijar matiz cambia la color de la pluma.
+#. TRANS: El bloque fijar matiz cambia la color de la pluma.
 msgid "The Set hue block changes the color of the pen."
 msgstr "El bloque fijar matiz cambia la color de la pluma."
 
 #: js/blocks/PenBlocks.js:1024
-#.TRANS: fijar sombra
+#. TRANS: fijar sombra
 msgid "set shade"
 msgstr "Llanthunta tahachiy "
 
 #: js/blocks/PenBlocks.js:1034
-#.TRANS: El bloque Fijar sombra cambia el color de la pluma de oscuro a claro.
+#. TRANS: El bloque Fijar sombra cambia el color de la pluma de oscuro a claro.
 msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
-#.TRANS: fijar gris
+#. TRANS: set the level of vividness of the pen color
+#. TRANS: fijar gris
 msgid "set grey"
 msgstr "Uqinta tahachiy "
 
 #: js/blocks/PenBlocks.js:1096
-#.TRANS: El bloque fijar gris cambia la intensidad de la pluma.
+#. TRANS: El bloque fijar gris cambia la intensidad de la pluma.
 msgid "The Set grey block changes the vividness of the pen color."
 msgstr "El bloque fijar gris cambia la intensidad de la pluma."
 
 #: js/blocks/PenBlocks.js:1149
-#.TRANS: fijar color
+#. TRANS: fijar color
 msgid "set color"
 msgstr "Llinpinta tahachiy"
 
 #: js/blocks/PenBlocks.js:1159
-#.TRANS: El bloque fijar color cambia el color de la pluma.
+#. TRANS: El bloque fijar color cambia el color de la pluma.
 msgid "The Set-color block changes the pen color."
 msgstr "Sayaq, tahachiy llmp’iyta qillqanaq llimp’iynita kutichin"
 
 #: js/blocks/SensorsBlocks.js:36
-#.TRANS: El bloque de entrada solicita la entrada del teclado.
+#. TRANS: El bloque de entrada solicita la entrada del teclado.
 msgid "The Input block prompts for keyboard input."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:46
-#.TRANS: el input
+#. TRANS: el input
 msgid "input"
 msgstr "haykuna"
 
 #: js/blocks/SensorsBlocks.js:64
-#.TRANS: ingrese un valor
+#. TRANS: ingrese un valor
 msgid "Input a value"
 msgstr "ingrese un valor"
 
 #: js/blocks/SensorsBlocks.js:126
-#.TRANS: valor de entrada
+#. TRANS: valor de entrada
 msgid "input value"
 msgstr "chaninchaqta haykuchiy"
 
 #: js/blocks/SensorsBlocks.js:131
-#.TRANS: El bloque de valor de entrada almacena la entrada.
+#. TRANS: El bloque de valor de entrada almacena la entrada.
 msgid "The Input-value block stores the input."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:238
-#.TRANS: volumen
+#. TRANS: volumen
 msgid "loudness"
 msgstr "p’ulin"
 
 #: js/blocks/SensorsBlocks.js:245
-#.TRANS: El bloque Volumen devuelve el volumen detectado por el micrófono.
+#. TRANS: El bloque Volumen devuelve el volumen detectado por el micrófono.
 msgid "The Loudness block returns the volume detected by the microphone."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:300
-#.TRANS: click
+#. TRANS: click
 msgid "click"
 msgstr "liq"
 
 #: js/blocks/SensorsBlocks.js:306
-#.TRANS: El bloque Click activa un evento si se ha hecho clic en un ratón.
+#. TRANS: El bloque Click activa un evento si se ha hecho clic en un ratón.
 msgid "The Click block triggers an event if a mouse has been clicked."
 msgstr "El bloque Click activa un evento si se ha hecho clic en un mouse."
 
 #: js/blocks/SensorsBlocks.js:313
-#.TRANS: El bloque Click activa un evento si se ha hecho clic en una tortuga.
+#. TRANS: El bloque Click activa un evento si se ha hecho clic en una tortuga.
 msgid "The Click block triggers an event if a turtle has been clicked."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:342
-#.TRANS: cursor sobre
+#. TRANS: cursor sobre
 msgid "cursor over"
 msgstr "cursor sobre"
 
 #: js/blocks/SensorsBlocks.js:387
-#.TRANS: cursor fuera
+#. TRANS: cursor fuera
 msgid "cursor out"
 msgstr "cursor fuera"
 
 #: js/blocks/SensorsBlocks.js:433
-#.TRANS: el botón presionado
+#. TRANS: el botón presionado
 msgid "cursor button down"
-msgstr "el botón presionado" "
+msgstr "el botón presionado"
 
 #: js/blocks/SensorsBlocks.js:477
-#.TRANS: el botón arriba
+#. TRANS: el botón arriba
 msgid "cursor button up"
 msgstr "el botón arriba"
 
 #: js/blocks/SensorsBlocks.js:638
-#.TRANS: El bloque Obtener rojo devuelve el componente rojo del píxel debajo del ratón.
+#. TRANS: El bloque Obtener rojo devuelve el componente rojo del píxel debajo del ratón.
 msgid "The Get red block returns the red component of the pixel under the mouse."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:644
-#.TRANS: El bloque Obtener rojo devuelve el componente rojo del píxel debajo de la tortuga.
+#. TRANS: El bloque Obtener rojo devuelve el componente rojo del píxel debajo de la tortuga.
 msgid "The Get red block returns the red component of the pixel under the turtle."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:685
 #: plugins/rodi.rtp:216
-#.TRANS: color del pixel
+#. TRANS: color del pixel
 msgid "pixel color"
 msgstr " llimp’iy k’anchaypa phatmin"
 
 #: js/blocks/SensorsBlocks.js:690
-#.TRANS: El bloque Obtener píxel devuelve el color del píxel debajo del ratón.
+#. TRANS: El bloque Obtener píxel devuelve el color del píxel debajo del ratón.
 msgid "The Get pixel block returns the color of the pixel under the mouse."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:696
-#.TRANS: El bloque Obtener píxel devuelve el color del píxel debajo de la tortuga.
+#. TRANS: El bloque Obtener píxel devuelve el color del píxel debajo de la tortuga.
 msgid "The Get pixel block returns the color of the pixel under the turtle."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:759
-#.TRANS: tiempo
+#. TRANS: tiempo
 msgid "time"
 msgstr "pacha"
 
 #: js/blocks/SensorsBlocks.js:805
-#.TRANS: cursor y
+#. TRANS: cursor y
 msgid "cursor y"
 msgstr "y t’uqpina"
 
 #: js/blocks/SensorsBlocks.js:810
-#.TRANS: El bloque Cursor Y devuelve la posición vertical del cursor.
+#. TRANS: El bloque Cursor Y devuelve la posición vertical del cursor.
 msgid "The Cursor Y block returns the vertical position of the mouse."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:846
-#.TRANS: cursor x
+#. TRANS: cursor x
 msgid "cursor x"
 msgstr "t’uqpina"
 
 #: js/blocks/SensorsBlocks.js:851
-#.TRANS: El bloque Cursor X devuelve la posición horizontal del ratón.
+#. TRANS: El bloque Cursor X devuelve la posición horizontal del ratón.
 msgid "The Cursor X block returns the horizontal position of the mouse."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:887
-#.TRANS: botón del ratón
+#. TRANS: botón del ratón
 msgid "mouse button"
 msgstr "Huk’uchapa ñup’unan"
 
 #: js/blocks/SensorsBlocks.js:889
-#.TRANS: El bloque Botón del ratón devuelve Verdadero si se presiona el botón del ratón.
+#. TRANS: El bloque Botón del ratón devuelve Verdadero si se presiona el botón del ratón.
 msgid "The Mouse-button block returns True if the mouse button is pressed."
 msgstr ""
 
 #: js/blocks/SensorsBlocks.js:935
-#.TRANS: a ASCII
+#. TRANS: a ASCII
 msgid "to ASCII"
 msgstr "ASCIIman"
 
 #: js/blocks/SensorsBlocks.js:939
-#.TRANS: El bloque a ASCII convierte números a letras.
+#. TRANS: El bloque a ASCII convierte números a letras.
 msgid "The To ASCII block converts numbers to letters."
 msgstr "El bloque a ASCII convierte números a letras."
 
 #: js/blocks/SensorsBlocks.js:1006
-#.TRANS: El bloque teclado devuelve entrada de teclado.
+#. TRANS: El bloque teclado devuelve entrada de teclado.
 msgid "The Keyboard block returns computer keyboard input."
 msgstr "El bloque teclado devuelve entrada de teclado."
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
-#.TRANS: Envolvente
+#. TRANS: sound envelope (ADSR)
+#. TRANS: Envolvente
 msgid "Envelope"
 msgstr "patapi"
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
-#.TRANS: atacar
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: atacar
 msgid "attack"
 msgstr "atacar"
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
-#.TRANS: decaer
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: decaer
 msgid "decay"
 msgstr "Pisipayay"
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
-#.TRANS: sostener
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: sostener
 msgid "sustain"
 msgstr "hap’ipay"
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
-#.TRANS: liberar
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: liberar
 msgid "release"
 msgstr "waqmanta ñawinchay"
 
 #: js/blocks/WidgetBlocks.js:113
-#.TRANS: El valor de atacar debe estar entre 0 y 100.
+#. TRANS: El valor de atacar debe estar entre 0 y 100.
 msgid "Attack value should be from 0 to 100."
 msgstr "El valor de atacar debe estar entre 0 y 100."
 
 #: js/blocks/WidgetBlocks.js:116
-#.TRANS: El valor de decaer debe estar entre 0 y 100.
+#. TRANS: El valor de decaer debe estar entre 0 y 100.
 msgid "Decay value should be from 0 to 100."
 msgstr "Pisipayachiyqa 0 – 100 kaman kanan"
 
 #: js/blocks/WidgetBlocks.js:119
-#.TRANS: El valor de sostener debe estar entre 0 y 100.
+#. TRANS: El valor de sostener debe estar entre 0 y 100.
 msgid "Sustain value should be from 0 to 100."
 msgstr "Hap’paypa tupuynin ch’usaqmanta pachaqkamann kanan"
 
 #: js/blocks/WidgetBlocks.js:122
-#.TRANS: El valor de liberar debe estar entre 0 y 100.
+#. TRANS: El valor de liberar debe estar entre 0 y 100.
 msgid "Release value should be from 0-100."
 msgstr "Kachariya tupun kanan 0 – 100 kama"
 
 #: js/blocks/WidgetBlocks.js:140
-#.TRANS: Está agregando varios bloques de envolvente.
+#. TRANS: Está agregando varios bloques de envolvente.
 msgid "You are adding multiple envelope blocks."
 msgstr "Está agregando varios bloques de envolvente."
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
-#.TRANS: Filtrar
+#. TRANS: a filter removes some unwanted components from a signal
+#. TRANS: Filtrar
 msgid "Filter"
 msgstr "ch’uyay"
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
-#.TRANS: rodar
+#. TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rodar
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
-#.TRANS: Roll off valor debe ser -12, -24, -48, o -96 decibelios.
+#. TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: Roll off valor debe ser -12, -24, -48, o -96 decibelios.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:252
-#.TRANS: La Herramienta temperamento se utiliza para definir la afinación personalizada.
+#. TRANS: La Herramienta temperamento se utiliza para definir la afinación personalizada.
 msgid "The Temperament tool is used to define custom tuning."
 msgstr "La Herramienta temperamento se utiliza para definir la afinación personalizada."
 
 #: js/blocks/WidgetBlocks.js:332
 #: js/blocks/WidgetBlocks.js:1574
 #: js/widgets/sampler.js:501
-#.TRANS: Sube una muestra de audio y ajusta su centro de tono.
+#. TRANS: Sube una muestra de audio y ajusta su centro de tono.
 msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
-#.TRANS: muestreador de audio
+#. TRANS: the speed at music is should be played.
+#. TRANS: muestreador de audio
 msgid "sampler"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:517
-#.TRANS: El bloque Meter abre una herramienta para seleccionar golpes fuertes para el metro.
+#. TRANS: El bloque Meter abre una herramienta para seleccionar golpes fuertes para el metro.
 msgid "The Meter block opens a tool to select strong beats for the meter."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:573
-#.TRANS: El bloque del osciloscopio abre una herramienta para visualizar formas de onda.
+#. TRANS: El bloque del osciloscopio abre una herramienta para visualizar formas de onda.
 msgid "The oscilloscope block opens a tool to visualize waveforms."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:578
-#.TRANS: osciloscopio
+#. TRANS: osciloscopio
 msgid "oscilloscope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:645
-#.TRANS: El bloque Modo personalizado abre una herramienta para explorar el modo musical (el espaciado de las notas en una escala).
+#. TRANS: El bloque Modo personalizado abre una herramienta para explorar el modo musical (el espaciado de las notas en una escala).
 msgid "The Custom mode block opens a tool to explore musical mode (the spacing of the notes in a scale)."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
-#.TRANS: modo personalizado
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: modo personalizado
 msgid "custom mode"
 msgstr "huk hinayuq runachasqa"
 
 #: js/blocks/WidgetBlocks.js:700
-#.TRANS: El bloque Tempo abre un metrónomo para visualizar el ritmo.
+#. TRANS: El bloque Tempo abre un metrónomo para visualizar el ritmo.
 msgid "The Tempo block opens a metronome to visualize the beat."
 msgstr "El bloque Tempo abre un metrónomo para visualizar el ritmo."
 
 #: js/blocks/WidgetBlocks.js:762
-#.TRANS: El Arpegio Widget se usa para componer secuencias de acordes.
+#. TRANS: El Arpegio Widget se usa para componer secuencias de acordes.
 msgid "The Arpeggio Widget is used to compose chord sequences."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:837
-#.TRANS: La Matriz de percusión de tono se utiliza para asignar tonos a los sonidos de tambor.
+#. TRANS: La Matriz de percusión de tono se utiliza para asignar tonos a los sonidos de tambor.
 msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
-#.TRANS: matriz de tono en tambor
+#. TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: matriz de tono en tambor
 msgid "pitch-drum mapper"
 msgstr "taki purihiq"
 
 #: js/blocks/WidgetBlocks.js:891
-#.TRANS: Debe tener al menos un bloque de tono y un bloque de tambor en la matriz.
+#. TRANS: Debe tener al menos un bloque de tono y un bloque de tambor en la matriz.
 msgid "You must have at least one pitch block and one drum block in the matrix."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:920
-#.TRANS: La Herramienta de control deslizante tono se utiliza para generar tonos en las frecuencias seleccionadas.
+#. TRANS: La Herramienta de control deslizante tono se utiliza para generar tonos en las frecuencias seleccionadas.
 msgid "The Pitch slider tool to is used to generate pitches at selected frequencies."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
-#.TRANS: deslizante de tono
+#. TRANS: widget to generate pitches using a slider
+#. TRANS: deslizante de tono
 msgid "pitch slider"
 msgstr "Kunka lluskhachik"
 
 #: js/blocks/WidgetBlocks.js:977
-#.TRANS: teclado cromático
+#. TRANS: teclado cromático
 msgid "chromatic keyboard"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
-#.TRANS: teclado musical
+#. TRANS: widget to generate pitches using a slider
+#. TRANS: teclado musical
 msgid "music keyboard"
 msgstr "taki t’upuna"
 
 #: js/blocks/WidgetBlocks.js:1062
 #: js/blocks/WidgetBlocks.js:1069
-#.TRANS: El bloque Teclado de música abre un teclado de piano que puede usarse para crear notas.
+#. TRANS: El bloque Teclado de música abre un teclado de piano que puede usarse para crear notas.
 msgid "The Music keyboard block opens a piano keyboard that can be used to create notes."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1128
-#.TRANS: La Herramienta escalera de tono se utiliza para generar tonos a partir de una relación dada.
+#. TRANS: La Herramienta escalera de tono se utiliza para generar tonos a partir de una relación dada.
 msgid "The Pitch staircase tool to is used to generate pitches from a given ratio."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
-#.TRANS: escalera de tono
+#. TRANS: generate a progressive sequence of pitches
+#. TRANS: escalera de tono
 msgid "pitch staircase"
 msgstr "Kunka siqachina"
 
 #: js/blocks/WidgetBlocks.js:1222
-#.TRANS: El bloque Hacer un ritmo abre una herramienta para crear cajas de ritmos.
+#. TRANS: El bloque Hacer un ritmo abre una herramienta para crear cajas de ritmos.
 msgid "The Rhythm Maker block opens a tool to create drum machines."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1291
-#.TRANS: escala mayor G
+#. TRANS: escala mayor G
 msgid "G major scale"
 msgstr "Kuraq G wichachina"
 
 #: js/blocks/WidgetBlocks.js:1326
-#.TRANS: escala mayor C
+#. TRANS: escala mayor C
 msgid "C major scale"
 msgstr "Kuraq C wichachina"
 
 #: js/blocks/WidgetBlocks.js:1366
-#.TRANS: El bloque Matriz de tono y tiempo abre una herramienta para crear frases musicales.
+#. TRANS: El bloque Matriz de tono y tiempo abre una herramienta para crear frases musicales.
 msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
-#.TRANS: matriz de tono en tiempo
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: matriz de tono en tiempo
 msgid "phrase maker"
 msgstr "Kunka pachapi paqarichiq "
 
 #: js/blocks/WidgetBlocks.js:1445
-#.TRANS: Debe tener al menos un bloque de tono y un bloque de ritmo en la matriz.
+#. TRANS: Debe tener al menos un bloque de tono y un bloque de ritmo en la matriz.
 msgid "You must have at least one pitch block and one rhythm block in the matrix."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1504
-#.TRANS: El bloque Estado abre una herramienta para inspeccionar el estado de Bloques de Música mientras se ejecuta.
+#. TRANS: El bloque Estado abre una herramienta para inspeccionar el estado de Bloques de Música mientras se ejecuta.
 msgid "The Status block opens a tool for inspecting the status of Music Blocks as it is running."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
-#.TRANS: Música de IA
+#. TRANS: AI-generated music
+#. TRANS: Música de IA
 msgid "AI Music"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:35
-#.TRANS: volumen del sintetizador
+#. TRANS: volumen del sintetizador
 msgid "synth volume"
 msgstr "volumen del sintetizador"
 
 #: js/blocks/VolumeBlocks.js:39
-#.TRANS: El bloque de volumen sintetizador devuelve el volumen actual del sintetizador actual.
+#. TRANS: El bloque de volumen sintetizador devuelve el volumen actual del sintetizador actual.
 msgid "The Synth volume block returns the current volume of the current synthesizer."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:105
-#.TRANS: volumen maestro
+#. TRANS: volumen maestro
 msgid "master volume"
 msgstr "t’uqya kamay"
 
 #: js/blocks/VolumeBlocks.js:109
-#.TRANS: El bloque volumen maestro devuelve nivel de volumen maestro.
+#. TRANS: El bloque volumen maestro devuelve nivel de volumen maestro.
 msgid "The Master volume block returns the master volume."
 msgstr "El bloque volumen maestro devuelve nivel de volumen maestro."
 
 #: js/blocks/VolumeBlocks.js:355
 #: js/blocks/VolumeBlocks.js:524
-#.TRANS: fijar volumen del sintetizador
+#. TRANS: fijar volumen del sintetizador
 msgid "set synth volume"
 msgstr "fijar volumen del sintetizador"
 
 #: js/blocks/VolumeBlocks.js:362
 #: js/blocks/VolumeBlocks.js:545
-#.TRANS: sintetizador
+#. TRANS: sintetizador
 msgid "synth"
 msgstr "sintetizador"
 
@@ -8414,209 +8414,209 @@ msgstr "sintetizador"
 #: js/blocks/VolumeBlocks.js:577
 #: js/blocks/VolumeBlocks.js:740
 #: js/turtleactions/VolumeActions.js:173
-#.TRANS: Ajuste el volumen a 0
+#. TRANS: Ajuste el volumen a 0
 msgid "Setting volume to 0."
 msgstr "Ajuste el volumen a 0"
 
 #: js/blocks/VolumeBlocks.js:440
-#.TRANS: No se encuentra el sintetizador.
+#. TRANS: No se encuentra el sintetizador.
 msgid "Synth not found"
 msgstr "No se encuentra el sintetizador."
 
 #: js/blocks/VolumeBlocks.js:494
-#.TRANS: filar volumen del tambor
+#. TRANS: filar volumen del tambor
 msgid "set drum volume"
 msgstr "filar volumen del tambor"
 
 #: js/blocks/VolumeBlocks.js:530
-#.TRANS: El bloque Ajuste volumen del sintetizador cambiará el volumen de un sintetizador particular,
+#. TRANS: El bloque Ajuste volumen del sintetizador cambiará el volumen de un sintetizador particular,
 msgid "The Set synth volume block will change the volume of a particular synth,"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:532
-#.TRANS: por ejemplo, guitarra, violín, tambor
+#. TRANS: por ejemplo, guitarra, violín, tambor
 msgid "eg guitar violin snare drum etc."
 msgstr "por ejemplo, guitarra, violín, tambor"
 
 #: js/blocks/VolumeBlocks.js:534
-#.TRANS: El volumen predeterminado es 50.
+#. TRANS: El volumen predeterminado es 50.
 msgid "The default volume is 50."
 msgstr "El volumen predeterminado es 50."
 
 #: js/blocks/VolumeBlocks.js:536
-#.TRANS: El rango es de 0 para el silencio a 100 para el volumen completo.
+#. TRANS: El rango es de 0 para el silencio a 100 para el volumen completo.
 msgid "The range is 0 for silence to 100 for full volume."
 msgstr "El rango es de 0 para el silencio a 100 para el volumen completo."
 
 #: js/blocks/VolumeBlocks.js:597
-#.TRANS: establecer panorámica
+#. TRANS: establecer panorámica
 msgid "set panning"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:603
-#.TRANS: El bloque Establecer Panorámica establece el panorama para todos los sintetizadores.
+#. TRANS: El bloque Establecer Panorámica establece el panorama para todos los sintetizadores.
 msgid "The Set Panning block sets the panning for all synthesizers."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:625
-#.TRANS: Advertencia: El sonido sale solo del lado izquierdo o derecho.
+#. TRANS: Advertencia: El sonido sale solo del lado izquierdo o derecho.
 msgid "Warning: Sound is coming out from only the left or right side."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:647
 #: js/blocks/VolumeBlocks.js:695
-#.TRANS: filar volumen maestro
+#. TRANS: filar volumen maestro
 msgid "set master volume"
 msgstr "qispichiq p’ulinta takyachiy"
 
 #: js/blocks/VolumeBlocks.js:653
-#.TRANS: El bloque Ajuste volumen maestro establece el volumen para todos los sintetizadores.
+#. TRANS: El bloque Ajuste volumen maestro establece el volumen para todos los sintetizadores.
 msgid "The Set master volume block sets the volume for all synthesizers."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:784
-#.TRANS: El bloque Fijar volumen relativo cambia el volumen de las notas contenidas.
+#. TRANS: El bloque Fijar volumen relativo cambia el volumen de las notas contenidas.
 msgid "The Set relative volume block changes the volume of the contained notes."
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:791
-#.TRANS: fijar volumen relativo
+#. TRANS: fijar volumen relativo
 msgid "set relative volume"
 msgstr "t’inkisqa p’ulinta takyachiy"
 
 #: js/blocks/VolumeBlocks.js:857
-#.TRANS: decrescendo
+#. TRANS: decrescendo
 msgid "decrescendo"
 msgstr ""
 
 #: js/blocks/VolumeBlocks.js:921
-#.TRANS: crescendo
+#. TRANS: crescendo
 msgid "crescendo"
 msgstr "wiñachkan"
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: uno
+#. TRANS: uno
 msgid "one"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: dos
+#. TRANS: dos
 msgid "two"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: tres
+#. TRANS: tres
 msgid "three"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: cuatro
+#. TRANS: cuatro
 msgid "four"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: cinco
+#. TRANS: cinco
 msgid "five"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: seis
+#. TRANS: seis
 msgid "six"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: siete
+#. TRANS: siete
 msgid "seven"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: ocho
+#. TRANS: ocho
 msgid "eight"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:113
-#.TRANS: nueve
+#. TRANS: nueve
 msgid "nine"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:140
-#.TRANS: abajo
+#. TRANS: abajo
 msgid "below"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: arriba
+#. TRANS: arriba
 msgid "above"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:131
-#.TRANS: más
+#. TRANS: más
 msgid "plus"
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:258
-#.TRANS: Agregar el número de tono que falta 0.
+#. TRANS: Agregar el número de tono que falta 0.
 msgid "Adding missing pitch number 0."
 msgstr "Agregar el número de tono que falta 0."
 
 #: js/turtleactions/IntervalsActions.js:266
-#.TRANS: Ignorando los números de tono menos de cero o más de once.
+#. TRANS: Ignorando los números de tono menos de cero o más de once.
 msgid "Ignoring pitch numbers less than zero or greater than eleven."
 msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:272
-#.TRANS: Ignorando números de tono duplicados.
+#. TRANS: Ignorando números de tono duplicados.
 msgid "Ignoring duplicate pitch numbers."
 msgstr "Ignorando números de tono duplicados."
 
 #: js/turtleactions/DictActions.js:75
 #: js/turtleactions/DictActions.js:142
 #: js/turtleactions/DictActions.js:172
-#.TRANS: fuente
+#. TRANS: fuente
 msgid "font"
 msgstr ""
 
 #: js/turtleactions/DictActions.js:255
-#.TRANS: No existe diccionario con este nombre
+#. TRANS: No existe diccionario con este nombre
 msgid "Dictionary with this name does not exist"
 msgstr ""
 
 #: js/turtleactions/DictActions.js:259
-#.TRANS: La clave con este nombre no existe en 
+#. TRANS: La clave con este nombre no existe en 
 msgid "Key with this name does not exist in "
 msgstr ""
 
 #: js/turtleactions/DrumActions.js:227
-#.TRANS: Bloque de ruido: Quizás quiso decir utilizar un bloque de nota?
+#. TRANS: Bloque de ruido: Quizás quiso decir utilizar un bloque de nota?
 msgid "Noise Block: Did you mean to use a Note block?"
 msgstr "Bloque de ruido: Quizás quiso decir utilizar un bloque de nota?"
 
 #: js/turtleactions/ToneActions.js:134
-#.TRANS: La intensidad del vibrato debe estar entre 1 y 100.
+#. TRANS: La intensidad del vibrato debe estar entre 1 y 100.
 msgid "Vibrato intensity must be between 1 and 100."
 msgstr " khatataypa kallpanqa huk hinallataq pachakpi kachkanan"
 
 #: js/turtleactions/ToneActions.js:139
-#.TRANS: La velocidad del vibrato debe ser mayor que 0.
+#. TRANS: La velocidad del vibrato debe ser mayor que 0.
 msgid "Vibrato rate must be greater than 0."
 msgstr " khatataypa utqayninqa ch’usaqpa kurakninmi kanan"
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
-#.TRANS: El valor de profundidad está fuera de rango.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: El valor de profundidad está fuera de rango.
 msgid "Depth is out of range."
 msgstr "ukhunchasqa chaninninqa manam t’aqanpichu kachkan"
 
 #: js/turtleactions/ToneActions.js:301
-#.TRANS: El valor de distorsión debe ser de 0 a 100.
+#. TRANS: El valor de distorsión debe ser de 0 a 100.
 msgid "Distortion must be from 0 to 100."
 msgstr "q’iwisqapa chaninninqa ch’usaqmanta pachakkama kanan"
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
-#.TRANS: Parcial debe ser mayor o igual a 0.
+#. TRANS: partials components in a harmonic series
+#. TRANS: Parcial debe ser mayor o igual a 0.
 msgid "Partial must be greater than or equal to 0."
 msgstr "chawaqa ch’usaqamanta kurakpas kikinpas kanan"
 
@@ -8624,31 +8624,31 @@ msgstr "chawaqa ch’usaqamanta kurakpas kikinpas kanan"
 #: js/turtleactions/ToneActions.js:417
 #: js/turtleactions/ToneActions.js:456
 #: js/widgets/timbre.js:776
-#.TRANS: No se puede usar el sintetizador debido al bloqueo del oscilador.
+#. TRANS: No se puede usar el sintetizador debido al bloqueo del oscilador.
 msgid "Unable to use synth due to existing oscillator"
 msgstr "Manam pisiyachiqta hap’ikunmanchu imaraykuchus maymikuq hark’asqa kaptin"
 
 #: js/turtleactions/ToneActions.js:388
 #: js/turtleactions/ToneActions.js:427
-#.TRANS: La entrada no puede ser negativa.
+#. TRANS: La entrada no puede ser negativa.
 msgid "The input cannot be negative."
 msgstr "haykunanqa manam manaqa kanmanchu"
 
 #: js/turtleactions/MeterActions.js:101
 #: js/turtleactions/MeterActions.js:139
-#.TRANS: latidos por minuto deben ser mayores que
+#. TRANS: latidos por minuto deben ser mayores que
 msgid "beats per minute must be greater than"
 msgstr "minutupi p’ullpuqiyqa kurak kanan"
 
 #: js/turtleactions/MeterActions.js:111
 #: js/turtleactions/MeterActions.js:149
-#.TRANS: máximo
+#. TRANS: máximo
 msgid "maximum"
 msgstr "tukupunankama"
 
 #: js/turtleactions/MeterActions.js:117
 #: js/turtleactions/MeterActions.js:155
-#.TRANS: latidos por minuto es
+#. TRANS: latidos por minuto es
 msgid "beats per minute is"
 msgstr "minutupi p’ullpuqiyninqa"
 
@@ -8658,7 +8658,7 @@ msgstr "minutupi p’ullpuqiyninqa"
 #: js/widgets/help.js:158
 #: js/widgets/help.js:378
 #: js/widgets/help.js:393
-#.TRANS: Hacer un recorrido
+#. TRANS: Hacer un recorrido
 msgid "Take a tour"
 msgstr "pusay"
 
@@ -8673,40 +8673,40 @@ msgstr "pusay"
 #: js/widgets/tempo.js:78
 #: js/widgets/tempo.js:97
 #: js/widgets/tempo.js:98
-#.TRANS: Pausa
+#. TRANS: Pausa
 msgid "Pause"
 msgstr "sayay"
 
 #: js/widgets/aiwidget.js:179
 #: js/widgets/sampler.js:225
-#.TRANS: Advertencia: la muestra es más grande que 1 MB.
+#. TRANS: Advertencia: la muestra es más grande que 1 MB.
 msgid "Warning: Sample is bigger than 1MB."
 msgstr ""
 
 #: js/widgets/aiwidget.js:538
-#.TRANS: Nuevo bloque de inicio generado
+#. TRANS: Nuevo bloque de inicio generado
 msgid "New start block generated"
 msgstr ""
 
 #: js/widgets/aiwidget.js:540
-#.TRANS: Carga MIDI. Esto puede tardar un tiempo dependiendo de la cantidad de notas en la pista.
+#. TRANS: Carga MIDI. Esto puede tardar un tiempo dependiendo de la cantidad de notas en la pista.
 msgid "MIDI loading. This may take some time depending upon the number of notes in the track"
 msgstr ""
 
 #: js/widgets/aiwidget.js:550
 #: js/widgets/sampler.js:252
-#.TRANS: Error en la carga: la muestra no es un archivo .WAV.
+#. TRANS: Error en la carga: la muestra no es un archivo .WAV.
 msgid "Upload failed: Sample is not a .wav file."
 msgstr ""
 
 #: js/widgets/aiwidget.js:677
 #: js/widgets/sampler.js:430
-#.TRANS: Guardar muestra de audio
+#. TRANS: Guardar muestra de audio
 msgid "Save sample"
 msgstr ""
 
 #: js/widgets/arpeggio.js:241
-#.TRANS: Haga clic en la cuadrícula para agregar pasos al arpegio.
+#. TRANS: Haga clic en la cuadrícula para agregar pasos al arpegio.
 msgid "Click in the grid to add steps to the arpeggio."
 msgstr ""
 
@@ -8724,27 +8724,27 @@ msgstr ""
 #: js/widgets/rhythmruler.js:1809
 #: js/widgets/rhythmruler.js:1810
 #: js/widgets/temperament.js:2165
-#.TRANS: Jugar todo
+#. TRANS: Jugar todo
 msgid "Play all"
 msgstr "llapanta pukllay"
 
 #: js/widgets/meterwidget.js:269
-#.TRANS: Reiniciar
+#. TRANS: Reiniciar
 msgid "Reset"
 msgstr ""
 
 #: js/widgets/meterwidget.js:295
-#.TRANS: Haga clic en el círculo para seleccionar ritmos fuertes para el medidor.
+#. TRANS: Haga clic en el círculo para seleccionar ritmos fuertes para el medidor.
 msgid "Click in the circle to select strong beats for the meter."
 msgstr "Haga clic en el círculo para seleccionar ritmos fuertes para el medidor."
 
 #: js/widgets/modewidget.js:125
-#.TRANS: Girar en sentido antihorario
+#. TRANS: Girar en sentido antihorario
 msgid "Rotate counter clockwise"
 msgstr "Girar en sentido antihorario"
 
 #: js/widgets/modewidget.js:131
-#.TRANS: Girar en sentido horario
+#. TRANS: Girar en sentido horario
 msgid "Rotate clockwise"
 msgstr "lluq’iman muyuy"
 
@@ -8752,13 +8752,13 @@ msgstr "lluq’iman muyuy"
 #: js/widgets/pitchstaircase.js:676
 #: js/widgets/rhythmruler.js:578
 #: js/widgets/timbre.js:957
-#.TRANS: Deshacer
+#. TRANS: Deshacer
 msgid "Undo"
 msgstr "paskay"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
-#.TRANS: Haga clic en el círculo para seleccionar notas para el modo.
+#. TRANS: A circle of notes represents the musical mode.
+#. TRANS: Haga clic en el círculo para seleccionar notas para el modo.
 msgid "Click in the circle to select notes for the mode."
 msgstr "Haga clic en el círculo para seleccionar notas para el modo."
 
@@ -8770,18 +8770,18 @@ msgstr "Haga clic en el círculo para seleccionar notas para el modo."
 #: js/widgets/temperament.js:1862
 #: js/widgets/tempo.js:412
 #: js/widgets/phrasemaker.js:5467
-#.TRANS: Nuevo bloque de acción creado.
+#. TRANS: Nuevo bloque de acción creado.
 msgid "New action block generated."
 msgstr ""
 
 #: js/widgets/musickeyboard.js:743
 #: js/widgets/phrasemaker.js:595
-#.TRANS: Agrega una nota
+#. TRANS: Agrega una nota
 msgid "Add note"
 msgstr "Agrega una nota"
 
 #: js/widgets/musickeyboard.js:762
-#.TRANS: Metrónomo
+#. TRANS: Metrónomo
 msgid "Metronome"
 msgstr ""
 
@@ -8790,80 +8790,80 @@ msgid "Note value"
 msgstr ""
 
 #: js/widgets/musickeyboard.js:3209
-#.TRANS: Nuevo bloques de acción creado.
+#. TRANS: Nuevo bloques de acción creado.
 msgid "New action blocks generated."
 msgstr ""
 
 #: js/widgets/musickeyboard.js:3393
 #: js/widgets/musickeyboard.js:3401
-#.TRANS: Dispositivo MIDI presente.
+#. TRANS: Dispositivo MIDI presente.
 msgid "MIDI device present."
 msgstr ""
 
 #: js/widgets/musickeyboard.js:3404
-#.TRANS: No se encontró ningún dispositivo MIDI.
+#. TRANS: No se encontró ningún dispositivo MIDI.
 msgid "No MIDI device found."
 msgstr ""
 
 #: js/widgets/musickeyboard.js:3414
-#.TRANS: Error al obtener acceso MIDI en el navegador.
+#. TRANS: Error al obtener acceso MIDI en el navegador.
 msgid "Failed to get MIDI access in browser."
 msgstr ""
 
 #: js/widgets/pitchdrummatrix.js:356
 #: js/widgets/pitchdrummatrix.js:741
-#.TRANS: Haga clic en la cuadrícula para asignar notas a sonidos de tambors
+#. TRANS: Haga clic en la cuadrícula para asignar notas a sonidos de tambors
 msgid "Click in the grid to map notes to drums."
 msgstr "Haga clic en la cuadrícula para asignar notas a sonidos de tambors"
 
 #: js/widgets/pitchslider.js:103
-#.TRANS: Ascender
+#. TRANS: Ascender
 msgid "Move up"
 msgstr "wichay"
 
 #: js/widgets/pitchslider.js:114
-#.TRANS: Descender
+#. TRANS: Descender
 msgid "Move down"
 msgstr "uraqay"
 
 #: js/widgets/pitchslider.js:136
-#.TRANS: Haga clic en el control deslizante para crear un bloque de notas.
+#. TRANS: Haga clic en el control deslizante para crear un bloque de notas.
 msgid "Click on the slider to create a note block."
 msgstr "Haga clic en el control deslizante para crear un bloque de notas."
 
 #: js/widgets/pitchstaircase.js:622
-#.TRANS: Tocar un acorde
+#. TRANS: Tocar un acorde
 msgid "Play chord"
 msgstr "Tocar un acorde"
 
 #: js/widgets/pitchstaircase.js:630
-#.TRANS: Tocar una escala
+#. TRANS: Tocar una escala
 msgid "Play scale"
 msgstr "Tocar una escala"
 
 #: js/widgets/pitchstaircase.js:694
-#.TRANS: Haga clic en una nota para crear un nuevo paso.
+#. TRANS: Haga clic en una nota para crear un nuevo paso.
 msgid "Click on a note to create a new step."
 msgstr "Haga clic en una nota para crear un nuevo paso."
 
 #: js/widgets/rhythmruler.js:486
-#.TRANS: Guardar ritmos
+#. TRANS: Guardar ritmos
 msgid "Save rhythms"
 msgstr "T’impuchisqata waqaychay"
 
 #: js/widgets/rhythmruler.js:512
-#.TRANS: Guardar la caja de ritmos
+#. TRANS: Guardar la caja de ritmos
 msgid "Save drum machine"
 msgstr "tawa k’uchu t’impumusqakuna waqaychana"
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
-#.TRANS: Toca un ritmo
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: Toca un ritmo
 msgid "Tap a rhythm"
 msgstr "Toca un ritmo"
 
 #: js/widgets/rhythmruler.js:813
-#.TRANS: Haga clic en la regla para dividirla.
+#. TRANS: Haga clic en la regla para dividirla.
 msgid "Click on the ruler to divide it."
 msgstr "Haga clic en la regla para dividirla."
 
@@ -8873,63 +8873,63 @@ msgstr "Haga clic en la regla para dividirla."
 #: js/widgets/rhythmruler.js:1149
 #: js/widgets/rhythmruler.js:1760
 #: js/widgets/rhythmruler.js:1761
-#.TRANS: tocar un ritmo
+#. TRANS: tocar un ritmo
 msgid "tap a rhythm"
 msgstr "tocar un ritmo"
 
 #: js/widgets/rhythmruler.js:1453
-#.TRANS: Se ha superado el valor máximo de 256.
+#. TRANS: Se ha superado el valor máximo de 256.
 msgid "Maximum value of 256 has been exceeded."
 msgstr "Se ha superado el valor máximo de 256."
 
 #: js/widgets/sampler.js:235
-#.TRANS: grabación comenzada
+#. TRANS: grabación comenzada
 msgid "Recording started"
 msgstr ""
 
 #: js/widgets/sampler.js:243
-#.TRANS: grabación completa
+#. TRANS: grabación completa
 msgid "Recording complete"
 msgstr ""
 
 #: js/widgets/sampler.js:281
-#.TRANS: Se generó un nuevo bloque de muestra de audio.
+#. TRANS: Se generó un nuevo bloque de muestra de audio.
 msgid "A new sample block was generated."
 msgstr ""
 
 #: js/widgets/sampler.js:376
-#.TRANS: Subir muestra de audio
+#. TRANS: Subir muestra de audio
 msgid "Upload sample"
 msgstr ""
 
 #: js/widgets/sampler.js:397
-#.TRANS: Advertencia: Su muestra no se puede cargar porque es >1 MB.
+#. TRANS: Advertencia: Su muestra no se puede cargar porque es >1 MB.
 msgid "Warning: Your sample cannot be loaded because it is >1MB."
 msgstr ""
 
 #: js/widgets/sampler.js:446
-#.TRANS: Alternar el micrófono
+#. TRANS: Alternar el micrófono
 msgid "Toggle Mic"
 msgstr ""
 
 #: js/widgets/sampler.js:453
-#.TRANS: Reproducir
+#. TRANS: Reproducir
 msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
-#.TRANS: tono de referencia
+#. TRANS: The reference tone is a sound used for comparison.
+#. TRANS: tono de referencia
 msgid "reference tone"
 msgstr ""
 
 #: js/widgets/temperament.js:319
-#.TRANS: volver al espacio de octava 2: 1
+#. TRANS: volver al espacio de octava 2: 1
 msgid "back to 2:1 octave space"
 msgstr ""
 
 #: js/widgets/temperament.js:445
-#.TRANS: editar
+#. TRANS: editar
 msgid "edit"
 msgstr ""
 
@@ -8943,39 +8943,39 @@ msgstr ""
 #: js/widgets/temperament.js:1379
 #: js/widgets/temperament.js:1448
 #: js/widgets/temperament.js:1529
-#.TRANS: terminado
+#. TRANS: terminado
 msgid "done"
 msgstr ""
 
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:587
 #: js/widgets/temperament.js:1021
-#.TRANS: proporción
+#. TRANS: proporción
 msgid "ratio"
 msgstr ""
 
 #: js/widgets/temperament.js:588
-#.TRANS: intervalo
+#. TRANS: intervalo
 msgid "interval"
 msgstr ""
 
 #: js/widgets/temperament.js:716
-#.TRANS: no escalar
+#. TRANS: no escalar
 msgid "non scalar"
 msgstr ""
 
 #: js/widgets/temperament.js:757
-#.TRANS: proporcións
+#. TRANS: proporcións
 msgid "ratios"
 msgstr ""
 
 #: js/widgets/temperament.js:757
-#.TRANS: arbitrario
+#. TRANS: arbitrario
 msgid "arbitrary"
 msgstr ""
 
 #: js/widgets/temperament.js:828
-#.TRANS: número de divisiones
+#. TRANS: número de divisiones
 msgid "number of divisions"
 msgstr ""
 
@@ -8983,278 +8983,278 @@ msgstr ""
 #: js/widgets/temperament.js:958
 #: js/widgets/temperament.js:1037
 #: js/widgets/temperament.js:1128
-#.TRANS: preestreno
+#. TRANS: preestreno
 msgid "preview"
 msgstr ""
 
 #: js/widgets/temperament.js:888
-#.TRANS: El número de divisiones es demasiado grande.
+#. TRANS: El número de divisiones es demasiado grande.
 msgid "The Number of divisions is too large."
 msgstr ""
 
 #: js/widgets/temperament.js:1023
-#.TRANS: recursividad
+#. TRANS: recursividad
 msgid "recursion"
 msgstr ""
 
 #: js/widgets/temperament.js:1549
-#.TRANS: La proporción de octavas ha cambiado. Esto cambia el temperamento de manera significativa.
+#. TRANS: La proporción de octavas ha cambiado. Esto cambia el temperamento de manera significativa.
 msgid "The octave ratio has changed. This changes temperament significantly."
 msgstr ""
 
 #: js/widgets/temperament.js:2177
-#.TRANS: Tabla
+#. TRANS: Tabla
 msgid "Table"
 msgstr "tawla"
 
 #: js/widgets/temperament.js:2285
-#.TRANS: añadir tonos
+#. TRANS: añadir tonos
 msgid "Add pitches"
 msgstr "kunkakuna yapay"
 
 #: js/widgets/tempo.js:111
-#.TRANS: Guardar tempo
+#. TRANS: Guardar tempo
 msgid "Save tempo"
 msgstr "Pacha waqaychay"
 
 #: js/widgets/tempo.js:142
-#.TRANS: acelerar
+#. TRANS: acelerar
 msgid "speed up"
 msgstr "utqhaychay"
 
 #: js/widgets/tempo.js:148
-#.TRANS: retardar
+#. TRANS: retardar
 msgid "slow down"
 msgstr "qhipariy"
 
 #: js/widgets/tempo.js:192
-#.TRANS: Ajusta el tempo con los botones.
+#. TRANS: Ajusta el tempo con los botones.
 msgid "Adjust the tempo with the buttons."
 msgstr "Ajusta el tempo con los botones."
 
 #: js/widgets/tempo.js:259
-#.TRANS: Por favor, introduzca un número entre 30 y 1000.
+#. TRANS: Por favor, introduzca un número entre 30 y 1000.
 msgid "Please enter a number between 30 and 1000"
 msgstr ""
 
 #: js/widgets/tempo.js:266
 #: js/widgets/tempo.js:269
-#.TRANS: Los latidos por minuto deben estar entre 30 y 1000.
+#. TRANS: Los latidos por minuto deben estar entre 30 y 1000.
 msgid "The beats per minute must be between 30 and 1000."
 msgstr "Los latidos por minuto deben estar entre 30 y 1000."
 
 #: js/widgets/tempo.js:285
-#.TRANS: Los latidos por minuto deben estar por debajo de 1000.
+#. TRANS: Los latidos por minuto deben estar por debajo de 1000.
 msgid "The beats per minute must be below 1000."
 msgstr ""
 
 #: js/widgets/tempo.js:301
-#.TRANS: Los latidos por minuto deben ser superiores a 30.
+#. TRANS: Los latidos por minuto deben ser superiores a 30.
 msgid "The beats per minute must be above 30"
 msgstr ""
 
 #: js/widgets/timbre.js:760
-#.TRANS: Sintetizador
+#. TRANS: Sintetizador
 msgid "Synthesizer"
 msgstr "Huch’uyachispa tikraq"
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: Efectos
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: Efectos
 msgid "Effects"
 msgstr "Tikrasqa kunka"
 
 #: js/widgets/timbre.js:940
-#.TRANS: Agregar un filtro
+#. TRANS: Agregar un filtro
 msgid "Add filter"
 msgstr "Ch’uyaqta churay"
 
 #: js/widgets/timbre.js:981
-#.TRANS: Haga clic en los botones para abrir las herramientas de diseño de timbre.
+#. TRANS: Haga clic en los botones para abrir las herramientas de diseño de timbre.
 msgid "Click on buttons to open the timbre design tools."
 msgstr "Haga clic en los botones para abrir las herramientas de diseño de timbre."
 
 #: js/widgets/timbre.js:1265
-#.TRANS: armonía
+#. TRANS: armonía
 msgid "harmonicity"
 msgstr "tupasqa"
 
 #: js/widgets/timbre.js:1332
 #: js/widgets/timbre.js:1398
-#.TRANS: índice de modulación
+#. TRANS: índice de modulación
 msgid "modulation index"
 msgstr "imanas kunka tupasqa"
 
 #: js/widgets/timbre.js:1476
-#.TRANS: cantidad de vibrato
+#. TRANS: cantidad de vibrato
 msgid "vibrato amount"
 msgstr "kunkachasqa"
 
 #: js/widgets/timbre.js:1911
-#.TRANS: filtro ya presente
+#. TRANS: filtro ya presente
 msgid "Filter already present."
 msgstr "filtro ya presente"
 
 #: js/widgets/timbre.js:2495
-#.TRANS: cantidad de distorsión
+#. TRANS: cantidad de distorsión
 msgid "distortion amount"
 msgstr "cantidad de distorsión"
 
 #: js/widgets/oscilloscope.js:79
-#.TRANS: Hacer zoom
+#. TRANS: Hacer zoom
 msgid "Zoom In"
 msgstr ""
 
 #: js/widgets/oscilloscope.js:88
-#.TRANS: Alejar
+#. TRANS: Alejar
 msgid "Zoom Out"
 msgstr ""
 
 #: js/widgets/phrasemaker.js:585
-#.TRANS: Exportar
+#. TRANS: Exportar
 msgid "Export"
 msgstr "hurquy"
 
 #: js/widgets/phrasemaker.js:592
-#.TRANS: Ordenar
+#. TRANS: Ordenar
 msgid "Sort"
 msgstr "ñiq’ichay"
 
 #: js/widgets/phrasemaker.js:1061
-#.TRANS: Haga clic en la tabla para agregar notas.
+#. TRANS: Haga clic en la tabla para agregar notas.
 msgid "Click on the table to add notes."
 msgstr "Haga clic en la tabla para agregar notas."
 
 #: js/widgets/phrasemaker.js:2755
 #: js/widgets/phrasemaker.js:2891
-#.TRANS: valor del tuplet
+#. TRANS: valor del tuplet
 msgid "tuplet value"
 msgstr "valor del tuplet"
 
 #: planet/js/GlobalCard.js:68
-#.TRANS: Compartir
+#. TRANS: Compartir
 msgid "Share"
 msgstr "rakinakuy"
 
 #: planet/js/GlobalCard.js:74
-#.TRANS: Banderas
+#. TRANS: Banderas
 msgid "Flags"
 msgstr "wiphalakuna"
 
 #: planet/js/GlobalPlanet.js:35
-#.TRANS: No se han encontrado resultados.
+#. TRANS: No se han encontrado resultados.
 msgid "No results found."
 msgstr "No se han encontrado resultados."
 
 #: planet/js/GlobalPlanet.js:51
-#.TRANS: Remix de
+#. TRANS: Remix de
 msgid "Remix of"
 msgstr "Remix de"
 
 #: planet/js/GlobalPlanet.js:509
-#.TRANS: No es posible conectar con el servidor.
+#. TRANS: No es posible conectar con el servidor.
 msgid "Cannot connect to server"
 msgstr "No es posible conectar con el servidor."
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: todos los proyectos
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: todos los proyectos
 msgid "All Projects"
 msgstr "llapam hatun llamk’anakuna"
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: Mis proyectos
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: Mis proyectos
 msgid "My Projects"
 msgstr "Mis proyectos"
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: ejemplos
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: ejemplos
 msgid "Examples"
 msgstr "ahinakuna"
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: arte
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: arte
 msgid "Art"
 msgstr "imapas t’ikray"
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: mates
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: mates
 msgid "Math"
 msgstr "mati"
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: interactivo
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: interactivo
 msgid "Interactive"
 msgstr "llapam llamk’aq"
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: diseño
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: diseño
 msgid "Design"
 msgstr "diseño"
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: juego
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: juego
 msgid "Game"
 msgstr "pukllay"
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
-#.TRANS: fragmento de código
+#. TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: fragmento de código
 msgid "Code Snippet"
 msgstr ""
 
 #: planet/js/LocalCard.js:36
-#.TRANS: Ver proyecto publicado
+#. TRANS: Ver proyecto publicado
 msgid "View published project"
 msgstr "Ver proyecto publicado"
 
 #: planet/js/LocalCard.js:42
 #: planet/js/StringHelper.js:38
-#.TRANS: Publicar proyecto
+#. TRANS: Publicar proyecto
 msgid "Publish project"
 msgstr "Publicar proyecto"
 
 #: planet/js/LocalCard.js:51
-#.TRANS: Editar proyecto
+#. TRANS: Editar proyecto
 msgid "Edit project"
 msgstr "Editar proyecto"
 
 #: planet/js/LocalCard.js:52
-#.TRANS: Borrar proyecto
+#. TRANS: Borrar proyecto
 msgid "Delete project"
 msgstr "Borrar proyecto"
 
 #: planet/js/LocalCard.js:53
-#.TRANS: Descargar proyecto
+#. TRANS: Descargar proyecto
 msgid "Download project"
 msgstr "Descargar proyecto"
 
 #: planet/js/LocalCard.js:55
-#.TRANS: Duplucar proyecto
+#. TRANS: Duplucar proyecto
 msgid "Duplicate project"
 msgstr "Duplucar proyecto"
 
 #: planet/js/ProjectStorage.js:243
-#.TRANS: anónimo
+#. TRANS: anónimo
 msgid "anonymous"
 msgstr "mana sutiyuq"
 
 #: planet/js/ProjectViewer.js:30
-#.TRANS: Error: No se pudo enviar el informe. Inténtalo de nuevo más tarde.
+#. TRANS: Error: No se pudo enviar el informe. Inténtalo de nuevo más tarde.
 msgid "Error: Report could not be submitted. Try again later."
 msgstr "pantay: manam willakuy apachiy atikunchu. Wakmanta ch’isiyaykuyman atipayay"
 
 #: planet/js/ProjectViewer.js:31
-#.TRANS: Gracias por reportar este proyecto. Un moderador revisará el proyecto en breve para verificar la violación del Código de conducta de Sugar Labs.
+#. TRANS: Gracias por reportar este proyecto. Un moderador revisará el proyecto en breve para verificar la violación del Código de conducta de Sugar Labs.
 msgid "Thank you for reporting this project. A moderator will review the project shortly, to verify violation of the Sugar Labs Code of Conduct."
 msgstr "Añay kay hatun llamk’aymanta willawasqaykimanta. Pisillamantan huk allipunaq hatun llamk’anata qhawanqa, Sugar labspa riqsichinanta qhillichasqanta qhawananpaq"
 
@@ -9262,527 +9262,527 @@ msgstr "Añay kay hatun llamk’aymanta willawasqaykimanta. Pisillamantan huk al
 #: planet/js/StringHelper.js:62
 #: planet/js/StringHelper.js:64
 #: planet/js/StringHelper.js:68
-#.TRANS: Informe de proyecto
+#. TRANS: Informe de proyecto
 msgid "Report Project"
 msgstr "hatun llamk’aymanta willakuy"
 
 #: planet/js/ProjectViewer.js:33
 #: planet/js/StringHelper.js:63
-#.TRANS: Proyecto informado
+#. TRANS: Proyecto informado
 msgid "Project Reported"
 msgstr "hatun llamk’asqa willasqa"
 
 #: planet/js/ProjectViewer.js:34
-#.TRANS: Descripción requerida
+#. TRANS: Descripción requerida
 msgid "Report description required"
 msgstr "willakusqa mañay"
 
 #: planet/js/ProjectViewer.js:35
-#.TRANS: La descripción es demasiado larga.
+#. TRANS: La descripción es demasiado larga.
 msgid "Report description too long"
 msgstr "willakuyqa sinchi chutasqa"
 
 #: planet/js/Publisher.js:30
-#.TRANS: Característica no disponible: no se puede conectar al servidor. Vuelve a cargar Bloques de Música para intentarlo de nuevo.
+#. TRANS: Característica no disponible: no se puede conectar al servidor. Vuelve a cargar Bloques de Música para intentarlo de nuevo.
 msgid "Feature unavailable - cannot connect to server. Reload Music Blocks to try again."
 msgstr " manan imayna kasqan kanchu: manam qarakuqman hap’ichiy atikunchu "
 
 #: planet/js/Publisher.js:220
 #: planet/js/Publisher.js:237
-#.TRANS: Este campo es requerido.
+#. TRANS: Este campo es requerido.
 msgid "This field is required"
 msgstr "kay chiqasqa mañasqa"
 
 #: planet/js/Publisher.js:227
-#.TRANS: Título es demasiado largo.
+#. TRANS: Título es demasiado largo.
 msgid "Title too long"
 msgstr "Sutinqa sinchi hatun"
 
 #: planet/js/Publisher.js:244
-#.TRANS: La descripción es demasiado largo.
+#. TRANS: La descripción es demasiado largo.
 msgid "Description too long"
 msgstr "riqsichikuyqa sinchi hatun"
 
 #: planet/js/Publisher.js:341
-#.TRANS: Error del Servidor
+#. TRANS: Error del Servidor
 msgid "Server Error"
 msgstr "qarakuqpa pantasqan"
 
 #: planet/js/Publisher.js:341
-#.TRANS: Inténtalo de nuevo
+#. TRANS: Inténtalo de nuevo
 msgid "Try Again"
 msgstr "wakmanta rurapakuy"
 
 #: planet/js/SaveInterface.js:34
-#.TRANS: Abrir en Bloques de Música
+#. TRANS: Abrir en Bloques de Música
 msgid "Open in Music Blocks"
 msgstr "Taki chiqaspi kichay"
 
 #: planet/js/SaveInterface.js:35
-#.TRANS: Abierto en TortuBloques
+#. TRANS: Abierto en TortuBloques
 msgid "Open in Turtle Blocks"
 msgstr ""
 
 #: planet/js/helper.js:149
 #: planet/js/StringHelper.js:49
-#.TRANS: Mostrar más etiquetas
+#. TRANS: Mostrar más etiquetas
 msgid "Show more tags"
 msgstr "Mostrar más etiquetas"
 
 #: planet/js/helper.js:150
-#.TRANS: Mostrar menos etiquetas
+#. TRANS: Mostrar menos etiquetas
 msgid "Show fewer tags"
 msgstr "pisi sutichasqakuna qhawachiy "
 
 #: planet/js/StringHelper.js:30
-#.TRANS: Planeta
+#. TRANS: Planeta
 msgid "Planet"
 msgstr "Planeta"
 
 #: planet/js/StringHelper.js:31
-#.TRANS: Cerrar Planeta
+#. TRANS: Cerrar Planeta
 msgid "Close Planet"
 msgstr "Cerrar Planeta"
 
 #: planet/js/StringHelper.js:32
-#.TRANS: Abrir proyecto desde archivo
+#. TRANS: Abrir proyecto desde archivo
 msgid "Open project from file"
 msgstr "Abrir proyecto desde archivo"
 
 #: planet/js/StringHelper.js:34
-#.TRANS: Local
+#. TRANS: Local
 msgid "Local"
 msgstr ""
 
 #: planet/js/StringHelper.js:35
-#.TRANS: Global
+#. TRANS: Global
 msgid "Global"
 msgstr ""
 
 #: planet/js/StringHelper.js:36
-#.TRANS: Buscar un proyecto
+#. TRANS: Buscar un proyecto
 msgid "Search for a project"
 msgstr "Buscar un proyecto"
 
 #: planet/js/StringHelper.js:40
-#.TRANS: Etiquetas (max 5)
+#. TRANS: Etiquetas (max 5)
 msgid "Tags (max 5)"
 msgstr "Etiquetas (max 5)"
 
 #: planet/js/StringHelper.js:41
 #: planet/js/StringHelper.js:61
-#.TRANS: Descripción
+#. TRANS: Descripción
 msgid "Description"
 msgstr "Descripción"
 
 #: planet/js/StringHelper.js:42
 #: planet/js/StringHelper.js:67
-#.TRANS: Presentar
+#. TRANS: Presentar
 msgid "Submit"
 msgstr "Presentar"
 
 #: planet/js/StringHelper.js:43
 #: planet/js/StringHelper.js:47
-#.TRANS: Cancelar
+#. TRANS: Cancelar
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: planet/js/StringHelper.js:44
-#.TRANS: Borrar \\"<span id=\\"deleter-title\\"></span>\\"?
+#. TRANS: Borrar \\"<span id=\\"deleter-title\\"></span>\\"?
 msgid "Delete \\"<span id=\\"deleter-title\\"></span>\\"?"
 msgstr "Borrar \\"<span id=\\"deleter-title\\"></span>\\"?"
 
 #: planet/js/StringHelper.js:45
-#.TRANS: Eliminar permanentemente el proyecto \\"<span id=\\"deleter-name\\"></span>\\"?
+#. TRANS: Eliminar permanentemente el proyecto \\"<span id=\\"deleter-name\\"></span>\\"?
 msgid "Permanently delete project \\"<span id=\\"deleter-name\\"></span>\\"?"
 msgstr "Eliminar permanentemente el proyecto \\"<span id=\\"deleter-name\\"></span>\\"?"
 
 #: planet/js/StringHelper.js:48
-#.TRANS: Explorar proyectos
+#. TRANS: Explorar proyectos
 msgid "Explore Projects"
 msgstr "Explorar proyectos"
 
 #: planet/js/StringHelper.js:50
-#.TRANS: Más reciente
+#. TRANS: Más reciente
 msgid "Most recent"
 msgstr "Más reciente"
 
 #: planet/js/StringHelper.js:51
-#.TRANS: Más gustado
+#. TRANS: Más gustado
 msgid "Most liked"
 msgstr "Más gustado"
 
 #: planet/js/StringHelper.js:52
-#.TRANS: Más descargados
+#. TRANS: Más descargados
 msgid "Most downloaded"
 msgstr "achka apaqasqakuna"
 
 #: planet/js/StringHelper.js:53
-#.TRANS: A-Z
+#. TRANS: A-Z
 msgid "A-Z"
 msgstr ""
 
 #: planet/js/StringHelper.js:54
-#.TRANS: Ordenar por
+#. TRANS: Ordenar por
 msgid "Sort by"
 msgstr "kamachisqa"
 
 #: planet/js/StringHelper.js:55
-#.TRANS: Cargar más proyectos
+#. TRANS: Cargar más proyectos
 msgid "Load More Projects"
 msgstr "astawan hatun llamk’aykunata q’ipichay"
 
 #: planet/js/StringHelper.js:56
-#.TRANS: ÃÂltima actualización
+#. TRANS: ÃÂltima actualización
 msgid "Last Updated"
 msgstr "qhipa kunanchay"
 
 #: planet/js/StringHelper.js:57
-#.TRANS: Fecha de creación
+#. TRANS: Fecha de creación
 msgid "Creation Date"
 msgstr "paqarichisqa p’unchaw"
 
 #: planet/js/StringHelper.js:58
-#.TRANS: Numero de descargas:
+#. TRANS: Numero de descargas:
 msgid "Number of Downloads:"
 msgstr "apaqasqa yupay"
 
 #: planet/js/StringHelper.js:59
-#.TRANS: Número de me gusta:
+#. TRANS: Número de me gusta:
 msgid "Number of Likes:"
 msgstr "munasqay yupay"
 
 #: planet/js/StringHelper.js:60
-#.TRANS: Etiquetas:
+#. TRANS: Etiquetas:
 msgid "Tags:"
 msgstr "sutichasqakuna"
 
 #: planet/js/StringHelper.js:65
-#.TRANS: Reportar proyectos que violen <a href=\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">el código de conducta de Sugar Labs</a>.
+#. TRANS: Reportar proyectos que violen <a href=\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">el código de conducta de Sugar Labs</a>.
 msgid "Report projects which violate the <a href=\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">Sugar Labs Code of Conduct</a>."
 msgstr " hatun llamk’aymanta willakuy may llik'iy"
 
 #: planet/js/StringHelper.js:66
-#.TRANS: Razón para informar el proyecto
+#. TRANS: Razón para informar el proyecto
 msgid "Reason for reporting project"
 msgstr "Ima rayku hatun llamk’anamanta willakuy"
 
 #: planet/js/StringHelper.js:70
-#.TRANS: Descargar como archivo
+#. TRANS: Descargar como archivo
 msgid "Download as File"
 msgstr "waqaychasqatahina apaqana"
 
 #: plugins/accelerometer.rtp:48
-#.TRANS: x del acelerómetro
+#. TRANS: x del acelerómetro
 msgid "motion x"
 msgstr "x del acelerómetro"
 
 #: plugins/accelerometer.rtp:56
-#.TRANS: y del acelerómetro
+#. TRANS: y del acelerómetro
 msgid "motion y"
 msgstr "y del acelerómetro"
 
 #: plugins/accelerometer.rtp:64
-#.TRANS: z del acelerómetro
+#. TRANS: z del acelerómetro
 msgid "motion z"
 msgstr "z del acelerómetro"
 
 #: plugins/facebook.rtp:27
-#.TRANS: publicar
+#. TRANS: publicar
 msgid "publish"
 msgstr "publicar"
 
 #: plugins/maths.rtp:62
-#.TRANS: poder
+#. TRANS: poder
 msgid "power"
 msgstr "poder"
 
 #: plugins/maths.rtp:62
-#.TRANS: base
+#. TRANS: base
 msgid "base"
 msgstr ""
 
 #: plugins/maths.rtp:62
-#.TRANS: exp
+#. TRANS: exp
 msgid "exp"
 msgstr ""
 
 #: plugins/maths.rtp:99
-#.TRANS: piso
+#. TRANS: piso
 msgid "floor"
 msgstr "piso"
 
 #: plugins/maths.rtp:104
-#.TRANS: techo
+#. TRANS: techo
 msgid "ceiling"
 msgstr "techo"
 
 #: plugins/maths.rtp:109
-#.TRANS: a grados
+#. TRANS: a grados
 msgid "to degrees"
 msgstr "a grados"
 
 #: plugins/maths.rtp:114
-#.TRANS: a radianes
+#. TRANS: a radianes
 msgid "to radians"
 msgstr "a radianes"
 
 #: plugins/nutrition.rtp:104
-#.TRANS: obtener calorías
+#. TRANS: obtener calorías
 msgid "get calories"
 msgstr "obtener calorías"
 
 #: plugins/nutrition.rtp:107
-#.TRANS: obtener proteínas
+#. TRANS: obtener proteínas
 msgid "get protein"
 msgstr "obtener proteínas"
 
 #: plugins/nutrition.rtp:110
-#.TRANS: obtener carbohidratos
+#. TRANS: obtener carbohidratos
 msgid "get carbs"
 msgstr "obtener carbohidratos"
 
 #: plugins/nutrition.rtp:113
-#.TRANS: obtener fibra
+#. TRANS: obtener fibra
 msgid "get fiber"
 msgstr "obtener fibra"
 
 #: plugins/nutrition.rtp:116
-#.TRANS: obtener grasas
+#. TRANS: obtener grasas
 msgid "get fat"
 msgstr "obtener grasas"
 
 #: plugins/nutrition.rtp:119
-#.TRANS: obtener nombre
+#. TRANS: obtener nombre
 msgid "get name"
 msgstr "obtener nombre"
 
 #: plugins/nutrition.rtp:122
-#.TRANS: calorías
+#. TRANS: calorías
 msgid "calories"
 msgstr "calorías"
 
 #: plugins/nutrition.rtp:128
-#.TRANS: proteína
+#. TRANS: proteína
 msgid "protein"
 msgstr "proteína"
 
 #: plugins/nutrition.rtp:134
-#.TRANS: carbohidratos
+#. TRANS: carbohidratos
 msgid "carbs"
 msgstr "carbohidratos"
 
 #: plugins/nutrition.rtp:140
-#.TRANS: fibra
+#. TRANS: fibra
 msgid "fiber"
 msgstr "fibra"
 
 #: plugins/nutrition.rtp:146
-#.TRANS: grasa
+#. TRANS: grasa
 msgid "fat"
 msgstr "grasa"
 
 #: plugins/nutrition.rtp:152
-#.TRANS: comer
+#. TRANS: comer
 msgid "eat"
 msgstr "comer"
 
 #: plugins/nutrition.rtp:155
-#.TRANS: digerir
+#. TRANS: digerir
 msgid "digest meal"
 msgstr "digerir"
 
 #: plugins/nutrition.rtp:158
-#.TRANS: manzana
+#. TRANS: manzana
 msgid "apple"
 msgstr "manzana"
 
 #: plugins/nutrition.rtp:161
-#.TRANS: banana
+#. TRANS: banana
 msgid "banana"
 msgstr ""
 
 #: plugins/nutrition.rtp:167
-#.TRANS: pan
+#. TRANS: pan
 msgid "wheat bread"
 msgstr "pan"
 
 #: plugins/nutrition.rtp:170
-#.TRANS: maíz
+#. TRANS: maíz
 msgid "corn"
 msgstr "maíz"
 
 #: plugins/nutrition.rtp:173
-#.TRANS: papa
+#. TRANS: papa
 msgid "potato"
 msgstr "papa"
 
 #: plugins/nutrition.rtp:176
-#.TRANS: boñato
+#. TRANS: boñato
 msgid "sweet potato"
 msgstr "boñato"
 
 #: plugins/nutrition.rtp:179
-#.TRANS: tomate
+#. TRANS: tomate
 msgid "tomato"
 msgstr "tomate"
 
 #: plugins/nutrition.rtp:182
-#.TRANS: brócoli
+#. TRANS: brócoli
 msgid "broccoli"
 msgstr "brócoli"
 
 #: plugins/nutrition.rtp:185
-#.TRANS: arroz y frijoles
+#. TRANS: arroz y frijoles
 msgid "rice and beans"
 msgstr "arroz y frijoles"
 
 #: plugins/nutrition.rtp:188
-#.TRANS: tamal
+#. TRANS: tamal
 msgid "tamale"
 msgstr "tamal"
 
 #: plugins/nutrition.rtp:191
-#.TRANS: queso
+#. TRANS: queso
 msgid "cheese"
 msgstr "queso"
 
 #: plugins/nutrition.rtp:194
-#.TRANS: pollo
+#. TRANS: pollo
 msgid "chicken"
 msgstr "pollo"
 
 #: plugins/nutrition.rtp:197
-#.TRANS: pescado
+#. TRANS: pescado
 msgid "fish"
 msgstr "pescado"
 
 #: plugins/nutrition.rtp:200
-#.TRANS: carne de res
+#. TRANS: carne de res
 msgid "beef"
 msgstr "carne de res"
 
 #: plugins/nutrition.rtp:203
-#.TRANS: pastel
+#. TRANS: pastel
 msgid "cake"
 msgstr "pastel"
 
 #: plugins/nutrition.rtp:206
-#.TRANS: galleta
+#. TRANS: galleta
 msgid "cookie"
 msgstr "galleta"
 
 #: plugins/nutrition.rtp:209
-#.TRANS: agua
+#. TRANS: agua
 msgid "water"
 msgstr "agua"
 
 #: plugins/weather.rtp:68
 #: plugins/weather.rtp:97
-#.TRANS: Los días siguientes deben estar en el rango de -1 a 5.
+#. TRANS: Los días siguientes deben estar en el rango de -1 a 5.
 msgid "Days ahead must be in the range of -1 to 5."
 msgstr "Los días siguientes deben estar en el rango de -1 a 5."
 
 #: plugins/weather.rtp:122
-#.TRANS: pronóstico
+#. TRANS: pronóstico
 msgid "forecast"
 msgstr "pronóstico"
 
 #: plugins/weather.rtp:123
 #: plugins/weather.rtp:137
 #: plugins/weather.rtp:150
-#.TRANS: ciudad
+#. TRANS: ciudad
 msgid "city"
 msgstr "ciudad"
 
 #: plugins/weather.rtp:124
 #: plugins/weather.rtp:138
 #: plugins/weather.rtp:151
-#.TRANS: día
+#. TRANS: día
 msgid "day"
 msgstr "día"
 
 #: plugins/weather.rtp:136
-#.TRANS: alta
+#. TRANS: alta
 msgid "high"
 msgstr "alta"
 
 #: plugins/weather.rtp:149
-#.TRANS: baja
+#. TRANS: baja
 msgid "low"
 msgstr "baja"
 
 #: plugins/rodi.rtp:172
-#.TRANS: parpadear
+#. TRANS: parpadear
 msgid "blink"
 msgstr "parpadear"
 
 #: plugins/rodi.rtp:246
-#.TRANS: LED
+#. TRANS: LED
 msgid "led"
 msgstr ""
 
 #: plugins/rodi.rtp:265
-#.TRANS: intensidad de luz
+#. TRANS: intensidad de luz
 msgid "light intensity"
 msgstr "intensidad de luz"
 
 #: plugins/rodi.rtp:282
-#.TRANS: luz infrarroja (izquierda)
+#. TRANS: luz infrarroja (izquierda)
 msgid "infrared light (left)"
 msgstr "luz infrarroja (izquierda)"
 
 #: plugins/rodi.rtp:296
-#.TRANS: luz infrarroja (derecha)
+#. TRANS: luz infrarroja (derecha)
 msgid "infrared light (right)"
 msgstr "luz infrarroja (derecha)"
 
 #: plugins/rodi.rtp:338
-#.TRANS: mover
+#. TRANS: mover
 msgid "move"
 msgstr "mover"
 
 #: js/activity.js:3323
 
-#.TRANS: Nada en la basura para restaurar.
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#. TRANS: Nada en la basura para restaurar.
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#.TRANS: Guarda audio de tu proyecto como WAV.
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#. TRANS: Guarda audio de tu proyecto como WAV.
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#.TRANS: Guarda tu proyecto como un archivo ABC.
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#. TRANS: Guarda tu proyecto como un archivo ABC.
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#.TRANS: Guarde el proyecto como un archivo de LilyPond.
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#. TRANS: Guarde el proyecto como un archivo de LilyPond.
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#.TRANS: Mostrar u ocultar las rejillas de coordenadas.
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#. TRANS: Mostrar u ocultar las rejillas de coordenadas.
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#.TRANS: Expandir/contraer los bloques
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#. TRANS: Expandir/contraer los bloques
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#.TRANS: Mostrar estos mensajes.
-#~msgid "Show these messages."
-#~msgstr ""
+#. TRANS: Mostrar estos mensajes.
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9790,8 +9790,8 @@ msgstr "mover"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -9801,8 +9801,8 @@ msgstr "mover"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -9814,35 +9814,35 @@ msgstr "mover"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "qhawachiy"
+#~ msgid "show"
+#~ msgstr "qhawachiy"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -9856,69 +9856,69 @@ msgstr "mover"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "chiqaskunata pakay"
+#~ msgid "hide blocks"
+#~ msgstr "chiqaskunata pakay"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr "iskay kikiyachiy"
+#~ msgid "duplicate"
+#~ msgstr "iskay kikiyachiy"
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -9938,13 +9938,13 @@ msgstr "mover"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "sayachiy"
+#~ msgid "stop"
+#~ msgstr "sayachiy"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "kawsapakuy"
+#~ msgid "duration (ms)"
+#~ msgstr "kawsapakuy"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -9952,58 +9952,58 @@ msgstr "mover"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "pichay"
+#~ msgid "clear"
+#~ msgstr "pichay"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "t’ikray"
+#~ msgid "invert"
+#~ msgstr "t’ikray"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr "maymikuynin"
+#~ msgid "oscillator"
+#~ msgstr "maymikuynin"
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr "qhipay"
+#~ msgid "delay"
+#~ msgstr "qhipay"
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr "envolventes"
+#~ msgid "envelope"
+#~ msgstr "envolventes"
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr "suysuy"
+#~ msgid "filter"
+#~ msgstr "suysuy"
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10019,25 +10019,25 @@ msgstr "mover"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr "Nuevo bloque de acción creado!"
+#~ msgid "New action block generated!"
+#~ msgstr "Nuevo bloque de acción creado!"
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "unaykachiy"
+#~ msgid "duration"
+#~ msgstr "unaykachiy"
 
 #: js/widgets/temperament.js:454
 
@@ -10047,43 +10047,43 @@ msgstr "mover"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr "wisq’ay"
+#~ msgid "close"
+#~ msgstr "wisq’ay"
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr "Publicar el proyecto"
+#~ msgid "Publish Project"
+#~ msgstr "Publicar el proyecto"
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr "tocar"
+#~ msgid "play"
+#~ msgstr "tocar"
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10093,190 +10093,190 @@ msgstr "mover"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr "video llamk’ana"
+#~ msgid "video material"
+#~ msgstr "video llamk’ana"
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10286,394 +10286,394 @@ msgstr "mover"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr "El bloque Arco mueve el ratón en un arco."
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr "El bloque Arco mueve el ratón en un arco."
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr "El bloque fijar rumbo establece el rumbo del mouse."
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr "El bloque fijar rumbo establece el rumbo del mouse."
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr "kaqpuni kasqan, cuartopa notan yupay"
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr "kaqpuni kasqan, cuartopa notan yupay"
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr "El cursor sobre el bloque activa un evento cuando el cursor se mueve sobre un ratón."
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr "El cursor sobre el bloque activa un evento cuando el cursor se mueve sobre un ratón."
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr "El bloque de salida del cursor desencadena un evento cuando el cursor se mueve fuera de un ratón."
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr "El bloque de salida del cursor desencadena un evento cuando el cursor se mueve fuera de un ratón."
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr "El bloque hacia abajo del botón del cursor activa un evento cuando se presiona el botón del cursor en un ratón."
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr "El bloque hacia abajo del botón del cursor activa un evento cuando se presiona el botón del cursor en un ratón."
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr "El bloque del botón del cursor hacia arriba desencadena un evento cuando se suelta el botón del cursor sobre un ratón."
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr "El bloque del botón del cursor hacia arriba desencadena un evento cuando se suelta el botón del cursor sobre un ratón."
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr "astawan imankunatapas"
+#~ msgid "More Details"
+#~ msgstr "astawan imankunatapas"
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr "hatun llamk’anata rakiykunakuy"
+#~ msgid "Share project"
+#~ msgstr "hatun llamk’anata rakiykunakuy"
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr "aypachinata raphi apaykachanaman Kikinchay "
+#~ msgid "Copy link to clipboard"
+#~ msgstr "aypachinata raphi apaykachanaman Kikinchay "
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr "qallariypi riqsinata hatarichiy "
+#~ msgid "Run project on startup."
+#~ msgstr "qallariypi riqsinata hatarichiy "
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr "qallariypi riqsinata qhawachiy"
+#~ msgid "Show code blocks on startup."
+#~ msgstr "qallariypi riqsinata qhawachiy"
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr "qallariypi riqsinata ch’uytuchiy"
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr "qallariypi riqsinata ch’uytuchiy"
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr "akllanakuna utqhasqakuna"
+#~ msgid "Advanced Options"
+#~ msgstr "akllanakuna utqhasqakuna"
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr "Hertz chiqas: ¿yaqapas huch’uy willakuy chiqaspi llamk’ayta munawaq karqan "
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr "Hertz chiqas: ¿yaqapas huch’uy willakuy chiqaspi llamk’ayta munawaq karqan "
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr " hatun llamk’ay \mana munani "
+#~ msgid "Unlike project"
+#~ msgstr " hatun llamk’ay \mana munani "
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr "Hatun llamk’ay / munani"
+#~ msgid "Like project"
+#~ msgstr "Hatun llamk’ay / munani"
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr "wakmanta hatun llamk’anata riqsichiy "
+#~ msgid "Republish Project"
+#~ msgstr "wakmanta hatun llamk’anata riqsichiy "
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr "5 tinkuq kunka"
+#~ msgid "chord5"
+#~ msgstr "5 tinkuq kunka"
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr "4 tinkuq kunka"
+#~ msgid "chord4"
+#~ msgstr "4 tinkuq kunka"
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr "1 tinkuq kunka"
+#~ msgid "chord1"
+#~ msgstr "1 tinkuq kunka"
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr "El bloque nombre de nth ratón devuelve el nombre de nth ratón"
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr "El bloque nombre de nth ratón devuelve el nombre de nth ratón"
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "moneda"
+#~ msgid "currency"
+#~ msgstr "moneda"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "desde"
+#~ msgid "from"
+#~ msgstr "desde"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "valor de acción"
+#~ msgid "stock price"
+#~ msgstr "valor de acción"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "traducir"
+#~ msgid "translate"
+#~ msgstr "traducir"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "hola"
+#~ msgid "hello"
+#~ msgstr "hola"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "detectar idioma"
+#~ msgid "detect lang"
+#~ msgstr "detectar idioma"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "cambiar idioma"
+#~ msgid "set lang"
+#~ msgstr "cambiar idioma"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "latitud de la ciudad"
+#~ msgid "city latitude"
+#~ msgstr "latitud de la ciudad"
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "longitud de la ciudad"
+#~ msgid "city longitude"
+#~ msgstr "longitud de la ciudad"
 
 #: plugins/gmap.rtp:71
 
@@ -10683,144 +10683,144 @@ msgstr "mover"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "Coordinar datos no disponibles."
+#~ msgid "Coordinate data not available."
+#~ msgstr "Coordinar datos no disponibles."
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "Mapa de Google"
+#~ msgid "Google map"
+#~ msgstr "Mapa de Google"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "coordenadas"
+#~ msgid "coordinates"
+#~ msgstr "coordenadas"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "latitud"
+#~ msgid "latitude"
+#~ msgstr "latitud"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "longitud"
+#~ msgid "longitude"
+#~ msgstr "longitud"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "grados"
+#~ msgid "degrees"
+#~ msgstr "grados"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "radianes"
+#~ msgid "radians"
+#~ msgstr "radianes"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "definir"
+#~ msgid "define"
+#~ msgstr "definir"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr "Debe seleccionar un archivo."
+#~ msgid "You need to select a file."
+#~ msgstr "Debe seleccionar un archivo."
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -10830,15 +10830,15 @@ msgstr "mover"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -10848,23 +10848,23 @@ msgstr "mover"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr "Bloque de tambor: Quizás quiso decir utilizar un bloque de nota?"
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr "Bloque de tambor: Quizás quiso decir utilizar un bloque de nota?"
 
 #: js/pitchtracker.js:181
 
@@ -10874,8 +10874,8 @@ msgstr "mover"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -10883,39 +10883,39 @@ msgstr "mover"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr "guardar ritmos"
+#~ msgid "save rhythms"
+#~ msgstr "guardar ritmos"
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr "arrastrar"
+#~ msgid "drag"
+#~ msgstr "arrastrar"
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr "kunka chiqas: ¿yaqapas huch’uy willakuy chiqaspi llamk’ayta munawaq karqan?"
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr "kunka chiqas: ¿yaqapas huch’uy willakuy chiqaspi llamk’ayta munawaq karqan?"
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr "Huk’uchaman liqta churarqunki chayqa,  liq chiqasqa chiqaq nisqantan kutichin "
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr "Huk’uchaman liqta churarqunki chayqa,  liq chiqasqa chiqaq nisqantan kutichin "
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr "2 tawa k’uchu t’aqa  2 tawa k’uchu waqaychasqaman chaninta kutichin"
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr "2 tawa k’uchu t’aqa  2 tawa k’uchu waqaychasqaman chaninta kutichin"
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr "1 tawa k’uchu t’aqa 1 tawa k’uchuta chanin waqaychasqata kutichin"
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr "1 tawa k’uchu t’aqa 1 tawa k’uchuta chanin waqaychasqata kutichin"
 
-#~msgid "This block converts the pitch value of the last note played into differ"
-#~msgstr "Este bloque convierte el valor de tono de la última nota tocada en dif"
+#~ msgid "This block converts the pitch value of the last note played into differ"
+#~ msgstr "Este bloque convierte el valor de tono de la última nota tocada en dif"
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -2217,7 +2217,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2284,7 +2284,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2298,33 +2298,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2653,8 +2653,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2813,7 +2813,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2823,14 +2823,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2861,7 +2861,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2916,7 +2916,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2934,8 +2934,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3037,7 +3037,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3171,14 +3171,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3789,7 +3789,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3801,8 +3801,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3812,7 +3812,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3824,8 +3824,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3835,15 +3835,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3852,14 +3852,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3868,14 +3868,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3916,7 +3916,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3925,7 +3925,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3942,7 +3942,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4011,8 +4011,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4034,7 +4034,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4320,7 +4320,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4651,21 +4651,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4674,12 +4674,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4692,62 +4692,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4760,7 +4760,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4769,7 +4769,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4782,7 +4782,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4791,17 +4791,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4810,12 +4810,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4828,7 +4828,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4837,17 +4837,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4864,56 +4864,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4921,7 +4921,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4929,7 +4929,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4938,7 +4938,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4946,7 +4946,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4955,8 +4955,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4978,116 +4978,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5106,19 +5106,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5126,61 +5126,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5190,149 +5190,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5341,7 +5341,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5420,22 +5420,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5592,7 +5592,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5614,7 +5614,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5625,7 +5625,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5654,7 +5654,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5663,7 +5663,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5696,7 +5696,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5706,7 +5706,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5715,7 +5715,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5724,7 +5724,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5747,13 +5747,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5771,7 +5771,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5791,7 +5791,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5816,7 +5816,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5830,7 +5830,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5840,7 +5840,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5878,7 +5878,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5887,7 +5887,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5900,18 +5900,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6032,7 +6032,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6051,7 +6051,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6060,7 +6060,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6090,7 +6090,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6119,7 +6119,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6142,7 +6142,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6159,7 +6159,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6168,7 +6168,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6185,7 +6185,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6194,7 +6194,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6228,7 +6228,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6237,7 +6237,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6254,7 +6254,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6269,7 +6269,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6303,12 +6303,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6317,12 +6317,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6331,13 +6331,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6355,7 +6355,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6387,8 +6387,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6444,7 +6444,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6601,12 +6601,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6616,8 +6616,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6625,12 +6625,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6639,7 +6639,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6656,7 +6656,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6666,12 +6666,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6681,7 +6681,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6690,7 +6690,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6740,7 +6740,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6773,7 +6773,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6782,12 +6782,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6796,7 +6796,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6805,7 +6805,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6814,7 +6814,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6825,8 +6825,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6836,7 +6836,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6862,7 +6862,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6900,12 +6900,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6917,12 +6917,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6931,7 +6931,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6977,22 +6977,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7001,7 +7001,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7014,7 +7014,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7023,47 +7023,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7076,7 +7076,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7085,7 +7085,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7093,7 +7093,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7107,8 +7107,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7137,7 +7137,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7162,14 +7162,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7179,7 +7179,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7198,7 +7198,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7208,7 +7208,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7225,17 +7225,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7244,7 +7244,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7254,7 +7254,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7264,7 +7264,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7276,7 +7276,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7284,7 +7284,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7294,7 +7294,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7315,7 +7315,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7330,7 +7330,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7340,7 +7340,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7354,7 +7354,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7410,7 +7410,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7588,7 +7588,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7597,7 +7597,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7606,7 +7606,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7615,7 +7615,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7625,13 +7625,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7644,7 +7644,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7653,7 +7653,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7662,7 +7662,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7671,7 +7671,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7680,7 +7680,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7689,7 +7689,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7698,7 +7698,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7707,7 +7707,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7717,17 +7717,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7736,7 +7736,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8163,7 +8163,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8173,7 +8173,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8217,12 +8217,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8231,7 +8231,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8288,7 +8288,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8306,7 +8306,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8319,7 +8319,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8384,7 +8384,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8449,7 +8449,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8458,12 +8458,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8472,7 +8472,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8481,7 +8481,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8490,7 +8490,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8515,7 +8515,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8650,27 +8650,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8696,18 +8696,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8722,7 +8722,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8743,7 +8743,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8760,7 +8760,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8773,7 +8773,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8783,7 +8783,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8797,7 +8797,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8818,7 +8818,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8832,7 +8832,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9019,7 +9019,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9028,7 +9028,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9150,7 +9150,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9233,7 +9233,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9283,7 +9283,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9400,7 +9400,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9479,48 +9479,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9953,38 +9953,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9992,8 +9992,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10003,8 +10003,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10016,35 +10016,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10058,69 +10058,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10140,13 +10140,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10154,58 +10154,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10221,25 +10221,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10249,43 +10249,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10295,190 +10295,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10488,305 +10488,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10796,97 +10796,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10896,144 +10896,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11043,15 +11043,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11061,23 +11061,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11087,8 +11087,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11096,224 +11096,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11329,37 +11329,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11367,28 +11367,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11402,8 +11402,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11413,65 +11413,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11479,8 +11479,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11490,127 +11490,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11618,608 +11618,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12229,165 +12229,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12401,28 +12401,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12430,133 +12430,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12564,136 +12564,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12703,127 +12703,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12831,397 +12831,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13233,196 +13233,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13430,155 +13430,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13586,257 +13586,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13850,223 +13850,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14076,144 +14076,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14221,57 +14221,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14281,30 +14281,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14312,112 +14312,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14425,287 +14425,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14713,13 +14713,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14727,86 +14727,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -2217,7 +2217,7 @@ msgstr "действие"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2284,7 +2284,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2298,33 +2298,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2653,8 +2653,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2813,7 +2813,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2823,14 +2823,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2861,7 +2861,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2916,7 +2916,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2934,8 +2934,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3037,7 +3037,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3171,14 +3171,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3789,7 +3789,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3801,8 +3801,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3812,7 +3812,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3824,8 +3824,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3835,15 +3835,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3852,14 +3852,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3868,14 +3868,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3916,7 +3916,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3925,7 +3925,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3942,7 +3942,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4011,8 +4011,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4034,7 +4034,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4320,7 +4320,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4651,21 +4651,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4674,12 +4674,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4692,62 +4692,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4760,7 +4760,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4769,7 +4769,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4782,7 +4782,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4791,17 +4791,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4810,12 +4810,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4828,7 +4828,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4837,17 +4837,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4864,56 +4864,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4921,7 +4921,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4929,7 +4929,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4938,7 +4938,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4946,7 +4946,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4955,8 +4955,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4978,116 +4978,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5106,19 +5106,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5126,61 +5126,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5190,149 +5190,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5341,7 +5341,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5420,22 +5420,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5592,7 +5592,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5614,7 +5614,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5625,7 +5625,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5654,7 +5654,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5663,7 +5663,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5696,7 +5696,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5706,7 +5706,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "пустая голова"
 
@@ -5715,7 +5715,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5724,7 +5724,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5747,13 +5747,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "вытолкнуть"
 
@@ -5771,7 +5771,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "затолкнуть"
 
@@ -5791,7 +5791,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5816,7 +5816,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5830,7 +5830,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5840,7 +5840,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5878,7 +5878,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5887,7 +5887,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5900,18 +5900,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6032,7 +6032,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6051,7 +6051,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6060,7 +6060,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6090,7 +6090,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6119,7 +6119,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6142,7 +6142,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6159,7 +6159,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6168,7 +6168,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6185,7 +6185,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6194,7 +6194,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6228,7 +6228,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6237,7 +6237,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6254,7 +6254,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6269,7 +6269,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6303,12 +6303,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6317,12 +6317,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6331,13 +6331,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6355,7 +6355,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6387,8 +6387,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6444,7 +6444,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6601,12 +6601,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6616,8 +6616,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6625,12 +6625,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6639,7 +6639,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6656,7 +6656,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6666,12 +6666,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6681,7 +6681,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6690,7 +6690,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6740,7 +6740,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6773,7 +6773,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6782,12 +6782,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6796,7 +6796,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6805,7 +6805,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6814,7 +6814,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6825,8 +6825,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6836,7 +6836,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6862,7 +6862,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6900,12 +6900,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6917,12 +6917,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6931,7 +6931,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6977,22 +6977,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7001,7 +7001,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7014,7 +7014,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7023,47 +7023,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7076,7 +7076,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7085,7 +7085,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7093,7 +7093,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7107,8 +7107,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7137,7 +7137,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7162,14 +7162,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7179,7 +7179,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7198,7 +7198,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7208,7 +7208,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7225,17 +7225,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7244,7 +7244,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7254,7 +7254,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7264,7 +7264,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7276,7 +7276,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7284,7 +7284,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7294,7 +7294,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7315,7 +7315,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7330,7 +7330,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7340,7 +7340,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7354,7 +7354,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7410,7 +7410,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7588,7 +7588,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7597,7 +7597,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7606,7 +7606,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7615,7 +7615,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7625,13 +7625,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7644,7 +7644,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7653,7 +7653,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7662,7 +7662,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7671,7 +7671,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7680,7 +7680,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7689,7 +7689,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7698,7 +7698,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7707,7 +7707,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7717,17 +7717,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7736,7 +7736,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8163,7 +8163,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8173,7 +8173,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8217,12 +8217,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8231,7 +8231,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8288,7 +8288,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8306,7 +8306,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8319,7 +8319,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8384,7 +8384,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8449,7 +8449,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8458,12 +8458,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "поднять перо"
 
@@ -8472,7 +8472,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "опустить перо"
 
@@ -8481,7 +8481,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "размер пера"
 
@@ -8490,7 +8490,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8515,7 +8515,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8650,27 +8650,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8696,18 +8696,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8722,7 +8722,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8743,7 +8743,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8760,7 +8760,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8773,7 +8773,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8783,7 +8783,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8797,7 +8797,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8818,7 +8818,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8832,7 +8832,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9019,7 +9019,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9028,7 +9028,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9150,7 +9150,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9233,7 +9233,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9283,7 +9283,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9400,7 +9400,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9479,48 +9479,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9953,38 +9953,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9992,8 +9992,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10003,8 +10003,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10016,35 +10016,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "показать"
+#~ msgid "show"
+#~ msgstr "показать"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10058,69 +10058,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Очистить"
+#~ msgid "Clean"
+#~ msgstr "Очистить"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "скрыть блоки"
+#~ msgid "hide blocks"
+#~ msgstr "скрыть блоки"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10140,13 +10140,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "Стоп"
+#~ msgid "stop"
+#~ msgstr "Стоп"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10154,58 +10154,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10221,25 +10221,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10249,43 +10249,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10295,190 +10295,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10488,305 +10488,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10796,97 +10796,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10896,144 +10896,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11043,15 +11043,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11061,23 +11061,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11087,8 +11087,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11096,224 +11096,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11329,37 +11329,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11367,28 +11367,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11402,8 +11402,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11413,65 +11413,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11479,8 +11479,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11490,127 +11490,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11618,608 +11618,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12229,165 +12229,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12401,28 +12401,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12430,133 +12430,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12564,136 +12564,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "черепашка"
+#~ msgid "turtle"
+#~ msgstr "черепашка"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12703,127 +12703,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12831,397 +12831,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Открыть"
+#~ msgid "Open"
+#~ msgstr "Открыть"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13233,196 +13233,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13430,155 +13430,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13586,257 +13586,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13850,223 +13850,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14076,144 +14076,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14221,57 +14221,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14281,30 +14281,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14312,112 +14312,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14425,287 +14425,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14713,13 +14713,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14727,86 +14727,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/rw.po
+++ b/po/rw.po
@@ -2216,7 +2216,7 @@ msgstr "igikorwa"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "sunika"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "akanyerezo y"
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "akanyerezo x"
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr "soza kuzuza"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "ikaramu hejuru"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "ikaramu hasi"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "tunganya ingano y'ikaramu"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "erekana"
+#~ msgid "show"
+#~ msgstr "erekana"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Sukura"
+#~ msgid "Clean"
+#~ msgstr "Sukura"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "Hisha amablock"
+#~ msgid "hide blocks"
+#~ msgstr "Hisha amablock"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "hejuru"
+#~ msgid "stop"
+#~ msgstr "hejuru"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "allo"
+#~ msgid "hello"
+#~ msgstr "allo"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "akanyamashyo"
+#~ msgid "turtle"
+#~ msgstr "akanyamashyo"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Fungura"
+#~ msgid "Open"
+#~ msgstr "Fungura"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/sd.po
+++ b/po/sd.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -2219,7 +2219,7 @@ msgstr "ක්‍රියාව"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2286,7 +2286,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2300,33 +2300,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2348,7 +2348,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2426,7 +2426,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2655,8 +2655,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2815,7 +2815,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2825,14 +2825,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2863,7 +2863,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2888,7 +2888,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2897,7 +2897,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2918,7 +2918,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2936,8 +2936,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3039,7 +3039,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3173,14 +3173,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3255,7 +3255,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3291,7 +3291,7 @@ msgstr "ගලනවා"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3300,7 +3300,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3791,7 +3791,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3803,8 +3803,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3814,7 +3814,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3826,8 +3826,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3837,15 +3837,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3854,14 +3854,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3870,14 +3870,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3918,7 +3918,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3927,7 +3927,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3944,7 +3944,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4013,8 +4013,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4036,7 +4036,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4653,21 +4653,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4676,12 +4676,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4694,62 +4694,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4762,7 +4762,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4771,7 +4771,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4793,17 +4793,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4812,12 +4812,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4830,7 +4830,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4839,17 +4839,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4866,56 +4866,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4931,7 +4931,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4940,7 +4940,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4948,7 +4948,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4957,8 +4957,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4966,7 +4966,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4980,116 +4980,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5108,19 +5108,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5128,61 +5128,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5192,149 +5192,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5343,7 +5343,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5422,22 +5422,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5594,7 +5594,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5616,7 +5616,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5627,7 +5627,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5656,7 +5656,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5665,7 +5665,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5698,7 +5698,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5708,7 +5708,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "හිස් මතක කොටස"
 
@@ -5717,7 +5717,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5726,7 +5726,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5749,13 +5749,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5764,7 +5764,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "පොප්"
 
@@ -5773,7 +5773,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "ඔබන්න"
 
@@ -5793,7 +5793,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5818,7 +5818,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5832,7 +5832,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5842,7 +5842,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5880,7 +5880,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5889,7 +5889,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5902,18 +5902,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6034,7 +6034,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6053,7 +6053,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6062,7 +6062,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6079,7 +6079,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6092,7 +6092,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6121,7 +6121,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6144,7 +6144,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6161,7 +6161,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6170,7 +6170,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6187,7 +6187,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6196,7 +6196,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6230,7 +6230,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6239,7 +6239,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6256,7 +6256,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6271,7 +6271,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6305,12 +6305,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6319,12 +6319,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6333,13 +6333,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6357,7 +6357,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6389,8 +6389,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6446,7 +6446,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6603,12 +6603,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6618,8 +6618,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6627,12 +6627,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6641,7 +6641,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6658,7 +6658,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6668,12 +6668,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6683,7 +6683,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6692,7 +6692,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6742,7 +6742,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6775,7 +6775,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6784,12 +6784,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6798,7 +6798,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6807,7 +6807,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6816,7 +6816,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6827,8 +6827,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6838,7 +6838,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6864,7 +6864,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6902,12 +6902,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6919,12 +6919,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6933,7 +6933,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6979,22 +6979,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7003,7 +7003,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7016,7 +7016,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7025,47 +7025,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7078,7 +7078,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7087,7 +7087,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7095,7 +7095,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7109,8 +7109,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7139,7 +7139,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7164,14 +7164,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7181,7 +7181,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7200,7 +7200,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7210,7 +7210,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7227,17 +7227,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7246,7 +7246,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7256,7 +7256,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7266,7 +7266,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7278,7 +7278,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7286,7 +7286,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7296,7 +7296,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7317,7 +7317,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7332,7 +7332,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7342,7 +7342,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7356,7 +7356,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7412,7 +7412,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7590,7 +7590,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7599,7 +7599,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7608,7 +7608,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7617,7 +7617,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7627,13 +7627,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7646,7 +7646,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7655,7 +7655,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "කැස්බෑවා"
 
@@ -7664,7 +7664,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7673,7 +7673,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "කැස්බෑවා"
 
@@ -7682,7 +7682,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7691,7 +7691,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7700,7 +7700,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7709,7 +7709,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7719,17 +7719,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7738,7 +7738,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8165,7 +8165,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8175,7 +8175,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8219,12 +8219,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8233,7 +8233,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8290,7 +8290,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8308,7 +8308,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8321,7 +8321,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8386,7 +8386,7 @@ msgstr "පිරවීම අවසාන කරන්න"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8451,7 +8451,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8460,12 +8460,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "පෑන ඔසවන්න"
 
@@ -8474,7 +8474,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "පැන් පහර පහළට"
 
@@ -8483,7 +8483,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "පෑනේ විශාලත්වය සකසන්න"
 
@@ -8492,7 +8492,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8517,7 +8517,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8652,27 +8652,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8698,18 +8698,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8724,7 +8724,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8745,7 +8745,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8762,7 +8762,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8775,7 +8775,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8785,7 +8785,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8799,7 +8799,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8820,7 +8820,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8834,7 +8834,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9021,7 +9021,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9030,7 +9030,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9152,7 +9152,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9235,7 +9235,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9285,7 +9285,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9402,7 +9402,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9481,48 +9481,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9955,38 +9955,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9994,8 +9994,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10005,8 +10005,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10018,35 +10018,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "පෙන්වන්න"
+#~ msgid "show"
+#~ msgstr "පෙන්වන්න"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10060,69 +10060,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "පැහැදිලි කරන්න"
+#~ msgid "Clean"
+#~ msgstr "පැහැදිලි කරන්න"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "කොටස් සගවන්න"
+#~ msgid "hide blocks"
+#~ msgstr "කොටස් සගවන්න"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10142,13 +10142,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "නවත්වන්න"
+#~ msgid "stop"
+#~ msgstr "නවත්වන්න"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10156,58 +10156,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10223,25 +10223,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10251,43 +10251,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10297,190 +10297,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10490,305 +10490,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10798,97 +10798,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10898,144 +10898,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11045,15 +11045,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11063,23 +11063,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11089,8 +11089,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11098,224 +11098,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11331,37 +11331,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11369,28 +11369,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11404,8 +11404,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11415,65 +11415,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11481,8 +11481,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11492,127 +11492,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11620,608 +11620,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12231,165 +12231,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12403,28 +12403,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12432,133 +12432,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12566,136 +12566,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "කැස්බෑවා"
+#~ msgid "turtle"
+#~ msgstr "කැස්බෑවා"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12705,127 +12705,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12833,397 +12833,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "විවෘත කරන්න"
+#~ msgid "Open"
+#~ msgstr "විවෘත කරන්න"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13235,196 +13235,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13432,155 +13432,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13588,257 +13588,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13852,223 +13852,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14078,144 +14078,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14223,57 +14223,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14283,30 +14283,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14314,112 +14314,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14427,287 +14427,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14715,13 +14715,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14729,86 +14729,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "pero dole"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -2217,7 +2217,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2284,7 +2284,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2298,33 +2298,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2653,8 +2653,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2813,7 +2813,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2823,14 +2823,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2861,7 +2861,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2916,7 +2916,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2934,8 +2934,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3037,7 +3037,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3171,14 +3171,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3789,7 +3789,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3801,8 +3801,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3812,7 +3812,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3824,8 +3824,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3835,15 +3835,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3852,14 +3852,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3868,14 +3868,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3916,7 +3916,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3925,7 +3925,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3942,7 +3942,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4011,8 +4011,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4034,7 +4034,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4320,7 +4320,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4651,21 +4651,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4674,12 +4674,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4692,62 +4692,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4760,7 +4760,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4769,7 +4769,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4782,7 +4782,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4791,17 +4791,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4810,12 +4810,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4828,7 +4828,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4837,17 +4837,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4864,56 +4864,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4921,7 +4921,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4929,7 +4929,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4938,7 +4938,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4946,7 +4946,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4955,8 +4955,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4978,116 +4978,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5106,19 +5106,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5126,61 +5126,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5190,149 +5190,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5341,7 +5341,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5420,22 +5420,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5592,7 +5592,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5614,7 +5614,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5625,7 +5625,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5654,7 +5654,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5663,7 +5663,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5696,7 +5696,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5706,7 +5706,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5715,7 +5715,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5724,7 +5724,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5747,13 +5747,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5771,7 +5771,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5791,7 +5791,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5816,7 +5816,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5830,7 +5830,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5840,7 +5840,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5878,7 +5878,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5887,7 +5887,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5900,18 +5900,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6032,7 +6032,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6051,7 +6051,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6060,7 +6060,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6090,7 +6090,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6119,7 +6119,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6142,7 +6142,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6159,7 +6159,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6168,7 +6168,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6185,7 +6185,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6194,7 +6194,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6228,7 +6228,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6237,7 +6237,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6254,7 +6254,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6269,7 +6269,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6303,12 +6303,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6317,12 +6317,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6331,13 +6331,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6355,7 +6355,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6387,8 +6387,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6444,7 +6444,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6601,12 +6601,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6616,8 +6616,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6625,12 +6625,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6639,7 +6639,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6656,7 +6656,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6666,12 +6666,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6681,7 +6681,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6690,7 +6690,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6740,7 +6740,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6773,7 +6773,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6782,12 +6782,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6796,7 +6796,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6805,7 +6805,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6814,7 +6814,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6825,8 +6825,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6836,7 +6836,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6862,7 +6862,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6900,12 +6900,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6917,12 +6917,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6931,7 +6931,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6977,22 +6977,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7001,7 +7001,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7014,7 +7014,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7023,47 +7023,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7076,7 +7076,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7085,7 +7085,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7093,7 +7093,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7107,8 +7107,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7137,7 +7137,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7162,14 +7162,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7179,7 +7179,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7198,7 +7198,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7208,7 +7208,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7225,17 +7225,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7244,7 +7244,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7254,7 +7254,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7264,7 +7264,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7276,7 +7276,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7284,7 +7284,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7294,7 +7294,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7315,7 +7315,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7330,7 +7330,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7340,7 +7340,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7354,7 +7354,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7410,7 +7410,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7588,7 +7588,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7597,7 +7597,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7606,7 +7606,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7615,7 +7615,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7625,13 +7625,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7644,7 +7644,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7653,7 +7653,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7662,7 +7662,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7671,7 +7671,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7680,7 +7680,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7689,7 +7689,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7698,7 +7698,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7707,7 +7707,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7717,17 +7717,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7736,7 +7736,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8163,7 +8163,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8173,7 +8173,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8217,12 +8217,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8231,7 +8231,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8288,7 +8288,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8306,7 +8306,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8319,7 +8319,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8384,7 +8384,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8449,7 +8449,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8458,12 +8458,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8472,7 +8472,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8481,7 +8481,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8490,7 +8490,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8515,7 +8515,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8650,27 +8650,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8696,18 +8696,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8722,7 +8722,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8743,7 +8743,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8760,7 +8760,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8773,7 +8773,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8783,7 +8783,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8797,7 +8797,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8818,7 +8818,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8832,7 +8832,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9019,7 +9019,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9028,7 +9028,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9150,7 +9150,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9233,7 +9233,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9283,7 +9283,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9400,7 +9400,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9479,48 +9479,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9953,38 +9953,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9992,8 +9992,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10003,8 +10003,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10016,35 +10016,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10058,69 +10058,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10140,13 +10140,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10154,58 +10154,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10221,25 +10221,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10249,43 +10249,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10295,190 +10295,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10488,305 +10488,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10796,97 +10796,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10896,144 +10896,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11043,15 +11043,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11061,23 +11061,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11087,8 +11087,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11096,224 +11096,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11329,37 +11329,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11367,28 +11367,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11402,8 +11402,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11413,65 +11413,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11479,8 +11479,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11490,127 +11490,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11618,608 +11618,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12229,165 +12229,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12401,28 +12401,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12430,133 +12430,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12564,136 +12564,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12703,127 +12703,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12831,397 +12831,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13233,196 +13233,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13430,155 +13430,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13586,257 +13586,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13850,223 +13850,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14076,144 +14076,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14221,57 +14221,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14281,30 +14281,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14312,112 +14312,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14425,287 +14425,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14713,13 +14713,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14727,86 +14727,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -2213,7 +2213,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2280,7 +2280,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2294,33 +2294,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2342,7 +2342,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2420,7 +2420,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2649,8 +2649,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2809,7 +2809,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2819,14 +2819,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2857,7 +2857,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2882,7 +2882,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2912,7 +2912,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2930,8 +2930,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3033,7 +3033,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3167,14 +3167,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3249,7 +3249,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3285,7 +3285,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3294,7 +3294,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3785,7 +3785,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3797,8 +3797,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3820,8 +3820,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3831,15 +3831,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3848,14 +3848,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3864,14 +3864,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3912,7 +3912,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3921,7 +3921,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3938,7 +3938,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4007,8 +4007,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4030,7 +4030,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4316,7 +4316,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4647,21 +4647,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4670,12 +4670,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4688,62 +4688,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4778,7 +4778,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4787,17 +4787,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4806,12 +4806,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4824,7 +4824,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4833,17 +4833,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4860,56 +4860,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4917,7 +4917,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4925,7 +4925,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4934,7 +4934,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4942,7 +4942,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4951,8 +4951,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4960,7 +4960,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4974,116 +4974,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5102,19 +5102,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5122,61 +5122,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5186,149 +5186,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5337,7 +5337,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5416,22 +5416,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5588,7 +5588,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5610,7 +5610,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5621,7 +5621,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5650,7 +5650,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5659,7 +5659,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5702,7 +5702,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5711,7 +5711,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5720,7 +5720,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5743,13 +5743,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5758,7 +5758,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5767,7 +5767,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5787,7 +5787,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5812,7 +5812,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5826,7 +5826,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5836,7 +5836,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5874,7 +5874,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5883,7 +5883,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5896,18 +5896,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6028,7 +6028,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6047,7 +6047,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6056,7 +6056,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6073,7 +6073,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6086,7 +6086,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6115,7 +6115,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6138,7 +6138,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6155,7 +6155,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6164,7 +6164,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6181,7 +6181,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6190,7 +6190,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6224,7 +6224,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6233,7 +6233,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6265,7 +6265,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6299,12 +6299,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6313,12 +6313,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6327,13 +6327,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6351,7 +6351,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6383,8 +6383,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6440,7 +6440,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6597,12 +6597,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6612,8 +6612,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6621,12 +6621,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6635,7 +6635,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6652,7 +6652,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6662,12 +6662,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6677,7 +6677,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6686,7 +6686,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6736,7 +6736,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6769,7 +6769,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6778,12 +6778,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6792,7 +6792,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6801,7 +6801,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6810,7 +6810,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6821,8 +6821,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6832,7 +6832,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6858,7 +6858,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6896,12 +6896,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6913,12 +6913,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6927,7 +6927,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6973,22 +6973,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6997,7 +6997,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7010,7 +7010,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7019,47 +7019,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7072,7 +7072,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7081,7 +7081,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7089,7 +7089,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7103,8 +7103,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7133,7 +7133,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7158,14 +7158,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7175,7 +7175,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7194,7 +7194,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7204,7 +7204,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7221,17 +7221,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7240,7 +7240,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7250,7 +7250,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7260,7 +7260,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7272,7 +7272,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7280,7 +7280,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7290,7 +7290,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7311,7 +7311,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7326,7 +7326,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7336,7 +7336,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7350,7 +7350,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7406,7 +7406,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7584,7 +7584,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7593,7 +7593,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7602,7 +7602,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7611,7 +7611,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7621,13 +7621,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7640,7 +7640,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7649,7 +7649,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7658,7 +7658,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7667,7 +7667,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7676,7 +7676,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7685,7 +7685,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7694,7 +7694,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7703,7 +7703,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7713,17 +7713,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7732,7 +7732,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8159,7 +8159,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8169,7 +8169,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8213,12 +8213,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8227,7 +8227,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8284,7 +8284,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8302,7 +8302,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8315,7 +8315,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8380,7 +8380,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8445,7 +8445,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8454,12 +8454,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8468,7 +8468,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8477,7 +8477,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8486,7 +8486,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8511,7 +8511,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8646,27 +8646,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8692,18 +8692,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8718,7 +8718,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8739,7 +8739,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8756,7 +8756,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8769,7 +8769,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8779,7 +8779,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8793,7 +8793,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8814,7 +8814,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8828,7 +8828,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9015,7 +9015,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9024,7 +9024,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9146,7 +9146,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9229,7 +9229,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9279,7 +9279,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9396,7 +9396,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9475,48 +9475,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9949,38 +9949,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9988,8 +9988,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -9999,8 +9999,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10012,35 +10012,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10054,69 +10054,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10136,13 +10136,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10150,58 +10150,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10217,25 +10217,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10245,43 +10245,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10291,190 +10291,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10484,305 +10484,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10792,97 +10792,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10892,144 +10892,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11039,15 +11039,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11057,23 +11057,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11083,8 +11083,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11092,224 +11092,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11325,37 +11325,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11363,28 +11363,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11398,8 +11398,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11409,65 +11409,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11475,8 +11475,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11486,127 +11486,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11614,608 +11614,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12225,165 +12225,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12397,28 +12397,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12426,133 +12426,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12560,136 +12560,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12699,127 +12699,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12827,397 +12827,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13229,196 +13229,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13426,155 +13426,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13582,257 +13582,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13846,223 +13846,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14072,144 +14072,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14217,57 +14217,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14277,30 +14277,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14308,112 +14308,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14421,287 +14421,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14709,13 +14709,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14723,86 +14723,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -2216,7 +2216,7 @@ msgstr "händelse"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "töm stapel"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "ta bort"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "lägg till sist"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "Ta upp penna"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "Sätt ned penna"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "Ange pennstorlek"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "visa"
+#~ msgid "show"
+#~ msgstr "visa"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "Rutnät"
+#~ msgid "grid"
+#~ msgstr "Rutnät"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "rensa"
+#~ msgid "Clean"
+#~ msgstr "rensa"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "dölj block"
+#~ msgid "hide blocks"
+#~ msgstr "dölj block"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "topp"
+#~ msgid "stop"
+#~ msgstr "topp"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "Sköldpadda"
+#~ msgid "turtle"
+#~ msgstr "Sköldpadda"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Öppna"
+#~ msgid "Open"
+#~ msgstr "Öppna"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/sw.po
+++ b/po/sw.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "Gridi"
+#~ msgid "grid"
+#~ msgstr "Gridi"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "kuacha"
+#~ msgid "stop"
+#~ msgstr "kuacha"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "turtle"
+#~ msgid "turtle"
+#~ msgstr "turtle"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -12,10 +12,10 @@ msgstr ""
 "Language: ta\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -101,7 +101,7 @@ msgstr "செயற்படு"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -168,7 +168,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -182,33 +182,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -230,7 +230,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -308,7 +308,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -537,8 +537,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -707,14 +707,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -745,7 +745,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -770,7 +770,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -779,7 +779,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -800,7 +800,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -818,8 +818,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -921,7 +921,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -1055,14 +1055,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -1182,7 +1182,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -1685,8 +1685,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -1696,7 +1696,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -1708,8 +1708,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -1719,15 +1719,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -1736,14 +1736,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -1752,14 +1752,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -1800,7 +1800,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -1809,7 +1809,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -1826,7 +1826,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -1895,8 +1895,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -2204,7 +2204,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -2535,21 +2535,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -2558,12 +2558,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -2576,62 +2576,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -2644,7 +2644,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -2653,7 +2653,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -2666,7 +2666,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -2675,17 +2675,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -2694,12 +2694,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -2721,17 +2721,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -2748,56 +2748,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -2805,7 +2805,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -2813,7 +2813,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -2822,7 +2822,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -2830,7 +2830,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -2839,8 +2839,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -2848,7 +2848,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -2862,116 +2862,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -2990,19 +2990,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -3010,61 +3010,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -3074,149 +3074,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -3225,7 +3225,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3304,22 +3304,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -3476,7 +3476,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -3498,7 +3498,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -3509,7 +3509,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -3538,7 +3538,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -3547,7 +3547,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -3580,7 +3580,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -3590,7 +3590,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "வெற்றுக்குவியல்"
 
@@ -3599,7 +3599,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -3608,7 +3608,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -3631,13 +3631,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -3646,7 +3646,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "வரல்"
 
@@ -3655,7 +3655,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "தள்ளு"
 
@@ -3675,7 +3675,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -3700,7 +3700,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -3714,7 +3714,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -3724,7 +3724,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -3762,7 +3762,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -3771,7 +3771,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -3784,18 +3784,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -3916,7 +3916,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -3935,7 +3935,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -3944,7 +3944,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -3961,7 +3961,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -3974,7 +3974,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -4003,7 +4003,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -4026,7 +4026,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -4043,7 +4043,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -4052,7 +4052,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -4069,7 +4069,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -4078,7 +4078,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -4112,7 +4112,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -4121,7 +4121,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -4138,7 +4138,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -4153,7 +4153,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -4187,12 +4187,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -4201,12 +4201,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -4215,13 +4215,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -4271,8 +4271,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -4328,7 +4328,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -4485,12 +4485,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -4500,8 +4500,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -4509,12 +4509,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -4523,7 +4523,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -4540,7 +4540,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -4550,12 +4550,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -4565,7 +4565,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -4574,7 +4574,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -4624,7 +4624,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -4657,7 +4657,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -4666,12 +4666,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -4680,7 +4680,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -4689,7 +4689,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -4698,7 +4698,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -4709,8 +4709,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -4720,7 +4720,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -4746,7 +4746,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -4784,12 +4784,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -4801,12 +4801,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -4815,7 +4815,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -4861,22 +4861,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -4885,7 +4885,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -4898,7 +4898,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -4907,47 +4907,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -4960,7 +4960,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -4969,7 +4969,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -4977,7 +4977,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -4991,8 +4991,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -5021,7 +5021,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -5046,14 +5046,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -5082,7 +5082,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -5092,7 +5092,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -5109,17 +5109,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -5128,7 +5128,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -5138,7 +5138,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -5148,7 +5148,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -5160,7 +5160,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -5168,7 +5168,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -5178,7 +5178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -5199,7 +5199,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -5214,7 +5214,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -5224,7 +5224,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -5238,7 +5238,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -5294,7 +5294,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -5472,7 +5472,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -5481,7 +5481,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -5490,7 +5490,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -5499,7 +5499,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -5509,13 +5509,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -5537,7 +5537,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -5546,7 +5546,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -5555,7 +5555,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -5564,7 +5564,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -5573,7 +5573,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -5582,7 +5582,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -5601,17 +5601,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -5620,7 +5620,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -6047,7 +6047,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -6057,7 +6057,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -6101,12 +6101,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -6115,7 +6115,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -6172,7 +6172,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -6190,7 +6190,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -6203,7 +6203,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr "கடைசி நிரப்பல்"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -6333,7 +6333,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -6342,12 +6342,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "பேனை மேலே"
 
@@ -6356,7 +6356,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "பேனை கீழே"
 
@@ -6365,7 +6365,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "பேனையின் அளவினை ஒழுங்குபடுத்து"
 
@@ -6374,7 +6374,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -6399,7 +6399,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -6534,27 +6534,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -6580,18 +6580,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -6606,7 +6606,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -6627,7 +6627,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -6644,7 +6644,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -6657,7 +6657,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -6667,7 +6667,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -6681,7 +6681,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -6702,7 +6702,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -6716,7 +6716,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -6903,7 +6903,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -6912,7 +6912,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -7034,7 +7034,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -7117,7 +7117,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -7167,7 +7167,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -7284,7 +7284,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -7363,48 +7363,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -7837,38 +7837,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -7876,8 +7876,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -7887,8 +7887,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -7900,35 +7900,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "காட்டு"
+#~ msgid "show"
+#~ msgstr "காட்டு"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -7942,69 +7942,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "சுத்தமக்கு"
+#~ msgid "Clean"
+#~ msgstr "சுத்தமக்கு"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "மறைந்துள்ள தொகுதி"
+#~ msgid "hide blocks"
+#~ msgstr "மறைந்துள்ள தொகுதி"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8024,13 +8024,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "நிறுத்து"
+#~ msgid "stop"
+#~ msgstr "நிறுத்து"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8038,58 +8038,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -8105,25 +8105,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -8133,46 +8133,46 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
-#~msgid ""Toggle Fullscreen"
-#~msgstr ""தமிழ்"
+#~ msgid "Toggle Fullscreen"
+#~ msgstr "தமிழ்"
 
 #: js/toolbar.js:70
 
@@ -8182,190 +8182,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -8375,305 +8375,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -8683,97 +8683,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -8783,144 +8783,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -8930,15 +8930,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -8948,23 +8948,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -8974,8 +8974,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -8983,224 +8983,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -9216,37 +9216,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -9254,28 +9254,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -9289,8 +9289,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -9300,65 +9300,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -9366,8 +9366,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -9377,127 +9377,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -9505,608 +9505,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -10116,165 +10116,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -10288,28 +10288,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10317,133 +10317,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10451,136 +10451,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "ஆமை"
+#~ msgid "turtle"
+#~ msgstr "ஆமை"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -10590,127 +10590,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -10718,397 +10718,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "திற"
+#~ msgid "Open"
+#~ msgstr "திற"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -11120,196 +11120,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11317,155 +11317,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11473,257 +11473,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -11737,223 +11737,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -11963,144 +11963,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -12108,57 +12108,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -12168,30 +12168,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12199,112 +12199,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -12312,287 +12312,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12600,13 +12600,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -12614,86 +12614,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -13,10 +13,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.0.5\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -102,7 +102,7 @@ msgstr "చర్య"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr "డక్"
 
@@ -169,7 +169,7 @@ msgstr "దాచు"
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "నా ప్రాజెక్ట్"
 
@@ -183,33 +183,33 @@ msgid "Your recording is in progress."
 msgstr "మీ రికార్డింగ్ ప్రగతిలో ఉంది."
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "ఫైల్ పేరు"
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "ప్రాజెక్ట్ టైటిల్"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "ప్రాజెక్ట్ రచయిత"
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "MIDI ఔట్పుట్ చేయవాలా?"
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "గిటార్ టాబ్లేచర్ ఔట్పుట్ చేయవాలా?"
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "Lilypondలో గీత పత్రంగా భద్రపరచు"
 
@@ -231,7 +231,7 @@ msgstr "Lilypondలో గీత పత్రంగా భద్రపరచు"
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "శ్రీమతి మౌస్"
 
@@ -309,7 +309,7 @@ msgstr "కార్టీషియన్ చూపు"
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr "స్కేల్ డిగ్రీ"
 
@@ -538,8 +538,8 @@ msgstr "బ్లాక్ సహాయాన్ని భద్రపరచు"
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "టి లా సోల్ ఫా మి రే దో"
 
@@ -698,7 +698,7 @@ msgstr "రూలర్"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "టింబ్రె"
 
@@ -708,14 +708,14 @@ msgstr "స్టేర్"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "టెంపో"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "మోడ్"
 
@@ -746,7 +746,7 @@ msgstr "డ్రమ్"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "రిద్ధమ్ మేకర్"
 
@@ -771,7 +771,7 @@ msgstr "రిద్ధమ్ మేకర్"
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "నోట్ విల్యూ"
 
@@ -780,7 +780,7 @@ msgstr "నోట్ విల్యూ"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "స్కాలర్ ఇంటర్వల్"
 
@@ -801,7 +801,7 @@ msgid "silence"
 msgstr "నిశ్శబ్దం"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "క్రిందకు"
 
@@ -819,8 +819,8 @@ msgstr "పైకు"
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "శ్రుతి"
 
@@ -922,7 +922,7 @@ msgstr "టెనర్"
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "బేస్"
 
@@ -1056,14 +1056,14 @@ msgstr "ఎటువంటి విభాగం ఎంచుకోలేదు"
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "అవతార్"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "నమూనా"
 
@@ -1138,7 +1138,7 @@ msgstr "డ్రమ్ ప్రారంభం"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "రిధం"
 
@@ -1174,7 +1174,7 @@ msgstr "ఫ్లో"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr "సెన్సార్లు"
 
@@ -1183,7 +1183,7 @@ msgstr "సెన్సార్లు"
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr "మీడియా"
 
@@ -1674,7 +1674,7 @@ msgstr "ప్లేబ్యాక్ సిద్ధం"
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "రెండు శార్పు"
 
@@ -1686,8 +1686,8 @@ msgstr "రెండు శార్పు"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "శార్ప్"
 
@@ -1697,7 +1697,7 @@ msgstr "శార్ప్"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "స్వాభావిక"
 
@@ -1709,8 +1709,8 @@ msgstr "స్వాభావిక"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "అలవు తగించు"
 
@@ -1720,15 +1720,15 @@ msgstr "అలవు తగించు"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "రెండు అలవు తగించు"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr "ఏకాంతము"
 
@@ -1737,14 +1737,14 @@ msgstr "ఏకాంతము"
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "ప్రధాన"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr "ఐయోనియన్"
 
@@ -1753,14 +1753,14 @@ msgstr "ఐయోనియన్"
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "క్షుద్ర"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr "ఏఓలియన్"
 
@@ -1801,7 +1801,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "మీరు కంటే కడిగినంత భారము-కంటే-భాగాలు బ్లాక్ లో కనుగొంటేందో ఉండాలి"
 
@@ -1810,7 +1810,7 @@ msgid "synth cannot play chords."
 msgstr "సింథ్ కార్డులను ప్లే చేయలేకపోవచ్చు."
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr "మార్గదర్శి URL"
 
@@ -1827,7 +1827,7 @@ msgstr "వెతకడానికి"
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "మీటర్"
 
@@ -1896,8 +1896,8 @@ msgstr "అదనపు"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "ప్రోగ్రామ్"
 
@@ -1919,7 +1919,7 @@ msgstr "తర్కము"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr "సంగీతం"
 
@@ -2205,7 +2205,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr "క్లియర్"
 
@@ -2536,21 +2536,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "1వ 2వ 3వ 4వ 5వ 6వ 7వ 8వ 9వ 10వ 11వ 12వ"
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "అభ్యంగం"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "తగినిపడించబడింది"
 
@@ -2559,12 +2559,12 @@ msgstr "తగినిపడించబడింది"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "పరిపూర్ణ"
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "క్రోమాటిక్"
 
@@ -2577,62 +2577,62 @@ msgid "spanish"
 msgstr "స్పానిష్"
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr "ఆక్టాటోనిక్"
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "హార్మోనిక్ మేజర్"
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "న్యాచరల్ మైనర్"
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "హార్మోనిక్ మైనర్"
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "మెలోడిక్ మైనర్"
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr "డోరియన్"
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr "ఫ్రిజియన్"
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr "లిడియన్"
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "మిక్సొలిడియన్"
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr "లొక్రియన్"
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "జాజ్ మైనర్"
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr "బిబొప్"
 
@@ -2645,7 +2645,7 @@ msgid "byzantine"
 msgstr "బిజంటీన్"
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "ఎనిగ్మాటిక్"
 
@@ -2654,7 +2654,7 @@ msgid "ethiopian"
 msgstr "ఇథియోపియన్"
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "గీజ్"
 
@@ -2667,7 +2667,7 @@ msgid "hungarian"
 msgstr "హంగేరియన్"
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "రొమానియన్ మైనర్"
 
@@ -2676,17 +2676,17 @@ msgid "spanish gypsy"
 msgstr "స్పానిష్ జిప్సి"
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "మాకం"
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "మైనర్ బ్లూస్"
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr "మేజర్ బ్లూస్"
 
@@ -2695,12 +2695,12 @@ msgid "whole tone"
 msgstr "హోల్ టోన్"
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "మైనర్ పెంటటోనిక్"
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "మేజర్ పెంటటోనిక్"
 
@@ -2713,7 +2713,7 @@ msgid "egyptian"
 msgstr "ఎజిప్షియన్"
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "హిరజోషి"
 
@@ -2722,17 +2722,17 @@ msgid "Japan"
 msgstr "జపాన్"
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "ఇన్"
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "మిన్యో"
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "ఫిబొనాచి"
 
@@ -2749,56 +2749,56 @@ msgstr "ఫిబొనాచి"
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr "అనుకూలం"
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr "హైపాస్ ఫిల్టర్"
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr "లోపాస్"
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr "బ్యాండ్‌పాస్"
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr "హై‌షెల్ఫ్"
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr "లో‌షెల్ఫ్"
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr "నాచ్"
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr "ఆల్‌పాస్"
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr "పికింగ్"
 
@@ -2806,7 +2806,7 @@ msgstr "పికింగ్"
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "సైన్"
 
@@ -2814,7 +2814,7 @@ msgstr "సైన్"
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "చదరం"
 
@@ -2823,7 +2823,7 @@ msgstr "చదరం"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "ముక్కోన"
 
@@ -2831,7 +2831,7 @@ msgstr "ముక్కోన"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "ముక్కోని"
 
@@ -2840,8 +2840,8 @@ msgstr "ముక్కోని"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr "సమం"
 
@@ -2849,7 +2849,7 @@ msgstr "సమం"
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr "అసమం"
 
@@ -2863,116 +2863,116 @@ msgstr "స్కాలర్"
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr "పియానో"
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr "వయలిన్"
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr "వాయలా"
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "జ్యానతి"
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "వైబ్రఫోన్"
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr "సెల్లో"
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr "డబుల్ బాస్"
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr "గిటార్"
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr "ఆకస్టిక్ గిటార్"
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr "ఫ్లూట్"
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr "క్లారినెట్"
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr "సాక్సోఫోన్"
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr "ట్యూబా"
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr "ట్రంపెట్"
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr "ఒబో"
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr "ట్రాంబోన్"
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr "ఎలక్ట్రానిక్ సింత్"
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "సింపుల్ 1"
 
@@ -2991,19 +2991,19 @@ msgstr "సింపుల్ 4"
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr "వైట్ నాయిజ్"
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "బ్రౌన్ నాయిస్"
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "పింక్ నాయిస్"
 
@@ -3011,61 +3011,61 @@ msgstr "పింక్ నాయిస్"
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr "స్నేర్ డ్రమ్"
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr "కిక్ డ్రమ్"
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr "టామ్ టామ్"
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr "ఫ్లోర్ టామ్"
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr "బాస్ డ్రమ్"
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "కప్ డ్రం"
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr "డార్బుకా డ్రం"
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr "హై హ్యాట్"
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr "రైడ్ బెల్"
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr "కౌ బెల్"
 
@@ -3075,149 +3075,149 @@ msgstr "జపనీస్ డ్రమ్"
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr "జపనీస్ బెల్"
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr "ట్రయాంగిల్ బెల్"
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr "ఫింగర్ సింబల్స్"
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "చైమ్"
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr "గాంగ్"
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr "క్లాంగ్"
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr "క్రాష్"
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr "బాటిల్"
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr "క్లాప్"
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr "స్లాప్"
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr "స్ప్లాష్"
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr "బబుల్స్"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr "రెయిండ్రాప్"
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr "క్యాట్"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr "క్రికెట్"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr "డాగ్"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr "బ్యాంజో"
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr "కోటో"
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr "డల్సిమర్"
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr "ఎలక్ట్రిక్ గిటార్"
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr "బాసూన్"
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr "సెలెస్ట్"
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr "సమాన"
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "పైతాగోరియన్"
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr "కేవల సరళ సమాంతరం"
 
@@ -3226,7 +3226,7 @@ msgstr "కేవల సరళ సమాంతరం"
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3305,22 +3305,22 @@ msgid "previous"
 msgstr "మునుపటి"
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "సింపుల్-2"
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "సింపుల్-3"
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "సింపుల్-4"
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr "టైకో"
 
@@ -3477,7 +3477,7 @@ msgstr "గెట్-డిక్ట్ బ్లాక్ ఒక కేటగ�
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "కొరకు డిక్షనరీ నుండి విలువను తరిమించు"
 
@@ -3499,7 +3499,7 @@ msgstr "కీ2"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "కీ"
 
@@ -3510,7 +3510,7 @@ msgstr "సెట్-డిక్ట్ బ్లాక్ ఒక కేటగ�
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr "కొరకు డిక్షనరీలో విలువను సెట్ చేయి"
 
@@ -3539,7 +3539,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr "పిచ్ యొక్క ప్రతి సంబంధాన్ను ఒక డ్రమ్ ధ్వనితో మార్చు."
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "పిచ్ను ఒక డ్రమ్ ధ్వనికి మ్యాప్ చేయండి"
 
@@ -3548,7 +3548,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "ప్రాచుర్యంలో, ఒక కిక్ డ్రమ్ ధ్వని సొల్ కాదు."
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "ప్లేబ్యాక్కు ప్రస్తుత డ్రమ్ ధ్వనిని సెట్ చేయండి"
 
@@ -3581,7 +3581,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "హీప్-ఖాళీ? బ్లాక్ హీప్ ఖాళీ ఉంటే నిజమేనని తిరిగిస్తుంది."
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "హీప్ ఖాళీ?"
 
@@ -3591,7 +3591,7 @@ msgstr "ఎంప్టీ-హీప్ బ్లాక్ హీప్ను �
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "ఖాళీ హీప్"
 
@@ -3600,7 +3600,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr "రివర్స్-హీప్ బ్లాక్ హీప్ యొక్క క్రమాను ప్రతిపలకం చేస్తుంది."
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr "హీప్ క్రమాను ప్రతిపలకం చేస్తుంది."
 
@@ -3609,7 +3609,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr "ఇండెక్స్-హీప్ బ్లాక్ హీప్లో ఒక క్షేత్రంలో విలువను తిరిగిస్తుంది."
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "ఇండెక్స్ హీప్"
 
@@ -3632,13 +3632,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "హీప్‌ను లోడ్ చేయండి"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "సూచి"
 
@@ -3647,7 +3647,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr "పాప్ బ్లాక్ హీప్ చేతిన విలువను తీసేస్తుంది."
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "ఎగసి"
 
@@ -3656,7 +3656,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr "పుష్ బ్లాక్ హీప్ చేతిన విలువను చేర్చిస్తుంది."
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "నెట్టు"
 
@@ -3676,7 +3676,7 @@ msgstr "టెంపరమెంట్ సెట్ చేయి"
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "ఆక్టేవ్"
 
@@ -3701,7 +3701,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr "రెండు స్వరాల మధ్య దూరం పరిమాణం పెంచడానికి మెయిజర్"
 
@@ -3715,7 +3715,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr "స్కాలార్ ఇంటర్వల్ బ్లాక్ ప్రస్తుత కీ మరియు మోడ్ లో రెండు స్వరాల మధ్య దూరం పరిమాణం పెంచివేస్తుంది."
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr "మ్యూజికల్ స్కేల్ స్టెప్ల మధ్య రెండు స్వరాల మధ్య దూరం పరిమాణం పెంచడానికి మెయిజర్"
 
@@ -3725,7 +3725,7 @@ msgstr "చిత్రలో, మేము సోల్# ను సోల్క
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr "సెమీ-టోన్ ఇంటర్వల్"
 
@@ -3763,7 +3763,7 @@ msgid "In the figure, we add la to sol."
 msgstr "చిత్రలో, మేము సోల్ కి లానిని జోడిస్తాము."
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr "కస్టమ్ మోడ్"
 
@@ -3772,7 +3772,7 @@ msgid "movable Do"
 msgstr "మూవబుల్ డో"
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "మోడ్ పొడవు"
 
@@ -3785,18 +3785,18 @@ msgid "Most Western scales have 7 notes."
 msgstr "అనేక పశ్చిమ స్కేల్లు 7 స్వరాలు ఉన్నాయి."
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "ప్రస్తుత మోడ్"
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr "ప్రస్తుత కీ"
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "కీని మరియు మోడ్ సెట్ చేయండి, ఉదా. C మేజర్"
 
@@ -3917,7 +3917,7 @@ msgstr "స్లర్ ఫ్యాక్టర్"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr "పడమాని"
 
@@ -3936,7 +3936,7 @@ msgstr "స్లర్"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "స్టాకాటో"
 
@@ -3945,7 +3945,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr "లోడ్-హీప్-ఫ్రం-యాప్ బ్లాక్ ఒక వెబ్ పేజీని నుండి హీప్‌ను లోడ్ చేస్తుంది."
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr "అప్‌ను నుండి హీప్ కంటెంట్‌ను లోడ్ చేయండి"
 
@@ -3962,7 +3962,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr "సేవ్-హీప్-టు-యాప్ బ్లాక్ హీప్‌ను ఒక వెబ్ పేజీకి భద్రపరచేస్తుంది."
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr "అప్‌కి హీప్ కంటెంట్‌ను భద్రపరచేయండి"
 
@@ -3975,7 +3975,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr "లోడ్-హీప్ బ్లాక్ హీప్‌ను ఒక ఫైల్‌నుండి లోడ్ చేస్తుంది."
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "హీప్‌ను ఫైల్ నుండి లోడ్ చేయండి"
 
@@ -4004,7 +4004,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr "లోడ్-డిక్షనరీ బ్లాక్ ఫైల్‌నుండి డిక్షనరీను లోడ్ చేస్తుంది."
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "డిక్షనరీను లోడ్ చేయండి"
 
@@ -4027,7 +4027,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr "సెట్-నిఘంటువు బ్లాక్ నిఘంటువును లోడ్ చేస్తుంది."
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr "సెట్ నిఘంటువు"
 
@@ -4044,7 +4044,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr "సేవ్-హీప్ బ్లాక్ హీప్ను ఒక ఫైల్కు సేవ్ చేస్తుంది."
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "హీప్ను సేవ్ చేయండి"
 
@@ -4053,7 +4053,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr "సేవ్-నిఘంటువు బ్లాక్ ఒక నిఘంటువును ఒక ఫైల్కు సేవ్ చేస్తుంది."
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr "నిఘంటువును సేవ్ చేయండి"
 
@@ -4070,7 +4070,7 @@ msgid "The Delete block block removes a block."
 msgstr "డిలీట్ బ్లాక్ బ్లాక్ ఒక బ్లాక్ను తీసేస్తుంది."
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr "ఈ బ్లాక్ను కచ్చివేయండి."
 
@@ -4079,7 +4079,7 @@ msgid "The Move block block moves a block."
 msgstr "మూవ్ బ్లాక్ బ్లాక్ ఒక బ్లాక్ను నేయిస్తుంది."
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr "బ్లాక్ను నేయండి"
 
@@ -4113,7 +4113,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr "ఈ బ్లాక్ను తొలగించండి"
 
@@ -4122,7 +4122,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr "ఒక బ్లాక్ను మరియునా ఒక బ్లాక్కు కలిగించండి."
 
@@ -4139,7 +4139,7 @@ msgid "The Make block block creates a new block."
 msgstr "మేక్ బ్లాక్ బ్లాక్ ఒక కొత్త బ్లాక్ను సృష్టిస్తుంది."
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr "ప్రోగ్రామ్తాత కొత్త బ్లాక్ను సృష్టించండి."
 
@@ -4154,7 +4154,7 @@ msgstr "ప్రోగ్రామ్తాత కొత్త బ్లాక�
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "నోట్"
 
@@ -4188,12 +4188,12 @@ msgstr "నోట్ విల్యూ కనీసం 0 కంటే ఎక్
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "స్వింగ్"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "స్వింగ్ విల్యూ"
 
@@ -4202,12 +4202,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr "స్కిప్ నోట్స్ బ్లాక్ నోట్లను విడిపిస్తుంది."
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "స్కిప్ నోట్స్"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "నోట్ విల్యూను ఎటువంటిని గట్టిగా పెరగండి, ఉదా. ఫ్యాక్టర్ 2 ని ఉపయోగించి 1/4 ను 1/8 నోట్లకు మార్చండి."
 
@@ -4216,13 +4216,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr "టై బ్లాక్ ద్వయాన్ని పనులను మిలకుగా వాటిని ఒక నోట్గా కలిగిస్తుంది."
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "బంధించు"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "డాట్"
 
@@ -4240,7 +4240,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr "ఉదా, ఒక డాట్ క్వార్టర్ నోట్ బీట్ కి 3/8 (1/4 + 1/8) ప్రకారం ప్రదర్శించబడుతుంది."
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr "నోటు విలువ డ్రమ్"
 
@@ -4272,8 +4272,8 @@ msgstr "ఆక్టేవ్ స్పేస్"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "రిదం1"
 
@@ -4329,7 +4329,7 @@ msgstr "పూర్ణ నోట్"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "ట్యూప్లెట్"
 
@@ -4486,12 +4486,12 @@ msgid "duplicate factor"
 msgstr "ఎంపికలు ఏమిటి ఎంపిక చేసేందుకు ఉపయోగపడే అంశం"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr "ప్రస్తుత మీటర్"
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "బీట్ ఫ్యాక్టర్"
 
@@ -4501,8 +4501,8 @@ msgstr "బీట్స్ పెర్ మినిట్ బ్లాక్ �
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "ప్రతి నిమిషం ప్రతి నిమిషం ప్రతి నిమిషం ప్రతి నిమిషం ప్రతి నిమిషం ప్రతి నిమిషం"
 
@@ -4510,12 +4510,12 @@ msgstr "ప్రతి నిమిషం ప్రతి నిమిషం �
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "మినిట్లో బీట్లు"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr "మీటర్ లో ప్రస్తుత సంగీత మెజరు సంఖ్య"
 
@@ -4524,7 +4524,7 @@ msgid "The Measure count block returns the current measure."
 msgstr "మీజర్ కౌంట్ బ్లాక్ ప్రస్తుత మీజర్ను తిరిగిస్తుంది."
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr "మీటర్ లో ప్రస్తుత బీట్ సంఖ్య"
 
@@ -4541,7 +4541,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr "ఉదాహరణగా, 1, 2, 3, లేదా 4."
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr "గానా విలువల సంఖ్య గణించండి"
 
@@ -4551,12 +4551,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr "గానా కౌంటర్ బ్లాక్ విలువలను కంటులో గణించడానికి ఉపయోగించవచ్చు."
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr "గానా కౌంటర్"
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -4566,7 +4566,7 @@ msgstr "హోల్ నోట్లు ప్రారంభించబడి�
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -4575,7 +4575,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr "నో క్లాక్ బ్లాక్ నోట్లను మాస్టర్ క్లాక్ నుంచి విరామం చేస్తుంది."
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "మాస్టర్ క్లాక్కు గానాలను లాక్ చేయాలేదు"
 
@@ -4625,7 +4625,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr "మాస్టర్ బీట్స్ పర్ మినిట్"
 
@@ -4658,7 +4658,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr "ప్రతిసారి నోటుకు 1/4 నోటుల సంఖ్యను మినిట్ కోసం మార్చేస్తుంది."
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr "పికప్"
 
@@ -4667,12 +4667,12 @@ msgid "number of beats"
 msgstr "బీట్స్ సంఖ్య"
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "స్వరాను సరిగా చేయడానికి సవరాను"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr "ప్రస్తుత సంగీత స్కేల్‌లో ఒక నోట్ క్రిందకి ఒక అంశం తగ్గిస్తుంది"
 
@@ -4681,7 +4681,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr "స్కేల్‌లో మునుపటి గానంకి డౌన్ చేసే సెమీ-టోన్స్ సంఖ్యను తరిచేస్తుంది."
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr "ప్రస్తుత సంగీత స్కేల్‌లో ఒక నోట్ పెరిగిపోయి ఉంచిస్తుంది"
 
@@ -4690,7 +4690,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr "స్కేల్‌లో తరిగిన గానంకి డబ్బుల సంఖ్యను తరిచేస్తుంది."
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr "ప్రస్తుత స్వరాన్ని మునుపటి స్వరంలో మారుకోవడానికి అనుమానాంకాల మార్గాన మార్గాన మారుతుంది."
 
@@ -4699,7 +4699,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr "ప్రస్తుత ప్లే చేయబడుతున్న స్వరాన్ని మునుపటి ప్లే చేయబడిన స్వరాన్ని (అంశాలలో) వ్యత్యాసం ఉంది."
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr "ధ్వనిలో స్కాలర్ మారుతోంది"
 
@@ -4710,8 +4710,8 @@ msgstr "ధ్వనిలో స్కాలర్ మారుతోంది"
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr "పిచ్ సంఖ్య"
 
@@ -4721,7 +4721,7 @@ msgstr "పిచ్ సంఖ్య బ్లాక్ ప్రస్తుత
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -4747,7 +4747,7 @@ msgid "alphabet"
 msgstr "అక్షరము"
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr "అక్షర వర్గం"
 
@@ -4785,12 +4785,12 @@ msgstr "పిచ్ ను రంగుకు"
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr "MIDI"
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr "పిచ్ సంఖ్య ఆఫ్‌సెట్ సెట్ చేయండి"
 
@@ -4802,12 +4802,12 @@ msgstr "పిచ్ సంఖ్యలను పిచ్ మరియు ఆ�
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "పేరు2"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "నంబర్ ను పిచ్ కి మార్చండి"
 
@@ -4816,7 +4816,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "నంబర్ ను ఒక్టేవ్‌కి మార్చండి"
 
@@ -4862,22 +4862,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr "అదనపు చేయు"
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "వామకాలానికి రోటేట్ చేస్తుంది (అసమం)"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "వామకాలానికి రోటేట్ చేస్తుంది (సమం)"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr "రిజిస్టర్"
 
@@ -4886,7 +4886,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr "రిజిస్టర్ బ్లాక్ అనుసరించే గానాల రిజిస్టర్ (ఆక్టేవ్) పరిష్కరించడానికి సులభ మార్గానే అందిస్తుంది."
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -4899,7 +4899,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr "ప్రదర్శించిన ఉదాహరణలో, సోల్ ను సోల్# కి అప్ చేయబడింది."
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr "సెమి-టోన్ ట్రాన్స్పోజ్"
 
@@ -4908,47 +4908,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr "రేషియో ద్వారా ట్రాన్స్పోజ్"
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr "ఆచు లోను కుడియుతుంది"
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr "మూడు లోను కుడియుతుంది"
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr "ఏడవ"
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr "ఆరవ"
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr "ఐదవ"
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr "నాలవ"
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr "మూడవ"
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr "రెండవ"
 
@@ -4961,7 +4961,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr "ప్రదర్శించిన ఉదాహరణలో, సోల్ ను లా కి అప్ చేయబడింది."
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr "స్కాలర్ ట్రాన్స్పోజ్"
 
@@ -4970,7 +4970,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr "అక్షిడెంటల్ ఓవర్రైడ్"
 
@@ -4978,7 +4978,7 @@ msgstr "అక్షిడెంటల్ ఓవర్రైడ్"
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr "హర్ట్జ్"
 
@@ -4992,8 +4992,8 @@ msgstr "పిచ్ నంబర్ బ్లాక్ ఒక సంఖ్య �
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr "మోడల్ పిచ్ యొక్క సంఖ్యాత్మక మ్యాపింగ్"
 
@@ -5022,7 +5022,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr "స్కేల్ డిగ్రీ 1 సదాగా ఒక ఇచ్చిన స్కేల్ లో మొదటి పిచ్ గా, ఆక్టేవ"
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr "స్కాలర్ స్టెప్"
 
@@ -5047,14 +5047,14 @@ msgstr "ఆస్కిలేటర్"
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr "రకము"
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr "పార్షల్స్"
 
@@ -5064,7 +5064,7 @@ msgstr "మీరు అనేక ఆసిలేటర్ బ్లాక్ల
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr "డ్యూవో సింథ్"
 
@@ -5083,7 +5083,7 @@ msgstr "విబ్రాటో కఠినత"
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr "AM సింథ్"
 
@@ -5093,7 +5093,7 @@ msgstr "AM సింథ్ బ్లాక్ ఒక ఏమ్ప్లిట్
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr "FM సింథ్"
 
@@ -5110,17 +5110,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr "పార్షల్ బ్లాక్ ఒక నిర్దిష్ట పార్షల్ హార్మోనిక్కు ఒక బరువును నిర్ధిష్టించడానికి ఉపయోగిస్తుంది."
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr "పార్షల్ బరువు 0 నుండి 1 మధ్యలో ఉండాలి."
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr "పార్షల్ బ్లాక్ ఒక బరువును నిర్ధిష్టించడానికి పైన Weighted-partials బ్లాక్ లో ఉపయోగించాలి."
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr "వేటెడ్ పార్షల్స్"
 
@@ -5129,7 +5129,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr "హార్మోనిక్ బ్లాక్ అంగీకరించిన నోట్లకు హార్మోనిక్స్ ను జోడిస్తుంది."
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr "హార్మోనిక్"
 
@@ -5139,7 +5139,7 @@ msgstr "డిస్టోర్షన్ బ్లాక్ పిచ్ కి
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr "డిస్టోర్షన్"
 
@@ -5149,7 +5149,7 @@ msgstr "ట్రెమోలో బ్లాక్ ఒక పలకింపు
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr "ట్రెమోలో"
 
@@ -5161,7 +5161,7 @@ msgstr "ట్రెమోలో"
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr "వేగం"
 
@@ -5169,7 +5169,7 @@ msgstr "వేగం"
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr "గాంభీర్యం"
 
@@ -5179,7 +5179,7 @@ msgstr "ఫేసర్ బ్లాక్ ఒక స్వీపింగ్ �
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr "ఫేసర్"
 
@@ -5200,7 +5200,7 @@ msgstr "ఛోరస్ బ్లాక్ ఒక ఛోరస్ ప్రభ�
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr "ఛోరస్"
 
@@ -5215,7 +5215,7 @@ msgstr "విబ్రాటో బ్లాక్ ఒక శీఘ్ర, స�
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr "విబ్రాటో"
 
@@ -5225,7 +5225,7 @@ msgid "intensity"
 msgstr "ప్రాధికూత్య"
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr "సింథెసైజర్ను ఎంచుకో"
 
@@ -5239,7 +5239,7 @@ msgstr "డిఫాల్ట్ వాద్యంను సెట్ చేయ
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr "అనుకూల వాద్యంను సెట్ చేయండి"
 
@@ -5295,7 +5295,7 @@ msgstr "కాలక్యూలేట్"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr "డూ బ్లాక్ ఒక యాక్షన్ను ప్రారంభించడానికి ఉపయోగిస్తారు."
 
@@ -5473,7 +5473,7 @@ msgid "Cannot find start block"
 msgstr "ప్రారంభించడానికి బ్లాక్ కనబడదు"
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "మౌస్ రంగు"
 
@@ -5482,7 +5482,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr "నిర్దిష్టమైన మౌస్ కోసం పెన్ రంగును తరిస్తుంది."
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "టర్టిల్ రంగు"
 
@@ -5491,7 +5491,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr "నిర్దిష్టమైన టర్టిల్ కోసం పెన్ రంగును తరిస్తుంది."
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "మౌస్ హెడింగ్"
 
@@ -5500,7 +5500,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr "నిర్దిష్టమైన మౌస్ కోసం హెడింగ్ ను తరిస్తుంది."
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "టర్టిల్ హెడింగ్"
 
@@ -5510,13 +5510,13 @@ msgstr "నిర్దిష్టమైన టర్టిల్ కోసం 
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr "మౌస్ స్థానాన్ని సెట్ చేయండి"
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr "టర్టిల్ స్థానాన్ని సెట్ చేయండి"
 
@@ -5529,7 +5529,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr "నిర్దిష్టమైన టర్టిల్ ద్వారా అభివృద్ధి చేయబడిన బ్లాక్ల స్టాక్ను పంపిస్తుంది."
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "మౌస్ Y స్థానం"
 
@@ -5538,7 +5538,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr "నిర్దిష్టమైన మౌస్ కోసం Y స్థానాన్ను తరిస్తుంది."
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "టర్టిల్ Y స్థానం"
 
@@ -5547,7 +5547,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr "నిర్దిష్టమైన టర్టిల్ కోసం Y స్థానాన్ను తరిస్తుంది."
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "మౌస్ X స్థానం"
 
@@ -5556,7 +5556,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr "నిర్దిష్టమైన మౌస్ కోసం X స్థానాన్ను తరిస్తుంది."
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "టర్టిల్ X స్థానం"
 
@@ -5565,7 +5565,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr "నిర్దిష్టమైన టర్టిల్ కోసం X స్థానాన్ను తరిస్తుంది."
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "మౌస్ ప్లే చేసిన నోట్లు"
 
@@ -5574,7 +5574,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr "నిర్దిష్టమైన మౌస్ కోసం Elapse చేసిన నోట్ల సంఖ్యను తరిస్తుంది."
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "టర్టిల్ ప్లే చేసిన నోట్లు"
 
@@ -5583,7 +5583,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr "నిర్దిష్టమైన టర్టిల్ కోసం Elapse చేసిన నోట్ల సంఖ్యను తరిస్తుంది."
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "మౌస్ పిచ్ సంఖ్య"
 
@@ -5592,7 +5592,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr "నిర్దిష్టమైన మౌస్ కోసం ప్రస్తుత పిచ్ సంఖ్యను తరిస్తుంది."
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "టర్టిల్ పిచ్ సంఖ్య"
 
@@ -5602,17 +5602,17 @@ msgstr "నిర్దిష్టమైన టర్టిల్ కోసం 
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr "మౌస్ నోట్ విల్యూ"
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "టర్టిల్ నోట్ విల్యూ"
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "మౌస్ సింక్"
 
@@ -5621,7 +5621,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "మౌస్ సింక్ బ్లాక్ మౌస్ల మధ్య బీట్ కౌంటును అమర్చుకుంది."
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "టర్టిల్ సింక్"
 
@@ -6048,7 +6048,7 @@ msgid "wrap"
 msgstr "ర్యాప్"
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr "డిక్షన్ (స్క్రీన్)"
 
@@ -6058,7 +6058,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr "రైట్ బ్లాక్ క్యానవాస్ యొక్క కూడా స్థానాన్ని తరిస్తుంది."
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "ఎడా (స్క్రీన్)"
 
@@ -6102,12 +6102,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr "ఎత్తు బ్లాక్ క్యానవాస్ యొక్క ఎత్తను తరిస్తుంది."
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "ప్లే నిలిపివేయి"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr "చిత్రాలు మరియు వచనాలను తొలగించు"
 
@@ -6116,7 +6116,7 @@ msgid "The Erase Media block erases text and images."
 msgstr "ఎరేస్ మీడియా బ్లాక్ వచనాలు మరియు చిత్రాలను తొలగించిపెట్టింది."
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "ప్లే బ్యాక్"
 
@@ -6165,7 +6165,7 @@ msgstr "స్టాప్ మీడియా బ్లాక్ ఆడియో
 #: js/widgets/temperament.js:1446
 #: js/widgets/timbre.js:1834
 msgid "frequency"
-msgstr "సంవర్ధన" "
+msgstr "సంవర్ధన"
 
 #: js/blocks/MediaBlocks.js:692
 #: plugins/rodi.rtp:193
@@ -6173,7 +6173,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "గానాను హర్ట్జ్‌కు అనువదించండి, ఉదాహరణ A4 -> 440HZ"
 
@@ -6191,7 +6191,7 @@ msgstr "ఆవతార్ బ్లాక్ టర్టిల్ యొక్
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "పరిమాణం"
 
@@ -6204,7 +6204,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr "షో బ్లాక్ టెక్స్ట్ లేదా చిత్రాలను క్యాన్వాస్‌పై ప్రదర్శించడానికి ఉపయోగిస్తారు."
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "ప్రదర్శించు1"
 
@@ -6269,7 +6269,7 @@ msgstr "భరించడానికి ముగింపు"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "బ్యాక్‌గ్రౌండ్"
 
@@ -6334,7 +6334,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr "హాలో లైన్ బ్లాక్ హాలో సెంటర్ తో ఒక రేఖను సృష్టిస్తుంది."
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "హాలో లైన్"
 
@@ -6343,12 +6343,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr "ఫిల్ బ్లాక్ రంగుతో ఒక ఆకారాన్ని భరిస్తుంది."
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "భరించు"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "కలం పట్టుకొను"
 
@@ -6357,7 +6357,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "పెన్-అప్ బ్లాక్ పెన్ను ఎగుపెడతాయి, అది దారిచేయడం లేదు."
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "కలం పక్కనపెట్టు"
 
@@ -6366,7 +6366,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "పెన్-డౌన్ బ్లాక్ పెన్ను కలిగిస్తుంది, అది దారిచేయడంలేదు."
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "కలం పరిమాణాన్ని అమర్చు"
 
@@ -6375,7 +6375,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr "సెట్-పెన్-సైజ్ బ్లాక్ పెన్ పరిమాణం మార్చిపెడతాయి."
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "పారదర్శకతను సెట్ చేయండి."
 
@@ -6400,7 +6400,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr "సెట్-షేడ్ బ్లాక్ పెన్ రంగును అంగడానికి మార్చిపెడతాయి."
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "గ్రే ను సెట్ చేయండి."
 
@@ -6535,27 +6535,27 @@ msgstr "కీబోర్డు బ్లాక్ కంప్యూటర్ 
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr "ఎన్వలప్"
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "ఆటాక్"
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "డికే"
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "సస్టేన్"
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "రిలీస్"
 
@@ -6581,18 +6581,18 @@ msgstr "మీరు అనేక ఎన్వలప్ బ్లాక్‌ల
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr "ఫిల్టర్"
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr "రోలాఫ్"
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr "రోలాఫ్ విలువ ఆరంభంగా -12, -24, -48 లేదా -96 డిసిబల్లాలు/అక్టావ్ అవసరం."
 
@@ -6607,7 +6607,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr "ఒక నమూనాను అప్లోడ్ చేసి అదిక పిచ్ కేంద్రాన్ని సరిచూడండి."
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "సాంప్లర్"
 
@@ -6628,7 +6628,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr "కస్టమ్ మోడ్ బ్లాక్ సంగీత మోడ్ (స్కేల్లో గానాల వడపోత) అన్నిటికి ఆవకాశాన్ని తెరిచివేస్తుంది."
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "కస్టమ్ మోడ్"
 
@@ -6645,7 +6645,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr "పిచ్ డ్రమ్ మ్యాట్రిక్స్ పిచ్లను డ్రమ్ సౌండ్లకు మ్యాప్ చేయడానికి ఉపయోగిస్తారు."
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "పిచ్-డ్రమ్ మ్యాప్పర్"
 
@@ -6658,7 +6658,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr "పిచ్ స్లైడర్ టూల్ ఎంచుకోబడి అంగులాలలో పిచ్లను ఉత్పత్తించడానికి ఉపయోగిస్తారు."
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "పిచ్ స్లైడర్"
 
@@ -6668,7 +6668,7 @@ msgstr "క్రోమాటిక్ కీబోర్డ్"
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr "సంగీత కీబోర్డ్"
 
@@ -6682,7 +6682,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr "పిచ్ స్టెయర్కేస్ టూల్ అంగులాలో ఇచ్చిన అనుపాతం నుండి పిచ్లను ఉత్పత్తించడానికి ఉపయోగిస్తారు."
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "పిచ్ స్టెయర్కేస్"
 
@@ -6703,7 +6703,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr "ఫ్రేస్ మేకర్ బ్లాక్ సంగీత ఫ్రేస్లను రచించడానికి టూల్ తెరిచివేస్తుంది."
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "ఫ్రేస్ మేకర్"
 
@@ -6717,7 +6717,7 @@ msgstr "స్టేటస్ బ్లాక్ మ్యూజిక్ బ్
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -6793,7 +6793,7 @@ msgstr "హెచ్చరిక: ధ్వని కేవలం ఎడమ ల�
 #: js/blocks/VolumeBlocks.js:647
 #: js/blocks/VolumeBlocks.js:695
 msgid "set master volume"
-msgstr ""మాస్టర్ వాల్యూమ్ ను సెట్ చేయండి."
+msgstr "మాస్టర్ వాల్యూమ్ ను సెట్ చేయండి."
 
 #: js/blocks/VolumeBlocks.js:653
 msgid "The Set master volume block sets the volume for all synthesizers."
@@ -6904,7 +6904,7 @@ msgstr "విబ్రాటో రేట్ 0 కంటే ఎక్కువ 
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr "డెప్త్ అవుట్ ఆఫ్ రేంజ్ లో ఉంది."
 
@@ -6913,7 +6913,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr "డిస్టోర్షన్ 0 నుండి 100 వరకు ఉండాలి."
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr "పార్షియల్ 0 నుండి కనీసం ఎక్కువ ఉండాలి."
 
@@ -7035,7 +7035,7 @@ msgid "Undo"
 msgstr "విస్తరించు"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr "మోడ్ కోసం నోట్లను ఎంచుకోవడానికి వృత్తంలో నొక్కండి."
 
@@ -7118,7 +7118,7 @@ msgid "Save drum machine"
 msgstr "డ్రమ్ యంత్రాన్ని భద్రపరచండి"
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr "రిదయాను గొట్టండి"
 
@@ -7168,7 +7168,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr "రెఫరెన్స్ టోన్"
 
@@ -7285,7 +7285,7 @@ msgstr "సింథిసైజర్"
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr "ప్రభావాలు"
 
@@ -7364,48 +7364,48 @@ msgid "Cannot connect to server"
 msgstr "సర్వర్‌కు కనెక్ట్ అవ్వడం అసాధ్యం"
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr "అన్ని ప్రాజెక్టులు"
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr "నా ప్రాజెక్టులు"
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr "ఉదాహరణలు"
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr "కళా"
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr "గణితం"
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr "ఇంటరాక్టివ్"
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr "డిజైన్"
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr "ఆట"
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr "కోడ్ స్నిపెట్"
 
@@ -7838,38 +7838,38 @@ msgstr "చలింపు"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr "మీ ప్రాజెక్ట్ ను WAV రూపంలో ఆడియోని భద్రపరచండి."
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr "మీ ప్రాజెక్ట్ ను WAV రూపంలో ఆడియోని భద్రపరచండి."
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr "మీ ప్రాజెక్ట్ ను ABC ఫైల్ గా భద్రపరచండి."
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr "మీ ప్రాజెక్ట్ ను ABC ఫైల్ గా భద్రపరచండి."
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "మీ ప్రాజెక్ట్ ను Lilypond ఫైల్ గా భద్రపరచండి."
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "మీ ప్రాజెక్ట్ ను Lilypond ఫైల్ గా భద్రపరచండి."
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr "ఒక కోఆర్డినేట్ గ్రిడ్‌ను చూపించాలి లేదా దాచాలి."
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr "ఒక కోఆర్డినేట్ గ్రిడ్‌ను చూపించాలి లేదా దాచాలి."
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr "పెరగాలి/కుగాలి మాడిన బ్లాక్‌లను విస్తరించండి/మూసివేయండి"
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr "పెరగాలి/కుగాలి మాడిన బ్లాక్‌లను విస్తరించండి/మూసివేయండి"
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "ఈ సందేశాలను చూపించండి."
+#~ msgid "Show these messages."
+#~ msgstr "ఈ సందేశాలను చూపించండి."
 
 #: js/rubrics.js:531
 
@@ -7877,8 +7877,8 @@ msgstr "చలింపు"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "సెన్సర్స్"
+#~ msgid "sensors"
+#~ msgstr "సెన్సర్స్"
 
 #: js/rubrics.js:532
 
@@ -7888,8 +7888,8 @@ msgstr "చలింపు"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "మీడియా"
+#~ msgid "media"
+#~ msgstr "మీడియా"
 
 #: js/block-verbose.js:3837
 
@@ -7901,35 +7901,35 @@ msgstr "చలింపు"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr "కార్టీషియన్ + పోలార్"
+#~ msgid "Cartesian+polar"
+#~ msgstr "కార్టీషియన్ + పోలార్"
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "చూపు"
+#~ msgid "show"
+#~ msgstr "చూపు"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr "బ్లాక్ ను చూపు/దాచు"
+#~ msgid "Show/hide block"
+#~ msgstr "బ్లాక్ ను చూపు/దాచు"
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "గ్రిడ్"
+#~ msgid "grid"
+#~ msgstr "గ్రిడ్"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr "మీరు ఎంచుకున్నారు కీ"
+#~ msgid "You have chosen key "
+#~ msgstr "మీరు ఎంచుకున్నారు కీ"
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr "మీ పిచ్ ప్రివ్యూ కోసం"
+#~ msgid " for your pitch preview."
+#~ msgstr "మీ పిచ్ ప్రివ్యూ కోసం"
 
 #: js/toolbar.js:113
 
@@ -7943,69 +7943,69 @@ msgstr "చలింపు"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr "పూర్తి స్క్రీన్"
+#~ msgid "Full Screen"
+#~ msgstr "పూర్తి స్క్రీన్"
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr "కొత్త ప్రాజెక్ట్"
+#~ msgid "New Project"
+#~ msgstr "కొత్త ప్రాజెక్ట్"
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr "సంగీతం"
+#~ msgid "music"
+#~ msgstr "సంగీతం"
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr "భద్రపరచండి"
+#~ msgid "save"
+#~ msgstr "భద్రపరచండి"
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "శుభ్రపరుచు"
+#~ msgid "Clean"
+#~ msgstr "శుభ్రపరుచు"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "ప్రాజెక్ట్‌ను నిధానంగా పరికరించండి"
+#~ msgid "Run slow"
+#~ msgstr "ప్రాజెక్ట్‌ను నిధానంగా పరికరించండి"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr "మీంటోన్"
+#~ msgid "meantone"
+#~ msgstr "మీంటోన్"
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "భాగాలను దాచు"
+#~ msgid "hide blocks"
+#~ msgstr "భాగాలను దాచు"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr "డ్యూప్లికేట్"
+#~ msgid "duplicate"
+#~ msgstr "డ్యూప్లికేట్"
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8025,13 +8025,13 @@ msgstr "చలింపు"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "పైన "
+#~ msgid "stop"
+#~ msgstr "పైన "
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "అవధి (మి.సె.)"
+#~ msgid "duration (ms)"
+#~ msgstr "అవధి (మి.సె.)"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8039,58 +8039,58 @@ msgstr "చలింపు"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "క్లియర్"
+#~ msgid "clear"
+#~ msgstr "క్లియర్"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "పిచ్ వామకాలానికి రోటేట్ చేస్తుంది"
+#~ msgid "invert"
+#~ msgstr "పిచ్ వామకాలానికి రోటేట్ చేస్తుంది"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr "n^th మోడల్ పిచ్ మోడ్లో సెమీటోన్ల పాటను తీసేసారు మరియు ప్రతి పాయింట్‌ను మోడ్ యొక్క ఒక డిగ్రీగా చేస్తారు,"
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr "n^th మోడల్ పిచ్ మోడ్లో సెమీటోన్ల పాటను తీసేసారు మరియు ప్రతి పాయింట్‌ను మోడ్ యొక్క ఒక డిగ్రీగా చేస్తారు,"
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr "N^th మోడల్ పిచ్ మోడ్ కోసం ఇన్‌పుట్ గా సంఖ్య ను తీసుకునిస్తుంది చివరి డిగ్రీ గా. 0 అందుకే మొదటి స్థానం, 1 అందుకే రెండవ, -1 అందుకే మొదటి ముందు గా ముందు ఉంది మరియు ఇతరు అనేకండి."
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr "N^th మోడల్ పిచ్ మోడ్ కోసం ఇన్‌పుట్ గా సంఖ్య ను తీసుకునిస్తుంది చివరి డిగ్రీ గా. 0 అందుకే మొదటి స్థానం, 1 అందుకే రెండవ, -1 అందుకే మొదటి ముందు గా ముందు ఉంది మరియు ఇతరు అనేకండి."
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr "ఆసిలేటర్"
+#~ msgid "oscillator"
+#~ msgstr "ఆసిలేటర్"
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr "విలంబన"
+#~ msgid "delay"
+#~ msgstr "విలంబన"
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr "ఎన్వలప్"
+#~ msgid "envelope"
+#~ msgstr "ఎన్వలప్"
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr "ఫిల్టర్"
+#~ msgid "filter"
+#~ msgstr "ఫిల్టర్"
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -8106,25 +8106,25 @@ msgstr "చలింపు"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr "కొత్త యాక్షన్ బ్లాక్ సృష్టించబడింది!"
+#~ msgid "New action block generated!"
+#~ msgstr "కొత్త యాక్షన్ బ్లాక్ సృష్టించబడింది!"
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "అవధి"
+#~ msgid "duration"
+#~ msgstr "అవధి"
 
 #: js/widgets/temperament.js:454
 
@@ -8134,46 +8134,46 @@ msgstr "చలింపు"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr "మూస"
+#~ msgid "close"
+#~ msgstr "మూస"
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr "ప్రచురించు ప్రాజెక్ట్"
+#~ msgid "Publish Project"
+#~ msgstr "ప్రచురించు ప్రాజెక్ట్"
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr "ఆడుకొను"
+#~ msgid "play"
+#~ msgstr "ఆడుకొను"
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr "Lilypondకు pickup ప్రాసెస్ చేయబడదు "
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr "Lilypondకు pickup ప్రాసెస్ చేయబడదు "
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr "ముందుగానే మోడ్ మార్చడానికి మీ బ్రౌజర్‌ను రిఫ్రెష్ చేయండి."
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr "ముందుగానే మోడ్ మార్చడానికి మీ బ్రౌజర్‌ను రిఫ్రెష్ చేయండి."
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr "మొదటి విద్యార్థి మోడ్‌కు మార్చడానికి మీ బ్రౌజర్‌ను రిఫ్రెష్ చేయండి."
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr "మొదటి విద్యార్థి మోడ్‌కు మార్చడానికి మీ బ్రౌజర్‌ను రిఫ్రెష్ చేయండి."
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
-#~msgid ""Toggle Fullscreen"
-#~msgstr ""పూర్తి పరిపూర్ణత మార్చు"
+#~ msgid "Toggle Fullscreen"
+#~ msgstr "పూర్తి పరిపూర్ణత మార్చు"
 
 #: js/toolbar.js:70
 
@@ -8183,205 +8183,205 @@ msgstr "చలింపు"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr "JavaScript ఎడిటర్‌ను టాగిల్ చేయండి"
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr "JavaScript ఎడిటర్‌ను టాగిల్ చేయండి"
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr "స్కేలార్ స్టెప్ బ్లాక్ నోట్ బ్లాక్ లో ఉపయోగించాలి."
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr "స్కేలార్ స్టెప్ బ్లాక్ నోట్ బ్లాక్ లో ఉపయోగించాలి."
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr "స్కేలార్ స్టెప్ బ్లాక్ పిచ్ బ్లాక్ ద్వారా ముందుకు వాడాలి."
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr "స్కేలార్ స్టెప్ బ్లాక్ పిచ్ బ్లాక్ ద్వారా ముందుకు వాడాలి."
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr "పూర్తి స్క్రీన్"
+#~ msgid "FullScreen"
+#~ msgstr "పూర్తి స్క్రీన్"
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr "పూర్తి స్క్రీన్ మోడ్‌ను టాగిల్ చేయండి."
+#~ msgid "Toggle full screen mode."
+#~ msgstr "పూర్తి స్క్రీన్ మోడ్‌ను టాగిల్ చేయండి."
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr "అధారణ టూల్‌బార్‌ను విస్తరించడానికి లేదా స్థానికం చేసినా కనిపించడానికి ఈ బటన్‌ను నొక్కండి."
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr "అధారణ టూల్‌బార్‌ను విస్తరించడానికి లేదా స్థానికం చేసినా కనిపించడానికి ఈ బటన్‌ను నొక్కండి."
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr "ట్యూప్లెట్ బ్లాక్ తగిన సమయాన్నిగా ప్రదర్శించిన గుంపును ఉత్పత్తి చేయడానికి ఉపయోగపడుతుంది."
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr "ట్యూప్లెట్ బ్లాక్ తగిన సమయాన్నిగా ప్రదర్శించిన గుంపును ఉత్పత్తి చేయడానికి ఉపయోగపడుతుంది."
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr "ట్యూప్లెట్లను ఉపయోగించడం సాధారణంగా 2 కు బేస్ కాని గుంపులను సృష్టించడానికి సులభం చేస్తుంది."
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr "ట్యూప్లెట్లను ఉపయోగించడం సాధారణంగా 2 కు బేస్ కాని గుంపులను సృష్టించడానికి సులభం చేస్తుంది."
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr "సెట్ టెంపరమెంట్ బ్లాక్ మ్యూజిక్ బ్లాక్స్ ద్వారా ఉపయోగించిన ట్యూనింగ్ సిస్టమ్ ఎంచుకోవడానికి ఉపయోగిస్తారు."
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr "సెట్ టెంపరమెంట్ బ్లాక్ మ్యూజిక్ బ్లాక్స్ ద్వారా ఉపయోగించిన ట్యూనింగ్ సిస్టమ్ ఎంచుకోవడానికి ఉపయోగిస్తారు."
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr "ఇంటర్వల్ నంబర్ బ్లాక్ ప్రస్తుత ఇంటర్వల్ లో స్కాలార్ అడుగుల సంఖ్యను తరిచివేస్తుంది."
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr "ఇంటర్వల్ నంబర్ బ్లాక్ ప్రస్తుత ఇంటర్వల్ లో స్కాలార్ అడుగుల సంఖ్యను తరిచివేస్తుంది."
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr "సెమీ-టోన్ ఇంటర్వల్ బ్లాక్ రెండు స్వరాల మధ్య దూరం పరిమాణం పెంచివేస్తుంది."
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr "సెమీ-టోన్ ఇంటర్వల్ బ్లాక్ రెండు స్వరాల మధ్య దూరం పరిమాణం పెంచివేస్తుంది."
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr "సెమీ-టోన్ ఇంటర్వల్ బ్లాక్ అర్ధపాదాల ఆధారంగా సంబంధిత ఇంటర్వల్ను గణనిస్తుంది."
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr "సెమీ-టోన్ ఇంటర్వల్ బ్లాక్ అర్ధపాదాల ఆధారంగా సంబంధిత ఇంటర్వల్ను గణనిస్తుంది."
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr "ఆర్పెజియో బ్లాక్ ప్రతి స్వర బ్లాక్ను ఎక్కువసారి ప్రదర్శిస్తుంది, నిర్దిష్ట కార్డ్ ఆధారంగా ఒక స్థానాన్ని కూడా జోడిస్తుంది."
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr "ఆర్పెజియో బ్లాక్ ప్రతి స్వర బ్లాక్ను ఎక్కువసారి ప్రదర్శిస్తుంది, నిర్దిష్ట కార్డ్ ఆధారంగా ఒక స్థానాన్ని కూడా జోడిస్తుంది."
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr "స్కాలార్ ఇంటర్వల్ బ్లాక్ ప్రస్తుత మోడ్ ఆధారంగా, మోడ్ బహిరంగంలోని అన్ని స్వరాలను తప్పించి ఉంటుంది."
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr "స్కాలార్ ఇంటర్వల్ బ్లాక్ ప్రస్తుత మోడ్ ఆధారంగా, మోడ్ బహిరంగంలోని అన్ని స్వరాలను తప్పించి ఉంటుంది."
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you to define a custom mode by specifying pitch numbers."
-#~msgstr "డిఫైన్ మోడ్ బ్లాక్ అంచనాలు ద్వారా మీరు కస్టమ్ మోడ్ను డిఫైన్ చేయవచ్చు."
+#~ msgid "The Define mode block allows you to define a custom mode by specifying pitch numbers."
+#~ msgstr "డిఫైన్ మోడ్ బ్లాక్ అంచనాలు ద్వారా మీరు కస్టమ్ మోడ్ను డిఫైన్ చేయవచ్చు."
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr "ఖచ్చితంగా మూవబుల్ డో ఉంటే, సొల్ఫేజ్ నోటు పేర్లు ఎలాగో క్రింది స్థాయిలో ఉంటాయి,"
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr "ఖచ్చితంగా మూవబుల్ డో ఉంటే, సొల్ఫేజ్ నోటు పేర్లు ఎలాగో క్రింది స్థాయిలో ఉంటాయి,"
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr "ఉదాహరణకు, మూవబుల్ డో నిజంగా ఉంటే, సొల్ఫేజ్ నోటు పేర్లు పరిమాణాలకు కేటాయిస్తాయి, \"డో\" అనేది మేజర్ స్కేల్ యొక్క మొదటి డిగ్రీకి పరిమాణం."
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr "ఉదాహరణకు, మూవబుల్ డో నిజంగా ఉంటే, సొల్ఫేజ్ నోటు పేర్లు పరిమాణాలకు కేటాయిస్తాయి, \"డో\" అనేది మేజర్ స్కేల్ యొక్క మొదటి డిగ్రీకి పరిమాణం."
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr "యాక్షన్ బ్లాక్ బ్లాక్లను గుంపుగా పరిచయించడానికి ఉపయోగిస్తారు."
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr "యాక్షన్ బ్లాక్ బ్లాక్లను గుంపుగా పరిచయించడానికి ఉపయోగిస్తారు."
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr "గ్రేటర్-థాన్ బ్లాక్ మేలు ఉన్న సంఖ్య కంటే కింది సంఖ్య ఎక్కువదు."
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr "గ్రేటర్-థాన్ బ్లాక్ మేలు ఉన్న సంఖ్య కంటే కింది సంఖ్య ఎక్కువదు."
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr "తక్కువగా ఉన్న మేలు సంఖ్య కంటే కింది సంఖ్య నుండి కనిష్ఠమైనది."
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr "తక్కువగా ఉన్న మేలు సంఖ్య కంటే కింది సంఖ్య నుండి కనిష్ఠమైనది."
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "ఈ ఉదాహరణలో, మౌస్ క్యానవాస్ యొక్క రైట్ ఎజ్ దాటి కొనసాగిస్తుంది; అప్పుడు అది క్యానవాస్ యొక్క ఎడంలో పునఃప్రకటిస్తుంది."
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "ఈ ఉదాహరణలో, మౌస్ క్యానవాస్ యొక్క రైట్ ఎజ్ దాటి కొనసాగిస్తుంది; అప్పుడు అది క్యానవాస్ యొక్క ఎడంలో పునఃప్రకటిస్తుంది."
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr "ఈ ఉదాహరణలో, టర్టిల్ రైట్ కి కూడినప్పుడు క్యానవాస్ యొక్క ఎడాజు వరకు చనిపోతుంది; అప్పుడు అది క్యానవాస్ యొక్క ఎడంలో మళ్లీ కనిపిస్తుంది."
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr "ఈ ఉదాహరణలో, టర్టిల్ రైట్ కి కూడినప్పుడు క్యానవాస్ యొక్క ఎడాజు వరకు చనిపోతుంది; అప్పుడు అది క్యానవాస్ యొక్క ఎడంలో మళ్లీ కనిపిస్తుంది."
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "ఈ ఉదాహరణలో, మౌస్ మేల్కొనలుడికి ముక్కను చేరుకుని పోతుంది; అప్పుడు అది క్యానవాస్ యొక్క కిందికి మళ్లీ ప్రకటిస్తుంది."
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "ఈ ఉదాహరణలో, మౌస్ మేల్కొనలుడికి ముక్కను చేరుకుని పోతుంది; అప్పుడు అది క్యానవాస్ యొక్క కిందికి మళ్లీ ప్రకటిస్తుంది."
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr "ఈ ఉదాహరణలో, టర్టిల్ మేల్కొనలుడికి ముక్కను చేరుకుని పోతుంది; అప్పుడు అది క్యానవాస్ యొక్క కిందికి మళ్లీ ప్రకటిస్తుంది."
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr "ఈ ఉదాహరణలో, టర్టిల్ మేల్కొనలుడికి ముక్కను చేరుకుని పోతుంది; అప్పుడు అది క్యానవాస్ యొక్క కిందికి మళ్లీ ప్రకటిస్తుంది."
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr "వీడియో సామగ్రి"
+#~ msgid "video material"
+#~ msgstr "వీడియో సామగ్రి"
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr "రన్ బ్లాక్ బ్లాక్ ఒక బ్లాక్ను పరిచయిస్తుంది. ఇది రెండు రకాల ఆర్గ్యుమెంట్లను అంగీకరిస్తుంది: బ్లాక్ సంఖ్య లేదా బ్లాక్ పేరు."
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr "రన్ బ్లాక్ బ్లాక్ ఒక బ్లాక్ను పరిచయిస్తుంది. ఇది రెండు రకాల ఆర్గ్యుమెంట్లను అంగీకరిస్తుంది: బ్లాక్ సంఖ్య లేదా బ్లాక్ పేరు."
 
 #: js/ProgramBlocks.js:649
 
-#~msgid "The Dock block block connects two blocks."
-#~msgstr "డాక్ బ్లాక్ బ్లాక్ రెండు బ్లాక్లను కలిగిస్తుంది."
+#~ msgid "The Dock block block connects two blocks."
+#~ msgstr "డాక్ బ్లాక్ బ్లాక్ రెండు బ్లాక్లను కలిగిస్తుంది."
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr "సెట్ డ్రమ్ బ్లాక్ అంగీకరించబడిన నోట్ల పిచ్ను మార్చడానికి ఒక డ్రమ్ ధ్వనిని ఎంచుకోడగితే."
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr "సెట్ డ్రమ్ బ్లాక్ అంగీకరించబడిన నోట్ల పిచ్ను మార్చడానికి ఒక డ్రమ్ ధ్వనిని ఎంచుకోడగితే."
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr "నోట్ విల్యూ బ్లాక్ ప్రస్తుతం ప్లే అవుతున్న నోట్ కాలం యొక్క విలువ."
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr "నోట్ విల్యూ బ్లాక్ ప్రస్తుతం ప్లే అవుతున్న నోట్ కాలం యొక్క విలువ."
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr "మిల్లీసెకన్ల బ్లాక్ ఒక నోట్ బ్లాక్ కి సమానంగా ఉంటుంది, కానీ అది నోట్ విలువను నిర్దిష్టం చేయడానికి సమయాన్ని (MS లో) ఉపయోగిస్తుంది."
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr "మిల్లీసెకన్ల బ్లాక్ ఒక నోట్ బ్లాక్ కి సమానంగా ఉంటుంది, కానీ అది నోట్ విలువను నిర్దిష్టం చేయడానికి సమయాన్ని (MS లో) ఉపయోగిస్తుంది."
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr "స్వింగ్ బ్లాక్ నోట్ విల్యూ ద్వయాన్ని (నోట్ విల్యూ ద్వారా) పనులను కలిగి, ఆది నోట్ కి కొంత కాలాన్ని (స్వింగ్ విల్యూ ద్వారా) జోడించి, రెండవ నోట్ నుండి అదిక మొత్తాన్ని తీసుకుపోతుంది."
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr "స్వింగ్ బ్లాక్ నోట్ విల్యూ ద్వయాన్ని (నోట్ విల్యూ ద్వారా) పనులను కలిగి, ఆది నోట్ కి కొంత కాలాన్ని (స్వింగ్ విల్యూ ద్వారా) జోడించి, రెండవ నోట్ నుండి అదిక మొత్తాన్ని తీసుకుపోతుంది."
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr "మల్టిప్లై నోట్ విల్యూ బ్లాక్ వాటి నోట్ విలువలను మార్చి, విలువల నొక్కినంత కాలాన్ని మార్చునుంది."
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr "మల్టిప్లై నోట్ విల్యూ బ్లాక్ వాటి నోట్ విలువలను మార్చి, విలువల నొక్కినంత కాలాన్ని మార్చునుంది."
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr "దరఖాస్తు చేసిన నోటు విలువ కాలాన్ని ఉపయోగించి సైలెన్స్ బ్లాక్ ని నిర్మించవచ్చు."
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr "దరఖాస్తు చేసిన నోటు విలువ కాలాన్ని ఉపయోగించి సైలెన్స్ బ్లాక్ ని నిర్మించవచ్చు."
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr "షో-హీప్ బ్లాక్ హీప్ యొక్క అంశాలను స్క్రీన్ పై చూపుతుంది."
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr "షో-హీప్ బ్లాక్ హీప్ యొక్క అంశాలను స్క్రీన్ పై చూపుతుంది."
 
 #: js/HeapBlocks.js:249
 
-#~msgid "The Set-heap entry block sets a value in the heap at the specified location."
-#~msgstr "సెట్-హీప్ ఎంట్రీ బ్లాక్ హీప్లో నిర్దిష్ట స్థానంలో ఒక విలువను సెట్ చేస్తుంది."
+#~ msgid "The Set-heap entry block sets a value in the heap at the specified location."
+#~ msgstr "సెట్-హీప్ ఎంట్రీ బ్లాక్ హీప్లో నిర్దిష్ట స్థానంలో ఒక విలువను సెట్ చేస్తుంది."
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr "ఉదాహరణ యొక్క ఆఉట్‌పుట్: సోల్, సోల్, సోల్, సోల్, రే, రే, రే, రే, సోల్, సోల్, సోల్, సోల్."
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr "ఉదాహరణ యొక్క ఆఉట్‌పుట్: సోల్, సోల్, సోల్, సోల్, రే, రే, రే, రే, సోల్, సోల్, సోల్, సోల్."
 
 #: js/FlowBlocks.js:679
 
@@ -8391,348 +8391,348 @@ msgstr "చలింపు"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr "పరిస్థితి ప్రకారం విభిన్న చర్యలను నమోదుతుంది."
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr "పరిస్థితి ప్రకారం విభిన్న చర్యలను నమోదుతుంది."
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr "ఈ ఉదాహరణలో మౌస్ బటన్ నొక్కితే స్నేర్ డ్రమ్ ప్లే అవుతుంది, ఇతరంగా కిక్ డ్రమ్ ప్లే అవుతుంది."
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr "ఈ ఉదాహరణలో మౌస్ బటన్ నొక్కితే స్నేర్ డ్రమ్ ప్లే అవుతుంది, ఇతరంగా కిక్ డ్రమ్ ప్లే అవుతుంది."
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr "ఈ సాధారణ డ్రమ్ మెషీన్ యొక్క ఉదాహరణలో కిక్ డ్రమ్ పునరావృత్తిలో 1/4 గానులు ప్లే అవుతుంది."
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr "ఈ సాధారణ డ్రమ్ మెషీన్ యొక్క ఉదాహరణలో కిక్ డ్రమ్ పునరావృత్తిలో 1/4 గానులు ప్లే అవుతుంది."
 
 #: js/PitchBlocks.js:373
 
-#~msgid "The Current Pitch block is used with the Pitch Converter block. In the example above, the current pitch, sol 4, is displayed as 392 hertz."
-#~msgstr "ప్రస్తుత పిచ్ బ్లాక్ పిచ్ కన్వర్టర్ బ్లాక్ తో ఉపయోగిస్తారు. ప్రధానంగా, ప్రస్తుత పిచ్, సోల్ 4, 392 హెర్ట్జ్‌లా పేరుతుంది."
+#~ msgid "The Current Pitch block is used with the Pitch Converter block. In the example above, the current pitch, sol 4, is displayed as 392 hertz."
+#~ msgstr "ప్రస్తుత పిచ్ బ్లాక్ పిచ్ కన్వర్టర్ బ్లాక్ తో ఉపయోగిస్తారు. ప్రధానంగా, ప్రస్తుత పిచ్, సోల్ 4, 392 హెర్ట్జ్‌లా పేరుతుంది."
 
 #: js/PitchBlocks.js:410
 
-#~msgid "This block converts the pitch value of the last note played into different formats such as hertz, letter name, pitch number, etc."
-#~msgstr "ఈ బ్లాక్ అంతర్నాడిన ప్రారంభించిన అంగడుని వివిధ స్వరూపాలకు (ఉదాహరణకు: హెర్ట్జ్, అక్షరం పేరు, పిచ్ సంఖ్య, మరియు ఇతరాలకు) మారుతుంది."
+#~ msgid "This block converts the pitch value of the last note played into different formats such as hertz, letter name, pitch number, etc."
+#~ msgstr "ఈ బ్లాక్ అంతర్నాడిన ప్రారంభించిన అంగడుని వివిధ స్వరూపాలకు (ఉదాహరణకు: హెర్ట్జ్, అక్షరం పేరు, పిచ్ సంఖ్య, మరియు ఇతరాలకు) మారుతుంది."
 
 #: js/PitchBlocks.js:670
 
-#~msgid "The Number to pitch block will convert a pitch number to a pitch name."
-#~msgstr "Number to pitch బ్లాక్ ఒక పిచ్ సంఖ్యను పిచ్ పేరుకు మార్చగలిగేది."
+#~ msgid "The Number to pitch block will convert a pitch number to a pitch name."
+#~ msgstr "Number to pitch బ్లాక్ ఒక పిచ్ సంఖ్యను పిచ్ పేరుకు మార్చగలిగేది."
 
 #: js/PitchBlocks.js:846
 
-#~msgid "పిచ్ ను ni dha pa ma ga re sa పదాలతో నిర్దిష్టించవచ్చు."
-#~msgstr ""
+#~ msgid "పిచ్ ను ni dha pa ma ga re sa పదాలతో నిర్దిష్టించవచ్చు."
+#~ msgstr ""
 
 #: js/PitchBlocks.js:860
 
-#~msgid "పిచ్ ను C D E F G A B పదాలతో నిర్దిష్టించవచ్చు."
-#~msgstr ""
+#~ msgid "పిచ్ ను C D E F G A B పదాలతో నిర్దిష్టించవచ్చు."
+#~ msgstr ""
 
 #: js/PitchBlocks.js:871
 
-#~msgid "సొల్ఫేజ్"
-#~msgstr ""
+#~ msgid "సొల్ఫేజ్"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:874
 
-#~msgid "పిచ్ ను do re mi fa sol la ti పదాలతో నిర్దిష్టించవచ్చు."
-#~msgstr ""
+#~ msgid "పిచ్ ను do re mi fa sol la ti పదాలతో నిర్దిష్టించవచ్చు."
+#~ msgstr ""
 
 #: js/PitchBlocks.js:908
 
-#~msgid "Invert బ్లాక్ యాత్రిక గానాలను గురి గానా సుత్రించి ఉండే నోట్‌లను రోటేట్ చేస్తుంది."
-#~msgstr ""
+#~ msgid "Invert బ్లాక్ యాత్రిక గానాలను గురి గానా సుత్రించి ఉండే నోట్‌లను రోటేట్ చేస్తుంది."
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1103
 
-#~msgid "The Transpose by Ratio block will shift the pitches contained inside Note blocks up (or down) by a ratio."
-#~msgstr "ట్రాన్స్పోజ్ బై రేషియో బ్లాక్ నోట్ బ్లాక్‌లో ఉండే పిచ్లను ఒక రేషియోతో అప్ (లేదా) అడుగుపెడతాయి."
+#~ msgid "The Transpose by Ratio block will shift the pitches contained inside Note blocks up (or down) by a ratio."
+#~ msgstr "ట్రాన్స్పోజ్ బై రేషియో బ్లాక్ నోట్ బ్లాక్‌లో ఉండే పిచ్లను ఒక రేషియోతో అప్ (లేదా) అడుగుపెడతాయి."
 
 #: js/PitchBlocks.js:1411
 
-#~msgid "The Accidental block is used to create sharps and flats."
-#~msgstr "అక్షిడెంటల్ బ్లాక్ షార్ప్స్ మరియు ఫ్లాట్స్ సృష్టించడానికి ఉపయోగిస్తుంది."
+#~ msgid "The Accidental block is used to create sharps and flats."
+#~ msgstr "అక్షిడెంటల్ బ్లాక్ షార్ప్స్ మరియు ఫ్లాట్స్ సృష్టించడానికి ఉపయోగిస్తుంది."
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr "ఆర్క్ బ్లాక్ మౌస్‌ను ఆర్క్లో జరుగుతుంది."
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr "ఆర్క్ బ్లాక్ మౌస్‌ను ఆర్క్లో జరుగుతుంది."
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr "ఆర్క్ బ్లాక్ టర్టిల్‌ను ఆర్క్లో జరుగుతుంది."
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr "ఆర్క్ బ్లాక్ టర్టిల్‌ను ఆర్క్లో జరుగుతుంది."
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr "సెట్ హెడింగ్ బ్లాక్ మౌస్ యొక్క హెడింగ్‌ను సెట్ చేస్తుంది."
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr "సెట్ హెడింగ్ బ్లాక్ మౌస్ యొక్క హెడింగ్‌ను సెట్ చేస్తుంది."
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr "ర్యాప్ బ్లాక్ వలన అలాగే అలాగే గ్రాఫిక్స్ యాక్షన్లకు స్క్రీన్ ర్యాపింగ్‌ను ప్రారంభిస్తుంది లేదా అనావరించేది."
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr "ర్యాప్ బ్లాక్ వలన అలాగే అలాగే గ్రాఫిక్స్ యాక్షన్లకు స్క్రీన్ ర్యాపింగ్‌ను ప్రారంభిస్తుంది లేదా అనావరించేది."
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr "స్లర్ బ్లాక్ నోట్‌ల సస్టెయిన్‌ని పెంచేందుకు వాడిని నిర్దిష్ట రిద్ధిమ్ విలువతో ఉంచేది."
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr "స్లర్ బ్లాక్ నోట్‌ల సస్టెయిన్‌ని పెంచేందుకు వాడిని నిర్దిష్ట రిద్ధిమ్ విలువతో ఉంచేది."
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr "స్టాకాటో బ్లాక్ నిర్దిష్ట రిద్ధిమ్ విలువతో నోట్ యొక్క నైపుణ్యానికి లాంచ్ చేస్తుంది."
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr "స్టాకాటో బ్లాక్ నిర్దిష్ట రిద్ధిమ్ విలువతో నోట్ యొక్క నైపుణ్యానికి లాంచ్ చేస్తుంది."
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr "డెక్రెసెండో బ్లాక్ ప్రతి నోటు ప్రారంభించినప్పుడు అన్ని నోట్ల వాల్యూమ్ను ఒక నిర్దిష్టమైన మొత్తంతో తగ్గించిపెడతాయి."
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "డెక్రెసెండో బ్లాక్ ప్రతి నోటు ప్రారంభించినప్పుడు అన్ని నోట్ల వాల్యూమ్ను ఒక నిర్దిష్టమైన మొత్తంతో తగ్గించిపెడతాయి."
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr "ఉదాహరణకు, మీకు ఒక డెక్రెసెండో బ్లాక్లో నిలిపిన ఒక మొత్తం 5 తో ఉన్న 7 నోట్లు ఉన్నప్పుడు, అంతములో చివర 35% తగ్గించిపెడతాయి."
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr "ఉదాహరణకు, మీకు ఒక డెక్రెసెండో బ్లాక్లో నిలిపిన ఒక మొత్తం 5 తో ఉన్న 7 నోట్లు ఉన్నప్పుడు, అంతములో చివర 35% తగ్గించిపెడతాయి."
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr "క్రిస్సెండో బ్లాక్ ప్రతి నోటు ప్రారంభించినప్పుడు అన్ని నోట్ల వాల్యూమ్ను ఒక నిర్దిష్టమైన మొత్తంతో పెంచిపెడతాయి."
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr "క్రిస్సెండో బ్లాక్ ప్రతి నోటు ప్రారంభించినప్పుడు అన్ని నోట్ల వాల్యూమ్ను ఒక నిర్దిష్టమైన మొత్తంతో పెంచిపెడతాయి."
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr "ఉదాహరణకు, మీకు ఒక క్రిస్సెండో బ్లాక్లో నిలిపిన ఒక మొత్తం 5 తో ఉన్న 7 నోట్లు ఉన్నప్పుడు, అంతములో చివర 35% తక్కువ అంగీకరించిపెడతాయి."
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr "ఉదాహరణకు, మీకు ఒక క్రిస్సెండో బ్లాక్లో నిలిపిన ఒక మొత్తం 5 తో ఉన్న 7 నోట్లు ఉన్నప్పుడు, అంతములో చివర 35% తక్కువ అంగీకరించిపెడతాయి."
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr "వేటెడ్ పార్షల్స్ బ్లాక్ టింబర్ తో సంబంధితమైన పార్షల్స్ను నిర్ధిష్టించడానికి ఉపయోగిస్తుంది."
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr "వేటెడ్ పార్షల్స్ బ్లాక్ టింబర్ తో సంబంధితమైన పార్షల్స్ను నిర్ధిష్టించడానికి ఉపయోగిస్తుంది."
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr "అంగీకారం సింథెసైజర్ నుండి డిఫాల్ట్ వాద్యంను మీ ఎంపిక వాద్యంకు మార్చేస్తుంది."
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr "అంగీకారం సింథెసైజర్ నుండి డిఫాల్ట్ వాద్యంను మీ ఎంపిక వాద్యంకు మార్చేస్తుంది."
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr "బీట్ ఫ్యాక్టర్ బ్లాక్ నోట్ విలువల కు మీటర్ నోట్ విలువల యొక్క అనుపాతాన్ని తిరిగిస్తుంది."
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr "బీట్ ఫ్యాక్టర్ బ్లాక్ నోట్ విలువల కు మీటర్ నోట్ విలువల యొక్క అనుపాతాన్ని తిరిగిస్తుంది."
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take action on the first beat of each measure."
-#~msgstr "చిత్రంలో, ప్రతి మీజర్ లో మొదటి బీట్ పై చర్య చేయడానికి ఉపయోగిస్తుంది."
+#~ msgid "In the figure, it is used to take action on the first beat of each measure."
+#~ msgstr "చిత్రంలో, ప్రతి మీజర్ లో మొదటి బీట్ పై చర్య చేయడానికి ఉపయోగిస్తుంది."
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr "(అప్రమేయంగా, అది క్వార్టర్ నోట్లను గణించితే.)"
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr "(అప్రమేయంగా, అది క్వార్టర్ నోట్లను గణించితే.)"
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr "షో-డిక్షనరీ బ్లాక్ స్క్రీన్ చోటకు డిక్షనరీ విషయాలను ప్రదర్శిస్తుంది."
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr "షో-డిక్షనరీ బ్లాక్ స్క్రీన్ చోటకు డిక్షనరీ విషయాలను ప్రదర్శిస్తుంది."
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr "కామెంట్ బ్లాక్ ప్రోగ్రామ్ స్లో మోడ్‌లో రన్ చేస్తూ స్క్రీన్ చోటకు ఒక కామెంట్ ముద్రిస్తుంది."
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr "కామెంట్ బ్లాక్ ప్రోగ్రామ్ స్లో మోడ్‌లో రన్ చేస్తూ స్క్రీన్ చోటకు ఒక కామెంట్ ముద్రిస్తుంది."
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr "కర్సర్ ఓవర్ బ్లాక్ ఒక మౌస్ పై కర్సర్ పరికరంలో పరికరం చేసేందుకు ఒక ఈవెంట్‌ను తెరిచిపెట్టుతుంది."
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr "కర్సర్ ఓవర్ బ్లాక్ ఒక మౌస్ పై కర్సర్ పరికరంలో పరికరం చేసేందుకు ఒక ఈవెంట్‌ను తెరిచిపెట్టుతుంది."
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr "కర్సర్ ఓవర్ బ్లాక్ టర్టిల్ పై కర్సర్ పరికరంలో పరికరం చేసేందుకు ఒక ఈవెంట్‌ను తెరిచిపెట్టుతుంది."
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr "కర్సర్ ఓవర్ బ్లాక్ టర్టిల్ పై కర్సర్ పరికరంలో పరికరం చేసేందుకు ఒక ఈవెంట్‌ను తెరిచిపెట్టుతుంది."
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr "కర్సర్ బయటకి రెండిపోయిందా అయితే, కర్సర్ బయటకి వచ్చిపోతే కర్సర్ బటన్‌ను ప్రెస్ చేసిందా ఒక ఈవెంట్‌ను తెరిచిపెట్టుతుంది."
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr "కర్సర్ బయటకి రెండిపోయిందా అయితే, కర్సర్ బయటకి వచ్చిపోతే కర్సర్ బటన్‌ను ప్రెస్ చేసిందా ఒక ఈవెంట్‌ను తెరిచిపెట్టుతుంది."
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr "కర్సర్ బయటకి రెండిపోయిందా అయితే, కర్సర్ బయటకి వచ్చిపోతే కర్సర్ బటన్‌ను ప్రెస్ చేసిందా ఒక ఈవెంట్‌ను తెరిచిపెట్టుతుంది."
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr "కర్సర్ బయటకి రెండిపోయిందా అయితే, కర్సర్ బయటకి వచ్చిపోతే కర్సర్ బటన్‌ను ప్రెస్ చేసిందా ఒక ఈవెంట్‌ను తెరిచిపెట్టుతుంది."
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the cursor button is press on a mouse."
-#~msgstr "కర్సర్ బటన్ డౌన్ బ్లాక్ మౌస్ పై కర్సర్ బటన్‌ను నొక్కినా ఒక ఈవెంట్‌ను తెరిచిపెట్టుతుంది."
+#~ msgid "The Cursor button down block triggers an event when the cursor button is press on a mouse."
+#~ msgstr "కర్సర్ బటన్ డౌన్ బ్లాక్ మౌస్ పై కర్సర్ బటన్‌ను నొక్కినా ఒక ఈవెంట్‌ను తెరిచిపెట్టుతుంది."
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the cursor button is press on a turtle."
-#~msgstr "కర్సర్ బటన్ డౌన్ బ్లాక్ టర్టిల్ పై కర్సర్ బటన్‌ను నొక్కినా ఒక ఈవెంట్‌ను తెరిచిపెట్టుతుంది."
+#~ msgid "The Cursor button down block triggers an event when the cursor button is press on a turtle."
+#~ msgstr "కర్సర్ బటన్ డౌన్ బ్లాక్ టర్టిల్ పై కర్సర్ బటన్‌ను నొక్కినా ఒక ఈవెంట్‌ను తెరిచిపెట్టుతుంది."
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr "కర్సర్ బటన్ అప్ బ్లాక్ మౌస్ పై కర్సర్ బటన్ విడుపివేసిందా ఒక ఈవెంట్ను తెరిచిపెట్టుత"
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr "కర్సర్ బటన్ అప్ బ్లాక్ మౌస్ పై కర్సర్ బటన్ విడుపివేసిందా ఒక ఈవెంట్ను తెరిచిపెట్టుత"
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr "కర్సర్ బటన్ అప్ బ్లాక్ టర్టిల్ పై ఉన్నప్పుడు కర్సర్ బటన్ విడుదల కార్యాన్ని ప్రేరేపిస్తుంది."
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr "కర్సర్ బటన్ అప్ బ్లాక్ టర్టిల్ పై ఉన్నప్పుడు కర్సర్ బటన్ విడుదల కార్యాన్ని ప్రేరేపిస్తుంది."
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr "గెట్ బ్లూ బ్లాక్ మౌస్ కంపోజన్ట్‌ని తెరిచిపెట్టుతుంది."
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr "గెట్ బ్లూ బ్లాక్ మౌస్ కంపోజన్ట్‌ని తెరిచిపెట్టుతుంది."
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr "గెట్ బ్లూ బ్లాక్ టర్టిల్ కంపోజన్ట్‌ని తెరిచిపెట్టుతుంది."
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr "గెట్ బ్లూ బ్లాక్ టర్టిల్ కంపోజన్ట్‌ని తెరిచిపెట్టుతుంది."
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr "గెట్ గ్రీన్ బ్లాక్ మౌస్ కంపోజన్ట్‌ని తెరిచిపెట్టుతుంది."
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr "గెట్ గ్రీన్ బ్లాక్ మౌస్ కంపోజన్ట్‌ని తెరిచిపెట్టుతుంది."
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr "గెట్ గ్రీన్ బ్లాక్ టర్టిల్ కంపోజన్ట్‌ని తెరిచిపెట్టుతుంది."
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr "గెట్ గ్రీన్ బ్లాక్ టర్టిల్ కంపోజన్ట్‌ని తెరిచిపెట్టుతుంది."
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr "టైమ్ బ్లాక్ ప్రోగ్రామ్ పరిస్థితిలో ఎక్కువ సమయాన్ని తెరిచిపెడతారు."
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr "టైమ్ బ్లాక్ ప్రోగ్రామ్ పరిస్థితిలో ఎక్కువ సమయాన్ని తెరిచిపెడతారు."
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr "మరింత వివరాలు"
+#~ msgid "More Details"
+#~ msgstr "మరింత వివరాలు"
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr "ప్రాజెక్ట్‌ను షేర్ చేయండి"
+#~ msgid "Share project"
+#~ msgstr "ప్రాజెక్ట్‌ను షేర్ చేయండి"
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr "లింక్‌ను క్లిప్‌బోర్డ్‌కు కాపీ చేయండి"
+#~ msgid "Copy link to clipboard"
+#~ msgstr "లింక్‌ను క్లిప్‌బోర్డ్‌కు కాపీ చేయండి"
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr "ప్రాజెక్ట్‌ను ప్రారంభంలో పరిచయంగా పరిపాలండి."
+#~ msgid "Run project on startup."
+#~ msgstr "ప్రాజెక్ట్‌ను ప్రారంభంలో పరిచయంగా పరిపాలండి."
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr "ప్రారంభంలో కోడ్ బ్లాక్‌లను చూపించండి."
+#~ msgid "Show code blocks on startup."
+#~ msgstr "ప్రారంభంలో కోడ్ బ్లాక్‌లను చూపించండి."
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr "ప్రారంభంలో కోడ్ బ్లాక్‌లను తగిలించండి."
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr "ప్రారంభంలో కోడ్ బ్లాక్‌లను తగిలించండి."
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr "ఉన్నత ఎంపికలు"
+#~ msgid "Advanced Options"
+#~ msgstr "ఉన్నత ఎంపికలు"
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr "హర్ట్జ్ బ్లాక్: మీరు నోట్ బ్లాక్ ఉపయోగించడానికి ఆనోళా వేచినా?"
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr "హర్ట్జ్ బ్లాక్: మీరు నోట్ బ్లాక్ ఉపయోగించడానికి ఆనోళా వేచినా?"
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr "ప్రాజెక్టునకు లైక్ లేదు"
+#~ msgid "Unlike project"
+#~ msgstr "ప్రాజెక్టునకు లైక్ లేదు"
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr "ప్రాజెక్టునకు లైక్"
+#~ msgid "Like project"
+#~ msgstr "ప్రాజెక్టునకు లైక్"
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr "లభిస్తున్న లక్షణం - సర్వర్కు కనెక్ట్ అవుతున్నట్లు లేదు. మళ్ళి టర్టిల్ బ్లాక్స్‌ని రీలోడ్ చేయండి."
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr "లభిస్తున్న లక్షణం - సర్వర్కు కనెక్ట్ అవుతున్నట్లు లేదు. మళ్ళి టర్టిల్ బ్లాక్స్‌ని రీలోడ్ చేయండి."
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr "ప్రాజెక్టుని పునరప్రచురించండి"
+#~ msgid "Republish Project"
+#~ msgstr "ప్రాజెక్టుని పునరప్రచురించండి"
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr "ఆడియో ఫైల్ 1"
+#~ msgid "audio file1"
+#~ msgstr "ఆడియో ఫైల్ 1"
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr "ఆడియో ఫైల్ 2"
+#~ msgid "audio file2"
+#~ msgstr "ఆడియో ఫైల్ 2"
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr "హెచ్చరిక: నోట్ విలువ 2 కంటి ఎక్కువ."
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr "హెచ్చరిక: నోట్ విలువ 2 కంటి ఎక్కువ."
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr "కార్డు 5"
+#~ msgid "chord5"
+#~ msgstr "కార్డు 5"
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr "కార్డు 4"
+#~ msgid "chord4"
+#~ msgstr "కార్డు 4"
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr "కార్డు 1"
+#~ msgid "chord1"
+#~ msgstr "కార్డు 1"
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr "కర్సర్ Y బ్లాక్ టర్టిల్ యొక్క ఉత్తరాధారిత స్థానాన్ని తరిమికొస్తుంది."
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr "కర్సర్ Y బ్లాక్ టర్టిల్ యొక్క ఉత్తరాధారిత స్థానాన్ని తరిమికొస్తుంది."
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr "కర్సర్ X బ్లాక్ టర్టిల్ యొక్క కంటిమితంని తరిమికొస్తుంది."
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr "కర్సర్ X బ్లాక్ టర్టిల్ యొక్క కంటిమితంని తరిమికొస్తుంది."
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr "Nth-Turtlee పేరు బ్లాక్ Nth టర్టిల్ పేరును తరిమికొస్తుంది."
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr "Nth-Turtlee పేరు బ్లాక్ Nth టర్టిల్ పేరును తరిమికొస్తుంది."
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "త్వరగా రన్ చేయండి"
+#~ msgid "Run fast"
+#~ msgstr "త్వరగా రన్ చేయండి"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "విస్తరించు/క్రింద స్థూలబ్లాక్లను కూడా స్థూలబ్లాక్లను చేయండి"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "విస్తరించు/క్రింద స్థూలబ్లాక్లను కూడా స్థూలబ్లాక్లను చేయండి"
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr "Nth-Mouse పేరు బ్లాక్ Nth మౌస్ పేరును తరిమికొస్తుంది."
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr "Nth-Mouse పేరు బ్లాక్ Nth మౌస్ పేరును తరిమికొస్తుంది."
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr "బ్లాక్లకు శోధించండి"
+#~ msgid "search for blocks"
+#~ msgstr "బ్లాక్లకు శోధించండి"
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr "దయచేసి బ్రౌజర్ జూమ్ స్థాయిని 100% కి సెట్ చేయండి"
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr "దయచేసి బ్రౌజర్ జూమ్ స్థాయిని 100% కి సెట్ చేయండి"
 
 #: js/toolbar.js:54
 
@@ -8742,97 +8742,97 @@ msgstr "చలింపు"
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr "ఆక్సిలరీ మెనూ"
+#~ msgid "Auxilary menu"
+#~ msgstr "ఆక్సిలరీ మెనూ"
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr "ఈ ప్రాజెక్టును రన్ చేయడానికి, వెబ్ బ్రౌజర్‌లో మ్యూజిక్ బ్లాక్స్‌ను తెరవండి మరియు ఈ ఫైల్‌ను బ్రౌజర్ విండోలో డ్రాగ్ అండ్ డ్రాప్ చేయండి."
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr "ఈ ప్రాజెక్టును రన్ చేయడానికి, వెబ్ బ్రౌజర్‌లో మ్యూజిక్ బ్లాక్స్‌ను తెరవండి మరియు ఈ ఫైల్‌ను బ్రౌజర్ విండోలో డ్రాగ్ అండ్ డ్రాప్ చేయండి."
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr "మీరు యాకదానికి కనిష్టమిష్టమి ఒక ప్రారంభ బ్లాక్ ఉండాలి."
+#~ msgid "You must always have at least one start block."
+#~ msgstr "మీరు యాకదానికి కనిష్టమిష్టమి ఒక ప్రారంభ బ్లాక్ ఉండాలి."
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr "పిచ్ అప్"
+#~ msgid "pitch up"
+#~ msgstr "పిచ్ అప్"
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr "పిచ్ డౌన్"
+#~ msgid "pitch down"
+#~ msgstr "పిచ్ డౌన్"
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr "అక్సిడెంటల్ అప్"
+#~ msgid "accidental up"
+#~ msgstr "అక్సిడెంటల్ అప్"
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr "అక్సిడెంటల్ డౌన్"
+#~ msgid "accidental down"
+#~ msgstr "అక్సిడెంటల్ డౌన్"
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr "ఆక్టావ్ అప్"
+#~ msgid "octave up"
+#~ msgstr "ఆక్టావ్ అప్"
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr "ఆక్టావ్ డౌన్"
+#~ msgid "octave down"
+#~ msgstr "ఆక్టావ్ డౌన్"
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "కరెన్సీ"
+#~ msgid "currency"
+#~ msgstr "కరెన్సీ"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "నుండి"
+#~ msgid "from"
+#~ msgstr "నుండి"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "శేరు ధర"
+#~ msgid "stock price"
+#~ msgstr "శేరు ధర"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "అనువదించండి"
+#~ msgid "translate"
+#~ msgstr "అనువదించండి"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "హలో"
+#~ msgid "hello"
+#~ msgstr "హలో"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "భాషను గుర్తించు"
+#~ msgid "detect lang"
+#~ msgstr "భాషను గుర్తించు"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "భాషను సెట్ చేయండి"
+#~ msgid "set lang"
+#~ msgstr "భాషను సెట్ చేయండి"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "నగర అక్షాంశం"
+#~ msgid "city latitude"
+#~ msgstr "నగర అక్షాంశం"
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "నగర రేఖాంశం"
+#~ msgid "city longitude"
+#~ msgstr "నగర రేఖాంశం"
 
 #: plugins/gmap.rtp:71
 
@@ -8842,144 +8842,144 @@ msgstr "చలింపు"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "సమిక్ష డేటా అందుబాటులో లేదు."
+#~ msgid "Coordinate data not available."
+#~ msgstr "సమిక్ష డేటా అందుబాటులో లేదు."
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "గూగుల్ మ్యాప్"
+#~ msgid "Google map"
+#~ msgstr "గూగుల్ మ్యాప్"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "సమిక్షలు"
+#~ msgid "coordinates"
+#~ msgstr "సమిక్షలు"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "జూమ్ ఫ్యాక్టర్"
+#~ msgid "zoom factor"
+#~ msgstr "జూమ్ ఫ్యాక్టర్"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "జూమ్"
+#~ msgid "zoom"
+#~ msgstr "జూమ్"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "అక్షాంశం"
+#~ msgid "latitude"
+#~ msgstr "అక్షాంశం"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "రేఖాంశం"
+#~ msgid "longitude"
+#~ msgstr "రేఖాంశం"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "డిగ్రీలు"
+#~ msgid "degrees"
+#~ msgstr "డిగ్రీలు"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "రేడియన్లు"
+#~ msgid "radians"
+#~ msgstr "రేడియన్లు"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "నిర్వచించు"
+#~ msgid "define"
+#~ msgstr "నిర్వచించు"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "బిట్‌కాయిన్"
+#~ msgid "bitcoin"
+#~ msgstr "బిట్‌కాయిన్"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr "మీరు ఒక ఫైల్‌ను ఎంచుకోవాలి."
+#~ msgid "You need to select a file."
+#~ msgstr "మీరు ఒక ఫైల్‌ను ఎంచుకోవాలి."
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr "ట్రెబుల్ చూపించు"
+#~ msgid "show treble"
+#~ msgstr "ట్రెబుల్ చూపించు"
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr "పోలార్ నిలిపించు"
+#~ msgid "hide Polar"
+#~ msgstr "పోలార్ నిలిపించు"
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr "బాస్ చూపించు"
+#~ msgid "show bass"
+#~ msgstr "బాస్ చూపించు"
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr "మెజో-సొప్రానో చూపించు"
+#~ msgid "show mezzo-soprano"
+#~ msgstr "మెజో-సొప్రానో చూపించు"
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr "ఆల్టో చూపించు"
+#~ msgid "show alto"
+#~ msgstr "ఆల్టో చూపించు"
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr "టెనర్ చూపించు"
+#~ msgid "show tenor"
+#~ msgstr "టెనర్ చూపించు"
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr "బాస్ నిలిపించు"
+#~ msgid "hide bass"
+#~ msgstr "బాస్ నిలిపించు"
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr "పోలార్ చూపించు"
+#~ msgid "show Polar"
+#~ msgstr "పోలార్ చూపించు"
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr "కార్టేసియన్ నిలిపించు"
+#~ msgid "hide Cartesian"
+#~ msgstr "కార్టేసియన్ నిలిపించు"
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr "లిలీపాండ్ వేగాన్ని ప్రాసెస్ చేయలేదు "
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr "లిలీపాండ్ వేగాన్ని ప్రాసెస్ చేయలేదు "
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr "PDFగా భద్రపరచండి"
+#~ msgid "Save as PDF"
+#~ msgstr "PDFగా భద్రపరచండి"
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr "లిలీపాండ్ అనవరోధిస్తుంది"
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr "లిలీపాండ్ అనవరోధిస్తుంది"
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr "జూమ్ ఇన్"
+#~ msgid "ZOOM IN"
+#~ msgstr "జూమ్ ఇన్"
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr "జూమ్ అవుట్"
+#~ msgid "ZOOM OUT"
+#~ msgstr "జూమ్ అవుట్"
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr "బ్లాక్ ఎంచుకోవడానికి నొక్కండి."
+#~ msgid "Click to select a block."
+#~ msgstr "బ్లాక్ ఎంచుకోవడానికి నొక్కండి."
 
 #: js/palette.js:1205
 
@@ -8989,15 +8989,15 @@ msgstr "చలింపు"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr "దాచు"
+#~ msgid "hide"
+#~ msgstr "దాచు"
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr "చూపించు2"
+#~ msgid "show2"
+#~ msgstr "చూపించు2"
 
 #: js/palette.js:1222
 
@@ -9007,23 +9007,23 @@ msgstr "చలింపు"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr "పాపౌట్"
+#~ msgid "popout"
+#~ msgstr "పాపౌట్"
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr "నా బ్లాక్లు"
+#~ msgid "myblocks"
+#~ msgstr "నా బ్లాక్లు"
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr "మీరు మీ ప్రాజెక్ట్‌ను భద్రపరచాలా?"
+#~ msgid "Do you want to save your project?"
+#~ msgstr "మీరు మీ ప్రాజెక్ట్‌ను భద్రపరచాలా?"
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr "డ్రం బ్లాక్: మీరు గమనించారా నోట్ బ్లాక్ ఉపయోగించడానికి?"
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr "డ్రం బ్లాక్: మీరు గమనించారా నోట్ బ్లాక్ ఉపయోగించడానికి?"
 
 #: js/pitchtracker.js:181
 
@@ -9033,8 +9033,8 @@ msgstr "చలింపు"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr "రికార్డింగ్ ప్రారంభించండి"
+#~ msgid "Start Recording"
+#~ msgstr "రికార్డింగ్ ప్రారంభించండి"
 
 #: js/pitchtracker.js:188
 
@@ -9042,214 +9042,214 @@ msgstr "చలింపు"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr "రికార్డింగ్ ఆపండి"
+#~ msgid "Stop Recording"
+#~ msgstr "రికార్డింగ్ ఆపండి"
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr "రిద్ధీలను భద్రపరచు"
+#~ msgid "save rhythms"
+#~ msgstr "రిద్ధీలను భద్రపరచు"
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr "దొంగదారి"
+#~ msgid "drag"
+#~ msgstr "దొంగదారి"
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr "పిచ్ బ్లాక్: మీరు నోట్ బ్లాక్ ఉపయోగించడానికి అంగీకరిస్తున్నారా?"
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr "పిచ్ బ్లాక్: మీరు నోట్ బ్లాక్ ఉపయోగించడానికి అంగీకరిస్తున్నారా?"
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr "శ్రీ. మౌస్\", 0, 0)]"
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr "శ్రీ. మౌస్\", 0, 0)]"
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr "క్లిక్ బ్లాక్ ఒక మౌస్ నొక్కించబడినట్టు నిజమైనదిగా తరచుకోతుంది."
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr "క్లిక్ బ్లాక్ ఒక మౌస్ నొక్కించబడినట్టు నిజమైనదిగా తరచుకోతుంది."
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr "box2 లో భద్రపరచబడిన విలువను తరిమిస్తుంది."
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr "box2 లో భద్రపరచబడిన విలువను తరిమిస్తుంది."
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr "box1 లో భద్రపరచబడిన విలువను తరిమిస్తుంది."
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr "box1 లో భద్రపరచబడిన విలువను తరిమిస్తుంది."
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr "బ్లాక్‌లను దాచు."
+#~ msgid "Hide blocks."
+#~ msgstr "బ్లాక్‌లను దాచు."
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr "మరింత తగినంత తగినడానికి కాదు"
+#~ msgid "Cannot be further decreased"
+#~ msgstr "మరింత తగినంత తగినడానికి కాదు"
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr "మరింత పెరగడానికి కాదు"
+#~ msgid "Cannot be further increased"
+#~ msgstr "మరింత పెరగడానికి కాదు"
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr "పొరపాటు: స్థానిక భండారణ తగినడం కారణంగా భద్రపరచడం సాధ్యపడదు. కొంత సేవ్ చేసిన ప్రాజెక్టులను తొలగించండి."
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr "పొరపాటు: స్థానిక భండారణ తగినడం కారణంగా భద్రపరచడం సాధ్యపడదు. కొంత సేవ్ చేసిన ప్రాజెక్టులను తొలగించండి."
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr "మౌస్ బ్లింక్ ఆఫ్ చేసిపోతుంది; FPSను 10కి సెట్ చేసిపోతుంది."
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr "మౌస్ బ్లింక్ ఆఫ్ చేసిపోతుంది; FPSను 10కి సెట్ చేసిపోతుంది."
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr "మౌస్ బ్లింక్ ఆన్ చేసిపెట్టిపోతుంది; FPSను 30కి సెట్ చేసిపోతుంది."
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr "మౌస్ బ్లింక్ ఆన్ చేసిపెట్టిపోతుంది; FPSను 30కి సెట్ చేసిపోతుంది."
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr "స్కాలర్ సరణులు కస్టమ్ సామర్థ్యాన్ని కోసం సేమిటోన్ సరణులకు సమానంగా ఉన్నాయి."
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr "స్కాలర్ సరణులు కస్టమ్ సామర్థ్యాన్ని కోసం సేమిటోన్ సరణులకు సమానంగా ఉన్నాయి."
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr "మీరు ఒకే పిచ్ యొక్క నోటులను సంప్రదించవచ్చు. మీరు స్లర్ ఉపయోగించడానికి అంగీకరిస్తున్నారా?"
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr "మీరు ఒకే పిచ్ యొక్క నోటులను సంప్రదించవచ్చు. మీరు స్లర్ ఉపయోగించడానికి అంగీకరిస్తున్నారా?"
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr "హెచ్చరిక: నోటు విలువ 2 కంటి ఎక్కువ."
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr "హెచ్చరిక: నోటు విలువ 2 కంటి ఎక్కువ."
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr "నోటు పేరు A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ లేదా A♭ లలో ఒకటి ఉండాలి."
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr "నోటు పేరు A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ లేదా A♭ లలో ఒకటి ఉండాలి."
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr "మీరు మీ \"%s\" పాలెట్ నుంచి అన్ని స్టాక్లను తరలారా?"
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr "మీరు మీ \"%s\" పాలెట్ నుంచి అన్ని స్టాక్లను తరలారా?"
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr "ఈ బటన్ ప్రాజెక్టులను భాగస్వామ్యం చేయడానికి మరియు ఉదాహరణ ప్రాజెక్టులను కనుగొనడానికి వ్యూయర్ ను తెరిచేస్తుంది."
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr "ఈ బటన్ ప్రాజెక్టులను భాగస్వామ్యం చేయడానికి మరియు ఉదాహరణ ప్రాజెక్టులను కనుగొనడానికి వ్యూయర్ ను తెరిచేస్తుంది."
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr "సంగీతం యొక్క బీట్ మీటర్ బ్లాక్ ద్వారా నిర్ధారించబడుతుంది (డిఫాల్ట్‌గా, ప్రతి పరిమాణంలో 4 1/4 నోటులు)."
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr "సంగీతం యొక్క బీట్ మీటర్ బ్లాక్ ద్వారా నిర్ధారించబడుతుంది (డిఫాల్ట్‌గా, ప్రతి పరిమాణంలో 4 1/4 నోటులు)."
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr "మాస్టర్ ప్రతిసారి నోటుకు 1/4 నోటుల సంఖ్యను మినిట్ కోసం మార్చేస్తుంది."
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr "మాస్టర్ ప్రతిసారి నోటుకు 1/4 నోటుల సంఖ్యను మినిట్ కోసం మార్చేస్తుంది."
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr "ప్రతి నోటుపై చేయడానికి On-every-note బ్లాక్ అనేది నిర్దిష్టమైన చర్యలను సూచించడానికి అవకాశం ఉంది."
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr "ప్రతి నోటుపై చేయడానికి On-every-note బ్లాక్ అనేది నిర్దిష్టమైన చర్యలను సూచించడానికి అవకాశం ఉంది."
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr "ప్రతి నోటును ప్రదర్శించడానికి Notes played బ్లాక్ అనేది ప్రదర్శించిన నోటుల సంఖ్య."
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr "ప్రతి నోటును ప్రదర్శించడానికి Notes played బ్లాక్ అనేది ప్రదర్శించిన నోటుల సంఖ్య."
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr "Pitch Number బ్లాక్ అనేది తన సంఖ్య ద్వారా అనేది సంబంధించిన పిచ్ ప్రదర్శించడానికి ఉదాహరణకు 0 కి C మరియు 7 కి G ఉండాలి."
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr "Pitch Number బ్లాక్ అనేది తన సంఖ్య ద్వారా అనేది సంబంధించిన పిచ్ ప్రదర్శించడానికి ఉదాహరణకు 0 కి C మరియు 7 కి G ఉండాలి."
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr "పిచ్-స్లైడర్ బ్లాక్ ఒక టూల్‌ను తెరువుతుంది అనేది."
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr "పిచ్-స్లైడర్ బ్లాక్ ఒక టూల్‌ను తెరువుతుంది అనేది."
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr "ప్లే బటన్ నొక్కితే అన్ని ఆరంభ బ్లాక్‌లు ఒక సమయంలో పరుగులు పడుతాయి."
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr "ప్లే బటన్ నొక్కితే అన్ని ఆరంభ బ్లాక్‌లు ఒక సమయంలో పరుగులు పడుతాయి."
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr "స్టోర్ ఇన్ బాక్స్1 బ్లాక్ వాల్యూను బాక్స్1లో నిలుచుకొనుటకు ఉపయోగిస్తారు."
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr "స్టోర్ ఇన్ బాక్స్1 బ్లాక్ వాల్యూను బాక్స్1లో నిలుచుకొనుటకు ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr "స్టోర్ ఇన్ బాక్స్2 బ్లాక్ వాల్యూను బాక్స్2లో నిలుచుకొనుటకు ఉపయోగిస్తారు."
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr "స్టోర్ ఇన్ బాక్స్2 బ్లాక్ వాల్యూను బాక్స్2లో నిలుచుకొనుటకు ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr "షెల్ బ్లాక్ మౌస్ యొక్క రూపాన్ని మార్చేందుకు ఉపయోగిస్తారు."
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr "షెల్ బ్లాక్ మౌస్ యొక్క రూపాన్ని మార్చేందుకు ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr "బీట్ ముందు వచ్చే ఏదో సంజ్ఞలను అనుమతించడానికి పికప్ బ్లాక్ ఉపయోగిస్తారు."
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr "బీట్ ముందు వచ్చే ఏదో సంజ్ఞలను అనుమతించడానికి పికప్ బ్లాక్ ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr "ఒక బలమైన బీట్ బ్లాక్ మీరు స్పష్టంగా ప్రతిష్టాత్మక బీట్లపై చేయడానికి అనుమతిస్తుంది."
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr "ఒక బలమైన బీట్ బ్లాక్ మీరు స్పష్టంగా ప్రతిష్టాత్మక బీట్లపై చేయడానికి అనుమతిస్తుంది."
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr "ఒక బలహీన బీట్ బ్లాక్ మీరు బలహీన (ఆఫ్) బీట్లపై చేయడానికి అనుమతిస్తుంది."
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr "ఒక బలహీన బీట్ బ్లాక్ మీరు బలహీన (ఆఫ్) బీట్లపై చేయడానికి అనుమతిస్తుంది."
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "ఉదాహరణకు, \"do\" సదా \"C-న్యాచరల్\"); మూవబుల్ డూ ఖచ్చితమైనప్పుడు, సొల్ఫేజ్ నోట్ పేర్లు స్కేల్ డిగ్రీలకు కేటాయించబడతాయి (\"do\" సదాకు ప్రధాన డిగ్రీ)."
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "ఉదాహరణకు, \"do\" సదా \"C-న్యాచరల్\"); మూవబుల్ డూ ఖచ్చితమైనప్పుడు, సొల్ఫేజ్ నోట్ పేర్లు స్కేల్ డిగ్రీలకు కేటాయించబడతాయి (\"do\" సదాకు ప్రధాన డిగ్రీ)."
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr "నోట్ వాల్యూమ్ బ్లాక్ ప్రస్తుత సింథిసైజర్ యొక్క ప్రస్తుత ఆయతనను తరచుకుపెడతాయి."
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr "నోట్ వాల్యూమ్ బ్లాక్ ప్రస్తుత సింథిసైజర్ యొక్క ప్రస్తుత ఆయతనను తరచుకుపెడతాయి."
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr "డిఫాల్ట్ బ్లాక్ స్విచ్ లో డిఫాల్ట్ చర్యను నిర్వచించడానికి ఉపయోగిస్తారు."
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr "డిఫాల్ట్ బ్లాక్ స్విచ్ లో డిఫాల్ట్ చర్యను నిర్వచించడానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr "మౌస్ నోట్ బ్లాక్ అంచనా మౌస్ ద్వారా ప్రస్తుత ప్రవర్తిస్తున్న నోట్ విలువను తరచుకుపెడతాయి."
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr "మౌస్ నోట్ బ్లాక్ అంచనా మౌస్ ద్వారా ప్రస్తుత ప్రవర్తిస్తున్న నోట్ విలువను తరచుకుపెడతాయి."
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr "తగిన సారి"
+#~ msgid "down minor"
+#~ msgstr "తగిన సారి"
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr "తగిన మేజర్"
+#~ msgid "down major"
+#~ msgstr "తగిన మేజర్"
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr "మూల్యాంకనం"
+#~ msgid "eval"
+#~ msgstr "మూల్యాంకనం"
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr "100"
+#~ msgid "100"
+#~ msgstr "100"
 
 #: js/playback.js:87
 
@@ -9265,37 +9265,37 @@ msgstr "చలింపు"
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr "లాగ్"
+#~ msgid "Drag"
+#~ msgstr "లాగ్"
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr "ప్లేబ్యాక్ సంగీతం"
+#~ msgid "playback music"
+#~ msgstr "ప్లేబ్యాక్ సంగీతం"
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr "ప్లేబ్యాక్ విరామం"
+#~ msgid "pause playback"
+#~ msgstr "ప్లేబ్యాక్ విరామం"
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr "ప్లేబ్యాక్ పునఃప్రారంభించు"
+#~ msgid "restart playback"
+#~ msgstr "ప్లేబ్యాక్ పునఃప్రారంభించు"
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr "ప్లేబ్యాక్ కోసం సంగీతంను సజీవపరచు"
+#~ msgid "prepare music for playback"
+#~ msgstr "ప్లేబ్యాక్ కోసం సంగీతంను సజీవపరచు"
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr "బ్లాక్లను లోడ్ చేయి"
+#~ msgid "Load blocks"
+#~ msgstr "బ్లాక్లను లోడ్ చేయి"
 
 #: js/turtledefs.js:304
 
@@ -9303,28 +9303,28 @@ msgstr "చలింపు"
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr "సెట్ టింబ్రె బ్లాక్ సింథిసైజర్ కోసం ఒక ధ్వనిని ఎంచుకున్నది,"
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr "సెట్ టింబ్రె బ్లాక్ సింథిసైజర్ కోసం ఒక ధ్వనిని ఎంచుకున్నది,"
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr "రన్ బ్లాక్ బ్లాక్ ను ప్రవర్తిస్తుంది."
+#~ msgid "The Run block block runs a block."
+#~ msgstr "రన్ బ్లాక్ బ్లాక్ ను ప్రవర్తిస్తుంది."
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr "సెట్ టింబ్రె"
+#~ msgid "set timbre"
+#~ msgstr "సెట్ టింబ్రె"
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr "కుడి2"
+#~ msgid "right2"
+#~ msgstr "కుడి2"
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr "ఎడమ2"
+#~ msgid "left2"
+#~ msgstr "ఎడమ2"
 
 #: js/pitchtimematrix.js:323
 
@@ -9338,8 +9338,8 @@ msgstr "చలింపు"
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr "విస్తరించు"
+#~ msgid "expand"
+#~ msgstr "విస్తరించు"
 
 #: js/pitchtimematrix.js:338
 
@@ -9349,65 +9349,65 @@ msgstr "చలింపు"
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr "పిచుకో"
+#~ msgid "collapse"
+#~ msgstr "పిచుకో"
 
-#~msgid "crescendo factor"
-#~msgstr "క్రెసెండో ఫ్యాక్టర్"
+#~ msgid "crescendo factor"
+#~ msgstr "క్రెసెండో ఫ్యాక్టర్"
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr "సంగీత బ్లాక్స్ కు హృదయంలో <em>Note</em> బ్లాక్ ఉంది. <em>Note</em> బ్లాక్ ఒక <em>Pitch</em> బ్లాక్ కొరకు ఒక కంటేనర్ అవుతుంది అనేది. ఇది పిచ్ యొక్క కాలం (నోట్ విలువ) ని నిర్దిష్టించడానికి ఉంది."
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr "సంగీత బ్లాక్స్ కు హృదయంలో <em>Note</em> బ్లాక్ ఉంది. <em>Note</em> బ్లాక్ ఒక <em>Pitch</em> బ్లాక్ కొరకు ఒక కంటేనర్ అవుతుంది అనేది. ఇది పిచ్ యొక్క కాలం (నోట్ విలువ) ని నిర్దిష్టించడానికి ఉంది."
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr "<em>టైమ్</em> బ్లాక్ ప్రోగ్రామ్ ప్రవర్తిస్తోని సెకన్ల సంఖ్యను తరచుకుపెడితే."
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr "<em>టైమ్</em> బ్లాక్ ప్రోగ్రామ్ ప్రవర్తిస్తోని సెకన్ల సంఖ్యను తరచుకుపెడితే."
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr "<em>స్టోర్ ఇన్ బాక్స్1</em> బ్లాక్ వాడు <em>బాక్స్1</em>లో విలువను భద్రపరచడానికి ఉంది."
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr "<em>స్టోర్ ఇన్ బాక్స్1</em> బ్లాక్ వాడు <em>బాక్స్1</em>లో విలువను భద్రపరచడానికి ఉంది."
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr "<em>మల్టిప్లై</em> బ్లాక్ గుణించడానికి ఉంది."
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr "<em>మల్టిప్లై</em> బ్లాక్ గుణించడానికి ఉంది."
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr "ఏ బ్లాక్ ఎంచుకోబడింది."
+#~ msgid "There is no block is selected."
+#~ msgstr "ఏ బ్లాక్ ఎంచుకోబడింది."
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr "<em>స్కాలర్ ట్రాన్స్పోజిషన్</em> బ్లాక్ అంగా ఉంచిన <em>Note</em> బ్లాక్లలో నిర్వచించిన పిచ్లను పరిమాణం (లేదా) అంకడికి మరియుండా పరిస్థానించడానికి ఉంది. ప్రదర్శించిన ఉదాహరణలో, <em>సోల్</em> అనే పిచ్ ను <em>లా</em> అనేది వరకు తగ్గించబడింది."
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr "<em>స్కాలర్ ట్రాన్స్పోజిషన్</em> బ్లాక్ అంగా ఉంచిన <em>Note</em> బ్లాక్లలో నిర్వచించిన పిచ్లను పరిమాణం (లేదా) అంకడికి మరియుండా పరిస్థానించడానికి ఉంది. ప్రదర్శించిన ఉదాహరణలో, <em>సోల్</em> అనే పిచ్ ను <em>లా</em> అనేది వరకు తగ్గించబడింది."
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr "కొత్త ప్రాజెక్ట్ ను ప్రారంభించండి."
+#~ msgid "Initialise a new project."
+#~ msgstr "కొత్త ప్రాజెక్ట్ ను ప్రారంభించండి."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr "జపనీస్"
+#~ msgid "japanese"
+#~ msgstr "జపనీస్"
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr "7వ"
+#~ msgid "7th"
+#~ msgstr "7వ"
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr "కార్డు' + ' ' + 'V"
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr "కార్డు' + ' ' + 'V"
 
 #: js/musicutils.js:345
 
@@ -9415,8 +9415,8 @@ msgstr "చలింపు"
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr "చైనీ"
+#~ msgid "chine"
+#~ msgstr "చైనీ"
 
 #: js/timbre.js:743
 
@@ -9426,127 +9426,127 @@ msgstr "చలింపు"
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr "అన్డో"
+#~ msgid "undo"
+#~ msgstr "అన్డో"
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr "కార్డు' + ' ' + 'I"
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr "కార్డు' + ' ' + 'I"
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr "ప్లేస్‌హోల్డర్"
+#~ msgid "placeholder"
+#~ msgstr "ప్లేస్‌హోల్డర్"
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr "<em>మూవ్ బ్లాక్</em> బ్లాక్ ఒకరిక నిండినండి."
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr "<em>మూవ్ బ్లాక్</em> బ్లాక్ ఒకరిక నిండినండి."
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr "<em>ఆక్సిడెంటల్</em> బ్లాక్ <em>షార్ప్స్</em> మరియు <em>ఫ్లాట్స్</em> ని రచించడానికి ఉంది."
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr "<em>ఆక్సిడెంటల్</em> బ్లాక్ <em>షార్ప్స్</em> మరియు <em>ఫ్లాట్స్</em> ని రచించడానికి ఉంది."
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr "<em>హైడ్ బ్లాక్స్</em> బ్లాక్లను దాచిపెట్టిపెట్టేందుకు ఉంది."
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr "<em>హైడ్ బ్లాక్స్</em> బ్లాక్లను దాచిపెట్టిపెట్టేందుకు ఉంది."
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr "<em>వేట్‌ఫార్</em> బ్లాక్ సరిపోతున్నప్పుడు వేచికి ఉంటుంది."
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr "<em>వేట్‌ఫార్</em> బ్లాక్ సరిపోతున్నప్పుడు వేచికి ఉంటుంది."
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr "ధ్వనియను సెట్ చేయండి."
+#~ msgid "set volume"
+#~ msgstr "ధ్వనియను సెట్ చేయండి."
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr "<em>ప్లే నాయిస్</em> బ్లాక్ వైట్, పింక్ లేదా బ్రౌన్ నాయిస్ సృష్టించబడుతుంది."
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr "<em>ప్లే నాయిస్</em> బ్లాక్ వైట్, పింక్ లేదా బ్రౌన్ నాయిస్ సృష్టించబడుతుంది."
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr "<em>బేజియర్</em> బ్లాక్ ఒక బేజియర్ కర్వ్ అనేది గోసరిని గోసరి గోసరి అనేది."
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr "<em>బేజియర్</em> బ్లాక్ ఒక బేజియర్ కర్వ్ అనేది గోసరిని గోసరి గోసరి అనేది."
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr "గంటల క్రితం"
+#~ msgid "hours ago"
+#~ msgstr "గంటల క్రితం"
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr "మెజర్ బ్లూస్"
+#~ msgid "Major Blues"
+#~ msgstr "మెజర్ బ్లూస్"
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr "<em>బ్యాక్</em> బ్లాక్ మౌస్ను వెనుకకు చెల్లిపెట్టుతుంది."
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr "<em>బ్యాక్</em> బ్లాక్ మౌస్ను వెనుకకు చెల్లిపెట్టుతుంది."
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr "<em>సెట్-నేమ్</em> బ్లాక్ మౌస్ని పేరుతో పేరు చేసేందుకు ఉంది."
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr "<em>సెట్-నేమ్</em> బ్లాక్ మౌస్ని పేరుతో పేరు చేసేందుకు ఉంది."
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr "<em>స్థితి</em> బ్లాక్ గతిస్థితిని పరిశీలించడానికి ఒక టూల్ని తెరుచుక"
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr "<em>స్థితి</em> బ్లాక్ గతిస్థితిని పరిశీలించడానికి ఒక టూల్ని తెరుచుక"
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr "ప్లే స్కేల్"
+#~ msgid "play scale"
+#~ msgstr "ప్లే స్కేల్"
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr "ఈ టూల్‌బార్‌లో మేట్రిక్స్, నోట్, టోన్, టర్టిల్ మరియు ఇతర పాలెట్ బటన్లు ఉన్నాయి. బ్లాక్ల పాలెట్లను చూపించడానికి క్లిక్ చేసి మరియు కాన్వాస్ పై నుండి బ్లాక్లను డ్రాగ్ చేయడానికి బ్లాక్లను తీసివేయండి."
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr "ఈ టూల్‌బార్‌లో మేట్రిక్స్, నోట్, టోన్, టర్టిల్ మరియు ఇతర పాలెట్ బటన్లు ఉన్నాయి. బ్లాక్ల పాలెట్లను చూపించడానికి క్లిక్ చేసి మరియు కాన్వాస్ పై నుండి బ్లాక్లను డ్రాగ్ చేయడానికి బ్లాక్లను తీసివేయండి."
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr "<em>ప్రతి నిమిషం బీట్లు</em> బ్లాక్ ప్రస్తుత ప్రతి నిమిషం బీట్లను తిరిగిస్తుంది."
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr "<em>ప్రతి నిమిషం బీట్లు</em> బ్లాక్ ప్రస్తుత ప్రతి నిమిషం బీట్లను తిరిగిస్తుంది."
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr "స్కేల్లో వచ్చే తరువాత పిచ్ ప్లే చేయడానికి (నంబర్ బ్లాక్ తో కలయిక) స్కేలర్ స్టెప్ బ్లాక్ ఉపయోగపడుతుంది,"
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr "స్కేల్లో వచ్చే తరువాత పిచ్ ప్లే చేయడానికి (నంబర్ బ్లాక్ తో కలయిక) స్కేలర్ స్టెప్ బ్లాక్ ఉపయోగపడుతుంది,"
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr "పిచ్చును <em>ని ధ ప మ గ రె స</em> అంశాలతో నిర్ధారించవచ్చు."
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr "పిచ్చును <em>ని ధ ప మ గ రె స</em> అంశాలతో నిర్ధారించవచ్చు."
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr "ఎనిగ్మాటిక్"
+#~ msgid "Enigmatic"
+#~ msgstr "ఎనిగ్మాటిక్"
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr "పంచములు"
+#~ msgid "fifths"
+#~ msgstr "పంచములు"
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr "ఎంఎల్"
+#~ msgid "ml"
+#~ msgstr "ఎంఎల్"
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr "మి"
+#~ msgid "mi"
+#~ msgstr "మి"
 
 #: js/turtledefs.js:251
 
@@ -9554,612 +9554,612 @@ msgstr "చలింపు"
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr "<em>డూ</em> బ్లాక్ ఒక చర్యను ప్రారంభించడానికి ఉంది."
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr "<em>డూ</em> బ్లాక్ ఒక చర్యను ప్రారంభించడానికి ఉంది."
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr "ఇండెక్స్హీప్ బ్లాక్ ఒక కేటగిరిలో ఒక స్థానంలో విలువను తిరిగిస్తుంది."
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr "ఇండెక్స్హీప్ బ్లాక్ ఒక కేటగిరిలో ఒక స్థానంలో విలువను తిరిగిస్తుంది."
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr "<em>పెన్-అప్</em> బ్లాక్ పెన్ను పెన్ను ఏం గోస్తుండని ఎలా ఉంచుతుందో చూపిస్తుంది."
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr "<em>పెన్-అప్</em> బ్లాక్ పెన్ను పెన్ను ఏం గోస్తుండని ఎలా ఉంచుతుందో చూపిస్తుంది."
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr "<em>కొత్త మౌస్</em> బ్లాక్ కొత్త మౌస్ రచించిపెట్టిపెట్టుతుంది."
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr "<em>కొత్త మౌస్</em> బ్లాక్ కొత్త మౌస్ రచించిపెట్టిపెట్టుతుంది."
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr "ప్లేబ్యాక్"
+#~ msgid "playback"
+#~ msgstr "ప్లేబ్యాక్"
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr "ప్రాజెక్ట్ను ఫైలు నుండి విలీనం చేయండి."
+#~ msgid "Merge project from file"
+#~ msgstr "ప్రాజెక్ట్ను ఫైలు నుండి విలీనం చేయండి."
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr "<em>ఎడమ</em> బ్లాక్ కాన్వాస్ ఎడమి ప్రాంతంను తిరిగిస్తుంది."
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr "<em>ఎడమ</em> బ్లాక్ కాన్వాస్ ఎడమి ప్రాంతంను తిరిగిస్తుంది."
 
-#~msgid "eatme"
-#~msgstr "తినండి"
+#~ msgid "eatme"
+#~ msgstr "తినండి"
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr "<em>ప్రతి నిమిషం ప్రతిసార్లు ప్రదానిచిన పూర్ణంగా గనుల సంఖ్య</em> బ్లాక్ తిరిగిస్తుంది."
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr "<em>ప్రతి నిమిషం ప్రతిసార్లు ప్రదానిచిన పూర్ణంగా గనుల సంఖ్య</em> బ్లాక్ తిరిగిస్తుంది."
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr "మావాళ్లను"
+#~ msgid "movable"
+#~ msgstr "మావాళ్లను"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr "బ్రౌన్ నాయిస్"
+#~ msgid "brown-noise"
+#~ msgstr "బ్రౌన్ నాయిస్"
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr "జపనీస్"
+#~ msgid "Japanese"
+#~ msgstr "జపనీస్"
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr "ట్రెయింగుల్-బెల్"
+#~ msgid "triangle-bell"
+#~ msgstr "ట్రెయింగుల్-బెల్"
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr "గ్రిడ్‌ను దాచు"
+#~ msgid "Hide grid"
+#~ msgstr "గ్రిడ్‌ను దాచు"
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr "<em>ఎఫ్‌ఎమ్ సింత్</em> బ్లాక్ ఒక టింబర్ను నిర్వచించడానికి ఉపయోగించిన ఫ్రిక్వెన్సీ మాడ్యులేటర్ ఉంది."
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr "<em>ఎఫ్‌ఎమ్ సింత్</em> బ్లాక్ ఒక టింబర్ను నిర్వచించడానికి ఉపయోగించిన ఫ్రిక్వెన్సీ మాడ్యులేటర్ ఉంది."
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr "షో హీప్ బ్లాక్ స్క్రీన్ యొక్క ముక్కలో హీప్ యొక్క అంశాలను ప్రదర్శిస్తుంది."
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr "షో హీప్ బ్లాక్ స్క్రీన్ యొక్క ముక్కలో హీప్ యొక్క అంశాలను ప్రదర్శిస్తుంది."
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr "<em>నంబర్</em> బ్లాక్ ఒక సంఖ్యను ఉంచికొనుతుంది."
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr "<em>నంబర్</em> బ్లాక్ ఒక సంఖ్యను ఉంచికొనుతుంది."
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr "<em>కేస్</em> బ్లాక్ ఒక <em>స్విచ్</em> లో సరిచేతనానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr "<em>కేస్</em> బ్లాక్ ఒక <em>స్విచ్</em> లో సరిచేతనానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr "బ్యాక్‌గ్రౌండ్ బ్లాక్ బ్యాక్గ్రౌండ్ రంగును సెట్ చేస్తుంది."
+#~ msgid "The Background block sets the background color."
+#~ msgstr "బ్యాక్‌గ్రౌండ్ బ్లాక్ బ్యాక్గ్రౌండ్ రంగును సెట్ చేస్తుంది."
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr "మునుపటి పేజీ"
+#~ msgid "Previous page"
+#~ msgstr "మునుపటి పేజీ"
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr "<em>ఓపెన్ ఫైల్</em> బ్లాక్ ఫైల్ను <em>షో</em> బ్లాక్తో ఉపయోగించడానికి తెరిచిపెట్టుతుంది."
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr "<em>ఓపెన్ ఫైల్</em> బ్లాక్ ఫైల్ను <em>షో</em> బ్లాక్తో ఉపయోగించడానికి తెరిచిపెట్టుతుంది."
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr "<em>సెట్-కలర్</em> బ్లాక్ పెన్ రంగును మార్చిపెట్టుతుంది."
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr "<em>సెట్-కలర్</em> బ్లాక్ పెన్ రంగును మార్చిపెట్టుతుంది."
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr "కార్డ్ + ' ' + 'IV"
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr "కార్డ్ + ' ' + 'IV"
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr "ప్రభావాలు"
+#~ msgid "effects"
+#~ msgstr "ప్రభావాలు"
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr "ఫ్లోర్-టామ్"
+#~ msgid "floor-tom"
+#~ msgstr "ఫ్లోర్-టామ్"
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr "<em>ఎత్తు</em> బ్లాక్ కాన్వాస్ యొక్క ఎత్తను తిరిగిస్తుంది."
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr "<em>ఎత్తు</em> బ్లాక్ కాన్వాస్ యొక్క ఎత్తను తిరిగిస్తుంది."
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr "ఫేస్‌బుక్లో షేర్ చేయండి"
+#~ msgid "Share on Facebook"
+#~ msgstr "ఫేస్‌బుక్లో షేర్ చేయండి"
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr "<em>షేడ్</em> బ్లాక్ ప్రస్తుత పెన్ షేడ్ విలువను తిరిగిస్తుంది."
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr "<em>షేడ్</em> బ్లాక్ ప్రస్తుత పెన్ షేడ్ విలువను తిరిగిస్తుంది."
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr "<em>అన్-ఎవెరీ-బీట్</em> బ్లాక్ మీరు ప్రతి బీట్ పై చేయడానికి చర్యలను నిర్దిష్టించవచ్చు."
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr "<em>అన్-ఎవెరీ-బీట్</em> బ్లాక్ మీరు ప్రతి బీట్ పై చేయడానికి చర్యలను నిర్దిష్టించవచ్చు."
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr "మిస్టర్ మౌస్ మాకు మ్యూజిక్ బ్లాక్స్ కండక్టర్. మిస్టర్ మౌస్ మీరు మ్యూజిక్ బ్లాక్స్ అన్వేషించడానికి ఆహ్వానిస్తారు. మాకు మా పర్యటనను ప్రారంభించండి!"
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr "మిస్టర్ మౌస్ మాకు మ్యూజిక్ బ్లాక్స్ కండక్టర్. మిస్టర్ మౌస్ మీరు మ్యూజిక్ బ్లాక్స్ అన్వేషించడానికి ఆహ్వానిస్తారు. మాకు మా పర్యటనను ప్రారంభించండి!"
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr "రే"
+#~ msgid "re"
+#~ msgstr "రే"
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr "స్పానిష్ జిప్సీ"
+#~ msgid "Spanish Gypsy"
+#~ msgstr "స్పానిష్ జిప్సీ"
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr "నోట్ విలువను భాగంగా చేయండి"
+#~ msgid "divide note value"
+#~ msgstr "నోట్ విలువను భాగంగా చేయండి"
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr "ఉదా, సి మేజర్"
+#~ msgid "e.g., C Major"
+#~ msgstr "ఉదా, సి మేజర్"
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr "ఆడియోను నిధానంగా ప్రవర్తించడానికి ఎక్స్ట్రా-లాంగ్ ప్రెస్"
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr "ఆడియోను నిధానంగా ప్రవర్తించడానికి ఎక్స్ట్రా-లాంగ్ ప్రెస్"
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr "డ్రమ్ మెషీన్ని భద్రపరచు"
+#~ msgid "save drum machine"
+#~ msgstr "డ్రమ్ మెషీన్ని భద్రపరచు"
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr "అరసుగా లాగింగ్ చేసుకోండి"
+#~ msgid "enable horizontal scrolling"
+#~ msgstr "అరసుగా లాగింగ్ చేసుకోండి"
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr "<em>పికప్</em> బ్లాక్ బీటు ముందుగా రాబోతున్న ఏమితో ఉన్న అన్ని నోట్లను ఆకర్షించడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr "<em>పికప్</em> బ్లాక్ బీటు ముందుగా రాబోతున్న ఏమితో ఉన్న అన్ని నోట్లను ఆకర్షించడానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr "<em>హోలో లైన్</em> బ్లాక్ ఒక ఖాళీ కేంద్రంతో ఒక రేఖను సృష్టించిస్తుంది."
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr "<em>హోలో లైన్</em> బ్లాక్ ఒక ఖాళీ కేంద్రంతో ఒక రేఖను సృష్టించిస్తుంది."
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr "ఒక స్ట్యాక్‌ను క్లిప్‌బోర్డ్కు నకలు చేయడానికి, స్ట్యాక్ పై క్లిక్ చేయండి."
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr "ఒక స్ట్యాక్‌ను క్లిప్‌బోర్డ్కు నకలు చేయడానికి, స్ట్యాక్ పై క్లిక్ చేయండి."
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr "<em>స్టాప్‌ప్లేబ్యాక్</em> బ్లాక్"
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr "<em>స్టాప్‌ప్లేబ్యాక్</em> బ్లాక్"
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr "ఎబీసీగా భద్రపరచండి"
+#~ msgid "Save as abc"
+#~ msgstr "ఎబీసీగా భద్రపరచండి"
 
 #: js/turtledefs.js:456
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr "<em>టు ఫ్రిక్వెన్సీ</em> బ్లాక్ పిచ్ పేరు మరియు ఆక్టేవ్ను హెర్ట్జ్‌కు మార్చిపెట్టేది."
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr "<em>టు ఫ్రిక్వెన్సీ</em> బ్లాక్ పిచ్ పేరు మరియు ఆక్టేవ్ను హెర్ట్జ్‌కు మార్చిపెట్టేది."
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr "టాప్"
+#~ msgid "top"
+#~ msgstr "టాప్"
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "మ్యూజిక్ బ్లాక్స్‌ను కాన్‌ఫిగర్ చేయడానికి ప్యానెల్ తెరుచు."
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "మ్యూజిక్ బ్లాక్స్‌ను కాన్‌ఫిగర్ చేయడానికి ప్యానెల్ తెరుచు."
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr "<em>ఆండ్</em> బ్లాక్ అండ్ అపరేటర్."
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr "<em>ఆండ్</em> బ్లాక్ అండ్ అపరేటర్."
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ".wav గా భద్రపరచండి"
+#~ msgid "Save as .wav"
+#~ msgstr ".wav గా భద్రపరచండి"
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr "ప్లానెట్ అందుబాటులో లేదు."
+#~ msgid "The Planet is unavailable."
+#~ msgstr "ప్లానెట్ అందుబాటులో లేదు."
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr "మీరు <em>డ్రమ్</em> బ్లాక్లను <em>నోట్</em> బ్లాక్లో ఉపయోగించవచ్చు."
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr "మీరు <em>డ్రమ్</em> బ్లాక్లను <em>నోట్</em> బ్లాక్లో ఉపయోగించవచ్చు."
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr "మీరు Alt+V ను ఉపయోగించి ఒక స్ట్యాక్ ను పేస్ట్ చేయవచ్చు."
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr "మీరు Alt+V ను ఉపయోగించి ఒక స్ట్యాక్ ను పేస్ట్ చేయవచ్చు."
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr "<em>వీడియో</em> బ్లాక్ వీడియోను <em>షో</em> బ్లాక్తో ఉపయోగిస్తుంది."
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr "<em>వీడియో</em> బ్లాక్ వీడియోను <em>షో</em> బ్లాక్తో ఉపయోగిస్తుంది."
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "<em>మూవాబుల్ డో</em> అంటే తప్పుడు, సోల్ఫేజ్ నోట్ పేర్లు ఎప్పటికి గుర్తులకు సంబంధించి ఉంటాయి (ఉదా, \"డో\" ఎప్పటికి \"సి-న్యాచరల్\"); <em>మూవాబుల్ డో</em> నిజంగా ఉంటే, సోల్ఫేజ్ నోట్ పేర్లు స్కేల్ డిగ్రీలకు కేటాయిస్తాయి (\"డో\" ఎప్పటికి మెజర్ స్కేల్ యొక్క మొదటి డిగ్రీ)."
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "<em>మూవాబుల్ డో</em> అంటే తప్పుడు, సోల్ఫేజ్ నోట్ పేర్లు ఎప్పటికి గుర్తులకు సంబంధించి ఉంటాయి (ఉదా, \"డో\" ఎప్పటికి \"సి-న్యాచరల్\"); <em>మూవాబుల్ డో</em> నిజంగా ఉంటే, సోల్ఫేజ్ నోట్ పేర్లు స్కేల్ డిగ్రీలకు కేటాయిస్తాయి (\"డో\" ఎప్పటికి మెజర్ స్కేల్ యొక్క మొదటి డిగ్రీ)."
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr "<em>పాప్</em> బ్లాక్ హీప్ క్రీతం వాల్యూను తీసేస్తుంది."
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr "<em>పాప్</em> బ్లాక్ హీప్ క్రీతం వాల్యూను తీసేస్తుంది."
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr "<em>డీక్రెస్కెండో</em> బ్లాక్ ప్రతి నోట్ ప్లే చేయడానికి ఆక్షరణాన్ని స్థిరంగా పరిమాణంతకు కూడి పడగిస్తుంది. ఉదాహరణకు, మీరు ఒక విలువతో ఉన్న 7 నోట్లు ఒక <em>డీక్రెస్కెండో</em> బ్లాక్‌లో ఉంచినట్లు, చివరి నోటు ప్రారంభ వాల్యూమ్ కంటే 35% తక్కువగా ఉంటుంది."
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr "<em>డీక్రెస్కెండో</em> బ్లాక్ ప్రతి నోట్ ప్లే చేయడానికి ఆక్షరణాన్ని స్థిరంగా పరిమాణంతకు కూడి పడగిస్తుంది. ఉదాహరణకు, మీరు ఒక విలువతో ఉన్న 7 నోట్లు ఒక <em>డీక్రెస్కెండో</em> బ్లాక్‌లో ఉంచినట్లు, చివరి నోటు ప్రారంభ వాల్యూమ్ కంటే 35% తక్కువగా ఉంటుంది."
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr "సేవ్-స్టాక్ బటన్ ఒక కస్టమ్ పాలెట్‌కు స్టాక్ భద్రపరచిస్తుంది."
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr "సేవ్-స్టాక్ బటన్ ఒక కస్టమ్ పాలెట్‌కు స్టాక్ భద్రపరచిస్తుంది."
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr "ఈజిప్షియన్"
+#~ msgid "Egyptian"
+#~ msgstr "ఈజిప్షియన్"
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr "క్లిప్‌బోర్డ్‌కు నకలు చేసుకుని ఉంటే, పేస్ట్ బటన్ ఎనేబుల్‌గా ఉంటుంది."
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr "క్లిప్‌బోర్డ్‌కు నకలు చేసుకుని ఉంటే, పేస్ట్ బటన్ ఎనేబుల్‌గా ఉంటుంది."
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr "అల్జీరియన్"
+#~ msgid "Algerian"
+#~ msgstr "అల్జీరియన్"
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr "హంతకారి"
+#~ msgid "denominator"
+#~ msgstr "హంతకారి"
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr "ఖాళీగా ఉన్న హీప్‌ను ఖాళీగా చేస్తుంది."
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr "ఖాళీగా ఉన్న హీప్‌ను ఖాళీగా చేస్తుంది."
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr "<em>ఫేసర్</em> బ్లాక్ ఒక స్వీపింగ్ ధ్వనిని జోడిస్తుంది."
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr "<em>ఫేసర్</em> బ్లాక్ ఒక స్వీపింగ్ ధ్వనిని జోడిస్తుంది."
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr "<em>ఓపెన్ ప్రాజెక్ట్</em> బ్లాక్ వెబ్ పేజీ నుండి ఒక ప్రాజెక్ట్‌ను తెరవడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr "<em>ఓపెన్ ప్రాజెక్ట్</em> బ్లాక్ వెబ్ పేజీ నుండి ఒక ప్రాజెక్ట్‌ను తెరవడానికి ఉపయోగిస్తారు."
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr "ఇంపాక్ట్ డేటా అందుబాటులో లేదు."
+#~ msgid "Impact data not available."
+#~ msgstr "ఇంపాక్ట్ డేటా అందుబాటులో లేదు."
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr "సాధారిగా ప్రవర్తించడానికి రన్ బటన్‌ని ఎక్స్ట్రా-లాంగ్ ప్రెస్ చేయండి."
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr "సాధారిగా ప్రవర్తించడానికి రన్ బటన్‌ని ఎక్స్ట్రా-లాంగ్ ప్రెస్ చేయండి."
 
-#~msgid "mashape"
-#~msgstr "మాషేప్"
+#~ msgid "mashape"
+#~ msgstr "మాషేప్"
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr "మూడు భాగాలు"
+#~ msgid "thirds"
+#~ msgstr "మూడు భాగాలు"
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr "<em>X</em> బ్లాక్ మౌస్ యొక్క అరసాను తిరిగిస్తుంది."
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr "<em>X</em> బ్లాక్ మౌస్ యొక్క అరసాను తిరిగిస్తుంది."
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr "<em>డిలీట్ బ్లాక్</em> బ్లాక్‌ను తొలగిస్తుంది."
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr "<em>డిలీట్ బ్లాక్</em> బ్లాక్‌ను తొలగిస్తుంది."
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr "<em>స్క్రోల్ XY</em> బ్లాక్ కాన్వాస్‌ను చలింపుగా చేస్తుంది."
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr "<em>స్క్రోల్ XY</em> బ్లాక్ కాన్వాస్‌ను చలింపుగా చేస్తుంది."
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr "<em>రిటర్న్ టు URL</em> బ్లాక్ ఒక విలువను వెబ్‌పేజీకి తిరిగి అందుబాటులోకి తరిలిస్తుంది."
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr "<em>రిటర్న్ టు URL</em> బ్లాక్ ఒక విలువను వెబ్‌పేజీకి తిరిగి అందుబాటులోకి తరిలిస్తుంది."
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr "<em>ఎడమ</em> బ్లాక్ మౌస్‌ను ఎడమకు తిరిగిస్తుంది."
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr "<em>ఎడమ</em> బ్లాక్ మౌస్‌ను ఎడమకు తిరిగిస్తుంది."
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr "ప్రవర్తించండి"
+#~ msgid "Run"
+#~ msgstr "ప్రవర్తించండి"
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "మీరు కోడ్‌ను ఫైల్ సిస్టమ్ నుండి లోడ్ చేసుకోవచ్చు."
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "మీరు కోడ్‌ను ఫైల్ సిస్టమ్ నుండి లోడ్ చేసుకోవచ్చు."
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr "సెట్టింగ్స్"
+#~ msgid "Settings"
+#~ msgstr "సెట్టింగ్స్"
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr "<em>బూలియన్</em> బ్లాక్ నిజమేమి లేదా అసత్యాన్ని నిర్దిష్టించడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr "<em>బూలియన్</em> బ్లాక్ నిజమేమి లేదా అసత్యాన్ని నిర్దిష్టించడానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr "<em>ఆన్-స్ట్రాంగ్-బీట్</em> బ్లాక్ మీరు నిర్దిష్టమైన బీటులపై ప్రవర్తించడానికి నిర్దిష్టించిస్తుంది."
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr "<em>ఆన్-స్ట్రాంగ్-బీట్</em> బ్లాక్ మీరు నిర్దిష్టమైన బీటులపై ప్రవర్తించడానికి నిర్దిష్టించిస్తుంది."
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr "<em>ఇండెక్స్‌హీప్</em> బ్లాక్ ఒక నిర్దిష్ట స్థానంలో హీప్‌లో ఒక విలువను తిరిగిస్తుంది."
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr "<em>ఇండెక్స్‌హీప్</em> బ్లాక్ ఒక నిర్దిష్ట స్థానంలో హీప్‌లో ఒక విలువను తిరిగిస్తుంది."
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr "<em>ఆర్గ్</em> బ్లాక్ ఒక కార్యాచరణకు పాస్ అయిన ఒక విలువను కలిగి ఉంది."
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr "<em>ఆర్గ్</em> బ్లాక్ ఒక కార్యాచరణకు పాస్ అయిన ఒక విలువను కలిగి ఉంది."
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr "క్రిందకు జరుగు"
+#~ msgid "move down"
+#~ msgstr "క్రిందకు జరుగు"
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr "సంయుక్త ప్రమాణాన్ని పెంపొందు"
+#~ msgid "consonant step up"
+#~ msgstr "సంయుక్త ప్రమాణాన్ని పెంపొందు"
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr "<em>ఎంప్టీహీప్</em> బ్లాక్ హీప్‌ను ఖాళీ చేస్తుంది."
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr "<em>ఎంప్టీహీప్</em> బ్లాక్ హీప్‌ను ఖాళీ చేస్తుంది."
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr "<em>డిఫాల్ట్</em> బ్లాక్ డిఫాల్ట్ కార్యాచరణను నిర్దిష్టించడానికి <em>స్విచ్</em> లో ఉపయోగిస్తారు."
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr "<em>డిఫాల్ట్</em> బ్లాక్ డిఫాల్ట్ కార్యాచరణను నిర్దిష్టించడానికి <em>స్విచ్</em> లో ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr "<em>స్కాలర్ ప్రమాణాన్ని పెంపొందు</em> బ్లాక్ ప్రస్తుత కీ మరియు మోడ్‌లో తర్వాత నోటుకు వచ్చిన అర సెమీ-టోన్ల సంఖ్యను తిరిగిస్తుంది."
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr "<em>స్కాలర్ ప్రమాణాన్ని పెంపొందు</em> బ్లాక్ ప్రస్తుత కీ మరియు మోడ్‌లో తర్వాత నోటుకు వచ్చిన అర సెమీ-టోన్ల సంఖ్యను తిరిగిస్తుంది."
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr "<em>రిద్ధం మేకర్</em> బ్లాక్ డ్రం మెషీన్‌లను సృష్టించడానికి ఒక టూల్‌ను తెరివిస్తుంది."
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr "<em>రిద్ధం మేకర్</em> బ్లాక్ డ్రం మెషీన్‌లను సృష్టించడానికి ఒక టూల్‌ను తెరివిస్తుంది."
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr "మౌస్ హెడింగ్ బ్లాక్ అంచనాను తనిఖీ చేసి తెరవికి తీసుకున్నది."
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr "మౌస్ హెడింగ్ బ్లాక్ అంచనాను తనిఖీ చేసి తెరవికి తీసుకున్నది."
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr "పిచ్ స్లైడర్"
+#~ msgid "pitchslider"
+#~ msgstr "పిచ్ స్లైడర్"
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr "మరిన్ని చూడండి"
+#~ msgid "View More"
+#~ msgstr "మరిన్ని చూడండి"
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr "కొలాప్స్"
+#~ msgid "collpase"
+#~ msgstr "కొలాప్స్"
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr "హీప్-ఖాళీ? బ్లాక్ అంచనా చేసినా ఖాళీ అయితే సత్యం తెలియదు."
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr "హీప్-ఖాళీ? బ్లాక్ అంచనా చేసినా ఖాళీ అయితే సత్యం తెలియదు."
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr "ఫిబోనాక్కి"
+#~ msgid "Fibonacci"
+#~ msgstr "ఫిబోనాక్కి"
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr "సంగీతాన్ని నిధానంగా అమలు చేయండి"
+#~ msgid "Run music slowly"
+#~ msgstr "సంగీతాన్ని నిధానంగా అమలు చేయండి"
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr "<em>సెట్ ట్రాన్స్లిసెన్సి</em> బ్లాక్ పెన్ యొక్క అప్యాక్సిటిని మార్చేందుకు ఉంది."
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr "<em>సెట్ ట్రాన్స్లిసెన్సి</em> బ్లాక్ పెన్ యొక్క అప్యాక్సిటిని మార్చేందుకు ఉంది."
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr "<em>పిచ్</em> బ్లాక్ నోటు యొక్క ఫ్రిక్వెన్సీని నిర్ధారించే నోటు యొక్క పిచ్ పేరు మరియు పిచ్ ఆక్టేవ్ను స్పష్టం చేస్తుంది."
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr "<em>పిచ్</em> బ్లాక్ నోటు యొక్క ఫ్రిక్వెన్సీని నిర్ధారించే నోటు యొక్క పిచ్ పేరు మరియు పిచ్ ఆక్టేవ్ను స్పష్టం చేస్తుంది."
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr "<em>స్టాక్కాటో</em> బ్లాక్ వాస్తవ నోటు పొడిచి ఉంచిస్తుంది - వాస్తవ నోటులను తిగులుకొని - మరియు నోటుల నిర్దిష్ట రిద్ధి విలువను ఉంచిపెడతాయి."
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr "<em>స్టాక్కాటో</em> బ్లాక్ వాస్తవ నోటు పొడిచి ఉంచిస్తుంది - వాస్తవ నోటులను తిగులుకొని - మరియు నోటుల నిర్దిష్ట రిద్ధి విలువను ఉంచిపెడతాయి."
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr "పిచ్ను మార్చడానికి స్లైడర్ ఉపయోగించండి."
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr "పిచ్ను మార్చడానికి స్లైడర్ ఉపయోగించండి."
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr "<em>రైట్</em> బ్లాక్ క్యాన్వాస్ యొక్క కుడితనాన్ని తిరిగివేస్తుంది."
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr "<em>రైట్</em> బ్లాక్ క్యాన్వాస్ యొక్క కుడితనాన్ని తిరిగివేస్తుంది."
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr "<em>సెట్ సింత్ వాల్యూమ్</em> బ్లాక్ ఒక ప్రతిష్ఠాత్మక సింథ్, ఉదాహరణకు, గిటార్, వయలిన్, స్నేర్ డ్రం, మొదటి ధ్వని రకాన్ని మార్చేందుకు ఉంది. ప్రముఖ ధ్వని 50; అంతా 0 (నిర్మాణం) నుండి 100 (పూర్తి ధ్వని) వరకు ఉంది."
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr "<em>సెట్ సింత్ వాల్యూమ్</em> బ్లాక్ ఒక ప్రతిష్ఠాత్మక సింథ్, ఉదాహరణకు, గిటార్, వయలిన్, స్నేర్ డ్రం, మొదటి ధ్వని రకాన్ని మార్చేందుకు ఉంది. ప్రముఖ ధ్వని 50; అంతా 0 (నిర్మాణం) నుండి 100 (పూర్తి ధ్వని) వరకు ఉంది."
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr "<em>క్రెస్కెండో</em> బ్లాక్ ప్రతినాడు అంచనాన్ని కొనసాగిస్తుంది. ఉదాహరణకు, మీకు కొనసాగిస్తున్న 7 నోటులు ఒక బ్లాక్లో ఉన్నాయి, అప్పుడు మొదటి ధ్వనికి కేవలం 5 నాణ్యాలకు నిర్దిష్ట ధ్వని విలువతో అంతపుదలే ముగిసేందుకు, చివరి నోటు మొదటి ధ్వని కంటే 35% ఎక్కువగా ఉంటుంది."
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr "<em>క్రెస్కెండో</em> బ్లాక్ ప్రతినాడు అంచనాన్ని కొనసాగిస్తుంది. ఉదాహరణకు, మీకు కొనసాగిస్తున్న 7 నోటులు ఒక బ్లాక్లో ఉన్నాయి, అప్పుడు మొదటి ధ్వనికి కేవలం 5 నాణ్యాలకు నిర్దిష్ట ధ్వని విలువతో అంతపుదలే ముగిసేందుకు, చివరి నోటు మొదటి ధ్వని కంటే 35% ఎక్కువగా ఉంటుంది."
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr "నోటు ధ్వని"
+#~ msgid "note volume"
+#~ msgstr "నోటు ధ్వని"
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr "వేలు-సింబల్స్"
+#~ msgid "finger-cymbals"
+#~ msgstr "వేలు-సింబల్స్"
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr "పిచ్-డ్రం మ్యాట్రిక్స్"
+#~ msgid "pitch-drum matrix"
+#~ msgstr "పిచ్-డ్రం మ్యాట్రిక్స్"
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr "ట్యూప్లెట్ బ్లాక్: మీరు మాట్రిక్స్ బ్లాక్ ఉపయోగించడానికి తప్పాయినా?"
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr "ట్యూప్లెట్ బ్లాక్: మీరు మాట్రిక్స్ బ్లాక్ ఉపయోగించడానికి తప్పాయినా?"
 
-#~msgid "set beats per minute"
-#~msgstr "ప్రతి నిమిషం బీట్లను సెట్ చేయండి"
+#~ msgid "set beats per minute"
+#~ msgstr "ప్రతి నిమిషం బీట్లను సెట్ చేయండి"
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr "అన్నినీ తొలగించు"
+#~ msgid "Delete all"
+#~ msgstr "అన్నినీ తొలగించు"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr "పింక్ నాయిస్"
+#~ msgid "pink-noise"
+#~ msgstr "పింక్ నాయిస్"
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr "UID"
+#~ msgid "UID"
+#~ msgstr "UID"
 
 #: js/musicutils.js:197
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr "క్రోమాటిక్"
+#~ msgid "Chromatic"
+#~ msgstr "క్రోమాటిక్"
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr "క్లాక్వైజ్ గా విస్తరించండి"
+#~ msgid "rotate clockwise"
+#~ msgstr "క్లాక్వైజ్ గా విస్తరించండి"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr "హిరాజోషి (జపాన్)"
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr "హిరాజోషి (జపాన్)"
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr "మైనర్ బ్లాక్కి ఇన్‌పుట్ అయితే 2, 3, 6 లేదా 7 అవుతుంది"
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr "మైనర్ బ్లాక్కి ఇన్‌పుట్ అయితే 2, 3, 6 లేదా 7 అవుతుంది"
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr "కొంతకం"
+#~ msgid "bottom"
+#~ msgstr "కొంతకం"
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr "<em>సెట్ కీ</em> బ్లాక్ కీ మరియు మోడ్ ని సెట్ చేయడానికి ఉపయోగిస్తారు, ఉదాహరణకు, <em>C మేజర్</em>"
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr "<em>సెట్ కీ</em> బ్లాక్ కీ మరియు మోడ్ ని సెట్ చేయడానికి ఉపయోగిస్తారు, ఉదాహరణకు, <em>C మేజర్</em>"
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr "<em>మల్టిప్లై నోటు విల్యూ</em> బ్లాక్ నోటుల కాలను మార్చడానికి వారు చేసిన నోటు విల్యూలను మార్చేందుకు ఉంది."
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr "<em>మల్టిప్లై నోటు విల్యూ</em> బ్లాక్ నోటుల కాలను మార్చడానికి వారు చేసిన నోటు విల్యూలను మార్చేందుకు ఉంది."
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr "<em>Y</em> బ్లాక్ మౌస్ యొక్క ఉత్తరవాదిత్వాన్ని తిరిగిస్తుంది."
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr "<em>Y</em> బ్లాక్ మౌస్ యొక్క ఉత్తరవాదిత్వాన్ని తిరిగిస్తుంది."
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr "నిర్వచనార్హం"
+#~ msgid "numerator"
+#~ msgstr "నిర్వచనార్హం"
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr "కప్-డ్రమ్"
+#~ msgid "cup-drum"
+#~ msgstr "కప్-డ్రమ్"
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr "హాయాట్"
+#~ msgid "hi-hat"
+#~ msgstr "హాయాట్"
 
 #: js/palette.js:1763
 
@@ -10169,165 +10169,165 @@ msgstr "చలింపు"
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr "సొల్"
+#~ msgid "sol"
+#~ msgstr "సొల్"
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr "<em>ఆర్క్</em> బ్లాక్ ఆర్క్ లో మౌస్ను చలించిపెట్టి ఉంది."
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr "<em>ఆర్క్</em> బ్లాక్ ఆర్క్ లో మౌస్ను చలించిపెట్టి ఉంది."
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr "<em>పిచ్ స్టేయిర్కేస్</em> టూల్ ఇక్కడ నిర్దిష్ట అనుపాతం నుండి పిచ్లను సృష్టించడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr "<em>పిచ్ స్టేయిర్కేస్</em> టూల్ ఇక్కడ నిర్దిష్ట అనుపాతం నుండి పిచ్లను సృష్టించడానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr "<em>నోట్ వాల్యూమ్</em> బ్లాక్ ప్రస్తుత సింథెసైజర్ యొక్క ప్రస్తుత వాల్యూమ్ను తిరిగిస్తుంది."
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr "<em>నోట్ వాల్యూమ్</em> బ్లాక్ ప్రస్తుత సింథెసైజర్ యొక్క ప్రస్తుత వాల్యూమ్ను తిరిగిస్తుంది."
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr "సంగీతంలో బీట్ <em>మీటర్</em> బ్లాక్ ద్వారా నిర్ధారించబడిపోతుంది (డిఫాల్ట్గా, ప్రతి మెజర్లో 4 1/4 నోటులు)."
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr "సంగీతంలో బీట్ <em>మీటర్</em> బ్లాక్ ద్వారా నిర్ధారించబడిపోతుంది (డిఫాల్ట్గా, ప్రతి మెజర్లో 4 1/4 నోటులు)."
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr "<em>అక్సిడెంటల్ సెలెక్టర్</em> బ్లాక్ ద్వారా డబుల్-షార్ప్, షార్ప్, న్యాచరల్, ఫ్లాట్, మరియు డబుల్-ఫ్లాట్ మధ్య ఎంచుకోవచ్చు."
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr "<em>అక్సిడెంటల్ సెలెక్టర్</em> బ్లాక్ ద్వారా డబుల్-షార్ప్, షార్ప్, న్యాచరల్, ఫ్లాట్, మరియు డబుల్-ఫ్లాట్ మధ్య ఎంచుకోవచ్చు."
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr "ఫ్రిజియన్"
+#~ msgid "Phrygian"
+#~ msgstr "ఫ్రిజియన్"
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr "<em>డిఫైన్ మోడ్</em> బ్లాక్ మీరు పిచ్ సంఖ్యలను నిర్దిష్టపరచి కస్టమ్ మోడ్ను నిర్వచించడం కానిస్తుంది."
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr "<em>డిఫైన్ మోడ్</em> బ్లాక్ మీరు పిచ్ సంఖ్యలను నిర్దిష్టపరచి కస్టమ్ మోడ్ను నిర్వచించడం కానిస్తుంది."
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr "త్వరగా ప్రారంభించండి / మెరుగు ప్రెస్ చేయండి అనేకం / ఎక్స్ట్రా-లాంగ్ ప్రెస్ చేయండి సంగీతం నిధానంగా ప్రారంభించండి"
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr "త్వరగా ప్రారంభించండి / మెరుగు ప్రెస్ చేయండి అనేకం / ఎక్స్ట్రా-లాంగ్ ప్రెస్ చేయండి సంగీతం నిధానంగా ప్రారంభించండి"
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr "మ్యూజిక్ బ్లాక్స్ అంటే మూసిక్ సిద్ధాంతాలను అధ్యయనించడానికి మరియు రంగంగా అంగీకరించడానికి ఉపయోగించే మంచి సాధనాల సమూహము."
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr "మ్యూజిక్ బ్లాక్స్ అంటే మూసిక్ సిద్ధాంతాలను అధ్యయనించడానికి మరియు రంగంగా అంగీకరించడానికి ఉపయోగించే మంచి సాధనాల సమూహము."
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr "ల"
+#~ msgid "la"
+#~ msgstr "ల"
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr "దూరం చూడండి"
+#~ msgid "see distance"
+#~ msgstr "దూరం చూడండి"
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr "ట్యూప్లెట్ బ్లాక్ ఒక కొంతమంది సమయంలో ప్లే చేసే సంగీతంలో ఒక గుండాపు నోట్ల సమూహాన్ని సృష్టిస్తుంది."
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr "ట్యూప్లెట్ బ్లాక్ ఒక కొంతమంది సమయంలో ప్లే చేసే సంగీతంలో ఒక గుండాపు నోట్ల సమూహాన్ని సృష్టిస్తుంది."
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr "స్విచ్ బ్లాక్ మ్యాచింగ్ కేసులో కోడ్ అమలు చేస్తుంది."
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr "స్విచ్ బ్లాక్ మ్యాచింగ్ కేసులో కోడ్ అమలు చేస్తుంది."
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr "సంబంధిత అంతరం"
+#~ msgid "relative interval"
+#~ msgstr "సంబంధిత అంతరం"
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr "<em>బీట్స్ పర్ మినిట్</em> బ్లాక్ ప్రతి నిమిషంలో 1/4 నోట్ల సంఖ్యను సెట్ చేస్తుంది."
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr "<em>బీట్స్ పర్ మినిట్</em> బ్లాక్ ప్రతి నిమిషంలో 1/4 నోట్ల సంఖ్యను సెట్ చేస్తుంది."
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr "<em>వెడ్త</em> బ్లాక్ క్యాన్వాస్ యొక్క వెడ్తను తరపుకు తీసుకోసిస్తుంది."
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr "<em>వెడ్త</em> బ్లాక్ క్యాన్వాస్ యొక్క వెడ్తను తరపుకు తీసుకోసిస్తుంది."
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr "సంగీతం (మరియు టర్టిల్స్) ని ఆపు."
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr "సంగీతం (మరియు టర్టిల్స్) ని ఆపు."
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr "వద్ద-టామ్-టామ్"
+#~ msgid "floor-tom-tom"
+#~ msgstr "వద్ద-టామ్-టామ్"
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr "<em>టై</em> బ్లాక్ నోట్ల యొక్క జోడులపై పనికి వస్తుంది, వాటిని ఒక నోట్గా కలిపిస్తుంది."
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr "<em>టై</em> బ్లాక్ నోట్ల యొక్క జోడులపై పనికి వస్తుంది, వాటిని ఒక నోట్గా కలిపిస్తుంది."
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr "పిచ్ <em>డో రే మి ఫా సోల్ లా టి</em> పదాల పరంగా నిర్దిష్టించవచ్చు."
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr "పిచ్ <em>డో రే మి ఫా సోల్ లా టి</em> పదాల పరంగా నిర్దిష్టించవచ్చు."
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr "<em>షో</em> బ్లాక్ వచనాన్ని లేదా చిత్రాన్ని క్యాన్వాస్ పై ప్రదర్శించడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr "<em>షో</em> బ్లాక్ వచనాన్ని లేదా చిత్రాన్ని క్యాన్వాస్ పై ప్రదర్శించడానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr "<em>బ్యాక్గ్రౌండ్</em> బ్లాక్ బ్యాక్గ్రౌండ్ రంగును సెట్ చేస్తుంది."
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr "<em>బ్యాక్గ్రౌండ్</em> బ్లాక్ బ్యాక్గ్రౌండ్ రంగును సెట్ చేస్తుంది."
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr "టర్టిల్ నోట్"
+#~ msgid "turtle note"
+#~ msgstr "టర్టిల్ నోట్"
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr "ఈ టూల్‌బార్ పాలెట్ బటన్లను కలిగించడానికి, ఇది రిద్ధి పిచ్ టోన్ టర్టిల్ మరియు ఇతర బటన్లను కలిగించింది."
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr "ఈ టూల్‌బార్ పాలెట్ బటన్లను కలిగించడానికి, ఇది రిద్ధి పిచ్ టోన్ టర్టిల్ మరియు ఇతర బటన్లను కలిగించింది."
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr "<em>వైల్</em> బ్లాక్ యాదృచ్ఛికంగా పరిస్థితి నిజమైనప్పటికీ మళ్లీ పునరావృత్తి చేస్తుంది."
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr "<em>వైల్</em> బ్లాక్ యాదృచ్ఛికంగా పరిస్థితి నిజమైనప్పటికీ మళ్లీ పునరావృత్తి చేస్తుంది."
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr "<em>మైనస్</em> బ్లాక్ కూడా నమోదకలను సెలవస్తుంది."
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr "<em>మైనస్</em> బ్లాక్ కూడా నమోదకలను సెలవస్తుంది."
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr "బ్లాక్ ఆర్ట్‌వర్క్"
+#~ msgid "block artwork"
+#~ msgstr "బ్లాక్ ఆర్ట్‌వర్క్"
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr "<em>నేబర్</em> బ్లాక్ తక్కువ సమయంలో పడిన పిచ్ల మధ్య తీసుకోవడానికి విజ్ఞానంగా మారుతుంది."
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr "<em>నేబర్</em> బ్లాక్ తక్కువ సమయంలో పడిన పిచ్ల మధ్య తీసుకోవడానికి విజ్ఞానంగా మారుతుంది."
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr "<em>డిస్టోర్షన్</em> బ్లాక్ పిచ్లకు వక్రత చేస్తుంది."
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr "<em>డిస్టోర్షన్</em> బ్లాక్ పిచ్లకు వక్రత చేస్తుంది."
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -10341,28 +10341,28 @@ msgstr "చలింపు"
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr "టర్టిల్ కనబడలేదు"
+#~ msgid "Could not find turtle"
+#~ msgstr "టర్టిల్ కనబడలేదు"
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr "స్లర్ బ్లాక్ నోట్ల సస్టేన్ను పెరిగిస్తుంది, విశిష్ట రిద్ధిమేర మీద నోట్ల విలువను అంగీకరిస్తుంది."
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr "స్లర్ బ్లాక్ నోట్ల సస్టేన్ను పెరిగిస్తుంది, విశిష్ట రిద్ధిమేర మీద నోట్ల విలువను అంగీకరిస్తుంది."
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr "హంగేరియన్"
+#~ msgid "Hungarian"
+#~ msgstr "హంగేరియన్"
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr "కార్డు ప్లే చేయండి"
+#~ msgid "play chord"
+#~ msgstr "కార్డు ప్లే చేయండి"
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr "అప్టిమైజ్ ఫీడ్బ్యాక్"
+#~ msgid "Optimize feedback"
+#~ msgstr "అప్టిమైజ్ ఫీడ్బ్యాక్"
 
 #: js/turtledefs.js:187
 
@@ -10370,128 +10370,128 @@ msgstr "చలింపు"
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr "బ్లాక్ ఆర్ట్‌వర్క్ భద్రపరచండి"
+#~ msgid "Save block artwork"
+#~ msgstr "బ్లాక్ ఆర్ట్‌వర్క్ భద్రపరచండి"
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr "<em>పిచ్-స్లైడర్<em> బ్లాక్ అంగీకరించడానికి ఒక సాధనాన్ని తెరవడానికి ఉంది."
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr "<em>పిచ్-స్లైడర్<em> బ్లాక్ అంగీకరించడానికి ఒక సాధనాన్ని తెరవడానికి ఉంది."
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr "స్కేలర్ స్టెప్ బ్లాక్ నోట్ బ్లాక్ యొక్క అంగడా ఉండాలి."
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr "స్కేలర్ స్టెప్ బ్లాక్ నోట్ బ్లాక్ యొక్క అంగడా ఉండాలి."
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr "సంగీత బ్లాక్స్ ఒక సంగీత అవగాహనాలను అన్వేషించడానికి ఉపయోగించే ఉద్యమాల ఒక సేకరణ. కనుగొనగా, సంగీత బ్లాక్స్ గిట్హబ్ రిపోజిటరీలో యొక్క సంపూర్ణ యొక్కుళ్ళది. సంగీత బ్లాక్స్ యాగద్ధరాయిత గురించి పూర్ణ జాబితా సేకరించవచ్చు. సంగీత బ్లాక్స్ AGPL క్రీడా కొరకు లైసెన్స్ అవుతుంది. ప్రస్తుత సంగతి సంచికలు:"
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr "సంగీత బ్లాక్స్ ఒక సంగీత అవగాహనాలను అన్వేషించడానికి ఉపయోగించే ఉద్యమాల ఒక సేకరణ. కనుగొనగా, సంగీత బ్లాక్స్ గిట్హబ్ రిపోజిటరీలో యొక్క సంపూర్ణ యొక్కుళ్ళది. సంగీత బ్లాక్స్ యాగద్ధరాయిత గురించి పూర్ణ జాబితా సేకరించవచ్చు. సంగీత బ్లాక్స్ AGPL క్రీడా కొరకు లైసెన్స్ అవుతుంది. ప్రస్తుత సంగతి సంచికలు:"
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr "నాలుగు"
+#~ msgid "fourths"
+#~ msgstr "నాలుగు"
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr "<em>కర్సర్ Y<em> బ్లాక్ మౌస్ యాక్షన్ యొక్క ఉత్తర ప్రాంతాన్ని తరలిస్తుంది."
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr "<em>కర్సర్ Y<em> బ్లాక్ మౌస్ యాక్షన్ యొక్క ఉత్తర ప్రాంతాన్ని తరలిస్తుంది."
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr "<em>క్రెస్సెండో<em> బ్లాక్ ప్రతి నోటు ఆడినప్పటికీ అలాగే (లేదా తగినవి) నోట్ల ఆవృత్తిని కంపెన్సేట్ చేయడానికి ఒక నిర్దిష్ట మొత్తంతనం పెంచుతుంది. ఉదాహరణకు, మీరు ఒక <em>క్రెస్సెండో<em> బ్లాక్ లో 5 యొక్క ఒక విలువతో ఉన్న 7 నోటులు ఉన్నా, చివరి నోటు ప్రారంభ విలువకు 35% కంటే ఎక్కువగా ఉండిపోతుంది."
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr "<em>క్రెస్సెండో<em> బ్లాక్ ప్రతి నోటు ఆడినప్పటికీ అలాగే (లేదా తగినవి) నోట్ల ఆవృత్తిని కంపెన్సేట్ చేయడానికి ఒక నిర్దిష్ట మొత్తంతనం పెంచుతుంది. ఉదాహరణకు, మీరు ఒక <em>క్రెస్సెండో<em> బ్లాక్ లో 5 యొక్క ఒక విలువతో ఉన్న 7 నోటులు ఉన్నా, చివరి నోటు ప్రారంభ విలువకు 35% కంటే ఎక్కువగా ఉండిపోతుంది."
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr "<em>కీబోర్డ్<em> బ్లాక్ కంప్యూటర్ కీబోర్డ్ ఇన్పుట్ని తరలిస్తుంది."
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr "<em>కీబోర్డ్<em> బ్లాక్ కంప్యూటర్ కీబోర్డ్ ఇన్పుట్ని తరలిస్తుంది."
 
-#~msgid "Save your project to a server."
-#~msgstr "మీ ప్రాజెక్ట్ను ఒక సర్వర్‌కు భద్రపరచండి."
+#~ msgid "Save your project to a server."
+#~ msgstr "మీ ప్రాజెక్ట్ను ఒక సర్వర్‌కు భద్రపరచండి."
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr "బీట్ విలువను గుణించండి"
+#~ msgid "multiply beat value"
+#~ msgstr "బీట్ విలువను గుణించండి"
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr "పూర్ణ ధ్వని"
+#~ msgid "Whole Tone"
+#~ msgstr "పూర్ణ ధ్వని"
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr "<em>ఇంట్<em> బ్లాక్ ఒక పూర్ణాంకంను తరలిస్తుంది."
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr "<em>ఇంట్<em> బ్లాక్ ఒక పూర్ణాంకంను తరలిస్తుంది."
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr "<em>బాక్స్ 2<em> బ్లాక్ <em>బాక్స్ 2</em> లో నిలువబడిన విలువను తరలిస్తుంది."
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr "<em>బాక్స్ 2<em> బ్లాక్ <em>బాక్స్ 2</em> లో నిలువబడిన విలువను తరలిస్తుంది."
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr "స్లో మోడ్లో కేవలం సంగీతాన్ని ప్రవేశించడానికి క్లిక్ చేయండి."
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr "స్లో మోడ్లో కేవలం సంగీతాన్ని ప్రవేశించడానికి క్లిక్ చేయండి."
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr "గ్రే బ్లాక్ ప్రస్తుత పెన్ గ్రే విలువను తరిమికొస్తుంది."
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr "గ్రే బ్లాక్ ప్రస్తుత పెన్ గ్రే విలువను తరిమికొస్తుంది."
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr "6వ"
+#~ msgid "6th"
+#~ msgstr "6వ"
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "ఆగమనికే బ్లాక్ కు ఇన్‌పుట్ 1, 2, 3, 4, 5, 6, 7, లేదా 8 ఉండాలి"
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "ఆగమనికే బ్లాక్ కు ఇన్‌పుట్ 1, 2, 3, 4, 5, 6, 7, లేదా 8 ఉండాలి"
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr "<em>డ్రం పేరు</em> బ్లాక్ ఒక డ్రం ఎంచుకోవడానికి ఉపయోగించబడుతుంది."
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr "<em>డ్రం పేరు</em> బ్లాక్ ఒక డ్రం ఎంచుకోవడానికి ఉపయోగించబడుతుంది."
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr "త్వరగా పరికరాలు / మంచిగా రన్ చేయడానికి పొడిగా నొక్కండి / ఆడియోని నివాళిగా ప్రవృత్తి చేయడానికి ఎక్స్ట్రా-పొడిగా నొక్కండి"
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr "త్వరగా పరికరాలు / మంచిగా రన్ చేయడానికి పొడిగా నొక్కండి / ఆడియోని నివాళిగా ప్రవృత్తి చేయడానికి ఎక్స్ట్రా-పొడిగా నొక్కండి"
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr "లిల్లీపాండ్‌గా సేవ్ చేయండి"
+#~ msgid "save as lilypond"
+#~ msgstr "లిల్లీపాండ్‌గా సేవ్ చేయండి"
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr "<em>భాగం</em> బ్లాక్ భాగం చేయడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr "<em>భాగం</em> బ్లాక్ భాగం చేయడానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partial harmonic."
-#~msgstr "<em>పార్టియల్</em> బ్లాక్ ఒక ప్రత్యేక పార్టియల్ హార్మోనిక్ కోసం భారంను నిర్దిష్టం చేయడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partial harmonic."
+#~ msgstr "<em>పార్టియల్</em> బ్లాక్ ఒక ప్రత్యేక పార్టియల్ హార్మోనిక్ కోసం భారంను నిర్దిష్టం చేయడానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr "<em>టెంపరామెంట్ పేరు</em> బ్లాక్ ఒక సరిహద్దు పద్ధతిని ఎంచుకోవడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr "<em>టెంపరామెంట్ పేరు</em> బ్లాక్ ఒక సరిహద్దు పద్ధతిని ఎంచుకోవడానికి ఉపయోగిస్తారు."
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr "తక్కువగా చేసినది"
+#~ msgid "Diminished"
+#~ msgstr "తక్కువగా చేసినది"
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr "టూల్‌బార్ను పెరిగించు/అప్పగించు"
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr "టూల్‌బార్ను పెరిగించు/అప్పగించు"
 
 #: js/turtledefs.js:187
 
@@ -10499,136 +10499,136 @@ msgstr "చలింపు"
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr "SVGగా సేవ్ చేయండి"
+#~ msgid "Save as SVG"
+#~ msgstr "SVGగా సేవ్ చేయండి"
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr "లోడ్హీప్ బ్లాక్ ఒక ఫైలు నుండి హీప్ లోడ్ చేస్తుంది."
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr "లోడ్హీప్ బ్లాక్ ఒక ఫైలు నుండి హీప్ లోడ్ చేస్తుంది."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr "(జపాన్)లో"
+#~ msgid "in (Japan)"
+#~ msgstr "(జపాన్)లో"
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr "ఇతరవారి కొరకు, మీరు ENTER లేదా RETURN కీని నొక్కవచ్చు."
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr "ఇతరవారి కొరకు, మీరు ENTER లేదా RETURN కీని నొక్కవచ్చు."
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr "<em>టింబర్ ను సెట్ చేయడానికి</em> బ్లాక్ ఒక సాంత్వనంను ఎంచుకోవడానికి ఉపయోగిస్తుంది, ఉదాహరణకు, గిటార్, పియానో, వాయలిన్, లేదా సెల్లో."
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr "<em>టింబర్ ను సెట్ చేయడానికి</em> బ్లాక్ ఒక సాంత్వనంను ఎంచుకోవడానికి ఉపయోగిస్తుంది, ఉదాహరణకు, గిటార్, పియానో, వాయలిన్, లేదా సెల్లో."
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "టర్టిల్"
+#~ msgid "turtle"
+#~ msgstr "టర్టిల్"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr "<em>Y మౌస్</em> బ్లాక్ నిర్దిష్టమైన మౌస్ యొక్క Y స్థితిని తరిమికొస్తుంది."
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr "<em>Y మౌస్</em> బ్లాక్ నిర్దిష్టమైన మౌస్ యొక్క Y స్థితిని తరిమికొస్తుంది."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr "మినోయో (జపాన్)"
+#~ msgid "minyo (Japan)"
+#~ msgstr "మినోయో (జపాన్)"
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr "ఇంపాక్ట్ సమయం కనబడలేదు."
+#~ msgid "Impact Time not found."
+#~ msgstr "ఇంపాక్ట్ సమయం కనబడలేదు."
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr "<em>ప్రతి కలకలంలో బీట్లు ప్రతి నిమిషాలు</em> బ్లాక్ అంచనానికి ప్రతి నిమిషాలు మార్చుతుంది."
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr "<em>ప్రతి కలకలంలో బీట్లు ప్రతి నిమిషాలు</em> బ్లాక్ అంచనానికి ప్రతి నిమిషాలు మార్చుతుంది."
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr "<em>ఆపండి మౌస్</em> బ్లాక్ నిర్దిష్టమైన మౌస్‌ను ఆపిస్తుంది."
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr "<em>ఆపండి మౌస్</em> బ్లాక్ నిర్దిష్టమైన మౌస్‌ను ఆపిస్తుంది."
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr "3వ"
+#~ msgid "3rd"
+#~ msgstr "3వ"
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr "<em>నకలు</em> బ్లాక్ ప్రతి బ్లాక్‌ను ఎక్కువసారి పరికరిస్తుంది. ఉదాహరణ యొక్క నివాళి అనుజ్ఞేషం: సోల్, సోల్, సోల్, సోల్, రే, రే, రే, రే, సోల్, సోల్, సోల్, సోల్."
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr "<em>నకలు</em> బ్లాక్ ప్రతి బ్లాక్‌ను ఎక్కువసారి పరికరిస్తుంది. ఉదాహరణ యొక్క నివాళి అనుజ్ఞేషం: సోల్, సోల్, సోల్, సోల్, రే, రే, రే, రే, సోల్, సోల్, సోల్, సోల్."
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr "<em>రెండు చుక్కల</em> బ్లాక్ ఒక ఇంటర్వల్ యొక్క పరిమాణాన్ని ఎక్కువ చేస్తుంది."
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr "<em>రెండు చుక్కల</em> బ్లాక్ ఒక ఇంటర్వల్ యొక్క పరిమాణాన్ని ఎక్కువ చేస్తుంది."
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr "<em>బ్లాక్ రన్</em> బ్లాక్ ఒక బ్లాక్‌ను రన్ చేస్తుంది."
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr "<em>బ్లాక్ రన్</em> బ్లాక్ ఒక బ్లాక్‌ను రన్ చేస్తుంది."
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr "సమర్పించు"
+#~ msgid "play forward"
+#~ msgstr "సమర్పించు"
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr "బేస్"
+#~ msgid "basse"
+#~ msgstr "బేస్"
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr "<em>హర్జ్</em> బ్లాక్ (నంబర్ బ్లాక్తో కలయబడుతుంది) ప్రతిష్ఠిత ఫ్రిక్వెన్సీలో ఒక ధ్వనిని ప్రదర్శిస్తుంది."
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr "<em>హర్జ్</em> బ్లాక్ (నంబర్ బ్లాక్తో కలయబడుతుంది) ప్రతిష్ఠిత ఫ్రిక్వెన్సీలో ఒక ధ్వనిని ప్రదర్శిస్తుంది."
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr "స్టాక్కాటో బ్లాక్ అసలు నోటుని చిక్కగా చేస్తుంది అయితే నోట్‌ల నిర్దిష్ట రిద్ధి విలువను కాయాంక్షిస్తుంది."
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr "స్టాక్కాటో బ్లాక్ అసలు నోటుని చిక్కగా చేస్తుంది అయితే నోట్‌ల నిర్దిష్ట రిద్ధి విలువను కాయాంక్షిస్తుంది."
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr "<em>ASCIIకు</em> బ్లాక్ సంఖ్యలను అక్షరాలకు మార్చేస్తుంది."
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr "<em>ASCIIకు</em> బ్లాక్ సంఖ్యలను అక్షరాలకు మార్చేస్తుంది."
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr "<em>మోడ్ లెంత్</em> బ్లాక్ ప్రస్తుత స్కేల్ యొక్క సంఖ్యలు. అనేక <em>వెస్టర్న్</em> స్కేల్లు 7 సంఖ్యలను కలిగిస్తాయి."
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr "<em>మోడ్ లెంత్</em> బ్లాక్ ప్రస్తుత స్కేల్ యొక్క సంఖ్యలు. అనేక <em>వెస్టర్న్</em> స్కేల్లు 7 సంఖ్యలను కలిగిస్తాయి."
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr "<em>చేర్చు-1-టు</em> బ్లాక్ ఒక పెట్టేందుకు కలిగి ఉన్న విలువకు ఒకటు చేస్తుంది."
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr "<em>చేర్చు-1-టు</em> బ్లాక్ ఒక పెట్టేందుకు కలిగి ఉన్న విలువకు ఒకటు చేస్తుంది."
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr "440 హర్జ్"
+#~ msgid "440 hertz"
+#~ msgstr "440 హర్జ్"
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr "<em>సెట్ XY</em> బ్లాక్ మౌస్‌ను స్క్రీన్ పై ఒక నిర్దిష్ట స్థానాన్ని కదిలిస్తుంది."
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr "<em>సెట్ XY</em> బ్లాక్ మౌస్‌ను స్క్రీన్ పై ఒక నిర్దిష్ట స్థానాన్ని కదిలిస్తుంది."
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr "కార్యాచరణను అద్దూరించండి"
+#~ msgid "Optimize performance"
+#~ msgstr "కార్యాచరణను అద్దూరించండి"
 
 #: js/playback.js:31
 
@@ -10638,127 +10638,127 @@ msgstr "చలింపు"
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr "అన్నింటిని ఆడండి"
+#~ msgid "play all"
+#~ msgstr "అన్నింటిని ఆడండి"
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr "<em>క్యామెరా</em> బ్లాక్ ఒక వెబ్‌క్యామ్‌ను <em>షో</em> బ్లాక్‌కు కనెక్ట్ చేస్తుంది."
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr "<em>క్యామెరా</em> బ్లాక్ ఒక వెబ్‌క్యామ్‌ను <em>షో</em> బ్లాక్‌కు కనెక్ట్ చేస్తుంది."
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr "వాలం సింబల్స్"
+#~ msgid "finger cymbols"
+#~ msgstr "వాలం సింబల్స్"
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr "సాధారణ-1"
+#~ msgid "simple-1"
+#~ msgstr "సాధారణ-1"
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr "సంధి చుక్కలు తగ్గుతాయి"
+#~ msgid "consonant step down"
+#~ msgstr "సంధి చుక్కలు తగ్గుతాయి"
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr "రెయ్డ్-బెల్"
+#~ msgid "ride-bell"
+#~ msgstr "రెయ్డ్-బెల్"
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr "మ్యూజిక్ బ్లాక్స్ ఒక సంగీత అవగాహనాలను అన్వేషించడానికి ఉపకరణాల సంగమం."
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr "మ్యూజిక్ బ్లాక్స్ ఒక సంగీత అవగాహనాలను అన్వేషించడానికి ఉపకరణాల సంగమం."
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr "పిక్సల్ రంగును చదవగలడు"
+#~ msgid "Cannot read pixel color"
+#~ msgstr "పిక్సల్ రంగును చదవగలడు"
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr "<em>రిదం రూలర్</em> బ్లాక్ ఒక డ్రం మెషీన్స్ సృష్టించడానికి ఒక సాధనాన్ని తెరిచిపెట్టుంది."
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr "<em>రిదం రూలర్</em> బ్లాక్ ఒక డ్రం మెషీన్స్ సృష్టించడానికి ఒక సాధనాన్ని తెరిచిపెట్టుంది."
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr "<em>స్క్వేర్ రూట్</em> బ్లాక్ వర్గ మూలానికి తిరిగివేయి."
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr "<em>స్క్వేర్ రూట్</em> బ్లాక్ వర్గ మూలానికి తిరిగివేయి."
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr "<em>నోట్ కౌంటర్</em> బ్లాక్ కలిగి ఉన్న నోట్ల సంఖ్యను లెక్కించడానికి ఉపయోగించవచ్చు."
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr "<em>నోట్ కౌంటర్</em> బ్లాక్ కలిగి ఉన్న నోట్ల సంఖ్యను లెక్కించడానికి ఉపయోగించవచ్చు."
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr "<em>హీప్ ఖాళీ?</em> బ్లాక్ హీప్ ఖాళీ ఉంటే నిజమే తిరిగి రాయి."
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr "<em>హీప్ ఖాళీ?</em> బ్లాక్ హీప్ ఖాళీ ఉంటే నిజమే తిరిగి రాయి."
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr "లిడియన్"
+#~ msgid "Lydian"
+#~ msgstr "లిడియన్"
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr "<em>నాయిస్ పేరు</em> బ్లాక్ ఒక నాయిస్ సింథిసైజర్‌ను ఎంచుకోవడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr "<em>నాయిస్ పేరు</em> బ్లాక్ ఒక నాయిస్ సింథిసైజర్‌ను ఎంచుకోవడానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr "<em>పిచ్ డ్రం మాట్రిక్స్</em> బ్లాక్ పిచ్లను డ్రం సౌండ్లకు మ్యాప్ చేయడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr "<em>పిచ్ డ్రం మాట్రిక్స్</em> బ్లాక్ పిచ్లను డ్రం సౌండ్లకు మ్యాప్ చేయడానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr "<em>డాట్</em> బ్లాక్ ఒక నోటుకు 50% వరకు వ్యాప్తిని పెంచుతుంది. ఉదాహరించాలి, డాటెడ్ క్వార్టర్ నోటు ఒక బీట్కి 3/8 (1/4 + 1/8) పాటు ప్రదర్శిస్తుంది."
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr "<em>డాట్</em> బ్లాక్ ఒక నోటుకు 50% వరకు వ్యాప్తిని పెంచుతుంది. ఉదాహరించాలి, డాటెడ్ క్వార్టర్ నోటు ఒక బీట్కి 3/8 (1/4 + 1/8) పాటు ప్రదర్శిస్తుంది."
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr "<em>బాక్స్2</em> బ్లాక్ <em>బాక్స్2</em> లో ఉన్న విలువను తిరిగివేయి."
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr "<em>బాక్స్2</em> బ్లాక్ <em>బాక్స్2</em> లో ఉన్న విలువను తిరిగివేయి."
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr "పిచ్ నంబర్ బ్లాక్ అది సంఖ్యతో జతచేసిన పిచ్ను ప్లే చేస్తుంది, ఉదాహరించాలి, C కోసం 1, G కోసం 7."
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr "పిచ్ నంబర్ బ్లాక్ అది సంఖ్యతో జతచేసిన పిచ్ను ప్లే చేస్తుంది, ఉదాహరించాలి, C కోసం 1, G కోసం 7."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr "హార్మోనిక్-మేజర్"
+#~ msgid "harmonic-major"
+#~ msgstr "హార్మోనిక్-మేజర్"
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr "ఆక్సిలరీ మెనూ"
+#~ msgid "Auxillary menu"
+#~ msgstr "ఆక్సిలరీ మెనూ"
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr "ప్రచురించు"
+#~ msgid "Publish"
+#~ msgstr "ప్రచురించు"
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr "<em>పుష్</em> బ్లాక్ ఒక విలువను హీప్ యొక్క చైతన్యకు చేర్చుంది."
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr "<em>పుష్</em> బ్లాక్ ఒక విలువను హీప్ యొక్క చైతన్యకు చేర్చుంది."
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr "రోమానియన్ మైనర్"
+#~ msgid "Romanian Minor"
+#~ msgstr "రోమానియన్ మైనర్"
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr "ఉదాహరణగా, ఇది <em>వన్ ఆఫ్</em> బ్లాక్తో ఒక యాదృచ్ఛిక దశను ఎంచుకోవడానికి ఉపయోగించబడింది."
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr "ఉదాహరణగా, ఇది <em>వన్ ఆఫ్</em> బ్లాక్తో ఒక యాదృచ్ఛిక దశను ఎంచుకోవడానికి ఉపయోగించబడింది."
 
 #: js/activity.js:2433
 
@@ -10766,397 +10766,397 @@ msgstr "చలింపు"
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr "అనామకం"
+#~ msgid "untitled"
+#~ msgstr "అనామకం"
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr "ప్రపంచవ్యాప్తం"
+#~ msgid "Worldwide"
+#~ msgstr "ప్రపంచవ్యాప్తం"
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr "ఉదాహరించాలి, డాటెడ్ క్వార్టర్ నోటు ఒక బీట్కి 3/8 (1/4 + 1/8) పాటు ప్రదర్శిస్తుంది."
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr "ఉదాహరించాలి, డాటెడ్ క్వార్టర్ నోటు ఒక బీట్కి 3/8 (1/4 + 1/8) పాటు ప్రదర్శిస్తుంది."
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr "నెమర్చినప్పుడు నిధానంగా పరిపాలాలి"
+#~ msgid "long press to run slowly"
+#~ msgstr "నెమర్చినప్పుడు నిధానంగా పరిపాలాలి"
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr "సేవ్ హీప్ టు యాప్ బ్లాక్ హీప్ ను ఒక వెబ్ పేజీకి సేవ్ చేస్తుంది."
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr "సేవ్ హీప్ టు యాప్ బ్లాక్ హీప్ ను ఒక వెబ్ పేజీకి సేవ్ చేస్తుంది."
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr "ప్లక్"
+#~ msgid "pluck"
+#~ msgstr "ప్లక్"
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr "<em>మౌస్ నోట్</em> బ్లాక్ ప్రస్తుత నిర్వాహకం చేసే మౌస్ ద్వారా ప్లే అయ్యే విలువను తిరిగివేస్తుంది."
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr "<em>మౌస్ నోట్</em> బ్లాక్ ప్రస్తుత నిర్వాహకం చేసే మౌస్ ద్వారా ప్లే అయ్యే విలువను తిరిగివేస్తుంది."
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr "మౌస్-సింక్ బ్లాక్ మౌస్లలో బీట్ కౌంటును అనుగుణంగా అమర్చుకున్నది."
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr "మౌస్-సింక్ బ్లాక్ మౌస్లలో బీట్ కౌంటును అనుగుణంగా అమర్చుకున్నది."
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "తెరుచు"
+#~ msgid "Open"
+#~ msgstr "తెరుచు"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr "<em>స్కేలర్ స్టెప్</em> బ్లాక్ (ఒక <em>నంబర్</em> బ్లాక్ తో సంయోజించి) ఒక స్కేల్లో తరువాత పలుకులో ఒక పిచ్ నోటును ప్రదర్శిస్తుంది, ఉదాహరించండి, కానీస్టినా ప్రదర్శిస్తున్న చివర నోటు <em>sol</em> అయితే, <em>స్కేలర్ స్టెప్ 1</em> బ్లాక్ <em>la</em> నోటును ప్రదర్శిస్తుంది."
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr "<em>స్కేలర్ స్టెప్</em> బ్లాక్ (ఒక <em>నంబర్</em> బ్లాక్ తో సంయోజించి) ఒక స్కేల్లో తరువాత పలుకులో ఒక పిచ్ నోటును ప్రదర్శిస్తుంది, ఉదాహరించండి, కానీస్టినా ప్రదర్శిస్తున్న చివర నోటు <em>sol</em> అయితే, <em>స్కేలర్ స్టెప్ 1</em> బ్లాక్ <em>la</em> నోటును ప్రదర్శిస్తుంది."
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr "temperamentX నిర్వచించండి"
+#~ msgid "define temperamentX"
+#~ msgstr "temperamentX నిర్వచించండి"
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr "<em>స్వింగ్</em> బ్లాక్ నోటు విలువతో కౌపిండి ఉంటుంది (నోటు విలువతో నిర్ధారించబడినవి), ప్రథమ నోటుకు కొంత విలువ (స్వింగ్ విలువతో నిర్ధారించబడినవి) జోడిస్తుంది, మరియు రెండవ నోటు నుంచి అది సమానంగా తీసేస్తుంది."
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr "<em>స్వింగ్</em> బ్లాక్ నోటు విలువతో కౌపిండి ఉంటుంది (నోటు విలువతో నిర్ధారించబడినవి), ప్రథమ నోటుకు కొంత విలువ (స్వింగ్ విలువతో నిర్ధారించబడినవి) జోడిస్తుంది, మరియు రెండవ నోటు నుంచి అది సమానంగా తీసేస్తుంది."
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr "సెట్ వాయిస్"
+#~ msgid "set voice"
+#~ msgstr "సెట్ వాయిస్"
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr "ఇతరవారితో అనేకర్లు అంగీకరించని అవాజాని ప్లే అవుతుంది."
+#~ msgid "Else a kick drum will play."
+#~ msgstr "ఇతరవారితో అనేకర్లు అంగీకరించని అవాజాని ప్లే అవుతుంది."
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr "ఆలింపిక్స్ గా సేవ్ చేయండి"
+#~ msgid "Save as wav"
+#~ msgstr "ఆలింపిక్స్ గా సేవ్ చేయండి"
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr "ఇక్కడ క్లిక్ చేయండి పేస్ట్ చేయడానికి."
+#~ msgid "Click here to paste."
+#~ msgstr "ఇక్కడ క్లిక్ చేయండి పేస్ట్ చేయడానికి."
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr "<em>పిచ్</em> బ్లాక్ ఒక నోటును ప్రదర్శిస్తున్నప్పటికీ అది నోటు యొక్క పిచ్ పేరు మరియు ఆక్టేవ్ నిర్ధారించే ఒక కొన్ని అంశాలను నిర్దిష్టం చేస్తుంది."
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr "<em>పిచ్</em> బ్లాక్ ఒక నోటును ప్రదర్శిస్తున్నప్పటికీ అది నోటు యొక్క పిచ్ పేరు మరియు ఆక్టేవ్ నిర్ధారించే ఒక కొన్ని అంశాలను నిర్దిష్టం చేస్తుంది."
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr "టామ్-టామ్"
+#~ msgid "tom-tom"
+#~ msgstr "టామ్-టామ్"
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr "ఐయోనియన్"
+#~ msgid "Ionian"
+#~ msgstr "ఐయోనియన్"
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr "చ్"
+#~ msgid "ch"
+#~ msgstr "చ్"
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr "<em>స్లర్</em> బ్లాక్ నోట్ల సస్టేన్‌ను పెరిగించేది, మరియు నోట్ల స్పష్ట రిద్ధి విలువను ఉంచాలి."
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr "<em>స్లర్</em> బ్లాక్ నోట్ల సస్టేన్‌ను పెరిగించేది, మరియు నోట్ల స్పష్ట రిద్ధి విలువను ఉంచాలి."
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr "పిచ్చులను జోడించు"
+#~ msgid "add pitches"
+#~ msgstr "పిచ్చులను జోడించు"
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr "<em>X మౌస్</em> బ్లాక్ ప్రస్తుతమైన మౌస్ యొక్క X స్థానాన్ని తనిఖీ చేస్తుంది."
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr "<em>X మౌస్</em> బ్లాక్ ప్రస్తుతమైన మౌస్ యొక్క X స్థానాన్ని తనిఖీ చేస్తుంది."
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr "సంగీత బ్లాక్స్ ఒక సంగీత అవగాహనాలను అన్వేషించడానికి ఉదాహరణాయిత కలకలం సంగ్రహం. కొన్ని యొక్క యొక్క యొక్క సాంకేతిక వివరాలను స్థానాలను అందిస్తుంది. Music Blocks గిట్‌హబ్ రిపోజిటరీలో రచయితల పూర్ణ జాబితా కనుగొనిపోతుంది. Music Blocks యాగా AGPL అడ్డంతాన్ని కలిగించబడింది. ప్రస్తుత సంగతి అంచనా: ' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr "సంగీత బ్లాక్స్ ఒక సంగీత అవగాహనాలను అన్వేషించడానికి ఉదాహరణాయిత కలకలం సంగ్రహం. కొన్ని యొక్క యొక్క యొక్క సాంకేతిక వివరాలను స్థానాలను అందిస్తుంది. Music Blocks గిట్‌హబ్ రిపోజిటరీలో రచయితల పూర్ణ జాబితా కనుగొనిపోతుంది. Music Blocks యాగా AGPL అడ్డంతాన్ని కలిగించబడింది. ప్రస్తుత సంగతి అంచనా: ' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr "సీబి"
+#~ msgid "cb"
+#~ msgstr "సీబి"
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr "సూచన పిచ్"
+#~ msgid "reference pitch"
+#~ msgstr "సూచన పిచ్"
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr "నోట్ నోట్ విస్తరించడానికి క్లిక్ చేయండి."
+#~ msgid "Click to run the music note by note."
+#~ msgstr "నోట్ నోట్ విస్తరించడానికి క్లిక్ చేయండి."
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr "పాలీ"
+#~ msgid "poly"
+#~ msgstr "పాలీ"
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr "ప్రాజెక్ట్కు శోధించండి\",""
+#~ msgid "Search for a project\","
+#~ msgstr "ప్రాజెక్ట్కు శోధించండి\","
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr "పైకి చలించండి"
+#~ msgid "move up"
+#~ msgstr "పైకి చలించండి"
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr "నిర్ధారించండి"
+#~ msgid "confirm"
+#~ msgstr "నిర్ధారించండి"
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr "<em>స్పేస్</em> బ్లాక్ బ్లాక్ల మధ్యలో ఖాళీ స్థానాన్ని జోడించడానికి ఉపయోగించబడిది."
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr "<em>స్పేస్</em> బ్లాక్ బ్లాక్ల మధ్యలో ఖాళీ స్థానాన్ని జోడించడానికి ఉపయోగించబడిది."
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr "మౌస్ సింక్ బ్లాక్ మౌస్లల నడుము కౌంటును అనుకూలపరచుతుంది."
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr "మౌస్ సింక్ బ్లాక్ మౌస్లల నడుము కౌంటును అనుకూలపరచుతుంది."
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr "మాకం"
+#~ msgid "Maqam"
+#~ msgstr "మాకం"
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr "ఎఓలియన్"
+#~ msgid "Aeolian"
+#~ msgstr "ఎఓలియన్"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr "హార్మోనిక్ మైనర్"
+#~ msgid "harmonic-minor"
+#~ msgstr "హార్మోనిక్ మైనర్"
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr "ఉదాహరణకు, మీరు ఒక డెక్రెసెండో బ్లాక్లో ఉన్నాయితే, మరియు అది మౌస్ల నడుమును 5 అంకెల విలువతో ఉన్నట్లు, అంతిమ నోటు ప్రారంభ ధ్వనికి 35% కనిష్టం అయితే."
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr "ఉదాహరణకు, మీరు ఒక డెక్రెసెండో బ్లాక్లో ఉన్నాయితే, మరియు అది మౌస్ల నడుమును 5 అంకెల విలువతో ఉన్నట్లు, అంతిమ నోటు ప్రారంభ ధ్వనికి 35% కనిష్టం అయితే."
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr "<em>గ్రేటర్-థాన్</em> బ్లాక్ ఈ స్తంభం మేనకు కింది సంఖ్య కింది సంఖ్య కంటే ఎక్కువగా ఉంటుంది"
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr "<em>గ్రేటర్-థాన్</em> బ్లాక్ ఈ స్తంభం మేనకు కింది సంఖ్య కింది సంఖ్య కంటే ఎక్కువగా ఉంటుంది"
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr "<em>అడ్-టు</em> బ్లాక్ ఒక బాక్స్‌లో భండించబడిన విలువకు కొలత చేయడానికి ఉపయోగిస్తారు. ఇది <em>రంగు</em>, <em>పెన్-సెక్స్</em> మరియు ఇతర బ్లాక్లతో ఉపయోగించవచ్చు. మరియు ఇతరులతో కూడా ఉపయోగించవచ్చు."
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr "<em>అడ్-టు</em> బ్లాక్ ఒక బాక్స్‌లో భండించబడిన విలువకు కొలత చేయడానికి ఉపయోగిస్తారు. ఇది <em>రంగు</em>, <em>పెన్-సెక్స్</em> మరియు ఇతర బ్లాక్లతో ఉపయోగించవచ్చు. మరియు ఇతరులతో కూడా ఉపయోగించవచ్చు."
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr "రివర్స్‌హీప్ బ్లాక్ హీప్ యొక్క క్రమాన్ని పలకాలుగా చేస్తుంది."
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr "రివర్స్‌హీప్ బ్లాక్ హీప్ యొక్క క్రమాన్ని పలకాలుగా చేస్తుంది."
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr "<em>ఒకటి</em> బ్లాక్ రెండు ఎంపికల నుండి ఒకటిని తరపుచేస్తుంది."
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr "<em>ఒకటి</em> బ్లాక్ రెండు ఎంపికల నుండి ఒకటిని తరపుచేస్తుంది."
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr "లోక్రియన్"
+#~ msgid "Locrian"
+#~ msgstr "లోక్రియన్"
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr "<em>సెట్ హ్యూ</em> బ్లాక్ పెన్‌న రంగుని మార్చిస్తుంది."
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr "<em>సెట్ హ్యూ</em> బ్లాక్ పెన్‌న రంగుని మార్చిస్తుంది."
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr "<em>స్టోర్ ఇన్</em> బ్లాక్ ఒక పట్టికలో ఒక విలువను భండించబడిస్తుంది."
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr "<em>స్టోర్ ఇన్</em> బ్లాక్ ఒక పట్టికలో ఒక విలువను భండించబడిస్తుంది."
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr "సేవ్ చేయండి .svg"
+#~ msgid "Save as .svg"
+#~ msgstr "సేవ్ చేయండి .svg"
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr "బ్లూస్"
+#~ msgid "Blues"
+#~ msgstr "బ్లూస్"
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr "\"డో\" బ్లాక్ను సృష్టించడానికి \"డీ\" టైప్ చేయండి, \"రే\" బ్లాక్ను సృష్టించడానికి \"ఆర్\" టైప్ చేయండి, ఇతరాలు కూడా అనుకరించవచ్చు."
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr "\"డో\" బ్లాక్ను సృష్టించడానికి \"డీ\" టైప్ చేయండి, \"రే\" బ్లాక్ను సృష్టించడానికి \"ఆర్\" టైప్ చేయండి, ఇతరాలు కూడా అనుకరించవచ్చు."
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr "Impact డేటాను పార్స్ చేయలేము."
+#~ msgid "Cannot parse Impact data."
+#~ msgstr "Impact డేటాను పార్స్ చేయలేము."
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr "ఉదాహరణకు, గిటార్, వయలిన్, స్నేయర్ డ్రం, మరియు ఇతరాలు."
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr "ఉదాహరణకు, గిటార్, వయలిన్, స్నేయర్ డ్రం, మరియు ఇతరాలు."
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr "<em>టెంపో</em> బ్లాక్ ఒక మెట్రానోమ్ ను బీట్ను దృశ్యపరిచిస్తుంది."
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr "<em>టెంపో</em> బ్లాక్ ఒక మెట్రానోమ్ ను బీట్ను దృశ్యపరిచిస్తుంది."
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr "<em>ఇన్వెర్ట్</em> బ్లాక్ లక్ష్యం నోటు సుత్తేందుకు ఉన్నంత అన్ని గమనికలను తిరిగిస్తుంది."
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr "<em>ఇన్వెర్ట్</em> బ్లాక్ లక్ష్యం నోటు సుత్తేందుకు ఉన్నంత అన్ని గమనికలను తిరిగిస్తుంది."
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr "ఫీల్డ్"
+#~ msgid "field"
+#~ msgstr "ఫీల్డ్"
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr "ఎం"
+#~ msgid "m"
+#~ msgstr "ఎం"
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr "<em>ఒన్-ఎవరి-బీట్</em> బ్లాక్ ప్రతి బీట్ని తీసుకోవడానికి కార్యాలను నిర్దిష్టించగలదు."
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr "<em>ఒన్-ఎవరి-బీట్</em> బ్లాక్ ప్రతి బీట్ని తీసుకోవడానికి కార్యాలను నిర్దిష్టించగలదు."
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr "మరియు మరిన్ని సమాచారానికి, దయచేసి <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">మ్యూజిక్ బ్లాక్స్ గైడ్</a> ని సంప్రదించండి."
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr "మరియు మరిన్ని సమాచారానికి, దయచేసి <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">మ్యూజిక్ బ్లాక్స్ గైడ్</a> ని సంప్రదించండి."
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr "ఆర్ఎస్"
+#~ msgid "rs"
+#~ msgstr "ఆర్ఎస్"
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr "<em>క్లిక్</em> బ్లాక్ మౌస్ నొక్కితే <em>ట్రు</em> ని తరచుకుపడిపోతుంది."
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr "<em>క్లిక్</em> బ్లాక్ మౌస్ నొక్కితే <em>ట్రు</em> ని తరచుకుపడిపోతుంది."
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr "Impact ఫీల్డ్ కనబడలేదు."
+#~ msgid "Impact field not found."
+#~ msgstr "Impact ఫీల్డ్ కనబడలేదు."
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr "జి.ఎస్"
+#~ msgid "gs"
+#~ msgstr "జి.ఎస్"
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr "మైనర్"
+#~ msgid "Minor"
+#~ msgstr "మైనర్"
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr " "
+#~ msgid " "
+#~ msgstr " "
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr "బిజాంటీన్"
+#~ msgid "Byzantine"
+#~ msgstr "బిజాంటీన్"
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr "జాజ్ మైనర్"
+#~ msgid "Jazz Minor"
+#~ msgstr "జాజ్ మైనర్"
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr "<em>డూ</em> బ్లాక్ కార్యాచరణను ప్రారంభించడానికి ఉపయోగిస్తారు. ఉదాహరణకు, ఇది <em>వన్ ఆఫ్</em> బ్లాక్తో ఒక యాదృచ్ఛిక భాగాన్ని ఎంచుకున్నప్పుడు ఉపయోగించబడుతుంది."
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr "<em>డూ</em> బ్లాక్ కార్యాచరణను ప్రారంభించడానికి ఉపయోగిస్తారు. ఉదాహరణకు, ఇది <em>వన్ ఆఫ్</em> బ్లాక్తో ఒక యాదృచ్ఛిక భాగాన్ని ఎంచుకున్నప్పుడు ఉపయోగించబడుతుంది."
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr "HTML గా భద్రపరచు"
+#~ msgid "Save as HTML"
+#~ msgstr "HTML గా భద్రపరచు"
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr "బీట్‌లో"
+#~ msgid "on beat"
+#~ msgstr "బీట్‌లో"
 
 #: js/activity.js:3857
 
@@ -11168,196 +11168,196 @@ msgstr "చలింపు"
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr "ఫైళ్ళ నుండి ప్రాజెక్ట్‌ను లోడ్ చేయండి"
+#~ msgid "Load project from files"
+#~ msgstr "ఫైళ్ళ నుండి ప్రాజెక్ట్‌ను లోడ్ చేయండి"
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr "<em>ట్యూనింగ్</em> సిస్టమ్ ఎంచుకోడానికి <em>సెట్ టెంపరమెంట్</em> బ్లాక్ ఉపయోగిస్తారు."
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr "<em>ట్యూనింగ్</em> సిస్టమ్ ఎంచుకోడానికి <em>సెట్ టెంపరమెంట్</em> బ్లాక్ ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr "<em>డిస్‌పాచ్</em> బ్లాక్ ఇవెంట్‌ను ట్రిగర్ చేయడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr "<em>డిస్‌పాచ్</em> బ్లాక్ ఇవెంట్‌ను ట్రిగర్ చేయడానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "బ్లాక్ పాలెట్‌ను దాచివేయండి లేదా చూపించండి."
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "బ్లాక్ పాలెట్‌ను దాచివేయండి లేదా చూపించండి."
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr "త్వరగా పరిక్రమించడానికి / నొక్కడానికి దీర్ఘ నొక్కడానికి"
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr "త్వరగా పరిక్రమించడానికి / నొక్కడానికి దీర్ఘ నొక్కడానికి"
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr "గ్రిడ్‌ను దాచండి"
+#~ msgid "hide grid"
+#~ msgstr "గ్రిడ్‌ను దాచండి"
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr "స్నేర్ డ్రమ్"
+#~ msgid "snare-drum"
+#~ msgstr "స్నేర్ డ్రమ్"
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr "<em>మెజర్ కౌంట్</em> బ్లాక్ ప్రస్తుత పరిమాణాన్ని తనిఖీ చేస్తుంది."
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr "<em>మెజర్ కౌంట్</em> బ్లాక్ ప్రస్తుత పరిమాణాన్ని తనిఖీ చేస్తుంది."
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr "<em>ఫౌండ్ మౌస్</em> బ్లాక్ కొనసాగితే నిజమవుతుంది అయితే పొందవచ్చు."
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr "<em>ఫౌండ్ మౌస్</em> బ్లాక్ కొనసాగితే నిజమవుతుంది అయితే పొందవచ్చు."
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr "ఇవెంట్‌ను ట్రిగర్ చేయడానికి డిస్‌పాచ్ బ్లాక్ ఉపయోగిస్తారు."
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr "ఇవెంట్‌ను ట్రిగర్ చేయడానికి డిస్‌పాచ్ బ్లాక్ ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr "వెతికండి"
+#~ msgid "Search"
+#~ msgstr "వెతికండి"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr "తెలుపు శబ్దం"
+#~ msgid "white-noise"
+#~ msgstr "తెలుపు శబ్దం"
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr "ఆక్టాటోనిక్"
+#~ msgid "Octatonic"
+#~ msgstr "ఆక్టాటోనిక్"
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr "<em>పిచ్-టైమ్ మేట్రిక్స్</em> బ్లాక్ సంగీత వాక్యాలను సృష్టించడానికి ఒక సాధనాన్ని తెరిచిపెట్టుకుంది."
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr "<em>పిచ్-టైమ్ మేట్రిక్స్</em> బ్లాక్ సంగీత వాక్యాలను సృష్టించడానికి ఒక సాధనాన్ని తెరిచిపెట్టుకుంది."
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr "<em>టాప్</em> బ్లాక్ కాన్వాస్‌ల చోటి యొక్క స్థానాన్ని తనిఖీ చేస్తుంది."
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr "<em>టాప్</em> బ్లాక్ కాన్వాస్‌ల చోటి యొక్క స్థానాన్ని తనిఖీ చేస్తుంది."
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr "<em>లిసెన్</em> బ్లాక్ మౌస్ క్లిక్ కింద అంగడి చేసినప్పుడు ఇవెంట్ వినడానికి ఉపయోగిస్తారు. ఈ ఇవెంట్ జరిగితే, <em>యాక్షన్</em> అంగడి చేయబడుతుంది."
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr "<em>లిసెన్</em> బ్లాక్ మౌస్ క్లిక్ కింద అంగడి చేసినప్పుడు ఇవెంట్ వినడానికి ఉపయోగిస్తారు. ఈ ఇవెంట్ జరిగితే, <em>యాక్షన్</em> అంగడి చేయబడుతుంది."
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr "ఎడమి అనుభూతి"
+#~ msgid "sense left"
+#~ msgstr "ఎడమి అనుభూతి"
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr "<em>సంగీత కీబోర్డ్</em> బ్లాక్ పియానో కీబోర్డ్‌ను తెరవడానికి ఉపయోగిస్తుంది."
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr "<em>సంగీత కీబోర్డ్</em> బ్లాక్ పియానో కీబోర్డ్‌ను తెరవడానికి ఉపయోగిస్తుంది."
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr "<em>సెట్‌హీప్‌ఎంట్రీ</em> బ్లాక్ నిర్దిష్ట స్థానంలో హీప్‌లో ఒక విలువ నిర్ధారిస్తుంది."
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr "<em>సెట్‌హీప్‌ఎంట్రీ</em> బ్లాక్ నిర్దిష్ట స్థానంలో హీప్‌లో ఒక విలువ నిర్ధారిస్తుంది."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr "జాజ్-మైనర్"
+#~ msgid "jazz-minor"
+#~ msgstr "జాజ్-మైనర్"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr "మైనర్-బ్లూస్"
+#~ msgid "minor-blues"
+#~ msgstr "మైనర్-బ్లూస్"
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr "మునుపటి పేజీ"
+#~ msgid "previous page"
+#~ msgstr "మునుపటి పేజీ"
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr "<em>పెన్-డౌన్</em> బ్లాక్ పెన్‌ను దాచివేయండి అంగడి చేస్తుంది."
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr "<em>పెన్-డౌన్</em> బ్లాక్ పెన్‌ను దాచివేయండి అంగడి చేస్తుంది."
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr "<em>సెమీ-టోన్ స్థానాంతరణ</em> బ్లాక్ మొదటి కంటెయిన్డ్ <em>నోట్</em> బ్లాక్లలో ఉన్న పిచ్లను అలాంటివిగా (లేదా) అంశాల ద్వారా పెరగాలిస్తుంది. ప్రదర్శించిన ఉదాహరణలో, <em>సోల్</em> ను <em>సోల్#</em> కి పరిగణిస్తుంది."
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr "<em>సెమీ-టోన్ స్థానాంతరణ</em> బ్లాక్ మొదటి కంటెయిన్డ్ <em>నోట్</em> బ్లాక్లలో ఉన్న పిచ్లను అలాంటివిగా (లేదా) అంశాల ద్వారా పెరగాలిస్తుంది. ప్రదర్శించిన ఉదాహరణలో, <em>సోల్</em> ను <em>సోల్#</em> కి పరిగణిస్తుంది."
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr "మీరు పేరుద్వారా బ్లాక్లను శోధించవచ్చు."
+#~ msgid "You can search for blocks by name."
+#~ msgstr "మీరు పేరుద్వారా బ్లాక్లను శోధించవచ్చు."
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr "గండె-బెల్"
+#~ msgid "cow-bell"
+#~ msgstr "గండె-బెల్"
 
 #: js/musicutils.js:209
 
-#~msgid "2nd"
-#~msgstr "2న"
+#~ msgid "2nd"
+#~ msgstr "2న"
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr "మీడియా బ్లాక్ చిత్రం దిగించడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr "మీడియా బ్లాక్ చిత్రం దిగించడానికి ఉపయోగిస్తారు."
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr "ఆఫ్‌లైన్. షేరింగ్ అందుబాటులో లేదు."
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr "ఆఫ్‌లైన్. షేరింగ్ అందుబాటులో లేదు."
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr "ఎఫ్.ఎస్."
+#~ msgid "fs"
+#~ msgstr "ఎఫ్.ఎస్."
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr "ప్లేబ్యాక్ అన్ని ఆడియో లేదా వీడియోను ఆపడానికి బ్లాక్"
+#~ msgid "The Stopplayback block"
+#~ msgstr "ప్లేబ్యాక్ అన్ని ఆడియో లేదా వీడియోను ఆపడానికి బ్లాక్"
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr "కండిషనల్స్ మీ ప్రోగ్రామ్‌కు అనేక కార్యాలను విధులు చేయడానికి అనేక కారణాలను ప్రదానం చేస్తుంది. ఈ ఉదాహరణలో, <em>అయితే</em> మౌస్ బటన్ నొక్కడానికి, స్నేర్ డ్రమ్ ప్లే అవుతుంది. అయితే (<em>ఇతరితరా</em>) కిక్ డ్రమ్ ప్లే అవుతుంది."
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr "కండిషనల్స్ మీ ప్రోగ్రామ్‌కు అనేక కార్యాలను విధులు చేయడానికి అనేక కారణాలను ప్రదానం చేస్తుంది. ఈ ఉదాహరణలో, <em>అయితే</em> మౌస్ బటన్ నొక్కడానికి, స్నేర్ డ్రమ్ ప్లే అవుతుంది. అయితే (<em>ఇతరితరా</em>) కిక్ డ్రమ్ ప్లే అవుతుంది."
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr "<em>లౌడ్‌నెస్</em> బ్లాక్ మైక్రోఫోన్ ద్వారా గుర్తించబడిన ధ్వనిని తిరిగి తీసుకుంది."
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr "<em>లౌడ్‌నెస్</em> బ్లాక్ మైక్రోఫోన్ ద్వారా గుర్తించబడిన ధ్వనిని తిరిగి తీసుకుంది."
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr "<em>షో బ్లాక్స్</em> బ్లాక్స్‌ను చూపిస్తుంది."
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr "<em>షో బ్లాక్స్</em> బ్లాక్స్‌ను చూపిస్తుంది."
 
-#~msgid "food"
-#~msgstr "ఆహారం"
+#~ msgid "food"
+#~ msgstr "ఆహారం"
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr "ఓఎస్సి సమయం"
+#~ msgid "osctime"
+#~ msgstr "ఓఎస్సి సమయం"
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr "బీట్ విలువను భాగంచేయండి"
+#~ msgid "divide beat value"
+#~ msgstr "బీట్ విలువను భాగంచేయండి"
 
 #: js/turtledefs.js:187
 
@@ -11365,282 +11365,282 @@ msgstr "చలింపు"
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr "PNG గా భద్రపరచు"
+#~ msgid "Save as PNG"
+#~ msgstr "PNG గా భద్రపరచు"
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr "<em>కామెంట్</em> బ్లాక్ ప్రోగ్రామ్ ని నిధానంగా పని చేస్తున్నప్పుడు స్క్రీన్ చోటలో కామెంట్ అంచనాను ప్రింట్ చేస్తుంది."
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr "<em>కామెంట్</em> బ్లాక్ ప్రోగ్రామ్ ని నిధానంగా పని చేస్తున్నప్పుడు స్క్రీన్ చోటలో కామెంట్ అంచనాను ప్రింట్ చేస్తుంది."
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr "<em>స్టాప్ మీడియా</em> బ్లాక్ ఆడియో లేదా వీడియో ప్లేబ్యాక్‌ను నిలిపివేస్తుంది."
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr "<em>స్టాప్ మీడియా</em> బ్లాక్ ఆడియో లేదా వీడియో ప్లేబ్యాక్‌ను నిలిపివేస్తుంది."
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr "<em>మౌస్-బటన్</em> బ్లాక్ మౌస్ బటన్ నొక్కడానికి <em>ట్రూ</em> ని తిరిగి తీసుకుంది."
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr "<em>మౌస్-బటన్</em> బ్లాక్ మౌస్ బటన్ నొక్కడానికి <em>ట్రూ</em> ని తిరిగి తీసుకుంది."
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr "బ్లూస్"
+#~ msgid "blues"
+#~ msgstr "బ్లూస్"
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr "మరింత"
+#~ msgid "More"
+#~ msgstr "మరింత"
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr "<em>కర్సర్ Y</em> బ్లాక్ మౌస్ నుండి ఉచ్చల స్థానాన్ని తిరిగి తీసుకుంది."
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr "<em>కర్సర్ Y</em> బ్లాక్ మౌస్ నుండి ఉచ్చల స్థానాన్ని తిరిగి తీసుకుంది."
 
-#~msgid "maths"
-#~msgstr "గణితం"
+#~ msgid "maths"
+#~ msgstr "గణితం"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr "ఇతరా (లేదా) కిక్ డ్రం ప్లే అవుతుంది."
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr "ఇతరా (లేదా) కిక్ డ్రం ప్లే అవుతుంది."
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr "\"ఫైలు నుండి ప్రాజెక్ట్ తెరుచు\","
+#~ msgid "Open project from file\","
+#~ msgstr "\"ఫైలు నుండి ప్రాజెక్ట్ తెరుచు\","
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr "ట్రిటోన్"
+#~ msgid "tritone"
+#~ msgstr "ట్రిటోన్"
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr "నోట్ విలువ కనిష్టమైన 0 ఉండాలి"
+#~ msgid "Note value must be greater than 0"
+#~ msgstr "నోట్ విలువ కనిష్టమైన 0 ఉండాలి"
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr "<em>టప్లెట్లు</em> విశిష్ట అవధికి స్కేలు చేస్తుంటాయి. టప్లెట్లను ఉపయోగించడంలో సహజంగా 2 కి ఆధారపడని నోటుల సమూహాలను సృష్టించడం సులభపరిచేస్తుంది."
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr "<em>టప్లెట్లు</em> విశిష్ట అవధికి స్కేలు చేస్తుంటాయి. టప్లెట్లను ఉపయోగించడంలో సహజంగా 2 కి ఆధారపడని నోటుల సమూహాలను సృష్టించడం సులభపరిచేస్తుంది."
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr "పిచ్-టైమ్ మ్యాట్రిక్స్"
+#~ msgid "pitch-time matrix"
+#~ msgstr "పిచ్-టైమ్ మ్యాట్రిక్స్"
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr "ఉదాహరణకు, గిటార్, వాయలిన్, స్నేయర్ డ్రమ్, మరియు మరియు."
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr "ఉదాహరణకు, గిటార్, వాయలిన్, స్నేయర్ డ్రమ్, మరియు మరియు."
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr "<em>స్కాలర్ అంతరం</em> బ్లాక్ సెమీ-టోన్లలో రెండు నోట్ల దూరాన్ని అంచనం చేస్తుంది."
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr "<em>స్కాలర్ అంతరం</em> బ్లాక్ సెమీ-టోన్లలో రెండు నోట్ల దూరాన్ని అంచనం చేస్తుంది."
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr "ప్రాజెక్ట్ను నిర్వహించడానికి స్లో మోడ్లో రన్ బటన్‌ను పొందించండి."
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr "ప్రాజెక్ట్ను నిర్వహించడానికి స్లో మోడ్లో రన్ బటన్‌ను పొందించండి."
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr "పిచ్ సంఖ్యలను పిచ్ మరియు ఆక్టావ్ను మ్యాప్ చేయడానికి <em>సెట్ పిచ్ నంబర్ ఆఫ్సెట్</em> బ్లాక్ ఉపయోగిస్తుంది."
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr "పిచ్ సంఖ్యలను పిచ్ మరియు ఆక్టావ్ను మ్యాప్ చేయడానికి <em>సెట్ పిచ్ నంబర్ ఆఫ్సెట్</em> బ్లాక్ ఉపయోగిస్తుంది."
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "పోలార్-కోఆర్డినేట్ గ్రిడ్ను చూపించాలి లేదా దాచాలి."
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "పోలార్-కోఆర్డినేట్ గ్రిడ్ను చూపించాలి లేదా దాచాలి."
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr "ఇది కలర్, పెన్-సైజ్ మరియు ఇతర బ్లాక్‌లతో కూడా ఉపయోగించవచ్చు."
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr "ఇది కలర్, పెన్-సైజ్ మరియు ఇతర బ్లాక్‌లతో కూడా ఉపయోగించవచ్చు."
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr "ఈ లింక్‌ను కాపీ చేసి మీ ప్రాజెక్ట్ ను భాగస్వామ్యం చేయండి."
+#~ msgid "Copy this link to share your project."
+#~ msgstr "ఈ లింక్‌ను కాపీ చేసి మీ ప్రాజెక్ట్ ను భాగస్వామ్యం చేయండి."
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "స్క్రీన్‌ను క్లియర్ చేయించి టర్టిల్స్‌ను అవసర స్థానాలకు తిరిగి పరిస్థితులు."
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "స్క్రీన్‌ను క్లియర్ చేయించి టర్టిల్స్‌ను అవసర స్థానాలకు తిరిగి పరిస్థితులు."
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr "<em>బాక్స్1</em> లో నిల్వ చేసిన విలువను తిరిగివేసేది."
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr "<em>బాక్స్1</em> లో నిల్వ చేసిన విలువను తిరిగివేసేది."
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr "మూడు బ్లాక్స్ లను ఒకటిలో ఉపయోగించడానికి <em>స్టెప్ పిచ్ బ్లాక్</em> అవసరం."
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr "మూడు బ్లాక్స్ లను ఒకటిలో ఉపయోగించడానికి <em>స్టెప్ పిచ్ బ్లాక్</em> అవసరం."
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr "బ్లింక్ (మిల్లీసెకన్లు)"
+#~ msgid "blink (ms)"
+#~ msgstr "బ్లింక్ (మిల్లీసెకన్లు)"
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr "<em>డ్యువో సింత్</em> బ్లాక్ ఒక డ్యువో-ఫ్రిక్వెన్సీ మోడ్యూలేటర్, టింబ్రెను నిర్వచించడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr "<em>డ్యువో సింత్</em> బ్లాక్ ఒక డ్యువో-ఫ్రిక్వెన్సీ మోడ్యూలేటర్, టింబ్రెను నిర్వచించడానికి ఉపయోగిస్తారు."
 
-#~msgid "begin hollow line"
-#~msgstr "ఖాళీ రేఖాను ప్రారంభించు"
+#~ msgid "begin hollow line"
+#~ msgstr "ఖాళీ రేఖాను ప్రారంభించు"
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr "గీజ్"
+#~ msgid "Geez"
+#~ msgstr "గీజ్"
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr "రిద్ధం బ్లాక్: మీరు నోట్ బ్లాక్ ఉపయోగించడానికి ఆలోచిస్తున్నారా?"
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr "రిద్ధం బ్లాక్: మీరు నోట్ బ్లాక్ ఉపయోగించడానికి ఆలోచిస్తున్నారా?"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr "ఈ ఉదాహరణలో, మౌస్ బటన్ నొక్కితే, ఒక స్నేయర్ డ్రం ప్లే అవుతుంది."
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr "ఈ ఉదాహరణలో, మౌస్ బటన్ నొక్కితే, ఒక స్నేయర్ డ్రం ప్లే అవుతుంది."
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr "ఈ టూల్‌బార్‌లో మ్యాట్రిక్స్, నోట్స్, టోన్, టర్టిల్ మరియు మరితనే పాలెట్ బటన్‌లు ఉన్నాయి. బ్లాక్‌ల పాలెట్‌లను చూపించడానికి క్లిక్ చేసి, పాలెట్ నుండి బ్లాక్‌లను క్యాన్వాస్‌కు వల్లి పెట్టండి."
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr "ఈ టూల్‌బార్‌లో మ్యాట్రిక్స్, నోట్స్, టోన్, టర్టిల్ మరియు మరితనే పాలెట్ బటన్‌లు ఉన్నాయి. బ్లాక్‌ల పాలెట్‌లను చూపించడానికి క్లిక్ చేసి, పాలెట్ నుండి బ్లాక్‌లను క్యాన్వాస్‌కు వల్లి పెట్టండి."
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr "<em>డాక్ బ్లాక్</em> బ్లాక్ల నడిచిపెట్టినది."
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr "<em>డాక్ బ్లాక్</em> బ్లాక్ల నడిచిపెట్టినది."
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr "<em>స్టెప్ పిచ్</em> బ్లాక్ (<em>నంబర్</em> బ్లాక్ తో కలయికలాను) ఒక స్కేల్‌లో తదుపరి పిచ్ నెంబర్ ను ప్లే చేస్తుంది, ఉదా.కానీ, కానీ, ఉదా. ఎగిరిన నోట్ <em>సోల్</em> అయితే, <em>స్టెప్ పిచ్ 1</em> ల <em>ల</em> ను ప్లే చేస్తుంది."
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr "<em>స్టెప్ పిచ్</em> బ్లాక్ (<em>నంబర్</em> బ్లాక్ తో కలయికలాను) ఒక స్కేల్‌లో తదుపరి పిచ్ నెంబర్ ను ప్లే చేస్తుంది, ఉదా.కానీ, కానీ, ఉదా. ఎగిరిన నోట్ <em>సోల్</em> అయితే, <em>స్టెప్ పిచ్ 1</em> ల <em>ల</em> ను ప్లే చేస్తుంది."
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr "<em>బ్యాక్‌వార్డ్</em> బ్లాక్ కోడ్ను తిరిగిపెట్టేది (సంగీత రెట్రోగ్రేడ్)."
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr "<em>బ్యాక్‌వార్డ్</em> బ్లాక్ కోడ్ను తిరిగిపెట్టేది (సంగీత రెట్రోగ్రేడ్)."
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr "ప్రాచీన నోట్ విల్యూ"
+#~ msgid "deprecated note value"
+#~ msgstr "ప్రాచీన నోట్ విల్యూ"
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr "అరబిక్"
+#~ msgid "Arabic"
+#~ msgstr "అరబిక్"
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr "ఈ ఉదాహరణలో, సాధారణ డ్రమ్ మెషిన్ని ఉపయోగించేందుకు, ఒక కిక్ డ్రం మెషిన్ ఎక్కువగా 1/4 నోట్‌లను ఆటండి."
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr "ఈ ఉదాహరణలో, సాధారణ డ్రమ్ మెషిన్ని ఉపయోగించేందుకు, ఒక కిక్ డ్రం మెషిన్ ఎక్కువగా 1/4 నోట్‌లను ఆటండి."
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr "హర్ట్జ్ బ్లాక్: మీరు నోట్ బ్లాక్ 3 ఉపయోగించడానికి ఆలోచిస్తున్నారా?"
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr "హర్ట్జ్ బ్లాక్: మీరు నోట్ బ్లాక్ 3 ఉపయోగించడానికి ఆలోచిస్తున్నారా?"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr "మేజర్-బ్ల్యూస్"
+#~ msgid "major-blues"
+#~ msgstr "మేజర్-బ్ల్యూస్"
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr "<em>మోడ్</em> బ్లాక్ ఒక విభాజనలో నిశ్శేషం తిరిగిస్తుంది."
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr "<em>మోడ్</em> బ్లాక్ ఒక విభాజనలో నిశ్శేషం తిరిగిస్తుంది."
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr "పిచ్ ని <em>C D E F G A B</em> గా పేర్కొని వ్యాఖ్యానించబడింది."
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr "పిచ్ ని <em>C D E F G A B</em> గా పేర్కొని వ్యాఖ్యానించబడింది."
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr "హిందూ"
+#~ msgid "Hindu"
+#~ msgstr "హిందూ"
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr "<em>మిల్లీసెకన్ల</em> బ్లాక్ ఒక <em>నోట్</em> బ్లాక్‌కి సామాన్యం. ఇది నోట్ వ్యాఖ్యానంగా చేసినట్లు, ఇది సమయాన్ని (MS లో) నోట్ కాలంను నిర్దిష్టించడానికి ఉపయోగిస్తుంది."
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr "<em>మిల్లీసెకన్ల</em> బ్లాక్ ఒక <em>నోట్</em> బ్లాక్‌కి సామాన్యం. ఇది నోట్ వ్యాఖ్యానంగా చేసినట్లు, ఇది సమయాన్ని (MS లో) నోట్ కాలంను నిర్దిష్టించడానికి ఉపయోగిస్తుంది."
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr "<em>నాట్</em> బ్లాక్ అసంగతం అంగిరేటర్."
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr "<em>నాట్</em> బ్లాక్ అసంగతం అంగిరేటర్."
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr "కొత్త ప్రాజెక్ట్\",""
+#~ msgid "New project\","
+#~ msgstr "కొత్త ప్రాజెక్ట్\","
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr "పట్టి పిచ్"
+#~ msgid "step pitch"
+#~ msgstr "పట్టి పిచ్"
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr "<em>బాక్స్2</em> లో నిల్వ చేసిన విలువను భద్రపరచడానికి <em>స్టోర్ ఇన్ బాక్స్2</em> బ్లాక్ ఉపయోగిస్తారు."
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr "<em>బాక్స్2</em> లో నిల్వ చేసిన విలువను భద్రపరచడానికి <em>స్టోర్ ఇన్ బాక్స్2</em> బ్లాక్ ఉపయోగిస్తారు."
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr "PNG గా భద్రపరచండి"
+#~ msgid "Save as png"
+#~ msgstr "PNG గా భద్రపరచండి"
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr "<em>స్కిప్ నోట్స్</em> బ్లాక్ నోట్‌లను విడిపించండి."
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr "<em>స్కిప్ నోట్స్</em> బ్లాక్ నోట్‌లను విడిపించండి."
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr "<em>స్కాలర్ ఇంటర్వల్</em> బ్లాక్ ప్రస్తుత మోడ్ పెరిగిపోయినప్పుడు అన్ని నోట్‌లను విడిపిస్తుంది. చిత్రంలో, మేము <em>సోల్</em> కు <em>ల</em> ని జోడించాం."
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr "<em>స్కాలర్ ఇంటర్వల్</em> బ్లాక్ ప్రస్తుత మోడ్ పెరిగిపోయినప్పుడు అన్ని నోట్‌లను విడిపిస్తుంది. చిత్రంలో, మేము <em>సోల్</em> కు <em>ల</em> ని జోడించాం."
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr "పిచ్ ని వెనుకకు ఆడు"
+#~ msgid "play backward"
+#~ msgstr "పిచ్ ని వెనుకకు ఆడు"
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr "<em>పిచ్ లో మారుకున్నది</em> బ్లాక్ ప్రస్తుత ఆడుతున్న పిచ్ మరియు మునుపటి ఆడిన పిచ్ (అంశాల లో) లో ఉన్న తేడాభిన్నంగా ఉంది."
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr "<em>పిచ్ లో మారుకున్నది</em> బ్లాక్ ప్రస్తుత ఆడుతున్న పిచ్ మరియు మునుపటి ఆడిన పిచ్ (అంశాల లో) లో ఉన్న తేడాభిన్నంగా ఉంది."
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr "<em>నియంత్రణ-బిందు 1</em> బ్లాక్ బేజియర్ వక్రాకారానికి మొదటి నియంత్రణ బిందుని సెట్ చేస్తుంది."
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr "<em>నియంత్రణ-బిందు 1</em> బ్లాక్ బేజియర్ వక్రాకారానికి మొదటి నియంత్రణ బిందుని సెట్ చేస్తుంది."
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr "బ్యాక్"
+#~ msgid "bk"
+#~ msgstr "బ్యాక్"
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr "బటం"
+#~ msgid "bt"
+#~ msgstr "బటం"
 
 #: js/logo.js:2175
 
@@ -11654,362 +11654,362 @@ msgstr "చలింపు"
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr "మౌస్ కనుగొనలేదు"
+#~ msgid "Could not find mouse"
+#~ msgstr "మౌస్ కనుగొనలేదు"
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr "<em>గెట్ గ్రీన్</em> బ్లాక్ మౌస్ కి అడిగిన పిక్సెల్ యొక్క ఆకుపచ్చదిని తిరిగివేస్తుంది."
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr "<em>గెట్ గ్రీన్</em> బ్లాక్ మౌస్ కి అడిగిన పిక్సెల్ యొక్క ఆకుపచ్చదిని తిరిగివేస్తుంది."
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr "<em>రిద్ధం</em> బ్లాక్ రిద్ధం నమూనాలను సృష్టించడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr "<em>రిద్ధం</em> బ్లాక్ రిద్ధం నమూనాలను సృష్టించడానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr "???"
+#~ msgid "???"
+#~ msgstr "???"
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr "<em>కర్సర్ X</em> బ్లాక్ మౌస్ యొక్క అక్షాంతర స్థానాన్ని తిరిగిస్తుంది."
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr "<em>కర్సర్ X</em> బ్లాక్ మౌస్ యొక్క అక్షాంతర స్థానాన్ని తిరిగిస్తుంది."
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr "ప్రాజెక్ట్ భద్రపరచు"
+#~ msgid "Save Project"
+#~ msgstr "ప్రాజెక్ట్ భద్రపరచు"
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr "<em>ఫాంట్ సెట్</em> బ్లాక్ <em>షో</em> బ్లాక్ ద్వారా ఉపయోగిస్తున్న ఫాంట్ను సెట్ చేస్తుంది."
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr "<em>ఫాంట్ సెట్</em> బ్లాక్ <em>షో</em> బ్లాక్ ద్వారా ఉపయోగిస్తున్న ఫాంట్ను సెట్ చేస్తుంది."
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr "దో రే మి ఫా సోల్ లా టి"
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr "దో రే మి ఫా సోల్ లా టి"
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr "<em>అంతవ్రిత్తించకుండా</em> బ్లాక్ పరిస్థితి నిజం అవుతుంది."
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr "<em>అంతవ్రిత్తించకుండా</em> బ్లాక్ పరిస్థితి నిజం అవుతుంది."
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr "<em>లాజికల్ లేదా</em> బ్లాక్ లాజికల్ లేదా ఆపరేటర్ కాదు."
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr "<em>లాజికల్ లేదా</em> బ్లాక్ లాజికల్ లేదా ఆపరేటర్ కాదు."
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr "ఎడమరి ఘడియారం లాంటి అవకాశం ఉంది"
+#~ msgid "rotate counter clockwise"
+#~ msgstr "ఎడమరి ఘడియారం లాంటి అవకాశం ఉంది"
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr "మరియు ఇతరాలు."
+#~ msgid "etc."
+#~ msgstr "మరియు ఇతరాలు."
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr "వర్గీకరించు"
+#~ msgid "sort"
+#~ msgstr "వర్గీకరించు"
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr "పిచ్ బ్లాక్: మీరు నోట్ బ్లాక్ ను ఉపయోగించాలా2?"
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr "పిచ్ బ్లాక్: మీరు నోట్ బ్లాక్ ను ఉపయోగించాలా2?"
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr "విరిపి శ్రేణిలో లేదు"
+#~ msgid "Distortion not in range"
+#~ msgstr "విరిపి శ్రేణిలో లేదు"
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr "<em>పెన్ పరిమాణం</em> బ్లాక్ ప్రస్తుత పెన్ పరిమాణం విలువను తిరిగిస్తుంది."
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr "<em>పెన్ పరిమాణం</em> బ్లాక్ ప్రస్తుత పెన్ పరిమాణం విలువను తిరిగిస్తుంది."
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr "<em>హీప్ ను యాప్‌కు భద్రపరచండి</em> బ్లాక్ హీప్‌ను వెబ్ పేజీకి భద్రపరచిస్తుంది."
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr "<em>హీప్ ను యాప్‌కు భద్రపరచండి</em> బ్లాక్ హీప్‌ను వెబ్ పేజీకి భద్రపరచిస్తుంది."
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr "<em>రండం</em> బ్లాక్ ఒక యాదృచ్ఛిక సంఖ్యను తిరిగిస్తుంది."
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr "<em>రండం</em> బ్లాక్ ఒక యాదృచ్ఛిక సంఖ్యను తిరిగిస్తుంది."
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr "పోలర్"
+#~ msgid "Polar"
+#~ msgstr "పోలర్"
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr "ప్రస్తుత పిచ్ పేరు"
+#~ msgid "current pitch name"
+#~ msgstr "ప్రస్తుత పిచ్ పేరు"
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "ఒక కార్టేషియన్-యొక్క సంకేత గ్రిడ్‌ను చూపించండి లేదా దాచండి."
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "ఒక కార్టేషియన్-యొక్క సంకేత గ్రిడ్‌ను చూపించండి లేదా దాచండి."
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr "<em>షో హీప్</em> బ్లాక్ స్క్రీన్ టాప్‌లో హీప్‌ను ప్రదర్శిస్తుంది."
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr "<em>షో హీప్</em> బ్లాక్ స్క్రీన్ టాప్‌లో హీప్‌ను ప్రదర్శిస్తుంది."
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr "మౌస్-పేరు</em> బ్లాక్ ఒక మౌస్ యొక్క పేరను తిరిగిస్తుంది."
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr "మౌస్-పేరు</em> బ్లాక్ ఒక మౌస్ యొక్క పేరను తిరిగిస్తుంది."
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ".png రూపంలో భద్రపరచండి"
+#~ msgid "Save as .png"
+#~ msgstr ".png రూపంలో భద్రపరచండి"
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr "మిక్సోలిడియన్"
+#~ msgid "Mixolydian"
+#~ msgstr "మిక్సోలిడియన్"
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr "mకీబోర్డ్"
+#~ msgid "mKeyboard"
+#~ msgstr "mకీబోర్డ్"
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr "<em>ఆపేక్షికంగా</em> (ఉదా.న్. మరియు, రీపీట్, వైల్, లేదా అంతవ్రిత్తించకుండా) బ్లాక్ ఆపండి."
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr "<em>ఆపేక్షికంగా</em> (ఉదా.న్. మరియు, రీపీట్, వైల్, లేదా అంతవ్రిత్తించకుండా) బ్లాక్ ఆపండి."
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr "<em>పిచ్ సంఖ్య</em> బ్లాక్ ప్రస్తుత ప్రస్తుతం ప్రదర్శిస్తున్న సంగీతం యొక్క పిచ్ విలువి."
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr "<em>పిచ్ సంఖ్య</em> బ్లాక్ ప్రస్తుత ప్రస్తుతం ప్రదర్శిస్తున్న సంగీతం యొక్క పిచ్ విలువి."
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr "<em>షెల్</em> బ్లాక్ మౌస్ యొక్క కనుక మార్చటానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr "<em>షెల్</em> బ్లాక్ మౌస్ యొక్క కనుక మార్చటానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr "<em>సరిచూచటాని</em> బ్లాక్ రెండు సంఖ్యలు సరిచూచే అవస్థలో <em>నిజం</em>ను తిరిగిస్తుంది."
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr "<em>సరిచూచటాని</em> బ్లాక్ రెండు సంఖ్యలు సరిచూచే అవస్థలో <em>నిజం</em>ను తిరిగిస్తుంది."
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr "ప్లానెట్‌కు అప్‌లోడ్ చేయండి"
+#~ msgid "Upload to Planet"
+#~ msgstr "ప్లానెట్‌కు అప్‌లోడ్ చేయండి"
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr "<em>స్కేలర్ పగిలింపు క్రిందక్కే</em> బ్లాక్ ప్రస్తుత కీ మరియు మోడ్ లో ముందు నోట్ కి సెమి-టోన్స్ పరిమాణాన్ని తిరిగిస్తుంది."
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr "<em>స్కేలర్ పగిలింపు క్రిందక్కే</em> బ్లాక్ ప్రస్తుత కీ మరియు మోడ్ లో ముందు నోట్ కి సెమి-టోన్స్ పరిమాణాన్ని తిరిగిస్తుంది."
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr "<em>గెట్ పిక్సెల్</em> బ్లాక్ మౌస్ కి ఉన్న పిక్సెల్ యొక్క రంగును తిరిగిస్తుంది."
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr "<em>గెట్ పిక్సెల్</em> బ్లాక్ మౌస్ కి ఉన్న పిక్సెల్ యొక్క రంగును తిరిగిస్తుంది."
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr "ప్లగిన్‌ను ఫైలు నుంచి లోడ్ చేయండి"
+#~ msgid "Load plugin from file"
+#~ msgstr "ప్లగిన్‌ను ఫైలు నుంచి లోడ్ చేయండి"
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr "<em>ప్లేబ్యాక్</em> బ్లాక్"
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr "<em>ప్లేబ్యాక్</em> బ్లాక్"
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ".abc రూపంలో భద్రపరచండి"
+#~ msgid "Save as .abc"
+#~ msgstr ".abc రూపంలో భద్రపరచండి"
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr "లిలీపాండ్ ఒక అంశాన్ని ప్రాసెస్ చేయలేదు"
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr "లిలీపాండ్ ఒక అంశాన్ని ప్రాసెస్ చేయలేదు"
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr "<em>పిచ్ ఇన్ హర్ట్జ్</em> బ్లాక్ ప్రస్తుత ప్రదర్శిస్తున్న నోట్ యొక్క పిచ్ యొక్క విలువను హర్ట్జ్ లో ఇచ్చేందుకు సమాచారం."
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr "<em>పిచ్ ఇన్ హర్ట్జ్</em> బ్లాక్ ప్రస్తుత ప్రదర్శిస్తున్న నోట్ యొక్క పిచ్ యొక్క విలువను హర్ట్జ్ లో ఇచ్చేందుకు సమాచారం."
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr "డిగ్రీ"
+#~ msgid "degree"
+#~ msgstr "డిగ్రీ"
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr "పాడు"
+#~ msgid "sing"
+#~ msgstr "పాడు"
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr "<em>కంట్రోల్-పాయింట్ 2</em> బ్లాక్ బేజియర్ కర్వ్ కు రెండవ నియంత్రణ పాయింట్ను సెట్ చేస్తుంది."
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr "<em>కంట్రోల్-పాయింట్ 2</em> బ్లాక్ బేజియర్ కర్వ్ కు రెండవ నియంత్రణ పాయింట్ను సెట్ చేస్తుంది."
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr "చైనీస్"
+#~ msgid "Chinese"
+#~ msgstr "చైనీస్"
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr "సంగీతం ప్రదర్శించండి"
+#~ msgid "Play music"
+#~ msgstr "సంగీతం ప్రదర్శించండి"
 
 #: js/samplesviewer.js:91
 
-#~msgid "Download"
-#~msgstr "దింపుకోండి"
+#~ msgid "Download"
+#~ msgstr "దింపుకోండి"
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr "డార్బుకా-డ్రం"
+#~ msgid "darbuka-drum"
+#~ msgstr "డార్బుకా-డ్రం"
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr "<em>సెమి-టోన్ అంతరం</em> బ్లాక్ అర్ధం పరిమాణంపై ఆధారపడి రిలేటివ్ అంతరం అంచనాను కలుగుతుంది. చిత్రంలో, మేము <em>సోల్#</em>ను <em>సోల్</em>కు జోడించాము."
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr "<em>సెమి-టోన్ అంతరం</em> బ్లాక్ అర్ధం పరిమాణంపై ఆధారపడి రిలేటివ్ అంతరం అంచనాను కలుగుతుంది. చిత్రంలో, మేము <em>సోల్#</em>ను <em>సోల్</em>కు జోడించాము."
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr "<em>ప్లస్</em> బ్లాక్ జోడించడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr "<em>ప్లస్</em> బ్లాక్ జోడించడానికి ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr "ఉదా., 1, 2, 3, లేదా 4."
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr "ఉదా., 1, 2, 3, లేదా 4."
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr "<em>లోడ్హీప్</em> బ్లాక్ ఫైలు నుండి హీప్ను లోడ్ చేస్తుంది."
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr "<em>లోడ్హీప్</em> బ్లాక్ ఫైలు నుండి హీప్ను లోడ్ చేస్తుంది."
 
-#~msgid "cloud"
-#~msgstr "క్లడ్"
+#~ msgid "cloud"
+#~ msgstr "క్లడ్"
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr "<em>బాటమ్</em> బ్లాక్ క్యాన్వాస్ కి దాని అవస్థాన్ని తిరిగిస్తుంది."
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr "<em>బాటమ్</em> బ్లాక్ క్యాన్వాస్ కి దాని అవస్థాన్ని తిరిగిస్తుంది."
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr "SVG గా భద్రపరచు"
+#~ msgid "Save as svg"
+#~ msgstr "SVG గా భద్రపరచు"
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr "ఇంపాక్ట్ UID కనబడలేదు."
+#~ msgid "Impact UID not found."
+#~ msgstr "ఇంపాక్ట్ UID కనబడలేదు."
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr "సోల్ఫా"
+#~ msgid "Solfa"
+#~ msgstr "సోల్ఫా"
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr "ఫిల్టర్ జోడించండి"
+#~ msgid "add filter"
+#~ msgstr "ఫిల్టర్ జోడించండి"
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr "turtleHeaps కు చెవిలో ఉన్న చెవిని కోసం యొక్క చెవి నిర్వాహణ చేయబడలేదు"
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr "turtleHeaps కు చెవిలో ఉన్న చెవిని కోసం యొక్క చెవి నిర్వాహణ చేయబడలేదు"
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr "మీరు కూడా Alt+C ను ఉపయోగించి బ్లాక్ల స్టాక్ను కాపీ చేయవచ్చు."
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr "మీరు కూడా Alt+C ను ఉపయోగించి బ్లాక్ల స్టాక్ను కాపీ చేయవచ్చు."
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr "పాలెట్లను చూపించండి / దాచండి"
+#~ msgid "Show/hide palettes"
+#~ msgstr "పాలెట్లను చూపించండి / దాచండి"
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr "హోమ్ + [హోమ్]"
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr "హోమ్ + [హోమ్]"
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr "<em>స్టార్ట్ మౌస్</em> బ్లాక్ కొంతకువంటి మౌస్ ను ప్రారంభిస్తుంది."
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr "<em>స్టార్ట్ మౌస్</em> బ్లాక్ కొంతకువంటి మౌస్ ను ప్రారంభిస్తుంది."
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr "అంగడాన్ని తీసుకొనండి"
+#~ msgid "fetch"
+#~ msgstr "అంగడాన్ని తీసుకొనండి"
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr "<em>బాక్స్</em> బ్లాక్ ఒక పట్టికలో నిలువడిని తిరిగిస్తుంది."
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr "<em>బాక్స్</em> బ్లాక్ ఒక పట్టికలో నిలువడిని తిరిగిస్తుంది."
 
-#~msgid "rodi"
-#~msgstr "rodi"
+#~ msgid "rodi"
+#~ msgstr "rodi"
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr "<em>సెట్ మౌస్</em> బ్లాక్ ఒక నిర్దిష్టమైన మౌస్ ద్వారా పరిచయించబడిన బ్లాక్ స్టాక్ను పంపిస్తుంది."
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr "<em>సెట్ మౌస్</em> బ్లాక్ ఒక నిర్దిష్టమైన మౌస్ ద్వారా పరిచయించబడిన బ్లాక్ స్టాక్ను పంపిస్తుంది."
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr "<em>బాక్స్1</em> బ్లాక్ <em>బాక్స్1</em> లో నిలువడిని తిరిగిస్తుంది."
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr "<em>బాక్స్1</em> బ్లాక్ <em>బాక్స్1</em> లో నిలువడిని తిరిగిస్తుంది."
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr "మీరు Alt+P ను ఉపయోగించి బ్లాక్ల స్టాక్ను పేస్ట్ చేయవచ్చు."
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr "మీరు Alt+P ను ఉపయోగించి బ్లాక్ల స్టాక్ను పేస్ట్ చేయవచ్చు."
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr "పెంటాటోనిక్"
+#~ msgid "pentatonic"
+#~ msgstr "పెంటాటోనిక్"
 
-#~msgid "blocks"
-#~msgstr "బ్లాక్లు"
+#~ msgid "blocks"
+#~ msgstr "బ్లాక్లు"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr "<em>పిచ్-టైమ్ మేట్రిక్స్</em> బ్లాక్ ఒక సంగీత ఫ్రేజెస్ సృష్టించడానికి ఒక సాధనాన్ని తెరవిస్తుంది."
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr "<em>పిచ్-టైమ్ మేట్రిక్స్</em> బ్లాక్ ఒక సంగీత ఫ్రేజెస్ సృష్టించడానికి ఒక సాధనాన్ని తెరవిస్తుంది."
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr "<em>హెడింగ్</em> బ్లాక్ మౌస్ యొక్క నిలువురాసంను తిరిగిస్తుంది."
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr "<em>హెడింగ్</em> బ్లాక్ మౌస్ యొక్క నిలువురాసంను తిరిగిస్తుంది."
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr "<em>అబ్స్</em> బ్లాక్ ఎక్కువగా వచ్చే విలువను తిరిగిస్తుంది."
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr "<em>అబ్స్</em> బ్లాక్ ఎక్కువగా వచ్చే విలువను తిరిగిస్తుంది."
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr "ఉదాహరణకు, మీరు మొదటి వాల్యూని 5 తో ఉన్న ఒక క్రెస్కెండో బ్లాక్లో కొనసాగే 7 నోట్లు ఉన్నప్పటికీ, అంతి."
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr "ఉదాహరణకు, మీరు మొదటి వాల్యూని 5 తో ఉన్న ఒక క్రెస్కెండో బ్లాక్లో కొనసాగే 7 నోట్లు ఉన్నప్పటికీ, అంతి."
 
 #: js/block.js:962
 
@@ -12017,57 +12017,57 @@ msgstr "చలింపు"
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr "రిద్ధం రూలర్"
+#~ msgid "rhythm ruler"
+#~ msgstr "రిద్ధం రూలర్"
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr "ఎంతోకానే ఆళ్ల ఎంటర్ చేయబడింది"
+#~ msgid "Depth entered is out of range"
+#~ msgstr "ఎంతోకానే ఆళ్ల ఎంటర్ చేయబడింది"
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr "<em>స్కేలర్ ఇంటర్వల్</em> బ్లాక్ ప్రస్తుత కీ మరియు మోడ్లో ఉన్నటి మధ్య దూరాన్ని అంచనం చేస్తుంది."
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr "<em>స్కేలర్ ఇంటర్వల్</em> బ్లాక్ ప్రస్తుత కీ మరియు మోడ్లో ఉన్నటి మధ్య దూరాన్ని అంచనం చేస్తుంది."
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr "<em>ఫార్వర్డ్</em> బ్లాక్ మౌస్ ను ముందుకు చలింపిస్తుంది."
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr "<em>ఫార్వర్డ్</em> బ్లాక్ మౌస్ ను ముందుకు చలింపిస్తుంది."
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr "పెంటాటోనిక్"
+#~ msgid "Pentatonic"
+#~ msgstr "పెంటాటోనిక్"
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr "<em>టెంపరమెంట్</em> టూల్ కస్టమ్ ట్యూనింగ్ని వ్యాఖ్యానిస్తారు."
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr "<em>టెంపరమెంట్</em> టూల్ కస్టమ్ ట్యూనింగ్ని వ్యాఖ్యానిస్తారు."
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr "మేజర్ బ్లాక్ కు ఇన్పుట్ అయితే 2, 3, 6 లేదా 7 ఉండాలి"
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr "మేజర్ బ్లాక్ కు ఇన్పుట్ అయితే 2, 3, 6 లేదా 7 ఉండాలి"
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr "<em>ప్రింట్</em> బ్లాక్ స్క్రీన్ యొక్క మేదకు టెక్స్ట్ చూపిస్తుంది."
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr "<em>ప్రింట్</em> బ్లాక్ స్క్రీన్ యొక్క మేదకు టెక్స్ట్ చూపిస్తుంది."
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr "<em>వెటడ్ పార్షల్స్</em> బ్లాక్ ఒక టింబర్ తో సంబంధించిన పార్షల్స్ ని నిర్దిష్టించడానికి ఉపయోగిస్తారు."
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr "<em>వెటడ్ పార్షల్స్</em> బ్లాక్ ఒక టింబర్ తో సంబంధించిన పార్షల్స్ ని నిర్దిష్టించడానికి ఉపయోగిస్తారు."
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr "ఆర్టిక్యులేషన్"
+#~ msgid "articulation"
+#~ msgstr "ఆర్టిక్యులేషన్"
 
 #: js/turtledefs.js:387
 
@@ -12077,30 +12077,30 @@ msgstr "చలింపు"
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr "<em>కాల్కులేట్</em> బ్లాక్ ఒక యాక్షన్ ద్వారా కలిగిన విలువను తిరిగిస్తుంది."
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr "<em>కాల్కులేట్</em> బ్లాక్ ఒక యాక్షన్ ద్వారా కలిగిన విలువను తిరిగిస్తుంది."
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr "ఉన్నత ఎంపికలు"
+#~ msgid "Advanced options"
+#~ msgstr "ఉన్నత ఎంపికలు"
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr "<em>రిటర్న్</em> బ్లాక్ యాక్షన్ నుండి విలువను తిరిగిస్తుంది."
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr "<em>రిటర్న్</em> బ్లాక్ యాక్షన్ నుండి విలువను తిరిగిస్తుంది."
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr "<em>యాక్షన్</em> బ్లాక్ బ్లాక్లను గుంపుగా కలిపించడానికి ఉపయోగిస్తారు, వారు అనేకసారి ఉపయోగిస్తారు. ఇది అక్కడిని పునరావృత్తం చేయడానికి చాలా సామాన్యంగా ఉపయోగిస్తారు."
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr "<em>యాక్షన్</em> బ్లాక్ బ్లాక్లను గుంపుగా కలిపించడానికి ఉపయోగిస్తారు, వారు అనేకసారి ఉపయోగిస్తారు. ఇది అక్కడిని పునరావృత్తం చేయడానికి చాలా సామాన్యంగా ఉపయోగిస్తారు."
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr "<em>గెట్ బ్లూ</em> బ్లాక్ మౌస్ కి చిత్రాన్ని క్రిందిని తిరిగిస్తుంది."
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr "<em>గెట్ బ్లూ</em> బ్లాక్ మౌస్ కి చిత్రాన్ని క్రిందిని తిరిగిస్తుంది."
 
 #: js/turtledefs.js:187
 
@@ -12108,112 +12108,112 @@ msgstr "చలింపు"
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr "షీట్ సంగీతం భద్రపరచండి"
+#~ msgid "Save sheet music"
+#~ msgstr "షీట్ సంగీతం భద్రపరచండి"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr "రోమేనియన్ మైనర్"
+#~ msgid "romanian-minor"
+#~ msgstr "రోమేనియన్ మైనర్"
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr "4వ"
+#~ msgid "4th"
+#~ msgstr "4వ"
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr "<em>సెట్ రిలేటివ్ వాల్యూమ్</em> బ్లాక్ కలిగిన నోట్ల వాల్యూమ్ను మార్చిపెట్టుంది."
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr "<em>సెట్ రిలేటివ్ వాల్యూమ్</em> బ్లాక్ కలిగిన నోట్ల వాల్యూమ్ను మార్చిపెట్టుంది."
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matching <em>Case</em>."
-#~msgstr "<em>స్విచ్</em> బ్లాక్ మ్యాచింగ్ <em>కేస్</em> లో కోడ్ ను పరిచయిస్తుంది."
+#~ msgid "The <em>Switch</em> block will run the code in the matching <em>Case</em>."
+#~ msgstr "<em>స్విచ్</em> బ్లాక్ మ్యాచింగ్ <em>కేస్</em> లో కోడ్ ను పరిచయిస్తుంది."
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr "ట్రాన్స్పోజిషన్ ని అమర్చండి"
+#~ msgid "adjust transposition"
+#~ msgstr "ట్రాన్స్పోజిషన్ ని అమర్చండి"
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "వేగంగా ప్రాజెక్ట్ ను రన్ చేయడానికి క్లిక్ చేయండి."
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "వేగంగా ప్రాజెక్ట్ ను రన్ చేయడానికి క్లిక్ చేయండి."
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr "నోట్ ను నోట్ చాలానే"
+#~ msgid "Run note by note"
+#~ msgstr "నోట్ ను నోట్ చాలానే"
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr "పార్షల్ బ్లాక్ ని బరిలో Weighted-partials బ్లాక్లో ఉపయోగించాలి."
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr "పార్షల్ బ్లాక్ ని బరిలో Weighted-partials బ్లాక్లో ఉపయోగించాలి."
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr "హీప్ పొడవు బ్లాక్ హీప్ యొక్క నొక్కమైన పొడవును తరంగపరచును."
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr "హీప్ పొడవు బ్లాక్ హీప్ యొక్క నొక్కమైన పొడవును తరంగపరచును."
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr "షెల్"
+#~ msgid "shell"
+#~ msgstr "షెల్"
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr "ప్లానెట్ దగ్గర మూయండి\","
+#~ msgid "Close Planet\","
+#~ msgstr "ప్లానెట్ దగ్గర మూయండి\","
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr "తరువాయ పేజీ"
+#~ msgid "Next page"
+#~ msgstr "తరువాయ పేజీ"
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr "బ్లాక్ల మీద పొడిగించడానికి నొక్కండి."
+#~ msgid "Long press on blocks to copy."
+#~ msgstr "బ్లాక్ల మీద పొడిగించడానికి నొక్కండి."
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr "<em>కారస్</em> బ్లాక్ ఒక కారస్ ప్రభావాన్ని జోడిస్తుంది."
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr "<em>కారస్</em> బ్లాక్ ఒక కారస్ ప్రభావాన్ని జోడిస్తుంది."
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr "<em>కస్టమ్ మోడ్</em> బ్లాక్ ఒక సంగీత మోడ్ను అన్వేషించడానికి ఒక సాధనాన్ని తెరిచిపెట్టుకుంది (ఒక స్కేల్లో నోటుల వ్యాసాలు)."
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr "<em>కస్టమ్ మోడ్</em> బ్లాక్ ఒక సంగీత మోడ్ను అన్వేషించడానికి ఒక సాధనాన్ని తెరిచిపెట్టుకుంది (ఒక స్కేల్లో నోటుల వ్యాసాలు)."
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr "కొత్తదాన్ని తెరవడానికి దానిని మూడు ముగిసివేయండి."
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr "కొత్తదాన్ని తెరవడానికి దానిని మూడు ముగిసివేయండి."
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr "వాయిదా <em>వేర్డు</em> బ్లాక్ ప్రోగ్రామ్ను ప్రస్తుతం సెకన్ల సంఖ్యను వాడుకోయిపెడతు."
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr "వాయిదా <em>వేర్డు</em> బ్లాక్ ప్రోగ్రామ్ను ప్రస్తుతం సెకన్ల సంఖ్యను వాడుకోయిపెడతు."
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr "వాయిదా <em>సెట్ డ్రమ్</em> బ్లాక్ అంతే ఏదో కంటెయిన్ చేసిన నోటుల పిచ్చను మార్చుకోవడానికి డ్రమ్ ధ్వనిని ఎంచుకోబడినట్లుగా ఉంటుంది. ప్రాముఖ్యంగా, ప్రారంభంలో, <em>కిక్ డ్రమ్</em> ధ్వని సోల్ పైలాగా ప్రసారం చేయబడతాయి."
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr "వాయిదా <em>సెట్ డ్రమ్</em> బ్లాక్ అంతే ఏదో కంటెయిన్ చేసిన నోటుల పిచ్చను మార్చుకోవడానికి డ్రమ్ ధ్వనిని ఎంచుకోబడినట్లుగా ఉంటుంది. ప్రాముఖ్యంగా, ప్రారంభంలో, <em>కిక్ డ్రమ్</em> ధ్వని సోల్ పైలాగా ప్రసారం చేయబడతాయి."
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr "<em>హీప్ పొడవు</em> బ్లాక్ హీప్ పొడవును తరంగపరచును."
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr "<em>హీప్ పొడవు</em> బ్లాక్ హీప్ పొడవును తరంగపరచును."
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr "ఆఫ్‌బీట్లో చేస్తే"
+#~ msgid "on offbeat do"
+#~ msgstr "ఆఫ్‌బీట్లో చేస్తే"
 
 #: js/StringHelper.js:17
 
@@ -12221,280 +12221,280 @@ msgstr "చలింపు"
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr "డేటా టూల్‌టిప్"
+#~ msgid "data-tooltip"
+#~ msgstr "డేటా టూల్‌టిప్"
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr "విరామం"
+#~ msgid "pause"
+#~ msgstr "విరామం"
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr "ఒక నిర్దిష్ట నోటు మౌల్య వ్యాఖ్యానం ద్వారా <em>సైలెన్స్</em> బ్లాక్ ఉపయోగించి నిర్మాణం చేయబడుతుంది."
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr "ఒక నిర్దిష్ట నోటు మౌల్య వ్యాఖ్యానం ద్వారా <em>సైలెన్స్</em> బ్లాక్ ఉపయోగించి నిర్మాణం చేయబడుతుంది."
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr "ఉదా, గిటార్, పియానో, వయలిన్, లేదా సెల్లో."
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr "ఉదా, గిటార్, పియానో, వయలిన్, లేదా సెల్లో."
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr "హార్డ్ స్టాప్"
+#~ msgid "Hard stop"
+#~ msgstr "హార్డ్ స్టాప్"
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr "<em>గెట్ రెడ్</em> బ్లాక్ మౌస్ కింద ఉన్న పిక్సెల్ ను తలపెట్టిన రెడ్ కాంపొనెంట్ ను తరంగపరచును."
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr "<em>గెట్ రెడ్</em> బ్లాక్ మౌస్ కింద ఉన్న పిక్సెల్ ను తలపెట్టిన రెడ్ కాంపొనెంట్ ను తరంగపరచును."
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr "ఉచిత సమయం"
+#~ msgid "free time"
+#~ msgstr "ఉచిత సమయం"
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr "ఉదా, మరియు చివరి నోటు ప్రదానం చేసినప్పటికే sol ఉండినట్లు, Scalar Step 1 లా ప్లే చేసిపెడతాయి."
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr "ఉదా, మరియు చివరి నోటు ప్రదానం చేసినప్పటికే sol ఉండినట్లు, Scalar Step 1 లా ప్లే చేసిపెడతాయి."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr "పూర్ణస్వరము"
+#~ msgid "whole-tone"
+#~ msgstr "పూర్ణస్వరము"
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr "మీరు కంటెయిన్ చేసిన ఒక స్టాక్ ను కాపీ చేసినట్లు Alt+C ఉపయోగించవచ్చు."
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr "మీరు కంటెయిన్ చేసిన ఒక స్టాక్ ను కాపీ చేసినట్లు Alt+C ఉపయోగించవచ్చు."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr "సహజవార్తి"
+#~ msgid "natural-minor"
+#~ msgstr "సహజవార్తి"
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr "పేస్ట్ చేయడానికి ఇక్కడ క్లిక్ చేయండి"
+#~ msgid "Click here to paste"
+#~ msgstr "పేస్ట్ చేయడానికి ఇక్కడ క్లిక్ చేయండి"
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr "ఈ బటన్ ముఖ్య టూల్‌బార్‌ను తెరుచుకోవడానికి మరియు మూసివేయడానికి ఉంది."
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr "ఈ బటన్ ముఖ్య టూల్‌బార్‌ను తెరుచుకోవడానికి మరియు మూసివేయడానికి ఉంది."
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr "మ్యూజిక్ను పట్టె పట్టి ప్రవృత్తిపరిచేయండి"
+#~ msgid "Run music step by step"
+#~ msgstr "మ్యూజిక్ను పట్టె పట్టి ప్రవృత్తిపరిచేయండి"
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr "<em>సేవ్‌హీప్</em> బ్లాక్ హీప్‌ను ఒక ఫైల్‌కు భద్రపరచుకుంటుంది."
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr "<em>సేవ్‌హీప్</em> బ్లాక్ హీప్‌ను ఒక ఫైల్‌కు భద్రపరచుకుంటుంది."
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr "ఇథియోపియన్"
+#~ msgid "Ethiopian"
+#~ msgstr "ఇథియోపియన్"
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr "ఒక స్టాక్ మీద దీర్ఘాక్షరణ తో చేపట్టి ఉంటుంది."
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr "ఒక స్టాక్ మీద దీర్ఘాక్షరణ తో చేపట్టి ఉంటుంది."
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr "పరిపూర్ణ బ్లాక్‌కి ఇన్‌పుట్ 1, 4, 5 లేదా 8 ఉండాలి"
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr "పరిపూర్ణ బ్లాక్‌కి ఇన్‌పుట్ 1, 4, 5 లేదా 8 ఉండాలి"
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr "పటము"
+#~ msgid "table"
+#~ msgstr "పటము"
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ".tb ఆక్సిజన్‌గా భద్రపరచండి"
+#~ msgid "Save as .tb"
+#~ msgstr ".tb ఆక్సిజన్‌గా భద్రపరచండి"
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr "సీపీ"
+#~ msgid "cp"
+#~ msgstr "సీపీ"
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr "<em>On-weak-beat</em> బ్లాక్ మీరు బలహీన (ఆఫ్) బీట్‌లలో చేయబడిన చర్యలను నిర్దిష్టించగలదు."
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr "<em>On-weak-beat</em> బ్లాక్ మీరు బలహీన (ఆఫ్) బీట్‌లలో చేయబడిన చర్యలను నిర్దిష్టించగలదు."
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr "కుడి అనుభూతి"
+#~ msgid "sense right"
+#~ msgstr "కుడి అనుభూతి"
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr "<em>లోడ్ హీప్ ఫ్రం యాప్</em> బ్లాక్ ఒక వెబ్ పేజీని నుండి హీప్‌ను లోడ్ చేసుకుంటుంది."
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr "<em>లోడ్ హీప్ ఫ్రం యాప్</em> బ్లాక్ ఒక వెబ్ పేజీని నుండి హీప్‌ను లోడ్ చేసుకుంటుంది."
 
-#~msgid "vspace"
-#~msgstr "వర్టికల్ అంతరాళం"
+#~ msgid "vspace"
+#~ msgstr "వర్టికల్ అంతరాళం"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr "స్పానిష్ జిప్సీ"
+#~ msgid "spanish-gypsy"
+#~ msgstr "స్పానిష్ జిప్సీ"
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr "<em>రంగు</em> బ్లాక్ ప్రస్తుత పెన్ రంగును తరచుకుంటుంది."
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr "<em>రంగు</em> బ్లాక్ ప్రస్తుత పెన్ రంగును తరచుకుంటుంది."
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr "బిబాప్"
+#~ msgid "Bebop"
+#~ msgstr "బిబాప్"
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr "పేస్ట్ బటన్ హైలైట్ చేయబడుతుంది."
+#~ msgid "The Paste Button will highlight."
+#~ msgstr "పేస్ట్ బటన్ హైలైట్ చేయబడుతుంది."
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr "లోడ్ హీప్ ఫ్రం యాప్ బ్లాక్ వెబ్ పేజీని నుండి హీప్‌ను లోడ్ చేసుకుంటుంది."
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr "లోడ్ హీప్ ఫ్రం యాప్ బ్లాక్ వెబ్ పేజీని నుండి హీప్‌ను లోడ్ చేసుకుంటుంది."
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr "స్టెప్ పిచ్ బ్లాక్ ఒక నోట్ బ్లాక్ని నడిపించాలి."
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr "స్టెప్ పిచ్ బ్లాక్ ఒక నోట్ బ్లాక్ని నడిపించాలి."
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "కాన్వాస్పై ఉన్న అన్ని కంటెంట్ను, బ్లాక్లను అన్ని తొలగించండి."
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "కాన్వాస్పై ఉన్న అన్ని కంటెంట్ను, బ్లాక్లను అన్ని తొలగించండి."
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr "SVG ను భద్రపరచండి."
+#~ msgid "save svg"
+#~ msgstr "SVG ను భద్రపరచండి."
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr "నా పరికరంపై"
+#~ msgid "On my device"
+#~ msgstr "నా పరికరంపై"
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr "<em>నో బ్యాక్‌గ్రౌండ్</em> బ్లాక్ సేవ్ చేయబడిన SVG ఔట్‌పుట్ నుండి బ్యాక్‌గ్రౌండ్‌ను తొలగిస్తుంది."
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr "<em>నో బ్యాక్‌గ్రౌండ్</em> బ్లాక్ సేవ్ చేయబడిన SVG ఔట్‌పుట్ నుండి బ్యాక్‌గ్రౌండ్‌ను తొలగిస్తుంది."
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr "నా సంగీతం బ్లాక్స్ సృష్టి"
+#~ msgid "My Music Blocks Creation"
+#~ msgstr "నా సంగీతం బ్లాక్స్ సృష్టి"
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr "<em>ఓపెన్ పాలెట్</em> బ్లాక్ ఒక పాలెట్‌ను తెరిచేస్తుంది."
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr "<em>ఓపెన్ పాలెట్</em> బ్లాక్ ఒక పాలెట్‌ను తెరిచేస్తుంది."
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr "<em>ఫారెవర్</em> బ్లాక్ ప్రతిసారినా కంటెయిన్ బ్లాక్‌లను పునరావర్తించును. ఈ ఉదాహరణలో, ఒక సాధారణ డ్రం యంత్రం, ఒక కిక్ డ్రమ్ 1/4 నోట్లను ఎప్పటికీ ప్రదర్శిస్తుంది."
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr "<em>ఫారెవర్</em> బ్లాక్ ప్రతిసారినా కంటెయిన్ బ్లాక్‌లను పునరావర్తించును. ఈ ఉదాహరణలో, ఒక సాధారణ డ్రం యంత్రం, ఒక కిక్ డ్రమ్ 1/4 నోట్లను ఎప్పటికీ ప్రదర్శిస్తుంది."
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr "డిమిన్ష్డ్ బ్లాక్‌కి ఇన్‌పుట్ 1, 2, 3, 4, 5, 6, 7, లేదా 8 ఉండాలి"
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr "డిమిన్ష్డ్ బ్లాక్‌కి ఇన్‌పుట్ 1, 2, 3, 4, 5, 6, 7, లేదా 8 ఉండాలి"
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr "సంగీతం నిధానంగా ప్రారంభించండి"
+#~ msgid "Run music slow"
+#~ msgstr "సంగీతం నిధానంగా ప్రారంభించండి"
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr "ఒక స్టాక్‌ను క్లిప్‌బోర్డ్‌కు కాపీ చేయడానికి, స్టాక్ పై దీర్ఘకాల ప్రెస్ చేయండి."
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr "ఒక స్టాక్‌ను క్లిప్‌బోర్డ్‌కు కాపీ చేయడానికి, స్టాక్ పై దీర్ఘకాల ప్రెస్ చేయండి."
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr "ఉదాహరణగా గిటార్, పియానో, వయలిన్, లేదా సెల్లో."
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr "ఉదాహరణగా గిటార్, పియానో, వయలిన్, లేదా సెల్లో."
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr "మైనర్-పెంటాటోనిక్"
+#~ msgid "minor-pentatonic"
+#~ msgstr "మైనర్-పెంటాటోనిక్"
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr "<em>AM సింత్</em> బ్లాక్ ఒక ఆంప్లిట్యూడ్ మాడ్యులేటర్ అనేది, ఒక టింబర్‌ను వ్యాఖ్యానిస్తే ఉపయోగపడేది."
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr "<em>AM సింత్</em> బ్లాక్ ఒక ఆంప్లిట్యూడ్ మాడ్యులేటర్ అనేది, ఒక టింబర్‌ను వ్యాఖ్యానిస్తే ఉపయోగపడేది."
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr "<em>రైట్</em> బ్లాక్ మౌస్‌ను కుడివేస్తుంది."
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr "<em>రైట్</em> బ్లాక్ మౌస్‌ను కుడివేస్తుంది."
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr "<em>హార్మోనిక్</em> బ్లాక్ కంటెయిన్‌డ్ నోట్లకు హార్మోనిక్స్ ను జోడిస్తుంది."
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr "<em>హార్మోనిక్</em> బ్లాక్ కంటెయిన్‌డ్ నోట్లకు హార్మోనిక్స్ ను జోడిస్తుంది."
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr "ఎగుమతి"
+#~ msgid "export"
+#~ msgstr "ఎగుమతి"
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr "<em>పవర్</em> బ్లాక్ ఒక పవర్ ఫంక్షన్‌ను లెక్కిస్తుంది."
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr "<em>పవర్</em> బ్లాక్ ఒక పవర్ ఫంక్షన్‌ను లెక్కిస్తుంది."
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr "<em>సెట్ హెడింగ్</em> బ్లాక్ మౌస్ యొక్క హెడింగ్‌ను సెట్ చేస్తుంది."
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr "<em>సెట్ హెడింగ్</em> బ్లాక్ మౌస్ యొక్క హెడింగ్‌ను సెట్ చేస్తుంది."
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr "<em>నోట్</em> బ్లాక్ ఒక లేదా అధిక <em>పిచ్</em> బ్లాక్‌ల కంటెయినర్. <em>నోట్</em> బ్లాక్ అన్నిటి కంటెంట్ల కొరత (నోట్ విలువ) ని నిర్దిష్టించేది."
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr "<em>నోట్</em> బ్లాక్ ఒక లేదా అధిక <em>పిచ్</em> బ్లాక్‌ల కంటెయినర్. <em>నోట్</em> బ్లాక్ అన్నిటి కంటెంట్ల కొరత (నోట్ విలువ) ని నిర్దిష్టించేది."
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr "<em>లెస్-తన్</em> బ్లాక్ టాప్ నంబర్ క్రింది నంబర్ కంటే తక్కని ఉంటే <em>ట్రు</em> నిర్దిష్టిస్తుంది."
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr "<em>లెస్-తన్</em> బ్లాక్ టాప్ నంబర్ క్రింది నంబర్ కంటే తక్కని ఉంటే <em>ట్రు</em> నిర్దిష్టిస్తుంది."
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr "బీట్ కౌంట్ బ్లాక్ ప్రస్తుత బీట్ యొక్క సంఖ్య, ఉదా, 1, 2, 3, లేదా 4.\n ఈ ఆచరణం వేయబడే కొన్ని ప్రమాణాల మొదల బీట్‌పై వాడబడేది."
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr "బీట్ కౌంట్ బ్లాక్ ప్రస్తుత బీట్ యొక్క సంఖ్య, ఉదా, 1, 2, 3, లేదా 4.\n ఈ ఆచరణం వేయబడే కొన్ని ప్రమాణాల మొదల బీట్‌పై వాడబడేది."
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr "<em>మౌస్ రంగం</em> బ్లాక్ కొంతంగా చేసిన మౌస్ యొక్క పెన్ రంగును తిరిగి వేస్తుంది."
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr "<em>మౌస్ రంగం</em> బ్లాక్ కొంతంగా చేసిన మౌస్ యొక్క పెన్ రంగును తిరిగి వేస్తుంది."
 
 #: js/turtledefs.js:187
 
@@ -12502,13 +12502,13 @@ msgstr "చలింపు"
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr "ABCగా భద్రపరచండి"
+#~ msgid "Save as ABC"
+#~ msgstr "ABCగా భద్రపరచండి"
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr "సింథిసైజర్"
+#~ msgid "synthesizer"
+#~ msgstr "సింథిసైజర్"
 
 #: js/logo.js:630
 
@@ -12516,86 +12516,86 @@ msgstr "చలింపు"
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr "మెజర్"
+#~ msgid "Major"
+#~ msgstr "మెజర్"
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr "సేవ్‌హీప్ బ్లాక్ హీప్‌ను ఒక కడిగా సేవ్ చేస్తుంది."
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr "సేవ్‌హీప్ బ్లాక్ హీప్‌ను ఒక కడిగా సేవ్ చేస్తుంది."
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr "<em>మాస్టర్ వాల్యూమ్ సెట్</em> బ్లాక్ అన్ని సింథిసైజర్లకు వాల్యూమ్ సెట్ చేస్తుంది."
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr "<em>మాస్టర్ వాల్యూమ్ సెట్</em> బ్లాక్ అన్ని సింథిసైజర్లకు వాల్యూమ్ సెట్ చేస్తుంది."
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr "నకలి గానాలు"
+#~ msgid "duplicate notes"
+#~ msgstr "నకలి గానాలు"
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr "సెట్హీప్ ఎంట్రీ బ్లాక్ నిర్దిష్టమైన స్థానంలో హీప్‌లో ఒక విలువ సెట్ చేస్తుంది."
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr "సెట్హీప్ ఎంట్రీ బ్లాక్ నిర్దిష్టమైన స్థానంలో హీప్‌లో ఒక విలువ సెట్ చేస్తుంది."
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr "స్క్రోలింగ్ నిలిపివేయండి."
+#~ msgid "Disable scrolling"
+#~ msgstr "స్క్రోలింగ్ నిలిపివేయండి."
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr "స్కేలర్ ఇంటర్వల్ బ్లాక్ పాటల నడిమీటర్లు లోని రంధ్రాలలో దూరానికి అంతరాన్ని మాపించి ఉంటుంది."
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr "స్కేలర్ ఇంటర్వల్ బ్లాక్ పాటల నడిమీటర్లు లోని రంధ్రాలలో దూరానికి అంతరాన్ని మాపించి ఉంటుంది."
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr "రిధం బ్లాక్: మీరు మ్యాట్రిక్స్ బ్లాక్ ఉపయోగించాలని అనిపించారా?"
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr "రిధం బ్లాక్: మీరు మ్యాట్రిక్స్ బ్లాక్ ఉపయోగించాలని అనిపించారా?"
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr "<em>ప్లే చేసిన గానాల సంఖ్య</em> బ్లాక్ ప్రస్తుతం ప్లే చేసిన గానాల సంఖ్యగా ఉంటుంది. (అప్రమేయంగా, అదనపు నోట్లను మాత్రమే అంగీకరిస్తుంది.)"
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr "<em>ప్లే చేసిన గానాల సంఖ్య</em> బ్లాక్ ప్రస్తుతం ప్లే చేసిన గానాల సంఖ్యగా ఉంటుంది. (అప్రమేయంగా, అదనపు నోట్లను మాత్రమే అంగీకరిస్తుంది.)"
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr "డిఫాల్ట్ వాల్యూమ్ 50; రేంజ్ 0 (నిశ్శబ్దం) నుండి 100 (పూర్తి వాల్యూమ్) వరకు."
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr "డిఫాల్ట్ వాల్యూమ్ 50; రేంజ్ 0 (నిశ్శబ్దం) నుండి 100 (పూర్తి వాల్యూమ్) వరకు."
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr "ప్రతి <em>ప్రారంభం</em> బ్లాక్ ఒక విశిష్ట ధ్వని. <em>ప్రారంభం</em> బ్లాక్లు <em>ప్లే</em> బటన్ నొక్కినప్పుడు అన్ని విశేషాలను రన్ చేయబడతాయి."
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr "ప్రతి <em>ప్రారంభం</em> బ్లాక్ ఒక విశిష్ట ధ్వని. <em>ప్రారంభం</em> బ్లాక్లు <em>ప్లే</em> బటన్ నొక్కినప్పుడు అన్ని విశేషాలను రన్ చేయబడతాయి."
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr "ఉదా. \"దో\" ఎందుకుంటే ఎనిమిది నిష్కలాంతమైనది.\"); మూవబుల్ దో సత్యమయ్యాక, సోల్ఫేజ్ నోట్ పేర్లను స్కేల్ డిగ్రీలకు కేటాయిస్తాయి (\"దో\" ముఖ్య స్కేల్లను ప్రధానముగా అనుకరిస్తాయి)."
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr "ఉదా. \"దో\" ఎందుకుంటే ఎనిమిది నిష్కలాంతమైనది.\"); మూవబుల్ దో సత్యమయ్యాక, సోల్ఫేజ్ నోట్ పేర్లను స్కేల్ డిగ్రీలకు కేటాయిస్తాయి (\"దో\" ముఖ్య స్కేల్లను ప్రధానముగా అనుకరిస్తాయి)."
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr "ప్రస్తుత పిచ్ ఒక్టేవ్"
+#~ msgid "current pitch octave"
+#~ msgstr "ప్రస్తుత పిచ్ ఒక్టేవ్"
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr "<em>రివర్స్ హీప్</em> బ్లాక్ హీప్ యొక్క క్రమాను పలచిస్తుంది."
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr "<em>రివర్స్ హీప్</em> బ్లాక్ హీప్ యొక్క క్రమాను పలచిస్తుంది."
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr "హిరాజోషి"
+#~ msgid "Hirajoshi"
+#~ msgstr "హిరాజోషి"
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr "<em>బ్లాక్ నిర్మాణం</em> బ్లాక్ కొత్త బ్లాక్ రచిస్తుంది."
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr "<em>బ్లాక్ నిర్మాణం</em> బ్లాక్ కొత్త బ్లాక్ రచిస్తుంది."
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr "స్పానిష్"
+#~ msgid "Spanish"
+#~ msgstr "స్పానిష్"
 

--- a/po/th.po
+++ b/po/th.po
@@ -13,10 +13,10 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Pootle 2.0.5\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -102,7 +102,7 @@ msgstr "การกระทำ"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -169,7 +169,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -183,33 +183,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -231,7 +231,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -309,7 +309,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -538,8 +538,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -708,14 +708,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "ค่าของโน้ต"
 
@@ -780,7 +780,7 @@ msgstr "ค่าของโน้ต"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -801,7 +801,7 @@ msgid "silence"
 msgstr "พัก"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -819,8 +819,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "ระดับเสียง"
 
@@ -922,7 +922,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -1056,14 +1056,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr "เริ่มเสียงกลอง"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "จังหวะ"
 
@@ -1174,7 +1174,7 @@ msgstr "ความคล่องตัว"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -1183,7 +1183,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -1674,7 +1674,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -1686,8 +1686,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "เสียงแหลม"
 
@@ -1697,7 +1697,7 @@ msgstr "เสียงแหลม"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -1709,8 +1709,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "ราบ"
 
@@ -1720,15 +1720,15 @@ msgstr "ราบ"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -1737,14 +1737,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -1753,14 +1753,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -1801,7 +1801,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -1810,7 +1810,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -1827,7 +1827,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "อัตราจังหวะ"
 
@@ -1896,8 +1896,8 @@ msgstr "เพิ่มเติม"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -1919,7 +1919,7 @@ msgstr "ตรรกะ"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -2205,7 +2205,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -2536,21 +2536,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -2559,12 +2559,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -2577,62 +2577,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -2645,7 +2645,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -2654,7 +2654,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -2667,7 +2667,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -2676,17 +2676,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -2695,12 +2695,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -2713,7 +2713,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -2722,17 +2722,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -2749,56 +2749,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -2806,7 +2806,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "ซายน์"
 
@@ -2814,7 +2814,7 @@ msgstr "ซายน์"
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "สี่เหลี่ยม"
 
@@ -2823,7 +2823,7 @@ msgstr "สี่เหลี่ยม"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "สามเหลี่ยม"
 
@@ -2831,7 +2831,7 @@ msgstr "สามเหลี่ยม"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "ฟันเลื้อย"
 
@@ -2840,8 +2840,8 @@ msgstr "ฟันเลื้อย"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -2849,7 +2849,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -2863,116 +2863,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -2991,19 +2991,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -3011,61 +3011,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -3075,149 +3075,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -3226,7 +3226,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3305,22 +3305,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -3477,7 +3477,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -3499,7 +3499,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "คีย์"
 
@@ -3510,7 +3510,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -3539,7 +3539,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -3548,7 +3548,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -3581,7 +3581,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "ลบฮีป?"
 
@@ -3591,7 +3591,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "heap ว่าง"
 
@@ -3600,7 +3600,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -3609,7 +3609,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "ดัชนีฮีป"
 
@@ -3632,13 +3632,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "ตั้งค่าฮีป"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "ดัชนี"
 
@@ -3647,7 +3647,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "ป๊อบ"
 
@@ -3656,7 +3656,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "ใส่เข้าไป"
 
@@ -3676,7 +3676,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "เสียงแปดคู่"
 
@@ -3701,7 +3701,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -3715,7 +3715,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -3725,7 +3725,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -3763,7 +3763,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -3772,7 +3772,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -3785,18 +3785,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "ตั้งคีย์"
 
@@ -3917,7 +3917,7 @@ msgstr "ปัจจัยslur"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -3936,7 +3936,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -3945,7 +3945,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -3962,7 +3962,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -3975,7 +3975,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "โหลดฮีป"
 
@@ -4004,7 +4004,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -4027,7 +4027,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -4044,7 +4044,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "บันทึกฮีป"
 
@@ -4053,7 +4053,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -4070,7 +4070,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -4079,7 +4079,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgid "y"
 msgstr "แกน y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -4122,7 +4122,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -4139,7 +4139,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -4154,7 +4154,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "โน้ต"
 
@@ -4188,12 +4188,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "แกว่ง"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -4202,12 +4202,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "ข้านโน้ต"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "หลายจังหวะ"
 
@@ -4216,13 +4216,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "รวม"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "จุด"
 
@@ -4240,7 +4240,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -4272,8 +4272,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr "โน้ตเต็ม"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "ทูเปรท"
 
@@ -4486,12 +4486,12 @@ msgid "duplicate factor"
 msgstr "ปัจจัยคักลอก"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "ปัจจัยให้เกิดจังหวะ"
 
@@ -4501,8 +4501,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -4510,12 +4510,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "บีทต่อนาที"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -4524,7 +4524,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -4541,7 +4541,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -4551,12 +4551,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -4566,7 +4566,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -4575,7 +4575,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -4625,7 +4625,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -4658,7 +4658,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -4667,12 +4667,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "การเปลี่ยนตำแหน่ง"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -4681,7 +4681,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -4690,7 +4690,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -4699,7 +4699,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -4710,8 +4710,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -4721,7 +4721,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -4747,7 +4747,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -4785,12 +4785,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -4802,12 +4802,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "จำนวนจนถึงระดับเสียง"
 
@@ -4816,7 +4816,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "จำนวนจนถึงโน้ตคู่แปด"
 
@@ -4862,22 +4862,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -4886,7 +4886,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -4899,7 +4899,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -4908,47 +4908,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -4961,7 +4961,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -4970,7 +4970,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -4978,7 +4978,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -4992,8 +4992,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -5022,7 +5022,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -5047,14 +5047,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -5064,7 +5064,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -5083,7 +5083,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -5093,7 +5093,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -5110,17 +5110,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -5129,7 +5129,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -5139,7 +5139,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -5149,7 +5149,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -5161,7 +5161,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -5169,7 +5169,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -5179,7 +5179,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -5200,7 +5200,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -5215,7 +5215,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -5225,7 +5225,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -5239,7 +5239,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -5295,7 +5295,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -5473,7 +5473,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -5482,7 +5482,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -5491,7 +5491,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -5500,7 +5500,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -5510,13 +5510,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -5529,7 +5529,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "หนูy"
 
@@ -5538,7 +5538,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "เต่า y"
 
@@ -5547,7 +5547,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "หนูx"
 
@@ -5556,7 +5556,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "เต่า x"
 
@@ -5565,7 +5565,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -5574,7 +5574,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -5583,7 +5583,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -5592,7 +5592,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "จำนวนเต่าระดับเสียง"
 
@@ -5602,17 +5602,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -5621,7 +5621,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -6048,7 +6048,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -6058,7 +6058,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -6102,12 +6102,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "หยุดเล่น"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -6116,7 +6116,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "เล่นย้อนหลัง"
 
@@ -6173,7 +6173,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "โน้ตความถี่"
 
@@ -6191,7 +6191,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "ขนาด"
 
@@ -6204,7 +6204,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -6269,7 +6269,7 @@ msgstr "จบการเทสี"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "พื้นหลัง"
 
@@ -6334,7 +6334,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "เส้นช่องโพรง"
 
@@ -6343,12 +6343,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "เติม"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "ยกปากกาขึ้น"
 
@@ -6357,7 +6357,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "จรดปากกา"
 
@@ -6366,7 +6366,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "ตั้งค่าขนาดปากกา"
 
@@ -6375,7 +6375,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -6400,7 +6400,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "ตั้งเป็นสีเทา"
 
@@ -6535,27 +6535,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -6581,18 +6581,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -6607,7 +6607,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -6628,7 +6628,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -6645,7 +6645,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -6658,7 +6658,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -6668,7 +6668,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -6682,7 +6682,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -6703,7 +6703,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -6717,7 +6717,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -6904,7 +6904,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -6913,7 +6913,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -7035,7 +7035,7 @@ msgid "Undo"
 msgstr "ยกเลิกคำสั่งเก่า"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -7118,7 +7118,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -7168,7 +7168,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -7285,7 +7285,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -7364,48 +7364,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -7838,38 +7838,38 @@ msgstr "ย้าย"
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr "บันทึกไฟล์เป็นไฟล์Lilypond"
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr "บันทึกไฟล์เป็นไฟล์Lilypond"
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr "แสดงข้อความ"
+#~ msgid "Show these messages."
+#~ msgstr "แสดงข้อความ"
 
 #: js/rubrics.js:531
 
@@ -7877,8 +7877,8 @@ msgstr "ย้าย"
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr "เซนเซอร์"
+#~ msgid "sensors"
+#~ msgstr "เซนเซอร์"
 
 #: js/rubrics.js:532
 
@@ -7888,8 +7888,8 @@ msgstr "ย้าย"
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr "สื่อ"
+#~ msgid "media"
+#~ msgstr "สื่อ"
 
 #: js/block-verbose.js:3837
 
@@ -7901,35 +7901,35 @@ msgstr "ย้าย"
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "แสดง"
+#~ msgid "show"
+#~ msgstr "แสดง"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr "กริด"
+#~ msgid "grid"
+#~ msgstr "กริด"
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -7943,69 +7943,69 @@ msgstr "ย้าย"
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "ล้าง"
+#~ msgid "Clean"
+#~ msgstr "ล้าง"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr "วิ่งช้า"
+#~ msgid "Run slow"
+#~ msgstr "วิ่งช้า"
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "ซ่อน blocks"
+#~ msgid "hide blocks"
+#~ msgstr "ซ่อน blocks"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr "คัดลอกโน้ต"
+#~ msgid "duplicate"
+#~ msgstr "คัดลอกโน้ต"
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8025,13 +8025,13 @@ msgstr "ย้าย"
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "หยุด"
+#~ msgid "stop"
+#~ msgstr "หยุด"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr "ระยะเวลาต่อ จุลวินาที"
+#~ msgid "duration (ms)"
+#~ msgstr "ระยะเวลาต่อ จุลวินาที"
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8039,58 +8039,58 @@ msgstr "ย้าย"
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr "ล้าง"
+#~ msgid "clear"
+#~ msgstr "ล้าง"
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr "สับเปลี่ยนที่กัน"
+#~ msgid "invert"
+#~ msgstr "สับเปลี่ยนที่กัน"
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -8106,25 +8106,25 @@ msgstr "ย้าย"
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "ช่วงเวลา"
+#~ msgid "duration"
+#~ msgstr "ช่วงเวลา"
 
 #: js/widgets/temperament.js:454
 
@@ -8134,46 +8134,46 @@ msgstr "ย้าย"
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr "เล่น"
+#~ msgid "play"
+#~ msgstr "เล่น"
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
-#~msgid ""Toggle Fullscreen"
-#~msgstr ""เติมหน้าจอเต็ม"
+#~ msgid "Toggle Fullscreen"
+#~ msgstr "เติมหน้าจอเต็ม"
 
 #: js/toolbar.js:70
 
@@ -8183,190 +8183,190 @@ msgstr "ย้าย"
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -8376,305 +8376,305 @@ msgstr "ย้าย"
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr "วิ่งเร็ว"
+#~ msgid "Run fast"
+#~ msgstr "วิ่งเร็ว"
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr "เพิ่ม/พัง บล๊อกที่สามารถพังได้"
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr "เพิ่ม/พัง บล๊อกที่สามารถพังได้"
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -8684,97 +8684,97 @@ msgstr "ย้าย"
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr "เงินตรา"
+#~ msgid "currency"
+#~ msgstr "เงินตรา"
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr "จาก"
+#~ msgid "from"
+#~ msgstr "จาก"
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr "ราคาหุ้น"
+#~ msgid "stock price"
+#~ msgstr "ราคาหุ้น"
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr "แปล"
+#~ msgid "translate"
+#~ msgstr "แปล"
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "สวัสดี"
+#~ msgid "hello"
+#~ msgstr "สวัสดี"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr "จับภาษา"
+#~ msgid "detect lang"
+#~ msgstr "จับภาษา"
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr "ตั้งค่าภาษา"
+#~ msgid "set lang"
+#~ msgstr "ตั้งค่าภาษา"
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr "เส้นรุ้งของเมือง"
+#~ msgid "city latitude"
+#~ msgstr "เส้นรุ้งของเมือง"
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr "เส้นแวงของเมือง"
+#~ msgid "city longitude"
+#~ msgstr "เส้นแวงของเมือง"
 
 #: plugins/gmap.rtp:71
 
@@ -8784,144 +8784,144 @@ msgstr "ย้าย"
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr "ไม่มีพิกัดข้อมูล"
+#~ msgid "Coordinate data not available."
+#~ msgstr "ไม่มีพิกัดข้อมูล"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr "แผนที่"
+#~ msgid "Google map"
+#~ msgstr "แผนที่"
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr "พิกัด"
+#~ msgid "coordinates"
+#~ msgstr "พิกัด"
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr "ปัจจัยที่น่าสนใจ"
+#~ msgid "zoom factor"
+#~ msgstr "ปัจจัยที่น่าสนใจ"
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr "ขยาย"
+#~ msgid "zoom"
+#~ msgstr "ขยาย"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr "เส้นรุ่ง"
+#~ msgid "latitude"
+#~ msgstr "เส้นรุ่ง"
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr "เส้นแวง"
+#~ msgid "longitude"
+#~ msgstr "เส้นแวง"
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr "ดีกรี"
+#~ msgid "degrees"
+#~ msgstr "ดีกรี"
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr "รัศมีเส้นโค้ง"
+#~ msgid "radians"
+#~ msgstr "รัศมีเส้นโค้ง"
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr "ความหมาย"
+#~ msgid "define"
+#~ msgstr "ความหมาย"
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr "บิตคอย์น"
+#~ msgid "bitcoin"
+#~ msgstr "บิตคอย์น"
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -8931,15 +8931,15 @@ msgstr "ย้าย"
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr "ซ่อน"
+#~ msgid "hide"
+#~ msgstr "ซ่อน"
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -8949,23 +8949,23 @@ msgstr "ย้าย"
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr "หน้าต่างแจ้งเตือน"
+#~ msgid "popout"
+#~ msgstr "หน้าต่างแจ้งเตือน"
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -8975,8 +8975,8 @@ msgstr "ย้าย"
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -8984,224 +8984,224 @@ msgstr "ย้าย"
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr "ประเมิน"
+#~ msgid "eval"
+#~ msgstr "ประเมิน"
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -9217,37 +9217,37 @@ msgstr "ย้าย"
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -9255,28 +9255,28 @@ msgstr "ย้าย"
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -9290,8 +9290,8 @@ msgstr "ย้าย"
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -9301,65 +9301,65 @@ msgstr "ย้าย"
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr "ปัจจัยcrescendo"
+#~ msgid "crescendo factor"
+#~ msgstr "ปัจจัยcrescendo"
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -9367,8 +9367,8 @@ msgstr "ย้าย"
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -9378,127 +9378,127 @@ msgstr "ย้าย"
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr "ปรับเสียง"
+#~ msgid "set volume"
+#~ msgstr "ปรับเสียง"
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr "หนึ่งชั่วโมงที่แล้ว"
+#~ msgid "hours ago"
+#~ msgstr "หนึ่งชั่วโมงที่แล้ว"
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr "กล่องเครื่องมีนี้มีปุ่มพิกัด โน้ต โทนเต่า และอีกมากมาย คลิ๊กเพื่อแสดงแถบสีของบล๊อกและลากบล๊อกจากแถบสีไปยังแสดงแสดงผล"
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr "กล่องเครื่องมีนี้มีปุ่มพิกัด โน้ต โทนเต่า และอีกมากมาย คลิ๊กเพื่อแสดงแถบสีของบล๊อกและลากบล๊อกจากแถบสีไปยังแสดงแสดงผล"
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -9506,603 +9506,603 @@ msgstr "ย้าย"
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr "กินฉัน"
+#~ msgid "eatme"
+#~ msgstr "กินฉัน"
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr "แยกบีท"
+#~ msgid "divide note value"
+#~ msgstr "แยกบีท"
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr "เปิดแผงสำหรับปรับแต่ง Music Blocks"
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr "เปิดแผงสำหรับปรับแต่ง Music Blocks"
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr "จะใช้ปุ่มวางได้ต่อเมื่อ คุณคัดลอกบล๊อกไว้บนคลิปบอร์ด"
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr "จะใช้ปุ่มวางได้ต่อเมื่อ คุณคัดลอกบล๊อกไว้บนคลิปบอร์ด"
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr "ส่วน"
+#~ msgid "denominator"
+#~ msgstr "ส่วน"
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr "คุณสามารถโหลดบล๊อกใหม่จากไฟล์ในเครือข่าย"
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr "คุณสามารถโหลดบล๊อกใหม่จากไฟล์ในเครือข่าย"
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr "ตั้งค่า"
+#~ msgid "Settings"
+#~ msgstr "ตั้งค่า"
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr "เสียงของโน๊ต"
+#~ msgid "note volume"
+#~ msgstr "เสียงของโน๊ต"
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr "ตั้งจังหวะต่อนาที"
+#~ msgid "set beats per minute"
+#~ msgstr "ตั้งจังหวะต่อนาที"
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr "ลบทั้งหมด"
+#~ msgid "Delete all"
+#~ msgstr "ลบทั้งหมด"
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr "เศษ"
+#~ msgid "numerator"
+#~ msgstr "เศษ"
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -10112,160 +10112,160 @@ msgstr "ย้าย"
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr "หยุดเพลง (และเต่า)"
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr "หยุดเพลง (และเต่า)"
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr "เต่าโน๊ต"
+#~ msgid "turtle note"
+#~ msgstr "เต่าโน๊ต"
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -10279,28 +10279,28 @@ msgstr "ย้าย"
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10308,128 +10308,128 @@ msgstr "ย้าย"
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr "บึนทึกงานของคุณที่เซอเวอร์"
+#~ msgid "Save your project to a server."
+#~ msgstr "บึนทึกงานของคุณที่เซอเวอร์"
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr "คลิ๊กเพื่อเล่นดนตรีในโหมดช้า"
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr "คลิ๊กเพื่อเล่นดนตรีในโหมดช้า"
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr "จัดเก็บเป็น lilypond"
+#~ msgid "save as lilypond"
+#~ msgstr "จัดเก็บเป็น lilypond"
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr "เพิ่ม/พัง กล่องเครื่องมือ"
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr "เพิ่ม/พัง กล่องเครื่องมือ"
 
 #: js/turtledefs.js:187
 
@@ -10437,136 +10437,136 @@ msgstr "ย้าย"
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "เต่า"
+#~ msgid "turtle"
+#~ msgstr "เต่า"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -10576,127 +10576,127 @@ msgstr "ย้าย"
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr "โพสสู่สาธารณะ"
+#~ msgid "Publish"
+#~ msgstr "โพสสู่สาธารณะ"
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -10704,402 +10704,402 @@ msgstr "ย้าย"
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr "ทั่วโลก"
+#~ msgid "Worldwide"
+#~ msgstr "ทั่วโลก"
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr "จบเส้นช่องโพรง"
+#~ msgid "end hollow line"
+#~ msgstr "จบเส้นช่องโพรง"
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr "ปัจจัยข้าม"
+#~ msgid "skip factor"
+#~ msgstr "ปัจจัยข้าม"
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "เปิด"
+#~ msgid "Open"
+#~ msgstr "เปิด"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr "คลิ๊กที่นี่เพื่อเล่นดนตรีโน้ตต่อโน้ต"
+#~ msgid "Click to run the music note by note."
+#~ msgstr "คลิ๊กที่นี่เพื่อเล่นดนตรีโน้ตต่อโน้ต"
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr "ยืนยัน"
+#~ msgid "confirm"
+#~ msgstr "ยืนยัน"
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr "เขตข้อมูล"
+#~ msgid "field"
+#~ msgstr "เขตข้อมูล"
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "r. Mouse encourages you to explore Music Blocks"
-#~msgstr "คุณหนูสนับสนุนให้คุณลองสำรวจ Music Block"
+#~ msgid "r. Mouse encourages you to explore Music Blocks"
+#~ msgstr "คุณหนูสนับสนุนให้คุณลองสำรวจ Music Block"
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -11111,191 +11111,191 @@ msgstr "ย้าย"
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr "ซ้อนหรือแสดงบล๊อก"
+#~ msgid "Hide or show the block palettes."
+#~ msgstr "ซ้อนหรือแสดงบล๊อก"
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr "อาหาร"
+#~ msgid "food"
+#~ msgstr "อาหาร"
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr "เวลาจากเครื่องกำเนิดสัญญาณ"
+#~ msgid "osctime"
+#~ msgstr "เวลาจากเครื่องกำเนิดสัญญาณ"
 
 #: js/turtledefs.js:187
 
@@ -11303,145 +11303,145 @@ msgstr "ย้าย"
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr "คณิตศาสตร์"
+#~ msgid "maths"
+#~ msgstr "คณิตศาสตร์"
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr "กล่องเครื่องมีนี้มีปุ่มพิกัด โน้ต โทนเต่า และอีกมากมาย"
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr "กล่องเครื่องมีนี้มีปุ่มพิกัด โน้ต โทนเต่า และอีกมากมาย"
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr "ช่องว่างแนวนอน"
+#~ msgid "hspace"
+#~ msgstr "ช่องว่างแนวนอน"
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11449,249 +11449,249 @@ msgstr "ย้าย"
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr "ค่าโน้ตต้องมากกว่า0"
+#~ msgid "Note value must be greater than 0"
+#~ msgstr "ค่าโน้ตต้องมากกว่า0"
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr "คำอธิบายเมตริกซ์ภาพ"
+#~ msgid "pitch-time matrix"
+#~ msgstr "คำอธิบายเมตริกซ์ภาพ"
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr "แสดง หรือซ่อนกราฟ พิกัดเชิงขั้ว"
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr "แสดง หรือซ่อนกราฟ พิกัดเชิงขั้ว"
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr "ลบจอทั้งหมด และให้เต่าไปอยู่ที่จุดตั้งต้น"
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr "ลบจอทั้งหมด และให้เต่าไปอยู่ที่จุดตั้งต้น"
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr "เริ่มเส้นช่องโพรง"
+#~ msgid "begin hollow line"
+#~ msgstr "เริ่มเส้นช่องโพรง"
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr "เล่นย้อนหลัง"
+#~ msgid "play backward"
+#~ msgstr "เล่นย้อนหลัง"
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -11705,228 +11705,228 @@ msgstr "ย้าย"
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr "ขั้ว"
+#~ msgid "Polar"
+#~ msgstr "ขั้ว"
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr "ชื่อระดับเสียงปัจจุบัน"
+#~ msgid "current pitch name"
+#~ msgstr "ชื่อระดับเสียงปัจจุบัน"
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr "แสดงหรือซ้อนกราฟพิกัดคาร์ทีเซียน"
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr "แสดงหรือซ้อนกราฟพิกัดคาร์ทีเซียน"
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr "โหลดปลั๊กอินจากไฟล์"
+#~ msgid "Load plugin from file"
+#~ msgstr "โหลดปลั๊กอินจากไฟล์"
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor."
-#~msgstr "คุณหนูคือวาทยากรของพวกเรา"
+#~ msgid "Mr. Mouse is our Music Blocks conductor."
+#~ msgstr "คุณหนูคือวาทยากรของพวกเรา"
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr "ร้อง"
+#~ msgid "sing"
+#~ msgstr "ร้อง"
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -11936,144 +11936,144 @@ msgstr "ย้าย"
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr "ดาวน์โหลด"
+#~ msgid "Download"
+#~ msgstr "ดาวน์โหลด"
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr "เครา"
+#~ msgid "cloud"
+#~ msgstr "เครา"
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr "แสดง/ซ่อนเมนูสี"
+#~ msgid "Show/hide palettes"
+#~ msgstr "แสดง/ซ่อนเมนูสี"
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr "จับ"
+#~ msgid "fetch"
+#~ msgstr "จับ"
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr "บล๊อก"
+#~ msgid "blocks"
+#~ msgstr "บล๊อก"
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -12081,57 +12081,57 @@ msgstr "ย้าย"
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -12141,30 +12141,30 @@ msgstr "ย้าย"
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12172,112 +12172,112 @@ msgstr "ย้าย"
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr "บันทึกโน้ตเพลง"
+#~ msgid "Save sheet music"
+#~ msgstr "บันทึกโน้ตเพลง"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr "ปรับการคมนาคม"
+#~ msgid "adjust transposition"
+#~ msgstr "ปรับการคมนาคม"
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr "คลิ๊กเพื่อเล่นโปรเจคในโหมดเร็ว"
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr "คลิ๊กเพื่อเล่นโปรเจคในโหมดเร็ว"
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr "เล่นโน้ตต่อโน้ต"
+#~ msgid "Run note by note"
+#~ msgstr "เล่นโน้ตต่อโน้ต"
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr "กระดอง"
+#~ msgid "shell"
+#~ msgstr "กระดอง"
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr "กรุณาปิดเมทริกซ์ปัจจุบันก่อนที่จะเปิดอันใหม่"
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr "กรุณาปิดเมทริกซ์ปัจจุบันก่อนที่จะเปิดอันใหม่"
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -12285,287 +12285,287 @@ msgstr "ย้าย"
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr "ปุ่มนี้เปิดและปิดแถบเครื่องมือหลัก"
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr "ปุ่มนี้เปิดและปิดแถบเครื่องมือหลัก"
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr "พื้นที่แนวตั้ง"
+#~ msgid "vspace"
+#~ msgstr "พื้นที่แนวตั้ง"
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr "ลบทุกอย่าง รวมทั้งบล๊อก"
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr "ลบทุกอย่าง รวมทั้งบล๊อก"
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr "บันทึกโปรเจคเป็นSVG"
+#~ msgid "save svg"
+#~ msgstr "บันทึกโปรเจคเป็นSVG"
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr "บนเครื่องของฉัน"
+#~ msgid "On my device"
+#~ msgstr "บนเครื่องของฉัน"
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr "เล่นเสียงดนตรี (ช้า)"
+#~ msgid "Run music slow"
+#~ msgstr "เล่นเสียงดนตรี (ช้า)"
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12573,13 +12573,13 @@ msgstr "ย้าย"
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -12587,81 +12587,81 @@ msgstr "ย้าย"
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr "เสียงโน้ตคู่แปด"
+#~ msgid "current pitch octave"
+#~ msgstr "เสียงโน้ตคู่แปด"
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,9 +1,5 @@
 msgid ""
 msgstr ""
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-01-07 00:30-0500\n"
@@ -2220,7 +2216,7 @@ msgstr "eylem"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr "ördek"
 
@@ -2287,7 +2283,7 @@ msgstr "Gizle"
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "benim projem"
 
@@ -2301,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr "Kaydınız devam ediyor"
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "dosya adı"
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "proje başlığı"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "proje yazarı"
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "midi çıkışını dahil et?"
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "gitar tablature çıktısını dahil et?"
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "lilypond olarak kaydet"
 
@@ -2349,7 +2345,7 @@ msgstr "lilypond olarak kaydet"
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "bay fare"
 
@@ -2427,7 +2423,7 @@ msgstr "kartezyen göster"
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr "ölçek derecesi"
 
@@ -2656,8 +2652,8 @@ msgstr "blok yardımını kaydet"
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "ti la sol fa mi re do"
 
@@ -2816,7 +2812,7 @@ msgstr "cetvel"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "tını"
 
@@ -2826,14 +2822,14 @@ msgstr "merdiven"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "tempo"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "mod"
 
@@ -2864,7 +2860,7 @@ msgstr "davul"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "ritim yapıcı"
 
@@ -2889,7 +2885,7 @@ msgstr "ritim yapıcı"
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "nota değeri"
 
@@ -2898,7 +2894,7 @@ msgstr "nota değeri"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "skaler aralık"
 
@@ -2919,7 +2915,7 @@ msgid "silence"
 msgstr "sessizlik"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "aşağı"
 
@@ -2937,8 +2933,8 @@ msgstr "yukarı"
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "perde"
 
@@ -3040,7 +3036,7 @@ msgstr "tenor"
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "bas"
 
@@ -3174,14 +3170,14 @@ msgstr "seçili bir blok yok"
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "avatar"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "örnek"
 
@@ -3256,7 +3252,7 @@ msgstr "başlangıç tamburu"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "ritim"
 
@@ -3292,7 +3288,7 @@ msgstr "akış"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr "Sensörler"
 
@@ -3301,7 +3297,7 @@ msgstr "Sensörler"
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr "Medya"
 
@@ -3792,7 +3788,7 @@ msgstr "oynatma hazır"
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "çift keskin"
 
@@ -3804,8 +3800,8 @@ msgstr "çift keskin"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "diyez"
 
@@ -3815,7 +3811,7 @@ msgstr "diyez"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "doğal"
 
@@ -3827,8 +3823,8 @@ msgstr "doğal"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "bemol"
 
@@ -3838,15 +3834,15 @@ msgstr "bemol"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "çİFT DAİRE"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr "unison"
 
@@ -3855,14 +3851,14 @@ msgstr "unison"
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "majör"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr "iyonyen"
 
@@ -3871,14 +3867,14 @@ msgstr "iyonyen"
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "minör"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr "aeolian"
 
@@ -3919,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr "satış konuşması önizlemeniz için anahtar seçtiniz"
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3928,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr "synth akor çalamaz"
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr "kılavuz url"
 
@@ -3945,7 +3941,7 @@ msgstr "arama"
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "ölçü"
 
@@ -4014,8 +4010,8 @@ msgstr "ekstralar"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "program"
 
@@ -4037,7 +4033,7 @@ msgstr "mantık"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr "Müzik"
 
@@ -4323,7 +4319,7 @@ msgstr "müzik kadrolarını açmak/kapatmak"
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr "Temizle"
 
@@ -4654,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr "eksiltilmiş yedili"
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "1 2 3 4 5 6 7 8 9 10 11 12"
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "augmented"
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "eksiltilmiş"
 
@@ -4677,12 +4673,12 @@ msgstr "eksiltilmiş"
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "mükemmel"
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "kromatik"
 
@@ -4695,62 +4691,62 @@ msgid "spanish"
 msgstr "ispanyolca"
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr "oktatonik"
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "armonik majör"
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "doğal minör"
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "armonik minör"
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "melodik minör"
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr "dorian"
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr "phrygian"
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr "lydian"
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "mixolydian"
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr "locrian"
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "caz yan dalı"
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr "bebop"
 
@@ -4763,7 +4759,7 @@ msgid "byzantine"
 msgstr "byzantine"
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "esrarengiz"
 
@@ -4772,7 +4768,7 @@ msgid "ethiopian"
 msgstr "etiyopyalı"
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "geez"
 
@@ -4785,7 +4781,7 @@ msgid "hungarian"
 msgstr "hungarian"
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "romanyali küçük"
 
@@ -4794,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr "ispanyol çingene"
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "makam"
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "minör blues"
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr "büyük blues"
 
@@ -4813,12 +4809,12 @@ msgid "whole tone"
 msgstr "tüm ton"
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "minör pentatonik"
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "majör pentatonik"
 
@@ -4831,7 +4827,7 @@ msgid "egyptian"
 msgstr "Mısır"
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "hirajoshi"
 
@@ -4840,17 +4836,17 @@ msgid "Japan"
 msgstr "Japonya"
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "in"
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "minyo"
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "fibonacci"
 
@@ -4867,56 +4863,56 @@ msgstr "fibonacci"
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr "özel"
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr "highpass"
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr "lowpass"
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr "bandpass"
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr "highshelf"
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr "lowshelf"
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr "çentik"
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr "allpass"
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr "zirve"
 
@@ -4924,7 +4920,7 @@ msgstr "zirve"
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "sinüs"
 
@@ -4932,7 +4928,7 @@ msgstr "sinüs"
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "kare"
 
@@ -4941,7 +4937,7 @@ msgstr "kare"
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "üçgen"
 
@@ -4949,7 +4945,7 @@ msgstr "üçgen"
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "testere dişi"
 
@@ -4958,8 +4954,8 @@ msgstr "testere dişi"
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr "çift"
 
@@ -4967,7 +4963,7 @@ msgstr "çift"
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr "tek"
 
@@ -4981,116 +4977,116 @@ msgstr "skaler"
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr "piyano"
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr "keman"
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr "viyola"
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "ksilofon"
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "vibrafon"
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr "viyolonsel"
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr "kontrbas"
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr "gitar"
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr "sitar"
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr "akustik gitar"
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr "flüt"
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr "klarnet"
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr "saksafon"
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr "tuba"
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr "trompet"
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr "obua"
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr "trombon"
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr "elektronik synth"
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "basit 1"
 
@@ -5109,19 +5105,19 @@ msgstr "basit 4"
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr "beyaz gürültü"
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "kahverengi gürültü"
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "pembe gürültü"
 
@@ -5129,61 +5125,61 @@ msgstr "pembe gürültü"
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr "trampet"
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr "tekme davulu"
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr "tom tom"
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr "zemin tom"
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr "bas davul"
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "fincan tamburu"
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr "darbuka davulu"
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr "merhaba şapka"
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr "çana binmek"
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr "inek çanı"
 
@@ -5193,149 +5189,149 @@ msgstr "japon davulu"
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr "japon çanı"
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr "üçgen çan"
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr "parmak zilleri"
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "çan"
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr "gong"
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr "clang"
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr "çarpma"
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr "şişe"
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr "alkış"
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr "tokat"
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr "sıçrama"
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr "baloncuklar"
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr "yağmur damlası"
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr "kedi"
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr "kriket"
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr "köpek"
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr "banjo"
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr "koto"
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr "santur"
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr "elektro gitar"
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr "fagot"
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr "celeste"
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr "eşit"
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "Pisagorcu"
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr "sadece tonlama"
 
@@ -5344,7 +5340,7 @@ msgstr "sadece tonlama"
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr "Meantone"
 
@@ -5423,22 +5419,22 @@ msgid "previous"
 msgstr "önceki"
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5595,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "değer al"
 
@@ -5617,7 +5613,7 @@ msgstr "key2"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "anahtar"
 
@@ -5628,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr "değer ayarla"
 
@@ -5657,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr "bir perdenin her örneğini bir davul sesiyle değiştirin"
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "perdeyi davula eşle"
 
@@ -5666,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "yukarıdaki örnekte"
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "set davulu"
 
@@ -5699,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "yığın boş?"
 
@@ -5709,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "boş yığın"
 
@@ -5718,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr "ters yığın"
 
@@ -5727,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "dizin yığını"
 
@@ -5750,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "yığın ayarla"
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "dizin"
 
@@ -5765,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr "pop bloğu yığının en üstündeki değeri kaldırır"
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "pop"
 
@@ -5774,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr "push bloğu yığının en üstüne bir değer ekler"
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "itmek"
 
@@ -5794,7 +5790,7 @@ msgstr "mizaç ayarlamak"
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "oktav"
 
@@ -5819,7 +5815,7 @@ msgid "current interval"
 msgstr "geçerli aralık"
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5833,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr "skaler aralık bloğu"
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr "skaler aralık ölçüsü"
 
@@ -5843,7 +5839,7 @@ msgstr "Şekilde"
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5881,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr "yı sol"
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr "modu tanımla"
 
@@ -5890,7 +5886,7 @@ msgid "movable Do"
 msgstr "hareketli do"
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "mod uzunluğu"
 
@@ -5903,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr "çoğu batı gamının 7 notası vardır"
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "geçerli mod"
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr "geçerli anahtar"
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "anahtar ayarla"
 
@@ -6035,7 +6031,7 @@ msgstr "slur faktörü"
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr "komşu"
 
@@ -6054,7 +6050,7 @@ msgstr "slur"
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "staccato"
 
@@ -6063,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr "uygulamadan yığın yükle"
 
@@ -6080,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr "yığını uygulamaya kaydet"
 
@@ -6093,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "yığın yükle"
 
@@ -6122,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "sözlük yükle"
 
@@ -6145,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr "sözlük ayarla"
 
@@ -6162,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "yığını kaydet"
 
@@ -6171,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr "sözlüğü kaydet"
 
@@ -6188,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr "delete block bloğu bir bloğu kaldırır"
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr "bloğu sil"
 
@@ -6197,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr "move block bloğu bir bloğu hareket ettirir"
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr "bloğu taşı"
 
@@ -6231,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr "blok çalıştır"
 
@@ -6240,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr "rıhtım bloğu blok bağlantıları iki blok"
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr "blokları bağla"
 
@@ -6257,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr "make block bloğu yeni bir blok oluşturur"
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr "blok yapmak"
 
@@ -6272,7 +6268,7 @@ msgstr "blok yapmak"
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "nota"
 
@@ -6306,12 +6302,12 @@ msgstr "nota değeri 0'dan büyük olmalıdır"
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "swing"
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "salınım değeri"
 
@@ -6320,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr "notları atla bloğu notların atlanmasına neden olur"
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "notları atla"
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "nota değerini çarp"
 
@@ -6334,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr "bağ bloğu nota çiftleri üzerinde çalışarak onları tek bir notada birleştirir"
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "bağ"
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "nokta"
 
@@ -6358,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr "i (1/4 + 1/8) kadar çalacaktır. (Bağlam: örneğin noktalı bir dörtlük nota bir vuruşun 3/8"
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr "nota değeri tamburu"
 
@@ -6390,8 +6386,8 @@ msgstr "oktav alanı"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "ritim1"
 
@@ -6447,7 +6443,7 @@ msgstr "bütün nota"
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr "tuplet"
 
@@ -6604,12 +6600,12 @@ msgid "duplicate factor"
 msgstr "yinelenen faktör"
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr "akım ölçer"
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "beat faktörü"
 
@@ -6619,8 +6615,8 @@ msgstr "the beats per minute bloğu geçerli dakika başına atım sayısını d
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "dakika başına atım2"
 
@@ -6628,12 +6624,12 @@ msgstr "dakika başına atım2"
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "dakika başına vuruş"
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr "hesaplama sayısı"
 
@@ -6642,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr "hesaplama sayımı bloğu geçerli hesaplamayı döndürür"
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr "vuruş sayısı"
 
@@ -6659,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr "örn"
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr "nota değerlerini topla"
 
@@ -6669,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr "nota sayacı bloğu"
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr "not sayacı"
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr "çalınan tüm notalar"
 
@@ -6684,7 +6680,7 @@ msgstr "the whole notes played bloğu çalınan tam notaların toplam sayısın�
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr "çalınan notalar"
 
@@ -6693,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr "saat yok bloğu notaları ana saatten ayırır"
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "saat yok"
 
@@ -6743,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr "dakika başına ana vuruş"
 
@@ -6776,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr "dakika başına vuruş bloğu dakika başına 1/4 nota sayısını belirler"
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr "pickup"
 
@@ -6785,12 +6781,12 @@ msgid "number of beats"
 msgstr "atım sayısı"
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "transpozisyon"
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr "skaler aşağı adım"
 
@@ -6799,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr "skaler adım yukarı"
 
@@ -6808,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr "perde değişikliği"
 
@@ -6817,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr "perde bloğundaki değişim"
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr "perdede skaler değişim"
 
@@ -6828,8 +6824,8 @@ msgstr "perdede skaler değişim"
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr "perde numarası"
 
@@ -6839,7 +6835,7 @@ msgstr "perde numarası bloğu o anda çalınmakta olan notanın perdesinin değ
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr "hertz cinsinden adım"
 
@@ -6865,7 +6861,7 @@ msgid "alphabet"
 msgstr "alfabe"
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr "harf sınıfı"
 
@@ -6903,12 +6899,12 @@ msgstr "renk için perde"
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr "MIDI"
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr "perde numarası ofsetini ayarla"
 
@@ -6920,12 +6916,12 @@ msgstr "set pitch number offset bloğu"
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "name2"
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "atış için numara"
 
@@ -6934,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr "number to pitch bloğu bir perde numarasını bir pich ismine dönüştürecektir"
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "sayıdan oktava"
 
@@ -6980,22 +6976,22 @@ msgstr "invert bloğu"
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr "Ters Çevirme"
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "invert (odd) (Bağlam"
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "invert (çift) (Bağlam"
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr "register"
 
@@ -7004,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr "ını (oktav) değiştirmek için kolay bir yol sağlar. (Bağlam: register bloğu, kendisini takip eden notaların register"
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr "50 sent"
 
@@ -7017,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr "yukarıda gösterilen örnekte sol"
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7026,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr "transpose by ratio bloğu nota bloklarının içinde bulunan perdeleri bir oran kadar yukarı (veya aşağı) kaydıracaktır (Bağlam"
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr "orana göre transpoze"
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr "altıncı sırada"
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr "üçte bir aşağı"
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr "yedinci"
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr "altıncı"
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr "beşinci"
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr "dördüncü"
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr "üçüncü"
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr "ikinci"
 
@@ -7079,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr "yukarıda gösterilen örnekte"
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr "skaler transpoze"
 
@@ -7088,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr "aksak blok diyez ve bemolleri oluşturmak için kullanılır"
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr "kazara geçersiz kılma"
 
@@ -7096,7 +7092,7 @@ msgstr "kazara geçersiz kılma"
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr "hertz"
 
@@ -7110,8 +7106,8 @@ msgstr "perde numarası bloğu"
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr "n'inci modal perde"
 
@@ -7140,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr "Skala derecesi 1"
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr "skaler adım"
 
@@ -7165,14 +7161,14 @@ msgstr "Osilatör"
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr "tip"
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr "partialler"
 
@@ -7182,7 +7178,7 @@ msgstr "birden fazla osilatör bloğu ekliyorsunuz"
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr "duo synth"
 
@@ -7201,7 +7197,7 @@ msgstr "vibrato yoğunluğu"
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr "am synth"
 
@@ -7211,7 +7207,7 @@ msgstr "am synth bloğu"
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr "fm synth"
 
@@ -7228,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr "kısmi blok"
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr "kısmi ağırlık 0 ile 1 arasında olmalıdır"
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr "ağırlıklı kısmi türevler"
 
@@ -7247,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr "harmonik blok içerdiği notalara harmonikler ekleyecektir"
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr "armonik"
 
@@ -7257,7 +7253,7 @@ msgstr "distorsiyon bloğu perdeye distorsiyon ekler"
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr "distorsiyon"
 
@@ -7267,7 +7263,7 @@ msgstr "tremolo bloğu bir dalgalanma efekti ekler"
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr "tremolo"
 
@@ -7279,7 +7275,7 @@ msgstr "tremolo"
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr "hız"
 
@@ -7287,7 +7283,7 @@ msgstr "hız"
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr "derinlik"
 
@@ -7297,7 +7293,7 @@ msgstr "fazer bloğu süpürme sesi ekler"
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr "fazer"
 
@@ -7318,7 +7314,7 @@ msgstr "koro bloğu bir koro efekti ekler"
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr "koro"
 
@@ -7333,7 +7329,7 @@ msgstr "vibrato bloğu perdede hızlı ve hafif bir değişim sağlar"
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr "vibrato"
 
@@ -7343,7 +7339,7 @@ msgid "intensity"
 msgstr "yoğunluk"
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr "synth ayarla"
 
@@ -7357,7 +7353,7 @@ msgstr "varsayılan enstrümanı ayarla"
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr "enstrümanı ayarla"
 
@@ -7413,7 +7409,7 @@ msgstr "hesaplamak"
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr "do bloğu bir eylem başlatmak için kullanılır"
 
@@ -7591,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr "başlangıç bloğunu bulamıyor"
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "fare rengi"
 
@@ -7600,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr "fare rengi bloğu belirtilen farenin kalem rengini döndürür"
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "kaplumbağa rengi"
 
@@ -7609,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr "the turtle color bloğu belirtilen kaplumbağanın kalem rengini döndürür"
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "fare başlığı"
 
@@ -7618,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr "fare başlığı bloğu belirtilen farenin başlığını döndürür"
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "kaplumbağa yönü"
 
@@ -7628,13 +7624,13 @@ msgstr "the turtle heading bloğu belirtilen kaplumbağanın başlığını dön
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr "fareyi ayarla"
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr "kaplumbağa ayarla"
 
@@ -7647,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr "set turtle bloğu"
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "fare y"
 
@@ -7656,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr "y fare bloğu belirtilen farenin y konumunu döndürür"
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "kaplumbağa y"
 
@@ -7665,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr "the y turtle bloğu belirtilen kaplumbağanın y konumunu döndürür"
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "fare x"
 
@@ -7674,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr "x fare bloğu belirtilen farenin x konumunu döndürür"
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "kaplumbağa x"
 
@@ -7683,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr "the x turtle bloğu belirtilen kaplumbağanın x konumunu döndürür"
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "fare notaları çalındı"
 
@@ -7692,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr "mouse elapse notes bloğu belirtilen fare tarafından çalınan notaların sayısını döndürür"
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "kaplumbağa notaları çalındı"
 
@@ -7701,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr "turtle elapse notes bloğu belirtilen kaplumbağa tarafından çalınan nota sayısını döndürür"
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "fare adım numarası"
 
@@ -7710,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr "fare perdesi bloğu"
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "kaplumbağa adım numarası"
 
@@ -7720,17 +7716,17 @@ msgstr "the turtle pitch bloğu belirtilen kaplumbağa tarafından çalınmakta 
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr "fare nota değeri"
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "kaplumbağa nota değeri"
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "fare senkronizasyonu"
 
@@ -7739,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "fare senkronizasyon bloğu fareler arasındaki vuruş sayısını hizalar"
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "kaplumbağa senkronizasyonu"
 
@@ -8166,7 +8162,7 @@ msgid "wrap"
 msgstr "sarma"
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr "sağ (ekran) (Bağlam"
 
@@ -8176,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr "the right bloğu tuvalin sağının konumunu döndürür"
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "sol (ekran) (Bağlam"
 
@@ -8220,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr "height bloğu tuvalin yüksekliğini döndürür"
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "oyunu durdur"
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr "medyayı sil"
 
@@ -8234,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr "medya silme bloğu metin ve görüntüleri siler"
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "geri oynat"
 
@@ -8291,7 +8287,7 @@ msgid "duration (MS)"
 msgstr "duration (ms) (Bağlam"
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "frekansa not"
 
@@ -8309,7 +8305,7 @@ msgstr "avatar bloğu kaplumbağanın görünümünü değiştirmek için kullan
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "boyut"
 
@@ -8322,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr "show bloğu tuval üzerinde metin veya resim görüntülemek için kullanılır"
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "show1"
 
@@ -8387,7 +8383,7 @@ msgstr "son dolgu"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "arka plan"
 
@@ -8452,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr "içi boş çizgi bloğu ortası boş bir çizgi oluşturur"
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "içi boş çizgi"
 
@@ -8461,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr "dolgu bloğu bir şekli bir renkle doldurur"
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "doldur"
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "kalem yukarı"
 
@@ -8475,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "kalem aşağı"
 
@@ -8484,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "kalem boyutunu ayarla"
 
@@ -8493,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "yarı saydamlığı ayarla"
 
@@ -8518,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "griyi ayarla"
 
@@ -8653,27 +8649,27 @@ msgstr "klavye bloğu bilgisayar klavye girdisini döndürür"
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr "Zarf"
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "atak"
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "çürüme"
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "sustain"
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "release"
 
@@ -8699,18 +8695,18 @@ msgstr "birden fazla zarf bloğu ekliyorsunuz"
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr "Filtre"
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr "rollloff"
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8725,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr "bir örnek yükleyin ve perde merkezini ayarlayın"
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "örnekleyici"
 
@@ -8746,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr "özel mod bloğu"
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "özel mod"
 
@@ -8763,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr "pitch drum matrisi"
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8776,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr "pitch slider aracı"
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "perde kaydırıcı"
 
@@ -8786,7 +8782,7 @@ msgstr "kromatik klavye"
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr "müzik klavyesi"
 
@@ -8800,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr "perde merdiveni aracı"
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "zift merdiveni"
 
@@ -8821,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr "phrase maker bloğu müzik cümleleri oluşturmak için bir araç açar"
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "ifade oluşturucu"
 
@@ -8835,7 +8831,7 @@ msgstr "durum bloğu"
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr "ai müzik"
 
@@ -9022,7 +9018,7 @@ msgstr "vibrato oranı 0'dan büyük olmalıdır"
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr "derinlik aralık dışında"
 
@@ -9031,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr "bozulma 0 ila 100 arasında olmalıdır"
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr "kısmi 0'dan büyük veya eşit olmalıdır"
 
@@ -9153,7 +9149,7 @@ msgid "Undo"
 msgstr "Geri Al"
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr "modun notalarını seçmek için daireye tıklayın"
 
@@ -9236,7 +9232,7 @@ msgid "Save drum machine"
 msgstr "davul makinesini kaydet"
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr "bir ritme dokunun"
 
@@ -9286,7 +9282,7 @@ msgid "Playback"
 msgstr "Playback"
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr "referans tonu"
 
@@ -9403,7 +9399,7 @@ msgstr "Synthesizer"
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr "Efektler"
 
@@ -9482,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9956,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9995,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10006,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10019,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10061,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10143,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10157,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10224,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10252,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10298,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10491,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr "chord"
+#~ msgid "chord1"
+#~ msgstr "chord"
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10799,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10899,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11046,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr "show"
+#~ msgid "show2"
+#~ msgstr "show"
 
 #: js/palette.js:1222
 
@@ -11064,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr "my blocks"
+#~ msgid "myblocks"
+#~ msgstr "my blocks"
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11090,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11099,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11332,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11370,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr "right"
+#~ msgid "right2"
+#~ msgstr "right"
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr "left"
+#~ msgid "left2"
+#~ msgstr "left"
 
 #: js/pitchtimematrix.js:323
 
@@ -11405,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11416,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11482,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11493,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11621,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12232,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12404,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12433,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12567,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12706,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12834,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13236,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13433,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr "This toolbar contains the palette buttons, Matrix, Notes, Tone, Turtle, and more."
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr "This toolbar contains the palette buttons, Matrix, Notes, Tone, Turtle, and more."
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13589,252 +13585,252 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13848,223 +13844,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14074,144 +14070,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14219,57 +14215,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14279,30 +14275,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14310,112 +14306,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14423,287 +14419,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14711,13 +14707,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14725,86 +14721,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/tvl.po
+++ b/po/tvl.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/tzo.po
+++ b/po/tzo.po
@@ -2215,7 +2215,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2296,33 +2296,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2422,7 +2422,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2651,8 +2651,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2821,14 +2821,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2859,7 +2859,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2884,7 +2884,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2893,7 +2893,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2914,7 +2914,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2932,8 +2932,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3035,7 +3035,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3169,14 +3169,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3251,7 +3251,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3287,7 +3287,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3296,7 +3296,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3787,7 +3787,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3799,8 +3799,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3810,7 +3810,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3822,8 +3822,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3833,15 +3833,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3850,14 +3850,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3866,14 +3866,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3923,7 +3923,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3940,7 +3940,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4009,8 +4009,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4032,7 +4032,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4318,7 +4318,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4649,21 +4649,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4672,12 +4672,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4690,62 +4690,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4758,7 +4758,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4767,7 +4767,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4780,7 +4780,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4789,17 +4789,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4808,12 +4808,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4835,17 +4835,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4862,56 +4862,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4927,7 +4927,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4936,7 +4936,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4944,7 +4944,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4953,8 +4953,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4962,7 +4962,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4976,116 +4976,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5104,19 +5104,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5124,61 +5124,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5188,149 +5188,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5339,7 +5339,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5418,22 +5418,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5590,7 +5590,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5612,7 +5612,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5623,7 +5623,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5652,7 +5652,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5661,7 +5661,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5694,7 +5694,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5704,7 +5704,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5713,7 +5713,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5722,7 +5722,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5745,13 +5745,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5760,7 +5760,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5769,7 +5769,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5789,7 +5789,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5814,7 +5814,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5828,7 +5828,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5838,7 +5838,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5876,7 +5876,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5885,7 +5885,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5898,18 +5898,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6030,7 +6030,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6049,7 +6049,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6058,7 +6058,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6075,7 +6075,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6088,7 +6088,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6117,7 +6117,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6140,7 +6140,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6157,7 +6157,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6166,7 +6166,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6183,7 +6183,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6192,7 +6192,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6226,7 +6226,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6235,7 +6235,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6252,7 +6252,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6267,7 +6267,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6301,12 +6301,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6315,12 +6315,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6329,13 +6329,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6353,7 +6353,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6385,8 +6385,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6442,7 +6442,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6599,12 +6599,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6614,8 +6614,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6623,12 +6623,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6637,7 +6637,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6654,7 +6654,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6664,12 +6664,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6679,7 +6679,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6688,7 +6688,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6738,7 +6738,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6771,7 +6771,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6780,12 +6780,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6794,7 +6794,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6803,7 +6803,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6812,7 +6812,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6823,8 +6823,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6834,7 +6834,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6860,7 +6860,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6898,12 +6898,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6915,12 +6915,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6929,7 +6929,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6975,22 +6975,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7012,7 +7012,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7021,47 +7021,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7074,7 +7074,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7083,7 +7083,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7091,7 +7091,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7105,8 +7105,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7135,7 +7135,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7160,14 +7160,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7177,7 +7177,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7196,7 +7196,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7206,7 +7206,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7223,17 +7223,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7242,7 +7242,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7252,7 +7252,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7262,7 +7262,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7274,7 +7274,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7292,7 +7292,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7313,7 +7313,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7328,7 +7328,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7352,7 +7352,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7408,7 +7408,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7586,7 +7586,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7595,7 +7595,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7604,7 +7604,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7613,7 +7613,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7623,13 +7623,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7642,7 +7642,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7651,7 +7651,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7660,7 +7660,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7669,7 +7669,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7678,7 +7678,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7687,7 +7687,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7696,7 +7696,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7705,7 +7705,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7715,17 +7715,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7734,7 +7734,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8161,7 +8161,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8171,7 +8171,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8215,12 +8215,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8229,7 +8229,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8286,7 +8286,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8304,7 +8304,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8317,7 +8317,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8382,7 +8382,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8447,7 +8447,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8456,12 +8456,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8470,7 +8470,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8479,7 +8479,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8488,7 +8488,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8513,7 +8513,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8648,27 +8648,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8694,18 +8694,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8720,7 +8720,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8741,7 +8741,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8758,7 +8758,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8771,7 +8771,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8781,7 +8781,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8795,7 +8795,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8816,7 +8816,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8830,7 +8830,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9017,7 +9017,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9026,7 +9026,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9148,7 +9148,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9231,7 +9231,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9281,7 +9281,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9398,7 +9398,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9477,48 +9477,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9951,38 +9951,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9990,8 +9990,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10001,8 +10001,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10014,35 +10014,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10056,69 +10056,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10138,13 +10138,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10152,58 +10152,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10219,25 +10219,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10247,43 +10247,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10293,190 +10293,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10486,305 +10486,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10794,97 +10794,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10894,144 +10894,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11041,15 +11041,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11059,23 +11059,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11085,8 +11085,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11094,224 +11094,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11327,37 +11327,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11365,28 +11365,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11400,8 +11400,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11411,65 +11411,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11477,8 +11477,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11488,127 +11488,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11616,608 +11616,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12227,165 +12227,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12399,28 +12399,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12428,133 +12428,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12562,136 +12562,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12701,127 +12701,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12829,397 +12829,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13231,196 +13231,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13428,155 +13428,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13584,257 +13584,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13848,223 +13848,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14074,144 +14074,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14219,57 +14219,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14279,30 +14279,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14310,112 +14310,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14423,287 +14423,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14711,13 +14711,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14725,86 +14725,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -2216,7 +2216,7 @@ msgstr "hành vi"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "miền nhớ trống"
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "Đẩy"
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "đẩy"
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr "y"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "Tọa độ y của chuột(vói y là tọa độ của trục hoành)"
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "Tọa độ x của chuột(vói x là tọa độ của trục hoành)"
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "bút lên"
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "bút xuống"
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "đặt kích cỡ bút"
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "hiển thị"
+#~ msgid "show"
+#~ msgstr "hiển thị"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "Làm sạch"
+#~ msgid "Clean"
+#~ msgstr "Làm sạch"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "ẩn khối"
+#~ msgid "hide blocks"
+#~ msgstr "ẩn khối"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "dừng"
+#~ msgid "stop"
+#~ msgstr "dừng"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "Duy trỳ"
+#~ msgid "duration"
+#~ msgstr "Duy trỳ"
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "Chào"
+#~ msgid "hello"
+#~ msgstr "Chào"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "rùa"
+#~ msgid "turtle"
+#~ msgstr "rùa"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr "Mở"
+#~ msgid "Open"
+#~ msgstr "Mở"
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/wa.po
+++ b/po/wa.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/yo.po
+++ b/po/yo.po
@@ -2216,7 +2216,7 @@ msgstr ""
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -2297,33 +2297,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -2423,7 +2423,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -2822,14 +2822,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -2885,7 +2885,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -2933,8 +2933,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -3170,14 +3170,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -3252,7 +3252,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -3297,7 +3297,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -3788,7 +3788,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -3800,8 +3800,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -3834,15 +3834,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -3851,14 +3851,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -3867,14 +3867,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -3924,7 +3924,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -4010,8 +4010,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -4650,21 +4650,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -4673,12 +4673,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -4691,62 +4691,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -4759,7 +4759,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -4768,7 +4768,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -4790,17 +4790,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -4809,12 +4809,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -4836,17 +4836,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -4863,56 +4863,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -4928,7 +4928,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -4937,7 +4937,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -4954,8 +4954,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -4963,7 +4963,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -4977,116 +4977,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -5105,19 +5105,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -5125,61 +5125,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -5189,149 +5189,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -5340,7 +5340,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -5419,22 +5419,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -5591,7 +5591,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -5624,7 +5624,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -5662,7 +5662,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -5705,7 +5705,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr ""
 
@@ -5714,7 +5714,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -5746,13 +5746,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -5761,7 +5761,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -5815,7 +5815,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -5899,18 +5899,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -6050,7 +6050,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -6076,7 +6076,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -6141,7 +6141,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -6193,7 +6193,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -6227,7 +6227,7 @@ msgid "y"
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -6236,7 +6236,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -6268,7 +6268,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -6302,12 +6302,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -6316,12 +6316,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -6330,13 +6330,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -6354,7 +6354,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -6386,8 +6386,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -6600,12 +6600,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -6615,8 +6615,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -6624,12 +6624,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -6665,12 +6665,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -6739,7 +6739,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -6772,7 +6772,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -6781,12 +6781,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -6824,8 +6824,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -6835,7 +6835,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -6861,7 +6861,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -6899,12 +6899,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -6916,12 +6916,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -6976,22 +6976,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -7013,7 +7013,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -7022,47 +7022,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -7075,7 +7075,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -7092,7 +7092,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -7106,8 +7106,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -7136,7 +7136,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -7161,14 +7161,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -7178,7 +7178,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -7207,7 +7207,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -7224,17 +7224,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -7253,7 +7253,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -7283,7 +7283,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -7293,7 +7293,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -7329,7 +7329,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -7409,7 +7409,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -7614,7 +7614,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -7624,13 +7624,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -7643,7 +7643,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -7661,7 +7661,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -7697,7 +7697,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -7706,7 +7706,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -7716,17 +7716,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -7735,7 +7735,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -8162,7 +8162,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -8216,12 +8216,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -8230,7 +8230,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -8287,7 +8287,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -8305,7 +8305,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -8318,7 +8318,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -8383,7 +8383,7 @@ msgstr ""
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -8457,12 +8457,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr ""
 
@@ -8471,7 +8471,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr ""
 
@@ -8480,7 +8480,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr ""
 
@@ -8489,7 +8489,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -8514,7 +8514,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -8649,27 +8649,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -8695,18 +8695,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -8742,7 +8742,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -8759,7 +8759,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -8772,7 +8772,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -8782,7 +8782,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -8796,7 +8796,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -8817,7 +8817,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -8831,7 +8831,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -9027,7 +9027,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -9149,7 +9149,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -9232,7 +9232,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -9282,7 +9282,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -9399,7 +9399,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -9478,48 +9478,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -9952,38 +9952,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -9991,8 +9991,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -10002,8 +10002,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -10015,35 +10015,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr ""
+#~ msgid "show"
+#~ msgstr ""
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -10057,69 +10057,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr ""
+#~ msgid "Clean"
+#~ msgstr ""
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr ""
+#~ msgid "hide blocks"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -10139,13 +10139,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr ""
+#~ msgid "stop"
+#~ msgstr ""
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -10153,58 +10153,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -10220,25 +10220,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr ""
+#~ msgid "duration"
+#~ msgstr ""
 
 #: js/widgets/temperament.js:454
 
@@ -10248,43 +10248,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -10294,190 +10294,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -10487,305 +10487,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -10795,97 +10795,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr ""
+#~ msgid "hello"
+#~ msgstr ""
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -10895,144 +10895,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -11042,15 +11042,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -11060,23 +11060,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -11086,8 +11086,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -11095,224 +11095,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -11328,37 +11328,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -11366,28 +11366,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -11401,8 +11401,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -11412,65 +11412,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -11478,8 +11478,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -11489,127 +11489,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -11617,608 +11617,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -12228,165 +12228,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -12400,28 +12400,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12429,133 +12429,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12563,136 +12563,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr ""
+#~ msgid "turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -12702,127 +12702,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -12830,397 +12830,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -13232,196 +13232,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13429,155 +13429,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -13585,257 +13585,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -13849,223 +13849,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -14075,144 +14075,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -14220,57 +14220,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -14280,30 +14280,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14311,112 +14311,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -14424,287 +14424,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -14712,13 +14712,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -14726,86 +14726,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -497,7 +497,7 @@ msgstr "動作"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr " 鸭子"
 
@@ -564,7 +564,7 @@ msgstr "隐藏"
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr "我的项目"
 
@@ -578,33 +578,33 @@ msgid "Your recording is in progress."
 msgstr "您的录音正在进行中"
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "文件名"
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "项目标题"
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "项目作者"
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "包含 MIDI 输出？"
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "包含吉他六线谱输出？"
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "另存为 Lilypond 文件"
 
@@ -626,7 +626,7 @@ msgstr "另存为 Lilypond 文件"
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "先生.Mouse"
 
@@ -704,7 +704,7 @@ msgstr "显示笛卡尔坐标系"
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr "音级"
 
@@ -933,8 +933,8 @@ msgstr "保存模块帮助"
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -1093,7 +1093,7 @@ msgstr "尺子"
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "音色"
 
@@ -1103,14 +1103,14 @@ msgstr "楼梯"
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "速度"
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "调式"
 
@@ -1141,7 +1141,7 @@ msgstr "鼓"
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "节奏制作器"
 
@@ -1166,7 +1166,7 @@ msgstr "节奏制作器"
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "音符时值"
 
@@ -1175,7 +1175,7 @@ msgstr "音符时值"
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "音阶音程"
 
@@ -1196,7 +1196,7 @@ msgid "silence"
 msgstr "沉默"
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "向下"
 
@@ -1214,8 +1214,8 @@ msgstr "向上"
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "音高"
 
@@ -1317,7 +1317,7 @@ msgstr "男高音"
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "低音"
 
@@ -1451,14 +1451,14 @@ msgstr "没有选择任何模块"
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "头像"
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "样本"
 
@@ -1533,7 +1533,7 @@ msgstr "开始鼓声"
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "节奏"
 
@@ -1569,7 +1569,7 @@ msgstr "流动"
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr "传感器"
 
@@ -1578,7 +1578,7 @@ msgstr "传感器"
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -2069,7 +2069,7 @@ msgstr "播放准备好了。"
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "双升音符"
 
@@ -2081,8 +2081,8 @@ msgstr "双升音符"
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "升号"
 
@@ -2092,7 +2092,7 @@ msgstr "升号"
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "还原音符"
 
@@ -2104,8 +2104,8 @@ msgstr "还原音符"
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "降号"
 
@@ -2115,15 +2115,15 @@ msgstr "降号"
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "双降音符"
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr "同音"
 
@@ -2132,14 +2132,14 @@ msgstr "同音"
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "大调音阶"
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr "艾奥尼安调式"
 
@@ -2148,14 +2148,14 @@ msgstr "艾奥尼安调式"
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "小调音阶"
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr "伊奥利安调式"
 
@@ -2196,7 +2196,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr "您已选择音调预览的音调。"
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "您必须在加权部分块内至少包含一个部分块"
 
@@ -2205,7 +2205,7 @@ msgid "synth cannot play chords."
 msgstr "合成器无法播放和弦"
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr "指南网址"
 
@@ -2222,7 +2222,7 @@ msgstr "搜索"
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "节拍"
 
@@ -2291,8 +2291,8 @@ msgstr "额外内容"
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "程序"
 
@@ -2314,7 +2314,7 @@ msgstr "逻辑"
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr "音乐"
 
@@ -2600,7 +2600,7 @@ msgstr "打开或关闭五线谱。"
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr "清除"
 
@@ -2615,7 +2615,7 @@ msgstr "折叠"
 
 #: js/turtledefs.js:751
 msgid "Collapse the graphics window."
-msgstr ""折叠图形窗口。
+msgstr "折叠图形窗口。"
 
 #: js/turtledefs.js:757
 msgid "Return all blocks to the center of the screen."
@@ -2931,21 +2931,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -2954,12 +2954,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -2972,62 +2972,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -3040,7 +3040,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -3049,7 +3049,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -3062,7 +3062,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -3071,17 +3071,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -3090,12 +3090,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -3108,7 +3108,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -3117,17 +3117,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -3144,56 +3144,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -3201,7 +3201,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -3209,7 +3209,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -3218,7 +3218,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -3226,7 +3226,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -3235,8 +3235,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -3244,7 +3244,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -3258,116 +3258,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -3386,19 +3386,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -3406,61 +3406,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -3470,149 +3470,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -3621,7 +3621,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3700,22 +3700,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -3872,7 +3872,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -3894,7 +3894,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -3905,7 +3905,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -3934,7 +3934,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -3943,7 +3943,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -3976,7 +3976,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -3986,7 +3986,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "清除堆疊"
 
@@ -3995,7 +3995,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -4004,7 +4004,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -4027,13 +4027,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "取出堆疊"
 
@@ -4051,7 +4051,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "存入堆疊"
 
@@ -4071,7 +4071,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -4096,7 +4096,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -4110,7 +4110,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -4120,7 +4120,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -4158,7 +4158,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -4167,7 +4167,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -4180,18 +4180,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -4312,7 +4312,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -4331,7 +4331,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -4340,7 +4340,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -4357,7 +4357,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -4370,7 +4370,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -4399,7 +4399,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -4422,7 +4422,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -4439,7 +4439,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -4448,7 +4448,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -4465,7 +4465,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -4474,7 +4474,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -4508,7 +4508,7 @@ msgid "y"
 msgstr "Y座標"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -4517,7 +4517,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -4534,7 +4534,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -4549,7 +4549,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "音符"
 
@@ -4583,12 +4583,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -4597,12 +4597,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -4611,13 +4611,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -4635,7 +4635,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -4667,8 +4667,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -4724,7 +4724,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -4881,12 +4881,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -4896,8 +4896,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -4905,12 +4905,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -4936,7 +4936,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -4946,12 +4946,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -4961,7 +4961,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -4970,7 +4970,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -5020,7 +5020,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -5053,7 +5053,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -5062,12 +5062,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -5076,7 +5076,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -5085,7 +5085,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -5094,7 +5094,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -5105,8 +5105,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -5116,7 +5116,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -5142,7 +5142,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -5180,12 +5180,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -5197,12 +5197,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -5211,7 +5211,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -5257,22 +5257,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -5281,7 +5281,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -5294,7 +5294,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -5303,47 +5303,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -5365,7 +5365,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -5373,7 +5373,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -5387,8 +5387,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -5417,7 +5417,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -5442,14 +5442,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -5459,7 +5459,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -5478,7 +5478,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -5488,7 +5488,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -5505,17 +5505,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -5524,7 +5524,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -5534,7 +5534,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -5544,7 +5544,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -5556,7 +5556,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -5564,7 +5564,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -5574,7 +5574,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -5595,7 +5595,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -5610,7 +5610,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -5620,7 +5620,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -5634,7 +5634,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -5690,7 +5690,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -5868,7 +5868,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -5877,7 +5877,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -5886,7 +5886,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -5895,7 +5895,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -5905,13 +5905,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -5924,7 +5924,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "滑鼠座標 y"
 
@@ -5933,7 +5933,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -5942,7 +5942,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "滑鼠座標 x"
 
@@ -5951,7 +5951,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -5969,7 +5969,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -5978,7 +5978,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -5987,7 +5987,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -5997,17 +5997,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -6016,7 +6016,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -6443,7 +6443,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -6453,7 +6453,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -6497,12 +6497,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -6511,7 +6511,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -6568,7 +6568,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -6586,7 +6586,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -6599,7 +6599,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -6664,7 +6664,7 @@ msgstr "停止填滿"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -6729,7 +6729,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -6738,12 +6738,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "提筆"
 
@@ -6752,7 +6752,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "落筆"
 
@@ -6761,7 +6761,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "設定畫筆大小"
 
@@ -6770,7 +6770,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -6795,7 +6795,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -6930,27 +6930,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -6976,18 +6976,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -7023,7 +7023,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -7040,7 +7040,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -7053,7 +7053,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -7063,7 +7063,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -7077,7 +7077,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -7098,7 +7098,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -7112,7 +7112,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -7299,7 +7299,7 @@ msgstr "震音率必须大于0"
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -7308,7 +7308,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -7430,7 +7430,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -7513,7 +7513,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -7563,7 +7563,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -7680,7 +7680,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -7759,48 +7759,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -8233,38 +8233,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -8272,8 +8272,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -8283,8 +8283,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -8296,35 +8296,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "顯示"
+#~ msgid "show"
+#~ msgstr "顯示"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -8338,69 +8338,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "清除畫面"
+#~ msgid "Clean"
+#~ msgstr "清除畫面"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "隱藏區塊"
+#~ msgid "hide blocks"
+#~ msgstr "隱藏區塊"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8420,13 +8420,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "停止"
+#~ msgid "stop"
+#~ msgstr "停止"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8434,58 +8434,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -8501,25 +8501,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "時間長度"
+#~ msgid "duration"
+#~ msgstr "時間長度"
 
 #: js/widgets/temperament.js:454
 
@@ -8529,43 +8529,43 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
 #: js/toolbar.js:70
 
@@ -8575,190 +8575,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -8768,305 +8768,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -9076,97 +9076,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "您好"
+#~ msgid "hello"
+#~ msgstr "您好"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -9176,144 +9176,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -9323,15 +9323,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -9341,23 +9341,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -9367,8 +9367,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -9376,224 +9376,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -9609,37 +9609,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -9647,28 +9647,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -9682,8 +9682,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -9693,65 +9693,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -9759,8 +9759,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -9770,127 +9770,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -9898,608 +9898,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -10509,165 +10509,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -10681,28 +10681,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10710,133 +10710,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10844,136 +10844,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "小烏龜"
+#~ msgid "turtle"
+#~ msgstr "小烏龜"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -10983,127 +10983,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -11111,397 +11111,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -11513,196 +11513,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11710,155 +11710,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11866,257 +11866,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -12130,223 +12130,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -12356,144 +12356,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -12501,57 +12501,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -12561,30 +12561,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12592,112 +12592,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -12705,287 +12705,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12993,13 +12993,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -13007,86 +13007,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -13,10 +13,10 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: ini-to-pot script\n"
 
-#js/toolbar.js:111
-#js/toolbar.js:230
-#js/turtledefs.js:504
-#js/turtledefs.js:505
+#: js/toolbar.js:111
+#: js/toolbar.js:230
+#: js/turtledefs.js:504
+#: js/turtledefs.js:505
 #: js/SaveInterface.js:59
 #: js/SaveInterface.js:61
 #: js/SaveInterface.js:93
@@ -102,7 +102,7 @@ msgstr "動作"
 #: js/macros.js:711
 #: js/utils/musicutils.js:1157
 #: js/utils/synthutils.js:204
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr ""
 
@@ -169,7 +169,7 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:469
 #: planet/js/GlobalPlanet.js:495
 #: planet/js/ProjectStorage.js:27
-#.TRANS: default project title when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
 msgid "My Project"
 msgstr ""
 
@@ -183,33 +183,33 @@ msgid "Your recording is in progress."
 msgstr ""
 
 #: js/SaveInterface.js:415
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr ""
 
 #: js/SaveInterface.js:417
 #: planet/js/StringHelper.js:39
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr ""
 
 #: js/SaveInterface.js:419
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr ""
 
 #: js/SaveInterface.js:421
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr ""
 
 #: js/SaveInterface.js:423
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr ""
 
 #: js/SaveInterface.js:425
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr ""
 
@@ -231,7 +231,7 @@ msgstr ""
 #: js/blocks/EnsembleBlocks.js:944
 #: js/blocks/EnsembleBlocks.js:1215
 #: js/blocks/EnsembleBlocks.js:1283
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr ""
 
@@ -309,7 +309,7 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:923
 #: js/blocks/PitchBlocks.js:442
 #: js/blocks/PitchBlocks.js:1786
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr ""
 
@@ -538,8 +538,8 @@ msgstr ""
 #: js/block.js:3450
 #: js/utils/musicutils.js:4005
 #: js/utils/musicutils.js:5517
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr ""
 
 #: js/block.js:1618
 #: js/blocks/WidgetBlocks.js:397
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr ""
 
@@ -708,14 +708,14 @@ msgstr ""
 
 #: js/block.js:1632
 #: js/blocks/WidgetBlocks.js:707
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr ""
 
 #: js/block.js:1639
 #: js/block.js:1702
 #: js/blocks/IntervalsBlocks.js:1464
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 #: js/block.js:1667
 #: js/blocks/WidgetBlocks.js:1190
 #: js/blocks/WidgetBlocks.js:1228
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 #: js/widgets/phrasemaker.js:2734
 #: js/widgets/phrasemaker.js:2777
 #: js/widgets/phrasemaker.js:2882
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr ""
 
@@ -780,7 +780,7 @@ msgstr ""
 #: js/block.js:2331
 #: js/blocks/IntervalsBlocks.js:1071
 #: js/blocks/OrnamentBlocks.js:312
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr ""
 
@@ -801,7 +801,7 @@ msgid "silence"
 msgstr ""
 
 #: js/block.js:2542
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr ""
 
@@ -819,8 +819,8 @@ msgstr ""
 #: js/blocks/SensorsBlocks.js:178
 #: js/widgets/musickeyboard.js:1961
 #: js/widgets/phrasemaker.js:1122
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr ""
 
@@ -922,7 +922,7 @@ msgstr ""
 #: js/utils/musicutils.js:1109
 #: js/utils/synthutils.js:80
 #: js/blocks/ExtrasBlocks.js:651
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr ""
 
@@ -1056,14 +1056,14 @@ msgstr ""
 
 #: js/blocks.js:5094
 #: js/blocks/MediaBlocks.js:803
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr ""
 
 #: js/blocks.js:5097
 #: js/blocks/ToneBlocks.js:1010
 #: js/widgets/sampler.js:929
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 #: js/widgets/rhythmruler.js:2123
 #: js/widgets/rhythmruler.js:2130
 #: js/widgets/rhythmruler.js:2209
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr ""
 
@@ -1174,7 +1174,7 @@ msgstr ""
 #: js/turtledefs.js:139
 #: js/turtledefs.js:240
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Sensors"
 msgstr ""
 
@@ -1183,7 +1183,7 @@ msgstr ""
 #: js/turtledefs.js:239
 #: js/blocks/MediaBlocks.js:930
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Media"
 msgstr ""
 
@@ -1674,7 +1674,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2375
 #: js/widgets/sampler.js:764
 #: js/widgets/phrasemaker.js:1991
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr ""
 
@@ -1686,8 +1686,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2376
 #: js/widgets/sampler.js:765
 #: js/widgets/phrasemaker.js:1992
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr ""
 
@@ -1697,7 +1697,7 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2377
 #: js/widgets/sampler.js:766
 #: js/widgets/phrasemaker.js:1993
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr ""
 
@@ -1709,8 +1709,8 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2378
 #: js/widgets/sampler.js:767
 #: js/widgets/phrasemaker.js:1994
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr ""
 
@@ -1720,15 +1720,15 @@ msgstr ""
 #: js/widgets/musickeyboard.js:2379
 #: js/widgets/sampler.js:768
 #: js/widgets/phrasemaker.js:1995
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr ""
 
 #: js/piemenus.js:2827
 #: js/utils/musicutils.js:1000
 #: js/blocks/PitchBlocks.js:1385
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr ""
 
@@ -1737,14 +1737,14 @@ msgstr ""
 #: js/utils/musicutils.js:1008
 #: js/utils/musicutils.js:1184
 #: js/utils/musicutils.js:1369
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr ""
 
 #: js/piemenus.js:2981
 #: js/piemenus.js:3054
 #: js/utils/musicutils.js:1026
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr ""
 
@@ -1753,14 +1753,14 @@ msgstr ""
 #: js/utils/musicutils.js:1006
 #: js/utils/musicutils.js:1185
 #: js/utils/musicutils.js:1366
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr ""
 
 #: js/piemenus.js:2983
 #: js/piemenus.js:3058
 #: js/utils/musicutils.js:1036
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr ""
 
@@ -1801,7 +1801,7 @@ msgid "You have chosen key for your pitch preview."
 msgstr ""
 
 #: js/turtle-singer.js:1364
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr ""
 
@@ -1810,7 +1810,7 @@ msgid "synth cannot play chords."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
 msgid "guide url"
 msgstr ""
 
@@ -1827,7 +1827,7 @@ msgstr ""
 #: js/turtledefs.js:224
 #: js/blocks/MeterBlocks.js:1344
 #: js/blocks/WidgetBlocks.js:522
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr ""
 
@@ -1896,8 +1896,8 @@ msgstr ""
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:246
-#.TRANS: program as in computer program
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr ""
 
@@ -1919,7 +1919,7 @@ msgstr ""
 #: js/turtledefs.js:188
 #: js/turtledefs.js:283
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr ""
 
@@ -2205,7 +2205,7 @@ msgstr ""
 #: js/widgets/temperament.js:317
 #: js/widgets/temperament.js:345
 #: js/widgets/phrasemaker.js:578
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr ""
 
@@ -2536,21 +2536,21 @@ msgid "Diminished seventh, plus an octave"
 msgstr ""
 
 #: js/utils/musicutils.js:836
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr ""
 
 #: js/utils/musicutils.js:1002
 #: js/utils/musicutils.js:1186
 #: js/utils/musicutils.js:1368
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr ""
 
 #: js/utils/musicutils.js:1004
 #: js/utils/musicutils.js:1187
 #: js/utils/musicutils.js:1367
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr ""
 
@@ -2559,12 +2559,12 @@ msgstr ""
 #: js/blocks/IntervalsBlocks.js:649
 #: js/turtleactions/IntervalsActions.js:120
 #: js/turtleactions/IntervalsActions.js:124
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr ""
 
 #: js/utils/musicutils.js:1012
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr ""
 
@@ -2577,62 +2577,62 @@ msgid "spanish"
 msgstr ""
 
 #: js/utils/musicutils.js:1016
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1018
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr ""
 
 #: js/utils/musicutils.js:1020
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1022
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1024
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1028
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr ""
 
 #: js/utils/musicutils.js:1030
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr ""
 
 #: js/utils/musicutils.js:1032
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1034
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr ""
 
 #: js/utils/musicutils.js:1038
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr ""
 
 #: js/utils/musicutils.js:1040
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr ""
 
 #: js/utils/musicutils.js:1042
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr ""
 
@@ -2645,7 +2645,7 @@ msgid "byzantine"
 msgstr ""
 
 #: js/utils/musicutils.js:1046
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr ""
 
@@ -2654,7 +2654,7 @@ msgid "ethiopian"
 msgstr ""
 
 #: js/utils/musicutils.js:1049
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr ""
 
@@ -2667,7 +2667,7 @@ msgid "hungarian"
 msgstr ""
 
 #: js/utils/musicutils.js:1053
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr ""
 
@@ -2676,17 +2676,17 @@ msgid "spanish gypsy"
 msgstr ""
 
 #: js/utils/musicutils.js:1056
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr ""
 
 #: js/utils/musicutils.js:1058
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr ""
 
 #: js/utils/musicutils.js:1060
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr ""
 
@@ -2695,12 +2695,12 @@ msgid "whole tone"
 msgstr ""
 
 #: js/utils/musicutils.js:1063
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr ""
 
 #: js/utils/musicutils.js:1065
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr ""
 
@@ -2713,7 +2713,7 @@ msgid "egyptian"
 msgstr ""
 
 #: js/utils/musicutils.js:1069
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr ""
 
@@ -2722,17 +2722,17 @@ msgid "Japan"
 msgstr ""
 
 #: js/utils/musicutils.js:1072
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr ""
 
 #: js/utils/musicutils.js:1074
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr ""
 
 #: js/utils/musicutils.js:1076
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr ""
 
@@ -2749,56 +2749,56 @@ msgstr ""
 #: js/blocks/VolumeBlocks.js:411
 #: js/turtleactions/VolumeActions.js:224
 #: js/widgets/modewidget.js:913
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr ""
 
 #: js/utils/musicutils.js:1079
 #: js/utils/musicutils.js:1574
 #: js/blocks/WidgetBlocks.js:176
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1081
 #: js/utils/musicutils.js:1575
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1083
 #: js/utils/musicutils.js:1576
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1085
 #: js/utils/musicutils.js:1577
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1087
 #: js/utils/musicutils.js:1578
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr ""
 
 #: js/utils/musicutils.js:1089
 #: js/utils/musicutils.js:1579
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr ""
 
 #: js/utils/musicutils.js:1091
 #: js/utils/musicutils.js:1580
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr ""
 
 #: js/utils/musicutils.js:1093
 #: js/utils/musicutils.js:1581
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr ""
 
@@ -2806,7 +2806,7 @@ msgstr ""
 #: js/utils/musicutils.js:1589
 #: js/utils/synthutils.js:128
 #: js/blocks/PitchBlocks.js:85
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr ""
 
@@ -2814,7 +2814,7 @@ msgstr ""
 #: js/utils/musicutils.js:1590
 #: js/utils/synthutils.js:130
 #: js/blocks/PitchBlocks.js:39
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr ""
 
@@ -2823,7 +2823,7 @@ msgstr ""
 #: js/utils/synthutils.js:134
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr ""
 
@@ -2831,7 +2831,7 @@ msgstr ""
 #: js/utils/musicutils.js:1592
 #: js/utils/synthutils.js:132
 #: js/blocks/PitchBlocks.js:108
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr ""
 
@@ -2840,8 +2840,8 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:931
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:469
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr ""
 
@@ -2849,7 +2849,7 @@ msgstr ""
 #: js/utils/musicutils.js:1356
 #: js/blocks/PitchBlocks.js:937
 #: js/turtleactions/PitchActions.js:471
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr ""
 
@@ -2863,116 +2863,116 @@ msgstr ""
 #: js/utils/musicutils.js:1103
 #: js/utils/synthutils.js:72
 #: js/blocks/VolumeBlocks.js:47
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr ""
 
 #: js/utils/musicutils.js:1104
 #: js/utils/synthutils.js:74
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr ""
 
 #: js/utils/musicutils.js:1105
 #: js/utils/synthutils.js:76
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr ""
 
 #: js/utils/musicutils.js:1106
 #: js/utils/synthutils.js:116
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1107
 #: js/utils/synthutils.js:138
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr ""
 
 #: js/utils/musicutils.js:1108
 #: js/utils/synthutils.js:78
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr ""
 
 #: js/utils/musicutils.js:1110
 #: js/utils/synthutils.js:82
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr ""
 
 #: js/utils/musicutils.js:1111
 #: js/utils/synthutils.js:86
 #: js/widgets/rhythmruler.js:2501
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1112
 #: js/utils/synthutils.js:84
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1113
 #: js/utils/synthutils.js:88
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1114
 #: js/utils/synthutils.js:90
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr ""
 
 #: js/utils/musicutils.js:1115
 #: js/utils/synthutils.js:92
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr ""
 
 #: js/utils/musicutils.js:1116
 #: js/utils/synthutils.js:94
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr ""
 
 #: js/utils/musicutils.js:1117
 #: js/utils/synthutils.js:96
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr ""
 
 #: js/utils/musicutils.js:1118
 #: js/utils/synthutils.js:98
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr ""
 
 #: js/utils/musicutils.js:1119
 #: js/utils/synthutils.js:100
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr ""
 
 #: js/utils/musicutils.js:1120
 #: js/utils/synthutils.js:102
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr ""
 
 #: js/utils/musicutils.js:1121
 #: js/utils/synthutils.js:118
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr ""
 
 #: js/utils/musicutils.js:1122
 #: js/utils/synthutils.js:120
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr ""
 
@@ -2991,19 +2991,19 @@ msgstr ""
 #: js/utils/musicutils.js:1126
 #: js/utils/synthutils.js:58
 #: js/blocks/DrumBlocks.js:191
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1127
 #: js/utils/synthutils.js:60
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr ""
 
 #: js/utils/musicutils.js:1128
 #: js/utils/synthutils.js:62
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr ""
 
@@ -3011,61 +3011,61 @@ msgstr ""
 #: js/utils/synthutils.js:150
 #: js/widgets/rhythmruler.js:2047
 #: js/widgets/rhythmruler.js:2309
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1131
 #: js/utils/synthutils.js:152
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1132
 #: js/utils/synthutils.js:154
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1133
 #: js/utils/synthutils.js:156
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr ""
 
 #: js/utils/musicutils.js:1134
 #: js/utils/synthutils.js:158
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1135
 #: js/utils/synthutils.js:160
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1136
 #: js/utils/synthutils.js:162
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr ""
 
 #: js/utils/musicutils.js:1137
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr ""
 
 #: js/utils/musicutils.js:1138
 #: js/utils/synthutils.js:168
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1139
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr ""
 
@@ -3075,149 +3075,149 @@ msgstr ""
 
 #: js/utils/musicutils.js:1141
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1142
 #: js/utils/synthutils.js:172
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr ""
 
 #: js/utils/musicutils.js:1143
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr ""
 
 #: js/utils/musicutils.js:1144
 #: js/utils/synthutils.js:178
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr ""
 
 #: js/utils/musicutils.js:1145
 #: js/utils/synthutils.js:180
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr ""
 
 #: js/utils/musicutils.js:1147
 #: js/utils/synthutils.js:184
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr ""
 
 #: js/utils/musicutils.js:1148
 #: js/utils/synthutils.js:186
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr ""
 
 #: js/utils/musicutils.js:1149
 #: js/utils/synthutils.js:188
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr ""
 
 #: js/utils/musicutils.js:1150
 #: js/utils/synthutils.js:190
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr ""
 
 #: js/utils/musicutils.js:1151
 #: js/utils/synthutils.js:192
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr ""
 
 #: js/utils/musicutils.js:1152
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr ""
 
 #: js/utils/musicutils.js:1153
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr ""
 
 #: js/utils/musicutils.js:1154
 #: js/utils/synthutils.js:198
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr ""
 
 #: js/utils/musicutils.js:1155
 #: js/utils/synthutils.js:200
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr ""
 
 #: js/utils/musicutils.js:1156
 #: js/utils/synthutils.js:202
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr ""
 
 #: js/utils/musicutils.js:1158
 #: js/utils/synthutils.js:104
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr ""
 
 #: js/utils/musicutils.js:1159
 #: js/utils/synthutils.js:106
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr ""
 
 #: js/utils/musicutils.js:1160
 #: js/utils/synthutils.js:108
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr ""
 
 #: js/utils/musicutils.js:1161
 #: js/utils/synthutils.js:110
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr ""
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:112
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr ""
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:114
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr ""
 
 #: js/utils/musicutils.js:1165
 #: js/widgets/temperament.js:757
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr ""
 
 #: js/utils/musicutils.js:1167
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr ""
 
 #: js/utils/musicutils.js:1169
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr ""
 
@@ -3226,7 +3226,7 @@ msgstr ""
 #: js/utils/musicutils.js:1608
 #: js/utils/musicutils.js:1623
 #: js/utils/musicutils.js:1624
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr ""
 
@@ -3305,22 +3305,22 @@ msgid "previous"
 msgstr ""
 
 #: js/utils/synthutils.js:122
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr ""
 
 #: js/utils/synthutils.js:124
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr ""
 
 #: js/utils/synthutils.js:126
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr ""
 
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr ""
 
@@ -3477,7 +3477,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr ""
 
@@ -3499,7 +3499,7 @@ msgstr ""
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1462
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr ""
 
@@ -3510,7 +3510,7 @@ msgstr ""
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr ""
 
@@ -3539,7 +3539,7 @@ msgid "Replace every instance of a pitch with a drum sound."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:328
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr ""
 
@@ -3548,7 +3548,7 @@ msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr ""
 
 #: js/blocks/DrumBlocks.js:407
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr ""
 
@@ -3581,7 +3581,7 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr ""
 
@@ -3591,7 +3591,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "清除堆疊"
 
@@ -3600,7 +3600,7 @@ msgid "The Reverse-heap block reverses the order of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr ""
 
@@ -3609,7 +3609,7 @@ msgid "The Index-heap block returns a value in the heap at a specified location.
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr ""
 
@@ -3632,13 +3632,13 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:299
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:96
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr ""
 
@@ -3647,7 +3647,7 @@ msgid "The Pop block removes the value at the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "取出堆疊"
 
@@ -3656,7 +3656,7 @@ msgid "The Push block adds a value to the top of the heap."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "存入堆疊"
 
@@ -3676,7 +3676,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:1025
 #: js/blocks/MediaBlocks.js:746
 #: js/turtleactions/IntervalsActions.js:114
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr ""
 
@@ -3701,7 +3701,7 @@ msgid "current interval"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:387
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr ""
 
@@ -3715,7 +3715,7 @@ msgid "The Scalar interval block measures the distance between two notes in the 
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:502
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr ""
 
@@ -3725,7 +3725,7 @@ msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:684
 #: js/blocks/OrnamentBlocks.js:220
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr ""
 
@@ -3763,7 +3763,7 @@ msgid "In the figure, we add la to sol."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1120
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr ""
 
@@ -3772,7 +3772,7 @@ msgid "movable Do"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1224
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr ""
 
@@ -3785,18 +3785,18 @@ msgid "Most Western scales have 7 notes."
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1284
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1337
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr ""
 
 #: js/blocks/IntervalsBlocks.js:1389
 #: js/blocks/IntervalsBlocks.js:1434
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr ""
 
@@ -3917,7 +3917,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr ""
 
@@ -3936,7 +3936,7 @@ msgstr ""
 
 #: js/blocks/OrnamentBlocks.js:558
 #: js/blocks/OrnamentBlocks.js:710
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr ""
 
@@ -3945,7 +3945,7 @@ msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr ""
 
@@ -3962,7 +3962,7 @@ msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:144
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr ""
 
@@ -3975,7 +3975,7 @@ msgid "The Load-heap block loads the heap from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:217
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr ""
 
@@ -4004,7 +4004,7 @@ msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:372
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr ""
 
@@ -4027,7 +4027,7 @@ msgid "The Set-dictionary block loads a dictionary."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:477
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr ""
 
@@ -4044,7 +4044,7 @@ msgid "The Save-heap block saves the heap to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:578
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr ""
 
@@ -4053,7 +4053,7 @@ msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:640
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr ""
 
@@ -4070,7 +4070,7 @@ msgid "The Delete block block removes a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:797
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr ""
 
@@ -4079,7 +4079,7 @@ msgid "The Move block block moves a block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:869
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgid "y"
 msgstr "Y座標"
 
 #: js/blocks/ProgramBlocks.js:935
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr ""
 
@@ -4122,7 +4122,7 @@ msgid "The Dock block block connections two blocks."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1036
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr ""
 
@@ -4139,7 +4139,7 @@ msgid "The Make block block creates a new block."
 msgstr ""
 
 #: js/blocks/ProgramBlocks.js:1152
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr ""
 
@@ -4154,7 +4154,7 @@ msgstr ""
 #: js/widgets/temperament.js:484
 #: js/widgets/temperament.js:589
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr ""
 
@@ -4188,12 +4188,12 @@ msgstr ""
 #: js/blocks/RhythmBlocks.js:215
 #: js/blocks/RhythmBlocks.js:278
 #: js/blocks/RhythmBlocks.js:350
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:355
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr ""
 
@@ -4202,12 +4202,12 @@ msgid "The Skip notes block will cause notes to be skipped."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:427
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr ""
 
@@ -4216,13 +4216,13 @@ msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:671
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr ""
 
 #: js/blocks/RhythmBlocks.js:765
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr ""
 
@@ -4272,8 +4272,8 @@ msgstr ""
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:50
 #: js/blocks/RhythmBlockPaletteBlocks.js:233
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 #: js/blocks/RhythmBlockPaletteBlocks.js:514
 #: js/blocks/RhythmBlockPaletteBlocks.js:583
 #: js/blocks/RhythmBlockPaletteBlocks.js:634
-#.TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: A tuplet is a note value divided into irregular time values.
 msgid "tuplet"
 msgstr ""
 
@@ -4486,12 +4486,12 @@ msgid "duplicate factor"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:85
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr ""
 
@@ -4501,8 +4501,8 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:170
 #: js/widgets/status.js:148
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr ""
 
@@ -4510,12 +4510,12 @@ msgstr ""
 #: js/blocks/MeterBlocks.js:1057
 #: js/blocks/MeterBlocks.js:1134
 #: js/blocks/MeterBlocks.js:1212
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:234
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr ""
 
@@ -4524,7 +4524,7 @@ msgid "The Measure count block returns the current measure."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:291
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr ""
 
@@ -4541,7 +4541,7 @@ msgid "eg 1, 2, 3, or 4."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:369
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr ""
 
@@ -4551,12 +4551,12 @@ msgid "The Note counter block can be used to count the number of contained notes
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:433
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:497
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr ""
 
@@ -4566,7 +4566,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:556
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr ""
 
@@ -4575,7 +4575,7 @@ msgid "The No clock block decouples the notes from the master clock."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:662
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr ""
 
@@ -4625,7 +4625,7 @@ msgstr ""
 
 #: js/blocks/MeterBlocks.js:929
 #: js/blocks/MeterBlocks.js:1000
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr ""
 
@@ -4658,7 +4658,7 @@ msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr ""
 
 #: js/blocks/MeterBlocks.js:1280
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr ""
 
@@ -4667,12 +4667,12 @@ msgid "number of beats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:141
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:168
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr ""
 
@@ -4681,7 +4681,7 @@ msgid "The Scalar step down block returns the number of semi-tones down to the p
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:190
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr ""
 
@@ -4690,7 +4690,7 @@ msgid "The Scalar step up block returns the number of semi-tones up to the next 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:212
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr ""
 
@@ -4699,7 +4699,7 @@ msgid "The Change in pitch block is the difference (in half steps) between the c
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:243
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr ""
 
@@ -4710,8 +4710,8 @@ msgstr ""
 #: js/widgets/temperament.js:582
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:824
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr ""
 
@@ -4721,7 +4721,7 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:329
 #: js/blocks/PitchBlocks.js:433
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr ""
 
@@ -4747,7 +4747,7 @@ msgid "alphabet"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:436
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr ""
 
@@ -4785,12 +4785,12 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:629
 #: js/widgets/musickeyboard.js:753
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:642
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr ""
 
@@ -4802,12 +4802,12 @@ msgstr ""
 #: js/blocks/PitchBlocks.js:934
 #: js/blocks/PitchBlocks.js:1866
 #: js/blocks/MediaBlocks.js:746
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr ""
 
@@ -4816,7 +4816,7 @@ msgid "The Number to pitch block will convert a pitch number to a pich name."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:715
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr ""
 
@@ -4862,22 +4862,22 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 #: js/widgets/modewidget.js:137
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:968
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1001
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1022
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr ""
 
@@ -4886,7 +4886,7 @@ msgid "The Register block provides an easy way to modify the register (octave) o
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1047
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr ""
 
@@ -4899,7 +4899,7 @@ msgid "In the example shown above, sol is shifted up to sol#."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1110
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr ""
 
@@ -4908,47 +4908,47 @@ msgid "The Transpose by Ratio block will shift the pitches contained inside Note
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1149
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1232
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1251
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1270
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1289
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1308
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1328
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1347
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1366
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr ""
 
@@ -4961,7 +4961,7 @@ msgid "In the example shown above, sol is shifted up to la."
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1416
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr ""
 
@@ -4970,7 +4970,7 @@ msgid "The Accidental block is used to create sharps and flats"
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1458
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr ""
 
@@ -4978,7 +4978,7 @@ msgstr ""
 #: js/blocks/MediaBlocks.js:679
 #: js/widgets/musickeyboard.js:1962
 #: js/widgets/phrasemaker.js:1123
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr ""
 
@@ -4992,8 +4992,8 @@ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1703
 #: js/blocks/PitchBlocks.js:1745
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr ""
 
@@ -5022,7 +5022,7 @@ msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of 
 msgstr ""
 
 #: js/blocks/PitchBlocks.js:1814
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr ""
 
@@ -5047,14 +5047,14 @@ msgstr ""
 #: js/blocks/WidgetBlocks.js:179
 #: js/widgets/timbre.js:1550
 #: js/widgets/timbre.js:1800
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
 msgid "type"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1554
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr ""
 
@@ -5064,7 +5064,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:144
 #: js/widgets/timbre.js:1217
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr ""
 
@@ -5083,7 +5083,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:185
 #: js/widgets/timbre.js:1215
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr ""
 
@@ -5093,7 +5093,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:224
 #: js/widgets/timbre.js:1216
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr ""
 
@@ -5110,17 +5110,17 @@ msgid "The Partial block is used to specify a weight for a specific partial harm
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:284
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:297
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:325
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr ""
 
@@ -5129,7 +5129,7 @@ msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:390
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr ""
 
@@ -5139,7 +5139,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:438
 #: js/widgets/timbre.js:2088
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr ""
 
@@ -5149,7 +5149,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:495
 #: js/widgets/timbre.js:2084
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr ""
 
@@ -5161,7 +5161,7 @@ msgstr ""
 #: js/widgets/timbre.js:2210
 #: js/widgets/timbre.js:2305
 #: js/widgets/timbre.js:2407
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr ""
 
@@ -5169,7 +5169,7 @@ msgstr ""
 #: js/blocks/ToneBlocks.js:630
 #: js/widgets/timbre.js:2125
 #: js/widgets/timbre.js:2316
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr ""
 
@@ -5179,7 +5179,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:566
 #: js/widgets/timbre.js:2087
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr ""
 
@@ -5200,7 +5200,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:627
 #: js/widgets/timbre.js:2086
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr ""
 
@@ -5215,7 +5215,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:686
 #: js/widgets/timbre.js:2085
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr ""
 
@@ -5225,7 +5225,7 @@ msgid "intensity"
 msgstr ""
 
 #: js/blocks/ToneBlocks.js:733
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr ""
 
@@ -5239,7 +5239,7 @@ msgstr ""
 
 #: js/blocks/ToneBlocks.js:895
 #: js/blocks/ToneBlocks.js:943
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr ""
 
@@ -5295,7 +5295,7 @@ msgstr ""
 #: js/blocks/ActionBlocks.js:593
 #: js/blocks/ActionBlocks.js:942
 #: js/blocks/ActionBlocks.js:1389
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr ""
 
@@ -5473,7 +5473,7 @@ msgid "Cannot find start block"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:294
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr ""
 
@@ -5482,7 +5482,7 @@ msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:308
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr ""
 
@@ -5491,7 +5491,7 @@ msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:340
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr ""
 
@@ -5500,7 +5500,7 @@ msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:354
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr ""
 
@@ -5510,13 +5510,13 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:386
 #: js/blocks/EnsembleBlocks.js:441
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:397
 #: js/blocks/EnsembleBlocks.js:454
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr ""
 
@@ -5529,7 +5529,7 @@ msgid "The Set turtle block sends a stack of blocks to be run by the specified t
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:482
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "滑鼠座標 y"
 
@@ -5538,7 +5538,7 @@ msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:496
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr ""
 
@@ -5547,7 +5547,7 @@ msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:528
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "滑鼠座標 x"
 
@@ -5556,7 +5556,7 @@ msgid "The X mouse block returns the X position of the specified mouse."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:542
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr ""
 
@@ -5565,7 +5565,7 @@ msgid "The X turtle block returns the X position of the specified turtle."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:575
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr ""
 
@@ -5574,7 +5574,7 @@ msgid "The Mouse elapse notes block returns the number of notes played by the sp
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:589
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr ""
 
@@ -5583,7 +5583,7 @@ msgid "The Turtle elapse notes block returns the number of notes played by the s
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:629
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr ""
 
@@ -5592,7 +5592,7 @@ msgid "The Mouse pitch block returns the current pitch number being played by th
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:643
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr ""
 
@@ -5602,17 +5602,17 @@ msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:749
 #: js/blocks/EnsembleBlocks.js:821
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:759
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:832
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr ""
 
@@ -5621,7 +5621,7 @@ msgid "The Mouse sync block aligns the beat count between mice."
 msgstr ""
 
 #: js/blocks/EnsembleBlocks.js:846
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr ""
 
@@ -6048,7 +6048,7 @@ msgid "wrap"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr ""
 
@@ -6058,7 +6058,7 @@ msgid "The Right block returns the position of the right of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:97
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr ""
 
@@ -6102,12 +6102,12 @@ msgid "The Height block returns the height of the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:369
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:404
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr ""
 
@@ -6116,7 +6116,7 @@ msgid "The Erase Media block erases text and images."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:439
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr ""
 
@@ -6173,7 +6173,7 @@ msgid "duration (MS)"
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:728
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr ""
 
@@ -6191,7 +6191,7 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:831
 #: js/blocks/MediaBlocks.js:891
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr ""
 
@@ -6204,7 +6204,7 @@ msgid "The Show block is used to display text or images on the canvas."
 msgstr ""
 
 #: js/blocks/MediaBlocks.js:888
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr ""
 
@@ -6269,7 +6269,7 @@ msgstr "停止填滿"
 
 #: js/blocks/PenBlocks.js:208
 #: js/blocks/PenBlocks.js:537
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr ""
 
@@ -6334,7 +6334,7 @@ msgid "The Hollow line block creates a line with a hollow center."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:583
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr ""
 
@@ -6343,12 +6343,12 @@ msgid "The Fill block fills in a shape with a color."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:661
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr ""
 
 #: js/blocks/PenBlocks.js:738
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "提筆"
 
@@ -6357,7 +6357,7 @@ msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:779
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "落筆"
 
@@ -6366,7 +6366,7 @@ msgid "The Pen-down block lowers the pen so that it draws."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:821
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "設定畫筆大小"
 
@@ -6375,7 +6375,7 @@ msgid "The Set-pen-size block changes the size of the pen."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:890
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr ""
 
@@ -6400,7 +6400,7 @@ msgid "The Set-shade block changes the pen color from dark to light."
 msgstr ""
 
 #: js/blocks/PenBlocks.js:1088
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr ""
 
@@ -6535,27 +6535,27 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 #: js/widgets/timbre.js:834
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:89
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:91
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:93
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:95
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr ""
 
@@ -6581,18 +6581,18 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 #: js/widgets/timbre.js:898
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:181
 #: js/widgets/timbre.js:1810
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:213
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr ""
 
@@ -6607,7 +6607,7 @@ msgid "Upload a sample and adjust its pitch center."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:339
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr ""
 
@@ -6628,7 +6628,7 @@ msgid "The Custom mode block opens a tool to explore musical mode (the spacing o
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:651
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr ""
 
@@ -6645,7 +6645,7 @@ msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:842
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr ""
 
@@ -6658,7 +6658,7 @@ msgid "The Pitch slider tool to is used to generate pitches at selected frequenc
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:925
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr ""
 
@@ -6668,7 +6668,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1011
 #: js/blocks/WidgetBlocks.js:1077
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr ""
 
@@ -6682,7 +6682,7 @@ msgid "The Pitch staircase tool to is used to generate pitches from a given rati
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1135
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr ""
 
@@ -6703,7 +6703,7 @@ msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1373
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr ""
 
@@ -6717,7 +6717,7 @@ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1581
 #: js/widgets/aiwidget.js:699
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr ""
 
@@ -6904,7 +6904,7 @@ msgstr ""
 
 #: js/turtleactions/ToneActions.js:192
 #: js/turtleactions/ToneActions.js:265
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr ""
 
@@ -6913,7 +6913,7 @@ msgid "Distortion must be from 0 to 100."
 msgstr ""
 
 #: js/turtleactions/ToneActions.js:332
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr ""
 
@@ -7035,7 +7035,7 @@ msgid "Undo"
 msgstr ""
 
 #: js/widgets/modewidget.js:161
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr ""
 
@@ -7118,7 +7118,7 @@ msgid "Save drum machine"
 msgstr ""
 
 #: js/widgets/rhythmruler.js:589
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr ""
 
@@ -7168,7 +7168,7 @@ msgid "Playback"
 msgstr ""
 
 #: js/widgets/sampler.js:933
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr ""
 
@@ -7285,7 +7285,7 @@ msgstr ""
 
 #: js/widgets/timbre.js:880
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr ""
 
@@ -7364,48 +7364,48 @@ msgid "Cannot connect to server"
 msgstr ""
 
 #: planet/js/GlobalTag.js:28
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:30
 #: planet/js/StringHelper.js:37
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr ""
 
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr ""
 
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr ""
 
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr ""
 
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr ""
 
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr ""
 
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr ""
 
 #: planet/js/GlobalTag.js:52
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr ""
 
@@ -7838,38 +7838,38 @@ msgstr ""
 
 #: js/activity.js:3323
 
-#~msgid "Nothing in the trash to restore."
-#~msgstr ""
+#~ msgid "Nothing in the trash to restore."
+#~ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "Save audio from your project as WAV."
-#~msgstr ""
+#~ msgid "Save audio from your project as WAV."
+#~ msgstr ""
 
 #: js/turtledefs.js:588
 
-#~msgid "Save your project to as an ABC file."
-#~msgstr ""
+#~ msgid "Save your project to as an ABC file."
+#~ msgstr ""
 
 #: js/turtledefs.js:592
 
-#~msgid "Save your project to as a Lilypond file."
-#~msgstr ""
+#~ msgid "Save your project to as a Lilypond file."
+#~ msgstr ""
 
 #: js/turtledefs.js:620
 
-#~msgid "Show or hide a coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:649
 
-#~msgid "Expand/collapse collapsable blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsable blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:752
 
-#~msgid "Show these messages."
-#~msgstr ""
+#~ msgid "Show these messages."
+#~ msgstr ""
 
 #: js/rubrics.js:531
 
@@ -7877,8 +7877,8 @@ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "sensors"
-#~msgstr ""
+#~ msgid "sensors"
+#~ msgstr ""
 
 #: js/rubrics.js:532
 
@@ -7888,8 +7888,8 @@ msgstr ""
 
 #: js/blocks/MediaBlocks.js:930
 
-#~msgid "media"
-#~msgstr ""
+#~ msgid "media"
+#~ msgstr ""
 
 #: js/block-verbose.js:3837
 
@@ -7901,35 +7901,35 @@ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:623
 
-#~msgid "Cartesian+polar"
-#~msgstr ""
+#~ msgid "Cartesian+polar"
+#~ msgstr ""
 
 #: js/blocks.js:5091
 
 #: js/blocks/MediaBlocks.js:888
 
-#~msgid "show"
-#~msgstr "顯示"
+#~ msgid "show"
+#~ msgstr "顯示"
 
 #: js/activity.js:5680
 
-#~msgid "Show/hide block"
-#~msgstr ""
+#~ msgid "Show/hide block"
+#~ msgstr ""
 
 #: js/palette.js:619
 
-#~msgid "grid"
-#~msgstr ""
+#~ msgid "grid"
+#~ msgstr ""
 
 #: js/piemenus.js:3854
 
-#~msgid "You have chosen key "
-#~msgstr ""
+#~ msgid "You have chosen key "
+#~ msgstr ""
 
 #: js/piemenus.js:3858
 
-#~msgid " for your pitch preview."
-#~msgstr ""
+#~ msgid " for your pitch preview."
+#~ msgstr ""
 
 #: js/toolbar.js:113
 
@@ -7943,69 +7943,69 @@ msgstr ""
 
 #: js/toolbar.js:235
 
-#~msgid "Full Screen"
-#~msgstr ""
+#~ msgid "Full Screen"
+#~ msgstr ""
 
 #: js/toolbar.js:1060
 
-#~msgid "New Project"
-#~msgstr ""
+#~ msgid "New Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
 #: js/turtledefs.js:280
 
-#~msgid "music"
-#~msgstr ""
+#~ msgid "music"
+#~ msgstr ""
 
 #: js/turtledefs.js:548
 
 #: js/turtledefs.js:569
 
-#~msgid "save"
-#~msgstr ""
+#~ msgid "save"
+#~ msgstr ""
 
 #: js/turtledefs.js:625
 
 #: js/turtles.js:953
 
-#~msgid "Clean"
-#~msgstr "清除畫面"
+#~ msgid "Clean"
+#~ msgstr "清除畫面"
 
 #: js/turtledefs.js:675
 
-#~msgid "Run slow"
-#~msgstr ""
+#~ msgid "Run slow"
+#~ msgstr ""
 
 #: js/turtles.js:900
 
-#~msgid "Clear Workspace"
-#~msgstr ""
+#~ msgid "Clear Workspace"
+#~ msgstr ""
 
 #: js/turtles.js:905
 
-#~msgid "Are you sure you want to clear the workspace ?"
-#~msgstr ""
+#~ msgid "Are you sure you want to clear the workspace ?"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1176
 
-#~msgid "meantone"
-#~msgstr ""
+#~ msgid "meantone"
+#~ msgstr ""
 
 #: js/utils/musicutils.js:1582
 
-#~msgid "Custom"
-#~msgstr ""
+#~ msgid "Custom"
+#~ msgstr ""
 
 #: js/blocks/ExtrasBlocks.js:274
 
-#~msgid "hide blocks"
-#~msgstr "隱藏區塊"
+#~ msgid "hide blocks"
+#~ msgstr "隱藏區塊"
 
 #: js/blocks/FlowBlocks.js:136
 
-#~msgid "duplicate"
-#~msgstr ""
+#~ msgid "duplicate"
+#~ msgstr ""
 
 #: js/blocks/FlowBlocks.js:604
 
@@ -8025,13 +8025,13 @@ msgstr ""
 
 #: plugins/rodi.rtp:413
 
-#~msgid "stop"
-#~msgstr "停止"
+#~ msgid "stop"
+#~ msgstr "停止"
 
 #: js/blocks/MediaBlocks.js:692
 
-#~msgid "duration (ms)"
-#~msgstr ""
+#~ msgid "duration (ms)"
+#~ msgstr ""
 
 #: js/blocks/GraphicsBlocks.js:373
 
@@ -8039,58 +8039,58 @@ msgstr ""
 
 #: js/widgets/temperament.js:347
 
-#~msgid "clear"
-#~msgstr ""
+#~ msgid "clear"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:929
 
-#~msgid "invert"
-#~msgstr ""
+#~ msgid "invert"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1706
 
-#~msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
-#~msgstr ""
+#~ msgid "n^th Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+#~ msgstr ""
 
 #: js/blocks/PitchBlocks.js:1749
 
-#~msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-#~msgstr ""
+#~ msgid "N^th Modal Pitch takes a number as an input as the n^th degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:34
 
-#~msgid "oscillator"
-#~msgstr ""
+#~ msgid "oscillator"
+#~ msgstr ""
 
 #: js/blocks/ToneBlocks.js:630
 
-#~msgid "delay"
-#~msgstr ""
+#~ msgid "delay"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:81
 
-#~msgid "envelope"
-#~msgstr ""
+#~ msgid "envelope"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:171
 
-#~msgid "filter"
-#~msgstr ""
+#~ msgid "filter"
+#~ msgstr ""
 
 #: js/blocks/WidgetBlocks.js:1580
 
-#~msgid "aimusic"
-#~msgstr ""
+#~ msgid "aimusic"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:119
 
-#~msgid "a"
-#~msgstr ""
+#~ msgid "a"
+#~ msgstr ""
 
 #: js/turtleactions/IntervalsActions.js:139
 
-#~msgid " below"
-#~msgstr ""
+#~ msgid " below"
+#~ msgstr ""
 
 #: js/widgets/modewidget.js:1017
 
@@ -8106,25 +8106,25 @@ msgstr ""
 
 #: js/widgets/temperament.js:1929
 
-#~msgid "New action block generated!"
-#~msgstr ""
+#~ msgid "New action block generated!"
+#~ msgstr ""
 
 #: js/widgets/sampler.js:237
 
-#~msgid "Recording started..."
-#~msgstr ""
+#~ msgid "Recording started..."
+#~ msgstr ""
 
 #: js/widgets/sampler.js:245
 
-#~msgid "Recording complete..."
-#~msgstr ""
+#~ msgid "Recording complete..."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:1549
 
 #: plugins/rodi.rtp:193
 
-#~msgid "duration"
-#~msgstr "時間長度"
+#~ msgid "duration"
+#~ msgstr "時間長度"
 
 #: js/widgets/temperament.js:454
 
@@ -8134,46 +8134,46 @@ msgstr ""
 
 #: js/widgets/temperament.js:1495
 
-#~msgid "close"
-#~msgstr ""
+#~ msgid "close"
+#~ msgstr ""
 
 #: planet/js/StringHelper.js:38
 
-#~msgid "Publish Project"
-#~msgstr ""
+#~ msgid "Publish Project"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:191
 
-#~msgid "play"
-#~msgstr ""
+#~ msgid "play"
+#~ msgstr ""
 
 #: js/notation.js:353
 
-#~msgid "Lilypond cannot process pickup of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process pickup of "
+#~ msgstr ""
 
 #: js/activity.js:1413
 
-#~msgid "Refresh your browser to change to advanced mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to advanced mode."
+#~ msgstr ""
 
 #: js/activity.js:1418
 
-#~msgid "Refresh your browser to change to beginner mode."
-#~msgstr ""
+#~ msgid "Refresh your browser to change to beginner mode."
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3179
 
-#~msgid "New action blocks generated"
-#~msgstr ""
+#~ msgid "New action blocks generated"
+#~ msgstr ""
 
 #: js/widgets/musickeyboard.js:3180
 
-#~msgid "New action block generated"
-#~msgstr ""
+#~ msgid "New action block generated"
+#~ msgstr ""
 
-#~msgid ""Toggle Fullscreen"
-#~msgstr ""切换全屏"
+#~ msgid "Toggle Fullscreen"
+#~ msgstr "切换全屏"
 
 #: js/toolbar.js:70
 
@@ -8183,190 +8183,190 @@ msgstr ""
 
 #: js/toolbar.js:249
 
-#~msgid "Toggle JavaScript Editor"
-#~msgstr ""
+#~ msgid "Toggle JavaScript Editor"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:643
 
-#~msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
-#~msgstr ""
+#~ msgid "The Turrle pitch block returns the current pitch number being played by the specified turtle."
+#~ msgstr ""
 
 #: js/PitchActions.js:88
 
-#~msgid "The Scalar Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/PitchActions.js:107
 
-#~msgid "The Scalar Step Block must be preceded by a Pitch Block."
-#~msgstr ""
+#~ msgid "The Scalar Step Block must be preceded by a Pitch Block."
+#~ msgstr ""
 
 #: js/musickeyboard.js:2840
 
-#~msgid "New action blocks generated!"
-#~msgstr ""
+#~ msgid "New action blocks generated!"
+#~ msgstr ""
 
 #: js/toolbar.js:110
 
 #: js/toolbar.js:204
 
-#~msgid "FullScreen"
-#~msgstr ""
+#~ msgid "FullScreen"
+#~ msgstr ""
 
 #: js/turtledefs.js:506
 
-#~msgid "Toggle full screen mode."
-#~msgstr ""
+#~ msgid "Toggle full screen mode."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:386
 
-#~msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/RhythmBlockPaletteBlocks.js:601
 
-#~msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:43
 
-#~msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:175
 
-#~msgid "The Interval number block returns the number of scalar steps in the current interval."
-#~msgstr ""
+#~ msgid "The Interval number block returns the number of scalar steps in the current interval."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:203
 
-#~msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:484
 
-#~msgid "The Semi-tone interval block calculates a relative interval based on half steps."
-#~msgstr ""
+#~ msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:522
 
-#~msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
-#~msgstr ""
+#~ msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:811
 
-#~msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-#~msgstr ""
+#~ msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:845
 
-#~msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The Define mode block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:894
 
-#~msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
-#~msgstr ""
+#~ msgid "When Movable do is false, the solfege note names are always tied to specific pitches,"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:896
 
-#~msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
+#~ msgstr ""
 
 #: js/ActionBlocks.js:750
 
-#~msgid "The Action block is used to group together blocks so that they can be used more than once."
-#~msgstr ""
+#~ msgid "The Action block is used to group together blocks so that they can be used more than once."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:188
 
-#~msgid "The Greater-than block returns True if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/BooleanBlocks.js:237
 
-#~msgid "The Less-than block returns True if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The Less-than block returns True if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:34
 
 #: js/MediaBlocks.js:72
 
-#~msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:43
 
 #: js/MediaBlocks.js:81
 
-#~msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:112
 
 #: js/MediaBlocks.js:150
 
-#~msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:121
 
 #: js/MediaBlocks.js:159
 
-#~msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-#~msgstr ""
+#~ msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
+#~ msgstr ""
 
 #: js/MediaBlocks.js:579
 
-#~msgid "video material"
-#~msgstr ""
+#~ msgid "video material"
+#~ msgstr ""
 
 #: js/ProgramBlocks.js:581
 
-#~msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
-#~msgstr ""
+#~ msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+#~ msgstr ""
 
 #: js/DrumBlocks.js:188
 
 #: js/DrumBlocks.js:195
 
-#~msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
-#~msgstr ""
+#~ msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:30
 
-#~msgid "The Note value block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The Note value block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:83
 
-#~msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:235
 
-#~msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:335
 
-#~msgid "The Multiply note value block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The Multiply note value block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/RhythmBlocks.js:506
 
-#~msgid "A rest of the specified note value duration can be constructed using a Silence block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a Silence block."
+#~ msgstr ""
 
 #: js/HeapBlocks.js:60
 
-#~msgid "The Show-heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:81
 
-#~msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:679
 
@@ -8376,305 +8376,305 @@ msgstr ""
 
 #: js/FlowBlocks.js:731
 
-#~msgid "Conditionals lets your program take different actions depending on the condition."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the condition."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:690
 
-#~msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
-#~msgstr ""
+#~ msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+#~ msgstr ""
 
 #: js/FlowBlocks.js:764
 
-#~msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:401
 
-#~msgid "The Arc block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:408
 
-#~msgid "The Arc block moves the turtle in a arc."
-#~msgstr ""
+#~ msgid "The Arc block moves the turtle in a arc."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:464
 
-#~msgid "The Set heading block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The Set heading block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/GraphicsBlocks.js:810
 
-#~msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
-#~msgstr ""
+#~ msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:295
 
-#~msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/OrnamentBlocks.js:324
 
-#~msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:592
 
-#~msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:594
 
-#~msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:632
 
-#~msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+#~ msgstr ""
 
 #: js/VolumeBlocks.js:634
 
-#~msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:176
 
-#~msgid "The Partial block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The Partial block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:213
 
-#~msgid "The Weighted partials block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/ToneBlocks.js:588
 
-#~msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
-#~msgstr ""
+#~ msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:54
 
-#~msgid "The Beat factor block returns the ratio of the note value to meter note value."
-#~msgstr ""
+#~ msgid "The Beat factor block returns the ratio of the note value to meter note value."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:168
 
 #: js/MeterBlocks.js:179
 
-#~msgid "In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/MeterBlocks.js:317
 
-#~msgid "(By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "(By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/DictBlocks.js:29
 
-#~msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+#~ msgstr ""
 
 #: js/ExtrasBlocks.js:268
 
-#~msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:235
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:242
 
-#~msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:264
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:272
 
-#~msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
-#~msgstr ""
+#~ msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:292
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:299
 
-#~msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button down block triggers an event when the curson button is press on a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:319
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:326
 
-#~msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
-#~msgstr ""
+#~ msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:346
 
-#~msgid "The Get blue block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:352
 
-#~msgid "The Get blue block returns the blue component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get blue block returns the blue component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:379
 
-#~msgid "The Get green block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:385
 
-#~msgid "The Get green block returns the green component of the pixel under the turtle."
-#~msgstr ""
+#~ msgid "The Get green block returns the green component of the pixel under the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:500
 
-#~msgid "The Time block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The Time block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "More Details"
-#~msgstr ""
+#~ msgid "More Details"
+#~ msgstr ""
 
 #: js/GlobalCard.js:54
 
-#~msgid "Share project"
-#~msgstr ""
+#~ msgid "Share project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:60
 
-#~msgid "Copy link to clipboard"
-#~msgstr ""
+#~ msgid "Copy link to clipboard"
+#~ msgstr ""
 
 #: js/GlobalCard.js:63
 
-#~msgid "Run project on startup."
-#~msgstr ""
+#~ msgid "Run project on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:64
 
-#~msgid "Show code blocks on startup."
-#~msgstr ""
+#~ msgid "Show code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:65
 
-#~msgid "Collapse code blocks on startup."
-#~msgstr ""
+#~ msgid "Collapse code blocks on startup."
+#~ msgstr ""
 
 #: js/GlobalCard.js:70
 
-#~msgid "Advanced Options"
-#~msgstr ""
+#~ msgid "Advanced Options"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:1540
 
-#~msgid "Hertz Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/GlobalCard.js:48
 
-#~msgid "Unlike project"
-#~msgstr ""
+#~ msgid "Unlike project"
+#~ msgstr ""
 
 #: js/GlobalCard.js:51
 
-#~msgid "Like project"
-#~msgstr ""
+#~ msgid "Like project"
+#~ msgstr ""
 
 #: js/GlobalPlanet.js:30
 
-#~msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
-#~msgstr ""
+#~ msgid "Feature unavailable - cannot connect to server. Reload Turtle Blocks to try again."
+#~ msgstr ""
 
 #: js/Publisher.js:179
 
-#~msgid "Republish Project"
-#~msgstr ""
+#~ msgid "Republish Project"
+#~ msgstr ""
 
 #: js/blocks.js:2379
 
-#~msgid "audio file1"
-#~msgstr ""
+#~ msgid "audio file1"
+#~ msgstr ""
 
 #: js/blocks.js:2387
 
-#~msgid "audio file2"
-#~msgstr ""
+#~ msgid "audio file2"
+#~ msgstr ""
 
 #: js/turtle-singer.js:1793
 
-#~msgid "Warning: Note value greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value greater than 2."
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:537
 
-#~msgid "chord5"
-#~msgstr ""
+#~ msgid "chord5"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:543
 
-#~msgid "chord4"
-#~msgstr ""
+#~ msgid "chord4"
+#~ msgstr ""
 
 #: js/IntervalsBlocks.js:549
 
-#~msgid "chord1"
-#~msgstr ""
+#~ msgid "chord1"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:535
 
-#~msgid "The Cursor Y block returns the vertical position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor Y block returns the vertical position of the turtle."
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:567
 
-#~msgid "The Cursor X block returns the horizontal position of the turtle."
-#~msgstr ""
+#~ msgid "The Cursor X block returns the horizontal position of the turtle."
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:1174
 
-#~msgid "The Nth-Turtlee name block returns the name of the nth turtle."
-#~msgstr ""
+#~ msgid "The Nth-Turtlee name block returns the name of the nth turtle."
+#~ msgstr ""
 
 #: js/turtledefs.js:538
 
-#~msgid "Run fast"
-#~msgstr ""
+#~ msgid "Run fast"
+#~ msgstr ""
 
 #: js/turtledefs.js:652
 
-#~msgid "Expand/collapse collapsible blocks"
-#~msgstr ""
+#~ msgid "Expand/collapse collapsible blocks"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:819
 
-#~msgid "The Nth-Mouse name block returns the name of the nth mice."
-#~msgstr ""
+#~ msgid "The Nth-Mouse name block returns the name of the nth mice."
+#~ msgstr ""
 
 #: js/activity.js:364
 
-#~msgid "search for blocks"
-#~msgstr ""
+#~ msgid "search for blocks"
+#~ msgstr ""
 
 #: js/activity.js:3298
 
-#~msgid "Please set browser zoom level to 100%"
-#~msgstr ""
+#~ msgid "Please set browser zoom level to 100%"
+#~ msgstr ""
 
 #: js/toolbar.js:54
 
@@ -8684,97 +8684,97 @@ msgstr ""
 
 #: js/toolbar.js:197
 
-#~msgid "Auxilary menu"
-#~msgstr ""
+#~ msgid "Auxilary menu"
+#~ msgstr ""
 
 #: js/SaveInterface.js:47
 
-#~msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-#~msgstr ""
+#~ msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
+#~ msgstr ""
 
 #: js/blocks.js:6143
 
-#~msgid "You must always have at least one start block."
-#~msgstr ""
+#~ msgid "You must always have at least one start block."
+#~ msgstr ""
 
 #: js/sampler.js:406
 
-#~msgid "pitch up"
-#~msgstr ""
+#~ msgid "pitch up"
+#~ msgstr ""
 
 #: js/sampler.js:416
 
-#~msgid "pitch down"
-#~msgstr ""
+#~ msgid "pitch down"
+#~ msgstr ""
 
 #: js/sampler.js:424
 
-#~msgid "accidental up"
-#~msgstr ""
+#~ msgid "accidental up"
+#~ msgstr ""
 
 #: js/sampler.js:434
 
-#~msgid "accidental down"
-#~msgstr ""
+#~ msgid "accidental down"
+#~ msgstr ""
 
 #: js/sampler.js:441
 
-#~msgid "octave up"
-#~msgstr ""
+#~ msgid "octave up"
+#~ msgstr ""
 
 #: js/sampler.js:451
 
-#~msgid "octave down"
-#~msgstr ""
+#~ msgid "octave down"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
-#~msgid "currency"
-#~msgstr ""
+#~ msgid "currency"
+#~ msgstr ""
 
 #: plugins/finance.rtp:28
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "from"
-#~msgstr ""
+#~ msgid "from"
+#~ msgstr ""
 
 #: plugins/finance.rtp:69
 
-#~msgid "stock price"
-#~msgstr ""
+#~ msgid "stock price"
+#~ msgstr ""
 
 #: plugins/translate.rtp:73
 
-#~msgid "translate"
-#~msgstr ""
+#~ msgid "translate"
+#~ msgstr ""
 
 #: plugins/translate.rtp:78
 
 #: plugins/translate.rtp:89
 
-#~msgid "hello"
-#~msgstr "您好"
+#~ msgid "hello"
+#~ msgstr "您好"
 
 #: plugins/translate.rtp:84
 
-#~msgid "detect lang"
-#~msgstr ""
+#~ msgid "detect lang"
+#~ msgstr ""
 
 #: plugins/translate.rtp:95
 
-#~msgid "set lang"
-#~msgstr ""
+#~ msgid "set lang"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:30
 
-#~msgid "city latitude"
-#~msgstr ""
+#~ msgid "city latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:40
 
-#~msgid "city longitude"
-#~msgstr ""
+#~ msgid "city longitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:71
 
@@ -8784,144 +8784,144 @@ msgstr ""
 
 #: plugins/gmap.rtp:107
 
-#~msgid "Coordinate data not available."
-#~msgstr ""
+#~ msgid "Coordinate data not available."
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "Google map"
-#~msgstr ""
+#~ msgid "Google map"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
 #: plugins/gmap.rtp:160
 
-#~msgid "coordinates"
-#~msgstr ""
+#~ msgid "coordinates"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:116
 
-#~msgid "zoom factor"
-#~msgstr ""
+#~ msgid "zoom factor"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:144
 
-#~msgid "zoom"
-#~msgstr ""
+#~ msgid "zoom"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "latitude"
-#~msgstr ""
+#~ msgid "latitude"
+#~ msgstr ""
 
 #: plugins/gmap.rtp:160
 
-#~msgid "longitude"
-#~msgstr ""
+#~ msgid "longitude"
+#~ msgstr ""
 
 #: plugins/maths.rtp:74
 
-#~msgid "degrees"
-#~msgstr ""
+#~ msgid "degrees"
+#~ msgstr ""
 
 #: plugins/maths.rtp:76
 
-#~msgid "radians"
-#~msgstr ""
+#~ msgid "radians"
+#~ msgstr ""
 
 #: plugins/dictionary.rtp:25
 
-#~msgid "define"
-#~msgstr ""
+#~ msgid "define"
+#~ msgstr ""
 
 #: plugins/bitcoin.rtp:27
 
-#~msgid "bitcoin"
-#~msgstr ""
+#~ msgid "bitcoin"
+#~ msgstr ""
 
 #: plugins/heap.rtp:81
 
 #: plugins/heap.rtp:85
 
-#~msgid "You need to select a file."
-#~msgstr ""
+#~ msgid "You need to select a file."
+#~ msgstr ""
 
 #: js/activity.js:1618
 
-#~msgid "show treble"
-#~msgstr ""
+#~ msgid "show treble"
+#~ msgstr ""
 
 #: js/activity.js:1621
 
-#~msgid "hide Polar"
-#~msgstr ""
+#~ msgid "hide Polar"
+#~ msgstr ""
 
 #: js/activity.js:1628
 
 #: js/activity.js:1652
 
-#~msgid "show bass"
-#~msgstr ""
+#~ msgid "show bass"
+#~ msgstr ""
 
 #: js/activity.js:1637
 
-#~msgid "show mezzo-soprano"
-#~msgstr ""
+#~ msgid "show mezzo-soprano"
+#~ msgstr ""
 
 #: js/activity.js:1642
 
-#~msgid "show alto"
-#~msgstr ""
+#~ msgid "show alto"
+#~ msgstr ""
 
 #: js/activity.js:1647
 
-#~msgid "show tenor"
-#~msgstr ""
+#~ msgid "show tenor"
+#~ msgstr ""
 
 #: js/activity.js:1657
 
-#~msgid "hide bass"
-#~msgstr ""
+#~ msgid "hide bass"
+#~ msgstr ""
 
 #: js/activity.js:1664
 
-#~msgid "show Polar"
-#~msgstr ""
+#~ msgid "show Polar"
+#~ msgstr ""
 
 #: js/activity.js:1668
 
-#~msgid "hide Cartesian"
-#~msgstr ""
+#~ msgid "hide Cartesian"
+#~ msgstr ""
 
 #: js/notation.js:296
 
-#~msgid "Lilypond cannot process tempo of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process tempo of "
+#~ msgstr ""
 
 #: js/SaveInterface.js:283
 
-#~msgid "Save as PDF"
-#~msgstr ""
+#~ msgid "Save as PDF"
+#~ msgstr ""
 
 #: js/lilypond.js:263
 
-#~msgid "Lilypond ignoring mode"
-#~msgstr ""
+#~ msgid "Lilypond ignoring mode"
+#~ msgstr ""
 
 #: js/oscilloscope.js:49
 
-#~msgid "ZOOM IN"
-#~msgstr ""
+#~ msgid "ZOOM IN"
+#~ msgstr ""
 
 #: js/oscilloscope.js:61
 
-#~msgid "ZOOM OUT"
-#~msgstr ""
+#~ msgid "ZOOM OUT"
+#~ msgstr ""
 
 #: js/palette.js:1188
 
-#~msgid "Click to select a block."
-#~msgstr ""
+#~ msgid "Click to select a block."
+#~ msgstr ""
 
 #: js/palette.js:1205
 
@@ -8931,15 +8931,15 @@ msgstr ""
 
 #: js/palette.js:1239
 
-#~msgid "hide"
-#~msgstr ""
+#~ msgid "hide"
+#~ msgstr ""
 
 #: js/palette.js:1214
 
 #: js/palette.js:1217
 
-#~msgid "show2"
-#~msgstr ""
+#~ msgid "show2"
+#~ msgstr ""
 
 #: js/palette.js:1222
 
@@ -8949,23 +8949,23 @@ msgstr ""
 
 #: js/palette.js:1253
 
-#~msgid "popout"
-#~msgstr ""
+#~ msgid "popout"
+#~ msgstr ""
 
 #: js/palette.js:2423
 
-#~msgid "myblocks"
-#~msgstr ""
+#~ msgid "myblocks"
+#~ msgstr ""
 
 #: js/SaveInterface.js:504
 
-#~msgid "Do you want to save your project?"
-#~msgstr ""
+#~ msgid "Do you want to save your project?"
+#~ msgstr ""
 
 #: js/DrumBlocks.js:416
 
-#~msgid "Drum Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Drum Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/pitchtracker.js:181
 
@@ -8975,8 +8975,8 @@ msgstr ""
 
 #: js/pitchtracker.js:210
 
-#~msgid "Start Recording"
-#~msgstr ""
+#~ msgid "Start Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:188
 
@@ -8984,224 +8984,224 @@ msgstr ""
 
 #: js/pitchtracker.js:224
 
-#~msgid "Stop Recording"
-#~msgstr ""
+#~ msgid "Stop Recording"
+#~ msgstr ""
 
 #: js/pitchtracker.js:312
 
-#~msgid "save rhythms"
-#~msgstr ""
+#~ msgid "save rhythms"
+#~ msgstr ""
 
 #: js/pitchtracker.js:475
 
-#~msgid "drag"
-#~msgstr ""
+#~ msgid "drag"
+#~ msgstr ""
 
 #: js/PitchBlocks.js:934
 
-#~msgid "Pitch Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/EnsembleBlocks.js:295
 
-#~msgid "Mr. Mouse\", 0, 0)]"
-#~msgstr ""
+#~ msgid "Mr. Mouse\", 0, 0)]"
+#~ msgstr ""
 
 #: js/SensorsBlocks.js:195
 
-#~msgid "The Click block returns True if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The Click block returns True if a mouse has been clicked."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:318
 
-#~msgid "The box2 block returns the value stored in box2."
-#~msgstr ""
+#~ msgid "The box2 block returns the value stored in box2."
+#~ msgstr ""
 
 #: js/BoxesBlocks.js:365
 
-#~msgid "The box1 block returns the value stored in box1."
-#~msgstr ""
+#~ msgid "The box1 block returns the value stored in box1."
+#~ msgstr ""
 
 #: js/activity.js:2054
 
-#~msgid "Hide blocks."
-#~msgstr ""
+#~ msgid "Hide blocks."
+#~ msgstr ""
 
 #: js/activity.js:3319
 
-#~msgid "Cannot be further decreased"
-#~msgstr ""
+#~ msgid "Cannot be further decreased"
+#~ msgstr ""
 
 #: js/activity.js:3327
 
-#~msgid "Cannot be further increased"
-#~msgstr ""
+#~ msgid "Cannot be further increased"
+#~ msgstr ""
 
 #: js/activity.js:4263
 
-#~msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
-#~msgstr ""
+#~ msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+#~ msgstr ""
 
 #: js/logo.js:386
 
-#~msgid "Turning off mouse blink; setting FPS to 10."
-#~msgstr ""
+#~ msgid "Turning off mouse blink; setting FPS to 10."
+#~ msgstr ""
 
 #: js/logo.js:391
 
-#~msgid "Turning on mouse blink; setting FPS to 30."
-#~msgstr ""
+#~ msgid "Turning on mouse blink; setting FPS to 30."
+#~ msgstr ""
 
 #: js/logo.js:4764
 
-#~msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
-#~msgstr ""
+#~ msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+#~ msgstr ""
 
 #: js/logo.js:8405
 
-#~msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
-#~msgstr ""
+#~ msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
+#~ msgstr ""
 
 #: js/logo.js:8794
 
-#~msgid "Warning: Note value is greater than 2."
-#~msgstr ""
+#~ msgid "Warning: Note value is greater than 2."
+#~ msgstr ""
 
 #: js/logo.js:11589
 
-#~msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
-#~msgstr ""
+#~ msgid "Note name must be one of A, A♯, B♭, B, C, C♯, D♭, D, D♯, E♭, E, F, F♯, G♭, G, G♯ or A♭."
+#~ msgstr ""
 
 #: js/palette.js:2009
 
 #: js/palette.js:2066
 
-#~msgid "Do you want to remove all the stacks from your \"%s\" palette?"
-#~msgstr ""
+#~ msgid "Do you want to remove all the stacks from your \"%s\" palette?"
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "This button opens a viewer for sharing projects and for finding example projects."
-#~msgstr ""
+#~ msgid "This button opens a viewer for sharing projects and for finding example projects."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "Click this button to expand or collapse the auxiliary toolbar."
-#~msgstr ""
+#~ msgid "Click this button to expand or collapse the auxiliary toolbar."
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
-#~msgstr ""
+#~ msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The On-every-note block let you specify actions to take on every note."
-#~msgstr ""
+#~ msgid "The On-every-note block let you specify actions to take on every note."
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The Notes played block is the number of notes that have been played."
-#~msgstr ""
+#~ msgid "The Notes played block is the number of notes that have been played."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number eg 0 for C and 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:328
 
-#~msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The Pitch-slider block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "All of the Start blocks run at the same time when the Play button is pressed."
-#~msgstr ""
+#~ msgid "All of the Start blocks run at the same time when the Play button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The Store in box1 block is used to store a value in box1."
-#~msgstr ""
+#~ msgid "The Store in box1 block is used to store a value in box1."
+#~ msgstr ""
 
 #: js/turtledefs.js:350
 
-#~msgid "The Store in box2 block is used to store a value in box2."
-#~msgstr ""
+#~ msgid "The Store in box2 block is used to store a value in box2."
+#~ msgstr ""
 
 #: js/turtledefs.js:389
 
-#~msgid "The Shell block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The Shell block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The Pickup block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The Beats per minute block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The Beats per minute block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The On-strong-beat block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The On-strong-beat block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The On-weak-beat block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:439
 
-#~msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "eg \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Note volume block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The Note volume block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The Default block is used inside of a Switch to define a default action."
-#~msgstr ""
+#~ msgid "The Default block is used inside of a Switch to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:573
 
-#~msgid "The Mouse note block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The Mouse note block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:2352
 
 #: js/basicblocks.js:2363
 
-#~msgid "down minor"
-#~msgstr ""
+#~ msgid "down minor"
+#~ msgstr ""
 
 #: js/basicblocks.js:2418
 
 #: js/basicblocks.js:2429
 
-#~msgid "down major"
-#~msgstr ""
+#~ msgid "down major"
+#~ msgstr ""
 
 #: js/basicblocks.js:3713
 
-#~msgid "eval"
-#~msgstr ""
+#~ msgid "eval"
+#~ msgstr ""
 
 #: js/basicblocks.js:4057
 
-#~msgid "100"
-#~msgstr ""
+#~ msgid "100"
+#~ msgstr ""
 
 #: js/playback.js:87
 
@@ -9217,37 +9217,37 @@ msgstr ""
 
 #: js/modewidget.js:132
 
-#~msgid "Drag"
-#~msgstr ""
+#~ msgid "Drag"
+#~ msgstr ""
 
 #: js/playbackbox.js:83
 
 #: js/playbackbox.js:91
 
-#~msgid "playback music"
-#~msgstr ""
+#~ msgid "playback music"
+#~ msgstr ""
 
 #: js/playbackbox.js:96
 
-#~msgid "pause playback"
-#~msgstr ""
+#~ msgid "pause playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:107
 
 #: js/playbackbox.js:116
 
-#~msgid "restart playback"
-#~msgstr ""
+#~ msgid "restart playback"
+#~ msgstr ""
 
 #: js/playbackbox.js:123
 
-#~msgid "prepare music for playback"
-#~msgstr ""
+#~ msgid "prepare music for playback"
+#~ msgstr ""
 
 #: js/help.js:217
 
-#~msgid "Load blocks"
-#~msgstr ""
+#~ msgid "Load blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
@@ -9255,28 +9255,28 @@ msgstr ""
 
 #: js/turtledefs.js:584
 
-#~msgid "The Set timbre block selects a voice for the synthesizer,"
-#~msgstr ""
+#~ msgid "The Set timbre block selects a voice for the synthesizer,"
+#~ msgstr ""
 
 #: js/turtledefs.js:525
 
-#~msgid "The Run block block runs a block."
-#~msgstr ""
+#~ msgid "The Run block block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:2018
 
-#~msgid "set timbre"
-#~msgstr ""
+#~ msgid "set timbre"
+#~ msgstr ""
 
 #: js/basicblocks.js:4413
 
-#~msgid "right2"
-#~msgstr ""
+#~ msgid "right2"
+#~ msgstr ""
 
 #: js/basicblocks.js:4429
 
-#~msgid "left2"
-#~msgstr ""
+#~ msgid "left2"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:323
 
@@ -9290,8 +9290,8 @@ msgstr ""
 
 #: js/rhythmruler.js:1711
 
-#~msgid "expand"
-#~msgstr ""
+#~ msgid "expand"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:338
 
@@ -9301,65 +9301,65 @@ msgstr ""
 
 #: js/rhythmruler.js:1721
 
-#~msgid "collapse"
-#~msgstr ""
+#~ msgid "collapse"
+#~ msgstr ""
 
-#~msgid "crescendo factor"
-#~msgstr ""
+#~ msgid "crescendo factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:181
 
-#~msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
-#~msgstr ""
+#~ msgid "At the heart of Music Blocks is the <em>Note</em> block. The <em>Note</em> block is a container for a <em>Pitch</em> block that specifies the duration (note value) of the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:466
 
-#~msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
-#~msgstr ""
+#~ msgid "The <em>Time</em> block returns the number of seconds that the program has been running."
+#~ msgstr ""
 
 #: js/turtledefs.js:253
 
-#~msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box1</em> block is used to store a value in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:265
 
-#~msgid "The <em>Multiply</em> block is used to multiply."
-#~msgstr ""
+#~ msgid "The <em>Multiply</em> block is used to multiply."
+#~ msgstr ""
 
 #: js/blocks.js:2837
 
 #: js/blocks.js:2863
 
-#~msgid "There is no block is selected."
-#~msgstr ""
+#~ msgid "There is no block is selected."
+#~ msgstr ""
 
 #: js/turtledefs.js:209
 
-#~msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) the scale. In the example shown above, <em>sol</em> is shifted up to <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:132
 
-#~msgid "Initialise a new project."
-#~msgstr ""
+#~ msgid "Initialise a new project."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:339
 
-#~msgid "japanese"
-#~msgstr ""
+#~ msgid "japanese"
+#~ msgstr ""
 
 #: js/block.js:1312
 
-#~msgid "7th"
-#~msgstr ""
+#~ msgid "7th"
+#~ msgstr ""
 
 #: js/basicblocks.js:2440
 
-#~msgid "chord' + ' ' + 'V"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'V"
+#~ msgstr ""
 
 #: js/musicutils.js:345
 
@@ -9367,8 +9367,8 @@ msgstr ""
 
 #: js/macros.js:38
 
-#~msgid "chine"
-#~msgstr ""
+#~ msgid "chine"
+#~ msgstr ""
 
 #: js/timbre.js:743
 
@@ -9378,127 +9378,127 @@ msgstr ""
 
 #: js/pitchstaircase.js:534
 
-#~msgid "undo"
-#~msgstr ""
+#~ msgid "undo"
+#~ msgstr ""
 
 #: js/basicblocks.js:2464
 
-#~msgid "chord' + ' ' + 'I"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'I"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "placeholder"
-#~msgstr ""
+#~ msgid "placeholder"
+#~ msgstr ""
 
 #: js/turtledefs.js:436
 
-#~msgid "The <em>Move block</em> block moves a block."
-#~msgstr ""
+#~ msgid "The <em>Move block</em> block moves a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:327
 
 #: js/turtledefs.js:329
 
-#~msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
-#~msgstr ""
+#~ msgid "The <em>Accidental</em> block is used to create <em>sharps</em> and <em>flats</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The <em>Hide blocks</em> block hides the blocks."
-#~msgstr ""
+#~ msgid "The <em>Hide blocks</em> block hides the blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:378
 
-#~msgid "The <em>Waitfor</em> block will wait until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Waitfor</em> block will wait until the condition is true."
+#~ msgstr ""
 
 #: js/basicblocks.js:3142
 
 #: js/basicblocks.js:3151
 
-#~msgid "set volume"
-#~msgstr ""
+#~ msgid "set volume"
+#~ msgstr ""
 
 #: js/turtledefs.js:366
 
-#~msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
-#~msgstr ""
+#~ msgid "The <em>Play noise</em> block will generate white, pink, or brown noise."
+#~ msgstr ""
 
 #: js/turtledefs.js:441
 
-#~msgid "The <em>Bezier</em> block draws a Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Bezier</em> block draws a Bezier curve."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "hours ago"
-#~msgstr ""
+#~ msgid "hours ago"
+#~ msgstr ""
 
 #: js/musicutils.js:243
 
-#~msgid "Major Blues"
-#~msgstr ""
+#~ msgid "Major Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:273
 
-#~msgid "The <em>Back</em> block moves the mouse backward."
-#~msgstr ""
+#~ msgid "The <em>Back</em> block moves the mouse backward."
+#~ msgstr ""
 
 #: js/turtledefs.js:307
 
-#~msgid "The <em>Set-name</em> block is used to name a mouse."
-#~msgstr ""
+#~ msgid "The <em>Set-name</em> block is used to name a mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:231
 
-#~msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
-#~msgstr ""
+#~ msgid "The <em>Status</em> block opens a tool for inspecting the status of Music Blocks as it is running."
+#~ msgstr ""
 
 #: js/pitchstaircase.js:480
 
-#~msgid "play scale"
-#~msgstr ""
+#~ msgid "play scale"
+#~ msgstr ""
 
-#~msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Note, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:326
 
-#~msgid "The <em>Beats per minute</em> block returns the current beats per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block returns the current beats per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
-#~msgstr ""
+#~ msgid "The Scaler Step block (in combination with a Number block) will play the next pitch in a scale,"
+#~ msgstr ""
 
 #: js/turtledefs.js:336
 
-#~msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>ni dha pa ma ga re sa<em>."
+#~ msgstr ""
 
 #: js/musicutils.js:229
 
-#~msgid "Enigmatic"
-#~msgstr ""
+#~ msgid "Enigmatic"
+#~ msgstr ""
 
 #: js/basicblocks.js:612
 
-#~msgid "fifths"
-#~msgstr ""
+#~ msgid "fifths"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ml"
-#~msgstr ""
+#~ msgid "ml"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "mi"
-#~msgstr ""
+#~ msgid "mi"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
@@ -9506,608 +9506,608 @@ msgstr ""
 
 #: js/turtledefs.js:390
 
-#~msgid "The <em>Do</em> block is used to initiate an action."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The Indexheap block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The Indexheap block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:284
 
-#~msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
-#~msgstr ""
+#~ msgid "The <em>Pen-up</em> block raises the pen so that it does not draw."
+#~ msgstr ""
 
 #: js/turtledefs.js:473
 
-#~msgid "The <em>New mouse</em> block will create a new mouse."
-#~msgstr ""
+#~ msgid "The <em>New mouse</em> block will create a new mouse."
+#~ msgstr ""
 
 #: js/activity.js:4353
 
-#~msgid "playback"
-#~msgstr ""
+#~ msgid "playback"
+#~ msgstr ""
 
 #: js/activity.js:4435
 
 #: js/activity.js:4470
 
-#~msgid "Merge project from file"
-#~msgstr ""
+#~ msgid "Merge project from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:299
 
-#~msgid "The <em>Left</em> block returns the position of the left of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block returns the position of the left of the canvas."
+#~ msgstr ""
 
-#~msgid "eatme"
-#~msgstr ""
+#~ msgid "eatme"
+#~ msgstr ""
 
 #: js/turtledefs.js:323
 
-#~msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
-#~msgstr ""
+#~ msgid "The <em>Whole notes played</em> block returns the total number of whole notes played."
+#~ msgstr ""
 
 #: js/basicblocks.js:1946
 
-#~msgid "movable"
-#~msgstr ""
+#~ msgid "movable"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:46
 
-#~msgid "brown-noise"
-#~msgstr ""
+#~ msgid "brown-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:251
 
-#~msgid "Japanese"
-#~msgstr ""
+#~ msgid "Japanese"
+#~ msgstr ""
 
 #: js/synthutils.js:90
 
-#~msgid "triangle-bell"
-#~msgstr ""
+#~ msgid "triangle-bell"
+#~ msgstr ""
 
 #: js/activity.js:1216
 
-#~msgid "Hide grid"
-#~msgstr ""
+#~ msgid "Hide grid"
+#~ msgstr ""
 
 #: js/turtledefs.js:358
 
-#~msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>FM synth</em> block is a frequency modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The Show heap block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The Show heap block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
-#~msgid "The <em>Number</em> block holds a number."
-#~msgstr ""
+#~ msgid "The <em>Number</em> block holds a number."
+#~ msgstr ""
 
 #: js/turtledefs.js:381
 
-#~msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
-#~msgstr ""
+#~ msgid "The <em>Case</em> block is used inside of a <em>Switch</em> to define matches."
+#~ msgstr ""
 
 #: js/turtledefs.js:539
 
-#~msgid "The Background block sets the background color."
-#~msgstr ""
+#~ msgid "The Background block sets the background color."
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "Previous page"
-#~msgstr ""
+#~ msgid "Previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:458
 
-#~msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Open file</em> block opens a file for use with the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:287
 
-#~msgid "The <em>Set-color</em> block changes the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set-color</em> block changes the pen color."
+#~ msgstr ""
 
 #: js/basicblocks.js:2452
 
-#~msgid "chord' + ' ' + 'IV"
-#~msgstr ""
+#~ msgid "chord' + ' ' + 'IV"
+#~ msgstr ""
 
 #: js/timbre.js:682
 
-#~msgid "effects"
-#~msgstr ""
+#~ msgid "effects"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "floor-tom"
-#~msgstr ""
+#~ msgid "floor-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:295
 
-#~msgid "The <em>Height</em> block returns the height of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Height</em> block returns the height of the canvas."
+#~ msgstr ""
 
 #: js/savebox.js:129
 
-#~msgid "Share on Facebook"
-#~msgstr ""
+#~ msgid "Share on Facebook"
+#~ msgstr ""
 
 #: js/turtledefs.js:452
 
-#~msgid "The <em>Shade</em> block returns the current pen shade value."
-#~msgstr ""
+#~ msgid "The <em>Shade</em> block returns the current pen shade value."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The On-every-beat block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The On-every-beat block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:76
 
-#~msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
-#~msgstr ""
+#~ msgid "Mr. Mouse is our Music Blocks conductor. Mr. Mouse encourages you to explore Music Blocks. Let us start our tour!"
+#~ msgstr ""
 
 #: js/palette.js:1771
 
 #: js/palette.js:1796
 
-#~msgid "re"
-#~msgstr ""
+#~ msgid "re"
+#~ msgstr ""
 
 #: js/musicutils.js:237
 
-#~msgid "Spanish Gypsy"
-#~msgstr ""
+#~ msgid "Spanish Gypsy"
+#~ msgstr ""
 
 #: js/basicblocks.js:893
 
-#~msgid "divide note value"
-#~msgstr ""
+#~ msgid "divide note value"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "e.g., C Major"
-#~msgstr ""
+#~ msgid "e.g., C Major"
+#~ msgstr ""
 
 #: js/activity.js:3743
 
-#~msgid "extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/rhythmruler.js:1442
 
-#~msgid "save drum machine"
-#~msgstr ""
+#~ msgid "save drum machine"
+#~ msgstr ""
 
 #: js/activity.js:4373
 
-#~msgid "enable horizontal scrolling"
-#~msgstr ""
+#~ msgid "enable horizontal scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:318
 
-#~msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
-#~msgstr ""
+#~ msgid "The <em>Pickup</em> block is used to accommodate any notes that come in before the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:449
 
-#~msgid "The <em>Hollow line</em> block creates a line with a hollow center."
-#~msgstr ""
+#~ msgid "The <em>Hollow line</em> block creates a line with a hollow center."
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "To copy a stack to the clipboard, right-click on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, right-click on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:462
 
-#~msgid "The <em>Stopplayback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Stopplayback</em> block"
+#~ msgstr ""
 
 #: js/toolbar.js:342
 
 #: js/toolbar.js:390
 
-#~msgid "Save as abc"
-#~msgstr ""
+#~ msgid "Save as abc"
+#~ msgstr ""
 
 #: js/turtledefs.js:456
 
-#~msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
-#~msgstr ""
+#~ msgid "The <em>To frequency</em> block converts a pitch name and octave to Hertz."
+#~ msgstr ""
 
 #: js/basicblocks.js:4422
 
-#~msgid "top"
-#~msgstr ""
+#~ msgid "top"
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Open a panel for configuring Music Blocks."
-#~msgstr ""
+#~ msgid "Open a panel for configuring Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:407
 
-#~msgid "The <em>And</em> block is the logical and operator."
-#~msgstr ""
+#~ msgid "The <em>And</em> block is the logical and operator."
+#~ msgstr ""
 
 #: js/activity.js:3533
 
-#~msgid "Save as .wav"
-#~msgstr ""
+#~ msgid "Save as .wav"
+#~ msgstr ""
 
 #: js/savebox.js:113
 
-#~msgid "The Planet is unavailable."
-#~msgstr ""
+#~ msgid "The Planet is unavailable."
+#~ msgstr ""
 
 #: js/turtledefs.js:194
 
-#~msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
-#~msgstr ""
+#~ msgid "You can use multiple <em>Drum</em> blocks within a <em>Note</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "You can also use Alt+V to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+V to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
-#~msgstr ""
+#~ msgid "The <em>Video</em> block selects video for use with the <em>Show</em> block. "
+#~ msgstr ""
 
 #: js/turtledefs.js:343
 
-#~msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "When <em>Movable do</em> is false, the solfege note names are always tied to specific pitches (e.g. \"do\" is always \"C-natural\"); when <em>Movable do</em> is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/turtledefs.js:412
 
-#~msgid "The <em>Pop</em> block removes the value at the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Pop</em> block removes the value at the top of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Decrescendo</em> block will decrease the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Decrescendo</em> block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "The save-stack button saves a stack onto a custom palette."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette."
+#~ msgstr ""
 
 #: js/musicutils.js:248
 
-#~msgid "Egyptian"
-#~msgstr ""
+#~ msgid "Egyptian"
+#~ msgstr ""
 
 #: js/turtledefs.js:186
 
-#~msgid "The paste button is enabled when there are blocks copied onto the clipboard."
-#~msgstr ""
+#~ msgid "The paste button is enabled when there are blocks copied onto the clipboard."
+#~ msgstr ""
 
 #: js/musicutils.js:198
 
-#~msgid "Algerian"
-#~msgstr ""
+#~ msgid "Algerian"
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "denominator"
-#~msgstr ""
+#~ msgid "denominator"
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The Emptyheap block empties the heap."
-#~msgstr ""
+#~ msgid "The Emptyheap block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "The <em>Phaser</em> block adds a sweeping sound."
-#~msgstr ""
+#~ msgid "The <em>Phaser</em> block adds a sweeping sound."
+#~ msgstr ""
 
 #: js/turtledefs.js:429
 
-#~msgid "The <em>Open project</em> block is used to open a project from a web page."
-#~msgstr ""
+#~ msgid "The <em>Open project</em> block is used to open a project from a web page."
+#~ msgstr ""
 
 #: plugins/impact.rtp:63
 
 #: plugins/impact.rtp:127
 
-#~msgid "Impact data not available."
-#~msgstr ""
+#~ msgid "Impact data not available."
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Extra-long press the run button to run the music in slow mode."
-#~msgstr ""
+#~ msgid "Extra-long press the run button to run the music in slow mode."
+#~ msgstr ""
 
-#~msgid "mashape"
-#~msgstr ""
+#~ msgid "mashape"
+#~ msgstr ""
 
 #: js/basicblocks.js:589
 
-#~msgid "thirds"
-#~msgstr ""
+#~ msgid "thirds"
+#~ msgstr ""
 
 #: js/turtledefs.js:279
 
-#~msgid "The <em>X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:437
 
-#~msgid "The <em>Delete block</em> block removes a block."
-#~msgstr ""
+#~ msgid "The <em>Delete block</em> block removes a block."
+#~ msgstr ""
 
 #: js/turtledefs.js:278
 
-#~msgid "The <em>Scroll XY</em> block moves the canvas."
-#~msgstr ""
+#~ msgid "The <em>Scroll XY</em> block moves the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:393
 
-#~msgid "The <em>Return to URL</em> block will return a value to a webpage."
-#~msgstr ""
+#~ msgid "The <em>Return to URL</em> block will return a value to a webpage."
+#~ msgstr ""
 
 #: js/turtledefs.js:274
 
-#~msgid "The <em>Left</em> block turns the mouse to the left."
-#~msgstr ""
+#~ msgid "The <em>Left</em> block turns the mouse to the left."
+#~ msgstr ""
 
 #: js/activity.js:4395
 
-#~msgid "Run"
-#~msgstr ""
+#~ msgid "Run"
+#~ msgstr ""
 
 #: js/turtledefs.js:169
 
-#~msgid "You can load new blocks from the file system."
-#~msgstr ""
+#~ msgid "You can load new blocks from the file system."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
 #: js/turtledefs.js:189
 
-#~msgid "Settings"
-#~msgstr ""
+#~ msgid "Settings"
+#~ msgstr ""
 
 #: js/turtledefs.js:409
 
-#~msgid "The <em>Boolean</em> block is used to specify true or false."
-#~msgstr ""
+#~ msgid "The <em>Boolean</em> block is used to specify true or false."
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
-#~msgstr ""
+#~ msgid "The <em>On-strong-beat</em> block let you specify actions to take on specified beats."
+#~ msgstr ""
 
 #: js/turtledefs.js:414
 
-#~msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
-#~msgstr ""
+#~ msgid "The <em>Indexheap</em> block returns a value in the heap at a specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:385
 
 #: js/turtledefs.js:386
 
-#~msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
-#~msgstr ""
+#~ msgid "The <em>Arg</em> block contains the value of an argument passed to an action."
+#~ msgstr ""
 
 #: js/pitchslider.js:394
 
-#~msgid "move down"
-#~msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: js/basicblocks.js:153
 
-#~msgid "consonant step up"
-#~msgstr ""
+#~ msgid "consonant step up"
+#~ msgstr ""
 
 #: js/turtledefs.js:418
 
-#~msgid "The <em>Emptyheap</em> block empties the heap."
-#~msgstr ""
+#~ msgid "The <em>Emptyheap</em> block empties the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:382
 
-#~msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
-#~msgstr ""
+#~ msgid "The <em>Default</em> block is used inside of a <em>Switch</em> to define a default action."
+#~ msgstr ""
 
 #: js/turtledefs.js:340
 
-#~msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step up</em> block returns the number of semi-tones up to the next note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Maker</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:482
 
-#~msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse heading</em> block returns the heading of the specified mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:505
 
-#~msgid "pitchslider"
-#~msgstr ""
+#~ msgid "pitchslider"
+#~ msgstr ""
 
 #: js/StringHelper.js:35
 
-#~msgid "View More"
-#~msgstr ""
+#~ msgid "View More"
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:305
 
 #: js/rhythmruler.js:1625
 
-#~msgid "collpase"
-#~msgstr ""
+#~ msgid "collpase"
+#~ msgstr ""
 
 #: js/turtledefs.js:498
 
-#~msgid "The Heap-empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap-empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:253
 
-#~msgid "Fibonacci"
-#~msgstr ""
+#~ msgid "Fibonacci"
+#~ msgstr ""
 
 #: js/activity.js:4425
 
-#~msgid "Run music slowly"
-#~msgstr ""
+#~ msgid "Run music slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:447
 
-#~msgid "The <em>Set translucency</em> block changes the opacity of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set translucency</em> block changes the opacity of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and pitch octave of a note that determine the frequency of the note."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note—making them tighter bursts—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchslider.js:402
 
-#~msgid "Use the slider to change the pitch."
-#~msgstr ""
+#~ msgid "Use the slider to change the pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:300
 
-#~msgid "The <em>Right</em> block returns the position of the right of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block returns the position of the right of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:226
 
-#~msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The <em>Set synth volume</em> block will change the volume of a particular synth, e.g., guitar, violin, snare drum, etc. The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:224
 
-#~msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The <em>Crescendo</em> block will increase the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/basicblocks.js:3078
 
-#~msgid "note volume"
-#~msgstr ""
+#~ msgid "note volume"
+#~ msgstr ""
 
 #: js/synthutils.js:92
 
-#~msgid "finger-cymbals"
-#~msgstr ""
+#~ msgid "finger-cymbals"
+#~ msgstr ""
 
 #: js/basicblocks.js:489
 
-#~msgid "pitch-drum matrix"
-#~msgstr ""
+#~ msgid "pitch-drum matrix"
+#~ msgstr ""
 
 #: js/logo.js:6101
 
 #: js/logo.js:6125
 
-#~msgid "Tuplet Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Tuplet Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
-#~msgid "set beats per minute"
-#~msgstr ""
+#~ msgid "set beats per minute"
+#~ msgstr ""
 
 #: js/activity.js:3887
 
-#~msgid "Delete all"
-#~msgstr ""
+#~ msgid "Delete all"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:48
 
-#~msgid "pink-noise"
-#~msgstr ""
+#~ msgid "pink-noise"
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "UID"
-#~msgstr ""
+#~ msgid "UID"
+#~ msgstr ""
 
 #: js/musicutils.js:197
 
-#~msgid "Chromatic"
-#~msgstr ""
+#~ msgid "Chromatic"
+#~ msgstr ""
 
 #: js/modewidget.js:83
 
-#~msgid "rotate clockwise"
-#~msgstr ""
+#~ msgid "rotate clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:334
 
-#~msgid "hirajoshi (Japan)"
-#~msgstr ""
+#~ msgid "hirajoshi (Japan)"
+#~ msgstr ""
 
 #: js/logo.js:5040
 
 #: js/logo.js:5061
 
-#~msgid "Input to Minor Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Minor Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/basicblocks.js:4432
 
-#~msgid "bottom"
-#~msgstr ""
+#~ msgid "bottom"
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
-#~msgstr ""
+#~ msgid "The <em>Set key</em> block is used to set the key and mode, e.g., <em>C Major</em>"
+#~ msgstr ""
 
 #: js/turtledefs.js:313
 
-#~msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
-#~msgstr ""
+#~ msgid "The <em>Multiply note value</em> block changes the duration of notes by changing their note values."
+#~ msgstr ""
 
 #: js/turtledefs.js:280
 
-#~msgid "The <em>Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:831
 
-#~msgid "numerator"
-#~msgstr ""
+#~ msgid "numerator"
+#~ msgstr ""
 
 #: js/synthutils.js:80
 
-#~msgid "cup-drum"
-#~msgstr ""
+#~ msgid "cup-drum"
+#~ msgstr ""
 
 #: js/synthutils.js:84
 
-#~msgid "hi-hat"
-#~msgstr ""
+#~ msgid "hi-hat"
+#~ msgstr ""
 
 #: js/palette.js:1763
 
@@ -10117,165 +10117,165 @@ msgstr ""
 
 #: js/palette.js:1796
 
-#~msgid "sol"
-#~msgstr ""
+#~ msgid "sol"
+#~ msgstr ""
 
 #: js/turtledefs.js:276
 
-#~msgid "The <em>Arc</em> block moves the mouse in a arc."
-#~msgstr ""
+#~ msgid "The <em>Arc</em> block moves the mouse in a arc."
+#~ msgstr ""
 
 #: js/turtledefs.js:370
 
-#~msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
-#~msgstr ""
+#~ msgid "The <em>Pitch staircase</em> tool to is used to generate pitches from a given ratio."
+#~ msgstr ""
 
 #: js/turtledefs.js:364
 
-#~msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Note volume</em> block returns the current volume of the current synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:198
 
-#~msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
-#~msgstr ""
+#~ msgid "The beat of the music is determined by the <em>Meter</em> block (by default, 4 1/4 notes per measure)."
+#~ msgstr ""
 
 #: js/turtledefs.js:337
 
-#~msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-#~msgstr ""
+#~ msgid "The <em>Accidental selector</em> block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
+#~ msgstr ""
 
 #: js/musicutils.js:211
 
-#~msgid "Phrygian"
-#~msgstr ""
+#~ msgid "Phrygian"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
-#~msgstr ""
+#~ msgid "The <em>Define mode</em> block allows you define a custom mode by specifiying pitch numbers."
+#~ msgstr ""
 
 #: js/activity.js:2166
 
-#~msgid "Run fast / long press to run slow / extra-long press to run music slow"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slow / extra-long press to run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:28
 
-#~msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of manipulative tools for exploring fundamental musical concepts in an integrative and fun way."
+#~ msgstr ""
 
 #: js/palette.js:1682
 
-#~msgid "la"
-#~msgstr ""
+#~ msgid "la"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:203
 
-#~msgid "see distance"
-#~msgstr ""
+#~ msgid "see distance"
+#~ msgstr ""
 
 #: js/turtledefs.js:374
 
-#~msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
-#~msgstr ""
+#~ msgid "The <em>Tuplet</em> block is used to generate a group of notes played in a condensed amount of time."
+#~ msgstr ""
 
 #: js/turtledefs.js:459
 
-#~msgid "The Switch block will run the code in the matchin Case."
-#~msgstr ""
+#~ msgid "The Switch block will run the code in the matchin Case."
+#~ msgstr ""
 
 #: js/basicblocks.js:1457
 
-#~msgid "relative interval"
-#~msgstr ""
+#~ msgid "relative interval"
+#~ msgstr ""
 
 #: js/turtledefs.js:199
 
-#~msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block sets the number of 1/4 notes per minute."
+#~ msgstr ""
 
 #: js/turtledefs.js:296
 
-#~msgid "The <em>Width</em> block returns the width of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Width</em> block returns the width of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:110
 
 #: js/turtledefs.js:148
 
-#~msgid "Stop the music (and the turtles)."
-#~msgstr ""
+#~ msgid "Stop the music (and the turtles)."
+#~ msgstr ""
 
 #: js/synthutils.js:78
 
-#~msgid "floor-tom-tom"
-#~msgstr ""
+#~ msgid "floor-tom-tom"
+#~ msgstr ""
 
 #: js/turtledefs.js:312
 
-#~msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
-#~msgstr ""
+#~ msgid "The <em>Tie</em> block works on pairs of notes, combining them into one note."
+#~ msgstr ""
 
 #: js/turtledefs.js:205
 
-#~msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>do re mi fa sol la ti<em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:292
 
-#~msgid "The <em>Show</em> block is used to display text or images on the canvas."
-#~msgstr ""
+#~ msgid "The <em>Show</em> block is used to display text or images on the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:450
 
-#~msgid "The <em>Background</em> block sets the background color."
-#~msgstr ""
+#~ msgid "The <em>Background</em> block sets the background color."
+#~ msgstr ""
 
 #: js/basicblocks.js:298
 
-#~msgid "turtle note"
-#~msgstr ""
+#~ msgid "turtle note"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Turtle and more."
+#~ msgstr ""
 
 #: js/turtledefs.js:376
 
-#~msgid "The <em>While</em> block will repeat while the condition is true."
-#~msgstr ""
+#~ msgid "The <em>While</em> block will repeat while the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:264
 
-#~msgid "The <em>Minus</em> block is used to subtract."
-#~msgstr ""
+#~ msgid "The <em>Minus</em> block is used to subtract."
+#~ msgstr ""
 
 #: js/savebox.js:159
 
-#~msgid "block artwork"
-#~msgstr ""
+#~ msgid "block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:222
 
-#~msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
-#~msgstr ""
+#~ msgid "The <em>Neighbor</em> block rapidly switches between neighboring pitches."
+#~ msgstr ""
 
 #: js/turtledefs.js:353
 
-#~msgid "The <em>Distortion</em> block adds distortion to the pitch."
-#~msgstr ""
+#~ msgid "The <em>Distortion</em> block adds distortion to the pitch."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "br"
-#~msgstr ""
+#~ msgid "br"
+#~ msgstr ""
 
 #: js/block.js:1306
 
-#~msgid "1st"
-#~msgstr ""
+#~ msgid "1st"
+#~ msgstr ""
 
 #: js/logo.js:2177
 
@@ -10289,28 +10289,28 @@ msgstr ""
 
 #: js/logo.js:8059
 
-#~msgid "Could not find turtle"
-#~msgstr ""
+#~ msgid "Could not find turtle"
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of noteswhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/musicutils.js:234
 
-#~msgid "Hungarian"
-#~msgstr ""
+#~ msgid "Hungarian"
+#~ msgstr ""
 
 #: js/pitchstaircase.js:475
 
-#~msgid "play chord"
-#~msgstr ""
+#~ msgid "play chord"
+#~ msgstr ""
 
 #: js/utilitybox.js:154
 
-#~msgid "Optimize feedback"
-#~msgstr ""
+#~ msgid "Optimize feedback"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10318,133 +10318,133 @@ msgstr ""
 
 #: js/toolbar.js:426
 
-#~msgid "Save block artwork"
-#~msgstr ""
+#~ msgid "Save block artwork"
+#~ msgstr ""
 
 #: js/turtledefs.js:234
 
-#~msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
-#~msgstr ""
+#~ msgid "The <em>Pitch-slider<em> block opens a tool to generate arbitray pitches."
+#~ msgstr ""
 
 #: js/logo.js:3711
 
-#~msgid "The Scaler Step Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Scaler Step Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:"
+#~ msgstr ""
 
 #: js/basicblocks.js:596
 
-#~msgid "fourths"
-#~msgstr ""
+#~ msgid "fourths"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the veritcal position of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "The Crescendo block will increase (or decrease) the volume of the contained notes by a specified amount for every note played. For example, if you have 7 notes in sequence contained in a <em>Crescendo</em> block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:464
 
-#~msgid "The <em>Keyboard</em> block returns computer keyboard input."
-#~msgstr ""
+#~ msgid "The <em>Keyboard</em> block returns computer keyboard input."
+#~ msgstr ""
 
-#~msgid "Save your project to a server."
-#~msgstr ""
+#~ msgid "Save your project to a server."
+#~ msgstr ""
 
 #: js/basicblocks.js:892
 
-#~msgid "multiply beat value"
-#~msgstr ""
+#~ msgid "multiply beat value"
+#~ msgstr ""
 
 #: js/musicutils.js:244
 
-#~msgid "Whole Tone"
-#~msgstr ""
+#~ msgid "Whole Tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:404
 
-#~msgid "The <em>Int</em> block returns an integer."
-#~msgstr ""
+#~ msgid "The <em>Int</em> block returns an integer."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> block returns the value stored in <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:82
 
-#~msgid "Click to run just the music in slow mode."
-#~msgstr ""
+#~ msgid "Click to run just the music in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:294
 
-#~msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
-#~msgstr ""
+#~ msgid "The <em>Speak</em> block outputs to the text-to-speech synthesizer"
+#~ msgstr ""
 
 #: js/turtledefs.js:451
 
-#~msgid "The <em>Grey</em> block returns the current pen grey value."
-#~msgstr ""
+#~ msgid "The <em>Grey</em> block returns the current pen grey value."
+#~ msgstr ""
 
 #: js/block.js:1311
 
-#~msgid "6th"
-#~msgstr ""
+#~ msgid "6th"
+#~ msgstr ""
 
 #: js/logo.js:4945
 
 #: js/logo.js:4966
 
-#~msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Augmented Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:367
 
-#~msgid "The <em>Drum name</em> block is used to select a drum."
-#~msgstr ""
+#~ msgid "The <em>Drum name</em> block is used to select a drum."
+#~ msgstr ""
 
 #: js/activity.js:2699
 
-#~msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly / extra-long press to run music slowly"
+#~ msgstr ""
 
 #: js/basicblocks.js:4872
 
-#~msgid "save as lilypond"
-#~msgstr ""
+#~ msgid "save as lilypond"
+#~ msgstr ""
 
 #: js/turtledefs.js:266
 
-#~msgid "The <em>Divide</em> block is used to divide."
-#~msgstr ""
+#~ msgid "The <em>Divide</em> block is used to divide."
+#~ msgstr ""
 
 #: js/turtledefs.js:357
 
-#~msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
-#~msgstr ""
+#~ msgid "The <em>Partial</em> block is used to specify a weight for a specific partical harmonic."
+#~ msgstr ""
 
 #: js/turtledefs.js:373
 
-#~msgid "The <em>Temperament name</em> block is used to select a tuning method."
-#~msgstr ""
+#~ msgid "The <em>Temperament name</em> block is used to select a tuning method."
+#~ msgstr ""
 
 #: js/musicutils.js:200
 
-#~msgid "Diminished"
-#~msgstr ""
+#~ msgid "Diminished"
+#~ msgstr ""
 
-#~msgid "Expand/collapse toolbar"
-#~msgstr ""
+#~ msgid "Expand/collapse toolbar"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -10452,136 +10452,136 @@ msgstr ""
 
 #: js/toolbar.js:421
 
-#~msgid "Save as SVG"
-#~msgstr ""
+#~ msgid "Save as SVG"
+#~ msgstr ""
 
 #: js/turtledefs.js:424
 
-#~msgid "The Loadheap block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The Loadheap block loads the heap from a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:335
 
-#~msgid "in (Japan)"
-#~msgstr ""
+#~ msgid "in (Japan)"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Alternatively, you can hit the ENTER or RETURN key."
-#~msgstr ""
+#~ msgid "Alternatively, you can hit the ENTER or RETURN key."
+#~ msgstr ""
 
 #: js/turtledefs.js:218
 
 #: js/turtledefs.js:350
 
-#~msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "The <em>Set timbre</em> block selects a voice for the synthesizer, e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
 #: js/analytics.js:316
 
-#~msgid "turtle"
-#~msgstr "小烏龜"
+#~ msgid "turtle"
+#~ msgstr "小烏龜"
 
 #: js/turtledefs.js:480
 
-#~msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Y mouse</em> block returns the Y position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:336
 
-#~msgid "minyo (Japan)"
-#~msgstr ""
+#~ msgid "minyo (Japan)"
+#~ msgstr ""
 
 #: plugins/impact.rtp:124
 
-#~msgid "Impact Time not found."
-#~msgstr ""
+#~ msgid "Impact Time not found."
+#~ msgstr ""
 
 #: js/turtledefs.js:319
 
-#~msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
-#~msgstr ""
+#~ msgid "The <em>Beats per minute</em> block changes the beats per minute of any contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:485
 
-#~msgid "The <em>Stop mouse</em> block stops the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Stop mouse</em> block stops the specified mouse."
+#~ msgstr ""
 
 #: js/block.js:1308
 
-#~msgid "3rd"
-#~msgstr ""
+#~ msgid "3rd"
+#~ msgstr ""
 
 #: js/turtledefs.js:383
 
-#~msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
-#~msgstr ""
+#~ msgid "The <em>Duplicate</em> block will run each block multiple times. The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+#~ msgstr ""
 
 #: js/turtledefs.js:348
 
-#~msgid "The <em>Doubly</em> block will double the size of an interval."
-#~msgstr ""
+#~ msgid "The <em>Doubly</em> block will double the size of an interval."
+#~ msgstr ""
 
 #: js/turtledefs.js:435
 
-#~msgid "The <em>Run block</em> block runs a block."
-#~msgstr ""
+#~ msgid "The <em>Run block</em> block runs a block."
+#~ msgstr ""
 
 #: js/basicblocks.js:510
 
-#~msgid "play forward"
-#~msgstr ""
+#~ msgid "play forward"
+#~ msgstr ""
 
 #: js/musicutils.js:308
 
-#~msgid "basse"
-#~msgstr ""
+#~ msgid "basse"
+#~ msgstr ""
 
 #: js/turtledefs.js:208
 
-#~msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
-#~msgstr ""
+#~ msgid "The <em>Hertz</em> block (in combination with a <em>Number</em> block) will play a sound at the specified frequency."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:465
 
-#~msgid "The <em>To ASCII</em> block converts numbers to letters."
-#~msgstr ""
+#~ msgid "The <em>To ASCII</em> block converts numbers to letters."
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
-#~msgstr ""
+#~ msgid "The <em>Mode length</em> block is the number of notes in the current scale. Most <em>Western</em> scales have 7 notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:258
 
-#~msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Add-1-to<em> block adds one to the value stored in a box."
+#~ msgstr ""
 
 #: js/basicblocks.js:579
 
-#~msgid "440 hertz"
-#~msgstr ""
+#~ msgid "440 hertz"
+#~ msgstr ""
 
 #: js/turtledefs.js:277
 
-#~msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
-#~msgstr ""
+#~ msgid "The <em>Set XY</em> block moves the mouse to a specific position on the screen."
+#~ msgstr ""
 
 #: js/utilitybox.js:153
 
-#~msgid "Optimize performance"
-#~msgstr ""
+#~ msgid "Optimize performance"
+#~ msgstr ""
 
 #: js/playback.js:31
 
@@ -10591,127 +10591,127 @@ msgstr ""
 
 #: js/rhythmruler.js:827
 
-#~msgid "play all"
-#~msgstr ""
+#~ msgid "play all"
+#~ msgstr ""
 
 #: js/turtledefs.js:460
 
-#~msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Camera</em> block connects a webcam to the <em>Show</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
-#~msgid "finger cymbols"
-#~msgstr ""
+#~ msgid "finger cymbols"
+#~ msgstr ""
 
 #: js/synthutils.js:36
 
-#~msgid "simple-1"
-#~msgstr ""
+#~ msgid "simple-1"
+#~ msgstr ""
 
 #: js/basicblocks.js:145
 
-#~msgid "consonant step down"
-#~msgstr ""
+#~ msgid "consonant step down"
+#~ msgstr ""
 
 #: js/synthutils.js:86
 
-#~msgid "ride-bell"
-#~msgstr ""
+#~ msgid "ride-bell"
+#~ msgstr ""
 
 #: js/turtledefs.js:23
 
-#~msgid "Music Blocks is a collection of tools for exploring musical concepts."
-#~msgstr ""
+#~ msgid "Music Blocks is a collection of tools for exploring musical concepts."
+#~ msgstr ""
 
 #: js/logo-test.js:9708
 
-#~msgid "Cannot read pixel color"
-#~msgstr ""
+#~ msgid "Cannot read pixel color"
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
-#~msgstr ""
+#~ msgid "The <em>Rhythm Ruler</em> block opens a tool to create drum machines."
+#~ msgstr ""
 
 #: js/turtledefs.js:401
 
-#~msgid "The <em>Sqrt</em> block returns the square root."
-#~msgstr ""
+#~ msgid "The <em>Sqrt</em> block returns the square root."
+#~ msgstr ""
 
 #: js/turtledefs.js:324
 
-#~msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
-#~msgstr ""
+#~ msgid "The <em>Note counter</em> block can be used to count the number of contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:419
 
-#~msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The <em>Heap empty?</em> block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/musicutils.js:213
 
-#~msgid "Lydian"
-#~msgstr ""
+#~ msgid "Lydian"
+#~ msgstr ""
 
 #: js/turtledefs.js:368
 
-#~msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
-#~msgstr ""
+#~ msgid "The <em>Noise name</em> block is used to select a noise synthesizer."
+#~ msgstr ""
 
 #: js/turtledefs.js:371
 
-#~msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
-#~msgstr ""
+#~ msgid "The <em>Pitch drum matrix</em> is used to map pitches to drum sounds."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "The <em>Dot</em> block extends the duration of a note by 50%. E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:256
 
-#~msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>box2</em> returns the value stored on <em>box2</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
-#~msgstr ""
+#~ msgid "The Pitch Number block will play a pitch associated by its number, e.g, 1 for C, 7 for G."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:285
 
-#~msgid "harmonic-major"
-#~msgstr ""
+#~ msgid "harmonic-major"
+#~ msgstr ""
 
 #: js/activity.js:4385
 
-#~msgid "Auxillary menu"
-#~msgstr ""
+#~ msgid "Auxillary menu"
+#~ msgstr ""
 
 #: js/samplesviewer.js:75
 
 #: js/samplesviewer.js:75
 
-#~msgid "Publish"
-#~msgstr ""
+#~ msgid "Publish"
+#~ msgstr ""
 
 #: js/turtledefs.js:411
 
-#~msgid "The <em>Push</em> block adds a value to the top of the heap."
-#~msgstr ""
+#~ msgid "The <em>Push</em> block adds a value to the top of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:236
 
-#~msgid "Romanian Minor"
-#~msgstr ""
+#~ msgid "Romanian Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/activity.js:2433
 
@@ -10719,397 +10719,397 @@ msgstr ""
 
 #: js/activity.js:2459
 
-#~msgid "untitled"
-#~msgstr ""
+#~ msgid "untitled"
+#~ msgstr ""
 
 #: js/samplesviewer.js:700
 
-#~msgid "Worldwide"
-#~msgstr ""
+#~ msgid "Worldwide"
+#~ msgstr ""
 
 #: js/turtledefs.js:320
 
-#~msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
-#~msgstr ""
+#~ msgid "E.g., a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
+#~ msgstr ""
 
 #: js/activity.js:3743
 
 #: js/activity.js:3759
 
-#~msgid "long press to run slowly"
-#~msgstr ""
+#~ msgid "long press to run slowly"
+#~ msgstr ""
 
 #: js/turtledefs.js:430
 
-#~msgid "The Save heap to app block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The Save heap to app block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/basicblocks.js:1370
 
-#~msgid "pluck"
-#~msgstr ""
+#~ msgid "pluck"
+#~ msgstr ""
 
 #: js/turtledefs.js:476
 
-#~msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse note</em> block returns the current note value being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:219
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes—running longer than the noted duration and blending it into the next note—while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/basicblocks.js:1545
 
 #: js/basicblocks.js:1550
 
-#~msgid "on weak beat"
-#~msgstr ""
+#~ msgid "on weak beat"
+#~ msgstr ""
 
 #: js/turtledefs.js:322
 
-#~msgid "The <em>No clock</em> block decouples the notes from the master clock."
-#~msgstr ""
+#~ msgid "The <em>No clock</em> block decouples the notes from the master clock."
+#~ msgstr ""
 
 #: js/turtledefs.js:283
 
-#~msgid "The <em>Set-pen-size</em> block changes the size of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set-pen-size</em> block changes the size of the pen."
+#~ msgstr ""
 
-#~msgid "end hollow line"
-#~msgstr ""
+#~ msgid "end hollow line"
+#~ msgstr ""
 
 #: js/turtledefs.js:448
 
-#~msgid "The <em>Fill</em> block fills in a shape with a color."
-#~msgstr ""
+#~ msgid "The <em>Fill</em> block fills in a shape with a color."
+#~ msgstr ""
 
 #: js/basicblocks.js:622
 
-#~msgid "skip factor"
-#~msgstr ""
+#~ msgid "skip factor"
+#~ msgstr ""
 
 #: js/turtledefs.js:221
 
-#~msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
-#~msgstr ""
+#~ msgid "The <em>Vibrato</em> block adds a rapid, slight variation in pitch."
+#~ msgstr ""
 
 #: js/turtledefs.js:311
 
-#~msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse-sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/samplesviewer.js:73
 
 #: js/samplesviewer.js:73
 
-#~msgid "Open"
-#~msgstr ""
+#~ msgid "Open"
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Scaler Step</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Scalar Step 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:1933
 
-#~msgid "define temperamentX"
-#~msgstr ""
+#~ msgid "define temperamentX"
+#~ msgstr ""
 
 #: js/turtledefs.js:315
 
-#~msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-#~msgstr ""
+#~ msgid "The <em>Swing</em> block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
+#~ msgstr ""
 
 #: js/basicblocks.js:703
 
-#~msgid "set voice"
-#~msgstr ""
+#~ msgid "set voice"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "Else a kick drum will play."
-#~msgstr ""
+#~ msgid "Else a kick drum will play."
+#~ msgstr ""
 
 #: js/toolbar.js:340
 
 #: js/toolbar.js:388
 
-#~msgid "Save as wav"
-#~msgstr ""
+#~ msgid "Save as wav"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Click here to paste."
-#~msgstr ""
+#~ msgid "Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:204
 
-#~msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
-#~msgstr ""
+#~ msgid "The <em>Pitch</em> block specifies the pitch name and octave of a note that together determine the frequency of the note."
+#~ msgstr ""
 
 #: js/synthutils.js:76
 
-#~msgid "tom-tom"
-#~msgstr ""
+#~ msgid "tom-tom"
+#~ msgstr ""
 
 #: js/musicutils.js:207
 
-#~msgid "Ionian"
-#~msgstr ""
+#~ msgid "Ionian"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "ch"
-#~msgstr ""
+#~ msgid "ch"
+#~ msgstr ""
 
 #: js/turtledefs.js:220
 
-#~msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Slur</em> block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/temperament.js:1700
 
-#~msgid "add pitches"
-#~msgstr ""
+#~ msgid "add pitches"
+#~ msgstr ""
 
 #: js/turtledefs.js:479
 
-#~msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>X mouse</em> block returns the X position of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:154
 
 #: js/turtledefs.js:200
 
-#~msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
-#~msgstr ""
+#~ msgid "Music Blocks is an open source collection of tools for exploring musical concepts. A full list of contributors can be found in the Music Blocks GitHub repository. Music Blocks is licensed under the AGPL. The current version is:' + ' ' + VERSION), 'images/logo.svg', 'https://github.com/sugarlabs/musicblocks', "
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cb"
-#~msgstr ""
+#~ msgid "cb"
+#~ msgstr ""
 
 #: js/basicblocks.js:1896
 
-#~msgid "reference pitch"
-#~msgstr ""
+#~ msgid "reference pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
 #: js/turtledefs.js:170
 
-#~msgid "Click to run the music note by note."
-#~msgstr ""
+#~ msgid "Click to run the music note by note."
+#~ msgstr ""
 
 #: js/musicutils.js:310
 
-#~msgid "poly"
-#~msgstr ""
+#~ msgid "poly"
+#~ msgstr ""
 
 #: js/StringHelper.js:22
 
-#~msgid "Search for a project\","
-#~msgstr ""
+#~ msgid "Search for a project\","
+#~ msgstr ""
 
 #: js/pitchslider.js:388
 
-#~msgid "move up"
-#~msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: js/activity.js:3565
 
-#~msgid "confirm"
-#~msgstr ""
+#~ msgid "confirm"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
 #: js/turtledefs.js:428
 
-#~msgid "The <em>Space</em> block is used to add space between blocks."
-#~msgstr ""
+#~ msgid "The <em>Space</em> block is used to add space between blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:475
 
-#~msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
-#~msgstr ""
+#~ msgid "The <em>Mouse sync</em> block aligns the beat count between mice."
+#~ msgstr ""
 
 #: js/musicutils.js:239
 
-#~msgid "Maqam"
-#~msgstr ""
+#~ msgid "Maqam"
+#~ msgstr ""
 
 #: js/musicutils.js:219
 
-#~msgid "Aeolian"
-#~msgstr ""
+#~ msgid "Aeolian"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:289
 
-#~msgid "harmonic-minor"
-#~msgstr ""
+#~ msgid "harmonic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Decrescendo block with a value of 5, the final note will be at 35% less than the starting volume."
+#~ msgstr ""
 
 #: js/turtledefs.js:268
 
-#~msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Greater-than</em> block returns <em>True</em> if the top number is greater than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:257
 
-#~msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
-#~msgstr ""
+#~ msgid "The <em>Add-to</em> block is used to add to the value stored in a box. It can also be used with other blocks, such as <em>Color</em>, <em>Pen-size</em>. etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The Reverseheap block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The Reverseheap block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/turtledefs.js:262
 
-#~msgid "The <em>One-of</em> block returns one of two choices."
-#~msgstr ""
+#~ msgid "The <em>One-of</em> block returns one of two choices."
+#~ msgstr ""
 
 #: js/musicutils.js:221
 
-#~msgid "Locrian"
-#~msgstr ""
+#~ msgid "Locrian"
+#~ msgstr ""
 
 #: js/turtledefs.js:445
 
-#~msgid "The <em>Set hue</em> block changes the color of the pen."
-#~msgstr ""
+#~ msgid "The <em>Set hue</em> block changes the color of the pen."
+#~ msgstr ""
 
 #: js/turtledefs.js:396
 
 #: js/turtledefs.js:397
 
-#~msgid "The <em>Store in</em> block will store a value in a box."
-#~msgstr ""
+#~ msgid "The <em>Store in</em> block will store a value in a box."
+#~ msgstr ""
 
 #: js/activity.js:3524
 
-#~msgid "Save as .svg"
-#~msgstr ""
+#~ msgid "Save as .svg"
+#~ msgstr ""
 
 #: js/musicutils.js:241
 
-#~msgid "Blues"
-#~msgstr ""
+#~ msgid "Blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:152
 
 #: js/turtledefs.js:198
 
-#~msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
-#~msgstr ""
+#~ msgid "You can type \"d\" to create a \"do\" block, \"r\" to create a \"re\" block, etc."
+#~ msgstr ""
 
 #: plugins/impact.rtp:69
 
-#~msgid "Cannot parse Impact data."
-#~msgstr ""
+#~ msgid "Cannot parse Impact data."
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "e.g., guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "e.g., guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:238
 
-#~msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
-#~msgstr ""
+#~ msgid "The <em>Tempo</em> block opens a metronome to visualize the beat."
+#~ msgstr ""
 
 #: js/turtledefs.js:332
 
-#~msgid "The <em>Invert</em> block rotates any contained notes around a target note."
-#~msgstr ""
+#~ msgid "The <em>Invert</em> block rotates any contained notes around a target note."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "field"
-#~msgstr ""
+#~ msgid "field"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "m"
-#~msgstr ""
+#~ msgid "m"
+#~ msgstr ""
 
 #: js/turtledefs.js:200
 
-#~msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
-#~msgstr ""
+#~ msgid "The <em>On-every-beat</em> block let you specify actions to take on every beat."
+#~ msgstr ""
 
 #: js/SaveInterface.js:24
 
-#~msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
-#~msgstr ""
+#~ msgid "For more information, please consult the <a href=\"https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md\" target=\"_blank\">Music Blocks guide</a>."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "rs"
-#~msgstr ""
+#~ msgid "rs"
+#~ msgstr ""
 
 #: js/turtledefs.js:305
 
-#~msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
-#~msgstr ""
+#~ msgid "The <em>Click</em> block returns <em>True</em> if a mouse has been clicked."
+#~ msgstr ""
 
 #: plugins/impact.rtp:100
 
 #: plugins/impact.rtp:114
 
-#~msgid "Impact field not found."
-#~msgstr ""
+#~ msgid "Impact field not found."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gs"
-#~msgstr ""
+#~ msgid "gs"
+#~ msgstr ""
 
 #: js/musicutils.js:217
 
-#~msgid "Minor"
-#~msgstr ""
+#~ msgid "Minor"
+#~ msgstr ""
 
 #: js/utilitybox.js:172
 
-#~msgid " "
-#~msgstr ""
+#~ msgid " "
+#~ msgstr ""
 
 #: js/musicutils.js:227
 
-#~msgid "Byzantine"
-#~msgstr ""
+#~ msgid "Byzantine"
+#~ msgstr ""
 
 #: js/musicutils.js:223
 
-#~msgid "Jazz Minor"
-#~msgstr ""
+#~ msgid "Jazz Minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:251
 
-#~msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
-#~msgstr ""
+#~ msgid "The <em>Do</em> block is used to initiate an action. In the example, it is used with the <em>One of</em> block to choose a random phase."
+#~ msgstr ""
 
 #: js/toolbar.js:372
 
 #: js/toolbar.js:420
 
-#~msgid "Save as HTML"
-#~msgstr ""
+#~ msgid "Save as HTML"
+#~ msgstr ""
 
 #: js/basicblocks.js:1156
 
-#~msgid "on beat"
-#~msgstr ""
+#~ msgid "on beat"
+#~ msgstr ""
 
 #: js/activity.js:3857
 
@@ -11121,196 +11121,196 @@ msgstr ""
 
 #: js/turtledefs.js:156
 
-#~msgid "Load project from files"
-#~msgstr ""
+#~ msgid "Load project from files"
+#~ msgstr ""
 
 #: js/turtledefs.js:216
 
-#~msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
-#~msgstr ""
+#~ msgid "The <em>Set temperament</em> block is used to choose the tuning system used by Music Blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:250
 
-#~msgid "The <em>Dispatch</em> block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The <em>Dispatch</em> block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:87
 
-#~msgid "Hide or show the block palettes."
-#~msgstr ""
+#~ msgid "Hide or show the block palettes."
+#~ msgstr ""
 
 #: js/activity.js:2712
 
-#~msgid "Run fast / long press to run slowly"
-#~msgstr ""
+#~ msgid "Run fast / long press to run slowly"
+#~ msgstr ""
 
 #: js/activity.js:913
 
-#~msgid "hide grid"
-#~msgstr ""
+#~ msgid "hide grid"
+#~ msgstr ""
 
 #: js/synthutils.js:72
 
-#~msgid "snare-drum"
-#~msgstr ""
+#~ msgid "snare-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:325
 
-#~msgid "The <em>Measure count</em> block returns the current measure."
-#~msgstr ""
+#~ msgid "The <em>Measure count</em> block returns the current measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:474
 
-#~msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
-#~msgstr ""
+#~ msgid "The <em>Found mouse</em> block will return true if the specified mouse can be found."
+#~ msgstr ""
 
 #: js/turtledefs.js:267
 
-#~msgid "The Dispatch block is used to trigger an event."
-#~msgstr ""
+#~ msgid "The Dispatch block is used to trigger an event."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
 #: js/utilitybox.js:239
 
-#~msgid "Search"
-#~msgstr ""
+#~ msgid "Search"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/synthutils.js:44
 
-#~msgid "white-noise"
-#~msgstr ""
+#~ msgid "white-noise"
+#~ msgstr ""
 
 #: js/musicutils.js:203
 
-#~msgid "Octatonic"
-#~msgstr ""
+#~ msgid "Octatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:309
 
-#~msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The Pitch-time Matrix block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:297
 
-#~msgid "The <em>Top</em> block returns the position of the top of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Top</em> block returns the position of the top of the canvas."
+#~ msgstr ""
 
 #: js/turtledefs.js:249
 
-#~msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
-#~msgstr ""
+#~ msgid "The <em>Listen</em> block is used to listen for an event such as a mouse click. When the event happens, an <em>action</em> is taken."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:91
 
-#~msgid "sense left"
-#~msgstr ""
+#~ msgid "sense left"
+#~ msgstr ""
 
 #: js/turtledefs.js:237
 
-#~msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
-#~msgstr ""
+#~ msgid "The <em>Music keyboard</em> block opens a piano keyboard that can be used to create notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:307
 
-#~msgid "jazz-minor"
-#~msgstr ""
+#~ msgid "jazz-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:325
 
-#~msgid "minor-blues"
-#~msgstr ""
+#~ msgid "minor-blues"
+#~ msgstr ""
 
 #: js/help.js:53
 
-#~msgid "previous page"
-#~msgstr ""
+#~ msgid "previous page"
+#~ msgstr ""
 
 #: js/turtledefs.js:285
 
-#~msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
-#~msgstr ""
+#~ msgid "The <em>Pen-down</em> block lowers the pen so that it draws."
+#~ msgstr ""
 
 #: js/turtledefs.js:330
 
-#~msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone transposition</em> block will shift the pitches contained inside <em>Note</em> blocks up (or down) by half steps. In the example shown above, <em>sol</em> is shifted up to <em>sol#</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:107
 
-#~msgid "You can search for blocks by name."
-#~msgstr ""
+#~ msgid "You can search for blocks by name."
+#~ msgstr ""
 
 #: js/synthutils.js:88
 
-#~msgid "cow-bell"
-#~msgstr ""
+#~ msgid "cow-bell"
+#~ msgstr ""
 
 #: js/block.js:1307
 
-#~msgid "2nd"
-#~msgstr ""
+#~ msgid "2nd"
+#~ msgstr ""
 
 #: js/turtledefs.js:291
 
-#~msgid "The <em>Media</em> block is used to import an image."
-#~msgstr ""
+#~ msgid "The <em>Media</em> block is used to import an image."
+#~ msgstr ""
 
 #: js/activity.js:3527
 
-#~msgid "Offline. Sharing is unavailable."
-#~msgstr ""
+#~ msgid "Offline. Sharing is unavailable."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "fs"
-#~msgstr ""
+#~ msgid "fs"
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The Stopplayback block"
-#~msgstr ""
+#~ msgid "The Stopplayback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:243
 
 #: js/turtledefs.js:244
 
-#~msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
-#~msgstr ""
+#~ msgid "Conditionals lets your program take different actions depending on the <em>condition</em>. In this example, <em>if</em> the mouse button is pressed, a snare drum will play. Otherwise (<em>else</em>) a kick drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:471
 
-#~msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
-#~msgstr ""
+#~ msgid "The <em>Loudness</em> block returns the volume detected by the microphone."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The <em>Show blocks</em> block shows the blocks."
-#~msgstr ""
+#~ msgid "The <em>Show blocks</em> block shows the blocks."
+#~ msgstr ""
 
-#~msgid "food"
-#~msgstr ""
+#~ msgid "food"
+#~ msgstr ""
 
 #: js/basicblocks.js:874
 
-#~msgid "osctime"
-#~msgstr ""
+#~ msgid "osctime"
+#~ msgstr ""
 
 #: js/basicblocks.js:901
 
-#~msgid "divide beat value"
-#~msgstr ""
+#~ msgid "divide beat value"
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11318,155 +11318,155 @@ msgstr ""
 
 #: js/toolbar.js:422
 
-#~msgid "Save as PNG"
-#~msgstr ""
+#~ msgid "Save as PNG"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
-#~msgstr ""
+#~ msgid "The <em>Comment</em> block prints a comment at the top of the screen when the program is running in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:457
 
-#~msgid "The <em>Stop media</em> block stops audio or video playback."
-#~msgstr ""
+#~ msgid "The <em>Stop media</em> block stops audio or video playback."
+#~ msgstr ""
 
 #: js/turtledefs.js:302
 
-#~msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
-#~msgstr ""
+#~ msgid "The <em>Mouse-button</em> block returns <em>True</em> if the mouse button is pressed."
+#~ msgstr ""
 
 #: js/musicutils.js:286
 
-#~msgid "blues"
-#~msgstr ""
+#~ msgid "blues"
+#~ msgstr ""
 
 #: js/activity.js:4401
 
-#~msgid "More"
-#~msgstr ""
+#~ msgid "More"
+#~ msgstr ""
 
 #: js/turtledefs.js:304
 
-#~msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor Y</em> block returns the vertical position of the mouse."
+#~ msgstr ""
 
-#~msgid "maths"
-#~msgstr ""
+#~ msgid "maths"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "Otherwise (else) a kick drum will play."
-#~msgstr ""
+#~ msgid "Otherwise (else) a kick drum will play."
+#~ msgstr ""
 
 #: js/StringHelper.js:18
 
-#~msgid "Open project from file\","
-#~msgstr ""
+#~ msgid "Open project from file\","
+#~ msgstr ""
 
 #: js/basicblocks.js:605
 
-#~msgid "tritone"
-#~msgstr ""
+#~ msgid "tritone"
+#~ msgstr ""
 
 #: js/musicutils.js:209
 
-#~msgid "Dorian"
-#~msgstr ""
+#~ msgid "Dorian"
+#~ msgstr ""
 
 #: js/turtledefs.js:79
 
-#~msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix Notes Tone Turtle and more."
+#~ msgstr ""
 
 #: js/synthutils.js:74
 
-#~msgid "kick-drum"
-#~msgstr ""
+#~ msgid "kick-drum"
+#~ msgstr ""
 
 #: js/block.js:1310
 
-#~msgid "5th"
-#~msgstr ""
+#~ msgid "5th"
+#~ msgstr ""
 
 #: js/turtledefs.js:478
 
-#~msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse elapse notes</em> block returns the number of notes played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:477
 
-#~msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse pitch</em> block returns the current pitch number being played by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:129
 
 #: js/turtledefs.js:164
 
-#~msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more."
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "next page"
-#~msgstr ""
+#~ msgid "next page"
+#~ msgstr ""
 
 #: js/turtledefs.js:241
 
-#~msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
-#~msgstr ""
+#~ msgid "The <em>Repeat</em> block will repeat the contained blocks. In this example, the note will be played 4 times."
+#~ msgstr ""
 
 #: js/turtledefs.js:97
 
-#~msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
-#~msgstr ""
+#~ msgid "The save-stack button saves a stack onto a custom palette. It appears after a \"long press\" on a stack."
+#~ msgstr ""
 
 #: js/basicblocks.js:4785
 
-#~msgid "Rhythm"
-#~msgstr ""
+#~ msgid "Rhythm"
+#~ msgstr ""
 
 #: js/turtledefs.js:338
 
-#~msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
-#~msgstr ""
+#~ msgid "The <em>Number to octave</em> block will convert a pitch number to an octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:95
 
-#~msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a \"long press\" on the stack. The Paste Button will highlight."
+#~ msgstr ""
 
-#~msgid "hspace"
-#~msgstr ""
+#~ msgid "hspace"
+#~ msgstr ""
 
 #: js/activity.js:2789
 
-#~msgid "Long press on block(s) to copy. Click here to paste."
-#~msgstr ""
+#~ msgid "Long press on block(s) to copy. Click here to paste."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:291
 
-#~msgid "melodic-minor"
-#~msgstr ""
+#~ msgid "melodic-minor"
+#~ msgstr ""
 
 #: js/turtledefs.js:427
 
-#~msgid "The Heap empty? block returns true if the heap is emptry."
-#~msgstr ""
+#~ msgid "The Heap empty? block returns true if the heap is emptry."
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The Playback block"
-#~msgstr ""
+#~ msgid "The Playback block"
+#~ msgstr ""
 
 #: js/turtledefs.js:196
 
-#~msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Note value</em> block is the value of the duration of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -11474,257 +11474,257 @@ msgstr ""
 
 #: js/toolbar.js:423
 
-#~msgid "Save as WAV"
-#~msgstr ""
+#~ msgid "Save as WAV"
+#~ msgstr ""
 
 #: js/turtledefs.js:354
 
-#~msgid "The <em>Tremolo</em> block adds a wavering effect."
-#~msgstr ""
+#~ msgid "The <em>Tremolo</em> block adds a wavering effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:446
 
-#~msgid "The <em>Set grey</em> block changes the vividness of the pen color."
-#~msgstr ""
+#~ msgid "The <em>Set grey</em> block changes the vividness of the pen color."
+#~ msgstr ""
 
 #: js/turtledefs.js:290
 
-#~msgid "The <em>Text</em> block holds a text string."
-#~msgstr ""
+#~ msgid "The <em>Text</em> block holds a text string."
+#~ msgstr ""
 
 #: js/turtledefs.js:21
 
-#~msgid "actions"
-#~msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: js/turtledefs.js:331
 
-#~msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
-#~msgstr ""
+#~ msgid "The <em>Register</em> block provides an easy way to modify the register (octave) of the notes that follow it."
+#~ msgstr ""
 
 #: js/logo.js:3384
 
-#~msgid "Note value must be greater than 0"
-#~msgstr ""
+#~ msgid "Note value must be greater than 0"
+#~ msgstr ""
 
 #: js/turtledefs.js:236
 
-#~msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
-#~msgstr ""
+#~ msgid "<em>Tuplets</em> are a collection of notes that get scaled to a specific duration. Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+#~ msgstr ""
 
 #: js/basicblocks.js:1398
 
-#~msgid "pitch-time matrix"
-#~msgstr ""
+#~ msgid "pitch-time matrix"
+#~ msgstr ""
 
 #: js/turtledefs.js:233
 
-#~msgid "eg guitar, violin, snare drum, etc."
-#~msgstr ""
+#~ msgid "eg guitar, violin, snare drum, etc."
+#~ msgstr ""
 
 #: js/turtledefs.js:347
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/turtledefs.js:144
 
-#~msgid "Long press the run button to run the project in slow mode."
-#~msgstr ""
+#~ msgid "Long press the run button to run the project in slow mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:339
 
-#~msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
-#~msgstr ""
+#~ msgid "The <em>Set pitch number offset</em> block is used to set the offset for mapping pitch numbers to pitch and octave."
+#~ msgstr ""
 
 #: js/turtledefs.js:188
 
-#~msgid "Show or hide a polar-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a polar-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "It can also be used with other blocks, such as Color, Pen-size."
-#~msgstr ""
+#~ msgid "It can also be used with other blocks, such as Color, Pen-size."
+#~ msgstr ""
 
 #: js/samplesviewer.js:80
 
-#~msgid "Copy this link to share your project."
-#~msgstr ""
+#~ msgid "Copy this link to share your project."
+#~ msgstr ""
 
 #: js/turtledefs.js:111
 
 #: js/turtledefs.js:149
 
-#~msgid "Clear the screen and return the turtles to their initial positions."
-#~msgstr ""
+#~ msgid "Clear the screen and return the turtles to their initial positions."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> returns the value stored on <em>box1</em>."
+#~ msgstr ""
 
 #: js/logo.js:3705
 
-#~msgid "The Step Pitch Block must be used inside of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used inside of a Note Block."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:30
 
-#~msgid "blink (ms)"
-#~msgstr ""
+#~ msgid "blink (ms)"
+#~ msgstr ""
 
 #: js/turtledefs.js:360
 
-#~msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>Duo synth</em> block is a duo-frequency modulator used to define a timbre."
+#~ msgstr ""
 
-#~msgid "begin hollow line"
-#~msgstr ""
+#~ msgid "begin hollow line"
+#~ msgstr ""
 
 #: js/musicutils.js:232
 
-#~msgid "Geez"
-#~msgstr ""
+#~ msgid "Geez"
+#~ msgstr ""
 
-#~msgid "Rhythm Block: Did you mean to use a Note block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Note block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:260
 
 #: js/turtledefs.js:261
 
-#~msgid "In this example, if the mouse button is pressed, a snare drum will play."
-#~msgstr ""
+#~ msgid "In this example, if the mouse button is pressed, a snare drum will play."
+#~ msgstr ""
 
 #: js/turtledefs.js:77
 
-#~msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-#~msgstr ""
+#~ msgid "This toolbar contains the palette buttons Matrix, Notes, Tone, Turtle, and more. Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
+#~ msgstr ""
 
 #: js/turtledefs.js:434
 
-#~msgid "The <em>Dock block</em> block connections two blocks."
-#~msgstr ""
+#~ msgid "The <em>Dock block</em> block connections two blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:203
 
-#~msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
-#~msgstr ""
+#~ msgid "The <em>Step pitch</em> block (in combination with a <em>Number</em> block) will play the next pitch in a scale, e.g., if the last note played was <em>sol</em>, <em>Step pitch 1</em> will play <em>la</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:245
 
-#~msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
-#~msgstr ""
+#~ msgid "The <em>Backward</em> block runs code in reverse order (Musical retrograde)."
+#~ msgstr ""
 
 #: js/basicblocks.js:583
 
-#~msgid "deprecated note value"
-#~msgstr ""
+#~ msgid "deprecated note value"
+#~ msgstr ""
 
 #: js/musicutils.js:226
 
-#~msgid "Arabic"
-#~msgstr ""
+#~ msgid "Arabic"
+#~ msgstr ""
 
 #: js/turtledefs.js:259
 
-#~msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:6824
 
-#~msgid "Hertz Block: Did you mean to use a Note block3?"
-#~msgstr ""
+#~ msgid "Hertz Block: Did you mean to use a Note block3?"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:327
 
-#~msgid "major-blues"
-#~msgstr ""
+#~ msgid "major-blues"
+#~ msgstr ""
 
 #: js/turtledefs.js:403
 
-#~msgid "The <em>Mod</em> block returns the remainder from a division."
-#~msgstr ""
+#~ msgid "The <em>Mod</em> block returns the remainder from a division."
+#~ msgstr ""
 
 #: js/turtledefs.js:206
 
-#~msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
-#~msgstr ""
+#~ msgid "Pitch can be specified in terms of <em>C D E F G A B</em>."
+#~ msgstr ""
 
 #: js/musicutils.js:233
 
-#~msgid "Hindu"
-#~msgstr ""
+#~ msgid "Hindu"
+#~ msgstr ""
 
 #: js/turtledefs.js:316
 
-#~msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
-#~msgstr ""
+#~ msgid "The <em>Milliseconds</em> block is similar to a <em>Note</em> block except that it uses time (in MS) to specify the note duration."
+#~ msgstr ""
 
 #: js/turtledefs.js:406
 
-#~msgid "The <em>Not</em> block is the logical not operator."
-#~msgstr ""
+#~ msgid "The <em>Not</em> block is the logical not operator."
+#~ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "New project\","
-#~msgstr ""
+#~ msgid "New project\","
+#~ msgstr ""
 
 #: js/basicblocks.js:1299
 
-#~msgid "step pitch"
-#~msgstr ""
+#~ msgid "step pitch"
+#~ msgstr ""
 
 #: js/turtledefs.js:255
 
-#~msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
-#~msgstr ""
+#~ msgid "The <em>Store in box2</em> block is used to store a value in <em>box2</em>."
+#~ msgstr ""
 
 #: js/toolbar.js:339
 
 #: js/toolbar.js:387
 
-#~msgid "Save as png"
-#~msgstr ""
+#~ msgid "Save as png"
+#~ msgstr ""
 
 #: js/turtledefs.js:314
 
-#~msgid "The <em>Skip notes</em> block will cause notes to be skipped."
-#~msgstr ""
+#~ msgid "The <em>Skip notes</em> block will cause notes to be skipped."
+#~ msgstr ""
 
 #: js/turtledefs.js:215
 
-#~msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block calculates a relative interval based on the current mode, skipping all notes outside of the mode. In the figure, we add <em>la</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:519
 
-#~msgid "play backward"
-#~msgstr ""
+#~ msgid "play backward"
+#~ msgstr ""
 
 #: js/turtledefs.js:333
 
-#~msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
-#~msgstr ""
+#~ msgid "The <em>Change in pitch</em> block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+#~ msgstr ""
 
 #: js/turtledefs.js:442
 
-#~msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 1</em> block sets the first control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bk"
-#~msgstr ""
+#~ msgid "bk"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "bt"
-#~msgstr ""
+#~ msgid "bt"
+#~ msgstr ""
 
 #: js/logo.js:2175
 
@@ -11738,223 +11738,223 @@ msgstr ""
 
 #: js/logo.js:8057
 
-#~msgid "Could not find mouse"
-#~msgstr ""
+#~ msgid "Could not find mouse"
+#~ msgstr ""
 
 #: js/turtledefs.js:469
 
-#~msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get green</em> block returns the green component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:235
 
-#~msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
-#~msgstr ""
+#~ msgid "The <em>Rhythm</em> block is used to generate rhythm patterns."
+#~ msgstr ""
 
 #: js/turtledefs.js:213
 
-#~msgid "???"
-#~msgstr ""
+#~ msgid "???"
+#~ msgstr ""
 
 #: js/turtledefs.js:303
 
-#~msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Cursor X</em> block returns the horizontal position of the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3444
 
-#~msgid "Save Project"
-#~msgstr ""
+#~ msgid "Save Project"
+#~ msgstr ""
 
 #: js/turtledefs.js:454
 
-#~msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
-#~msgstr ""
+#~ msgid "The <em>Set font</em> block sets the font used by the <em>Show</em> block."
+#~ msgstr ""
 
-#~msgid "do re mi fa sol la ti"
-#~msgstr ""
+#~ msgid "do re mi fa sol la ti"
+#~ msgstr ""
 
 #: js/turtledefs.js:377
 
-#~msgid "The <em>Until</em> block will repeat until the condition is true."
-#~msgstr ""
+#~ msgid "The <em>Until</em> block will repeat until the condition is true."
+#~ msgstr ""
 
 #: js/turtledefs.js:408
 
-#~msgid "The <em>Or</em> block is the logical or operator."
-#~msgstr ""
+#~ msgid "The <em>Or</em> block is the logical or operator."
+#~ msgstr ""
 
 #: js/modewidget.js:77
 
-#~msgid "rotate counter clockwise"
-#~msgstr ""
+#~ msgid "rotate counter clockwise"
+#~ msgstr ""
 
 #: js/turtledefs.js:344
 
-#~msgid "etc."
-#~msgstr ""
+#~ msgid "etc."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:203
 
-#~msgid "sort"
-#~msgstr ""
+#~ msgid "sort"
+#~ msgstr ""
 
 #: js/logo.js:5000
 
-#~msgid "Pitch Block: Did you mean to use a Note block2?"
-#~msgstr ""
+#~ msgid "Pitch Block: Did you mean to use a Note block2?"
+#~ msgstr ""
 
 #: js/logo.js:3606
 
-#~msgid "Distortion not in range"
-#~msgstr ""
+#~ msgid "Distortion not in range"
+#~ msgstr ""
 
 #: js/turtledefs.js:453
 
-#~msgid "The <em>Pen size</em> block returns the current pen size value."
-#~msgstr ""
+#~ msgid "The <em>Pen size</em> block returns the current pen size value."
+#~ msgstr ""
 
 #: js/turtledefs.js:422
 
-#~msgid "The <em>Save heap to app</em> block saves the heap to a web page."
-#~msgstr ""
+#~ msgid "The <em>Save heap to app</em> block saves the heap to a web page."
+#~ msgstr ""
 
 #: js/turtledefs.js:261
 
-#~msgid "The <em>Random</em> block returns a random number."
-#~msgstr ""
+#~ msgid "The <em>Random</em> block returns a random number."
+#~ msgstr ""
 
 #: js/turtledefs.js:143
 
 #: js/turtledefs.js:180
 
-#~msgid "Polar"
-#~msgstr ""
+#~ msgid "Polar"
+#~ msgstr ""
 
 #: js/basicblocks.js:74
 
-#~msgid "current pitch name"
-#~msgstr ""
+#~ msgid "current pitch name"
+#~ msgstr ""
 
 #: js/turtledefs.js:134
 
-#~msgid "Show or hide a Cartesian-coordinate grid."
-#~msgstr ""
+#~ msgid "Show or hide a Cartesian-coordinate grid."
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Show heap</em> block displays the contents of the heap at the top of the screen."
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "gp"
-#~msgstr ""
+#~ msgid "gp"
+#~ msgstr ""
 
 #: js/turtledefs.js:308
 
-#~msgid "The <em>Mouse-name</em> block returns the name of a mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse-name</em> block returns the name of a mouse."
+#~ msgstr ""
 
 #: js/activity.js:3528
 
-#~msgid "Save as .png"
-#~msgstr ""
+#~ msgid "Save as .png"
+#~ msgstr ""
 
 #: js/musicutils.js:215
 
-#~msgid "Mixolydian"
-#~msgstr ""
+#~ msgid "Mixolydian"
+#~ msgstr ""
 
 #: js/block.js:909
 
-#~msgid "mKeyboard"
-#~msgstr ""
+#~ msgid "mKeyboard"
+#~ msgstr ""
 
 #: js/turtledefs.js:379
 
-#~msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
-#~msgstr ""
+#~ msgid "The <em>Stop</em> block will stop a loop (e.g., Forever, Repeat, While, or Until)."
+#~ msgstr ""
 
 #: js/turtledefs.js:211
 
-#~msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch number</em> block is the value of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/turtledefs.js:293
 
-#~msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Shell</em> block is used to change the appearance of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:270
 
-#~msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
-#~msgstr ""
+#~ msgid "The <em>Equal</em> block returns <em>True</em> if the two numbers are equal."
+#~ msgstr ""
 
 #: js/savebox.js:105
 
-#~msgid "Upload to Planet"
-#~msgstr ""
+#~ msgid "Upload to Planet"
+#~ msgstr ""
 
 #: js/turtledefs.js:341
 
-#~msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar step down</em> block returns the number of semi-tones down to the previous note in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:467
 
-#~msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get pixel</em> block returns the color of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/activity.js:3607
 
-#~msgid "Load plugin from file"
-#~msgstr ""
+#~ msgid "Load plugin from file"
+#~ msgstr ""
 
 #: js/turtledefs.js:461
 
-#~msgid "The <em>Playback</em> block"
-#~msgstr ""
+#~ msgid "The <em>Playback</em> block"
+#~ msgstr ""
 
 #: js/activity.js:3541
 
-#~msgid "Save as .abc"
-#~msgstr ""
+#~ msgid "Save as .abc"
+#~ msgstr ""
 
 #: js/logo.js:10269
 
-#~msgid "Lilypond cannot process partial of "
-#~msgstr ""
+#~ msgid "Lilypond cannot process partial of "
+#~ msgstr ""
 
 #: js/turtledefs.js:210
 
-#~msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
-#~msgstr ""
+#~ msgid "The <em>Pitch in Hertz</em> block is the value in Hertz of the pitch of the note currently being played."
+#~ msgstr ""
 
 #: js/block.js:1453
 
-#~msgid "degree"
-#~msgstr ""
+#~ msgid "degree"
+#~ msgstr ""
 
 #: plugins/rodi.rtp:169
 
-#~msgid "sing"
-#~msgstr ""
+#~ msgid "sing"
+#~ msgstr ""
 
 #: js/turtledefs.js:443
 
-#~msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
-#~msgstr ""
+#~ msgid "The <em>Control-point 2</em> block sets the second control point for the Bezier curve."
+#~ msgstr ""
 
 #: js/musicutils.js:247
 
-#~msgid "Chinese"
-#~msgstr ""
+#~ msgid "Chinese"
+#~ msgstr ""
 
 #: js/turtledefs.js:165
 
-#~msgid "Play music"
-#~msgstr ""
+#~ msgid "Play music"
+#~ msgstr ""
 
 #: js/samplesviewer.js:91
 
@@ -11964,144 +11964,144 @@ msgstr ""
 
 #: js/samplesviewer.js:115
 
-#~msgid "Download"
-#~msgstr ""
+#~ msgid "Download"
+#~ msgstr ""
 
 #: js/synthutils.js:82
 
-#~msgid "darbuka-drum"
-#~msgstr ""
+#~ msgid "darbuka-drum"
+#~ msgstr ""
 
 #: js/turtledefs.js:345
 
-#~msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Semi-tone interval</em> block calculates a relative interval based on half steps. In the figure, we add <em>sol#</em> to <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:263
 
-#~msgid "The <em>Plus</em> block is used to add."
-#~msgstr ""
+#~ msgid "The <em>Plus</em> block is used to add."
+#~ msgstr ""
 
 #: js/turtledefs.js:207
 
-#~msgid "e.g., 1, 2, 3, or 4."
-#~msgstr ""
+#~ msgid "e.g., 1, 2, 3, or 4."
+#~ msgstr ""
 
 #: js/turtledefs.js:416
 
-#~msgid "The <em>Loadheap</em> block loads the heap from a file."
-#~msgstr ""
+#~ msgid "The <em>Loadheap</em> block loads the heap from a file."
+#~ msgstr ""
 
-#~msgid "cloud"
-#~msgstr ""
+#~ msgid "cloud"
+#~ msgstr ""
 
 #: js/turtledefs.js:298
 
-#~msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
-#~msgstr ""
+#~ msgid "The <em>Bottom</em> block returns the position of the bottom of the canvas."
+#~ msgstr ""
 
 #: js/toolbar.js:338
 
 #: js/toolbar.js:386
 
-#~msgid "Save as svg"
-#~msgstr ""
+#~ msgid "Save as svg"
+#~ msgstr ""
 
 #: plugins/impact.rtp:122
 
-#~msgid "Impact UID not found."
-#~msgstr ""
+#~ msgid "Impact UID not found."
+#~ msgstr ""
 
 #: js/pitchdrummatrix.js:141
 
-#~msgid "Solfa"
-#~msgstr ""
+#~ msgid "Solfa"
+#~ msgstr ""
 
 #: js/timbre.js:727
 
-#~msgid "add filter"
-#~msgstr ""
+#~ msgid "add filter"
+#~ msgstr ""
 
 #: js/logo.js:2688
 
-#~msgid "turtleHeaps does not contain a valid heap for"
-#~msgstr ""
+#~ msgid "turtleHeaps does not contain a valid heap for"
+#~ msgstr ""
 
 #: js/turtledefs.js:98
 
-#~msgid "You can also use Alt+C to copy a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks. "
+#~ msgstr ""
 
 #: js/activity.js:3523
 
-#~msgid "Show/hide palettes"
-#~msgstr ""
+#~ msgid "Show/hide palettes"
+#~ msgstr ""
 
 #: js/activity.js:3066
 
-#~msgid "Home' + ' [HOME]"
-#~msgstr ""
+#~ msgid "Home' + ' [HOME]"
+#~ msgstr ""
 
 #: js/turtledefs.js:484
 
-#~msgid "The <em>Start mouse</em> block starts the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Start mouse</em> block starts the specified mouse."
+#~ msgstr ""
 
 #: plugins/impact.rtp:32
 
-#~msgid "fetch"
-#~msgstr ""
+#~ msgid "fetch"
+#~ msgstr ""
 
 #: js/turtledefs.js:398
 
-#~msgid "The <em>Box</em> block returns the value stored in a box."
-#~msgstr ""
+#~ msgid "The <em>Box</em> block returns the value stored in a box."
+#~ msgstr ""
 
-#~msgid "rodi"
-#~msgstr ""
+#~ msgid "rodi"
+#~ msgstr ""
 
 #: js/turtledefs.js:481
 
-#~msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Set mouse</em> block sends a stack of blocks to be run by the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:254
 
-#~msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
-#~msgstr ""
+#~ msgid "The <em>box1</em> block returns the value stored in <em>box1</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "You can also use Alt+P to paste a stack of blocks. "
-#~msgstr ""
+#~ msgid "You can also use Alt+P to paste a stack of blocks. "
+#~ msgstr ""
 
 #: js/musicutils.js:291
 
-#~msgid "pentatonic"
-#~msgstr ""
+#~ msgid "pentatonic"
+#~ msgstr ""
 
-#~msgid "blocks"
-#~msgstr ""
+#~ msgid "blocks"
+#~ msgstr ""
 
 #: js/turtledefs.js:232
 
-#~msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
-#~msgstr ""
+#~ msgid "The <em>Pitch-time Matrix</em> block opens a tool to create musical phrases."
+#~ msgstr ""
 
 #: js/turtledefs.js:281
 
-#~msgid "The <em>Heading</em> block returns the orientation of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Heading</em> block returns the orientation of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:400
 
-#~msgid "The <em>Abs</em> block returns the absolute value."
-#~msgstr ""
+#~ msgid "The <em>Abs</em> block returns the absolute value."
+#~ msgstr ""
 
 #: js/turtledefs.js:240
 
-#~msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
-#~msgstr ""
+#~ msgid "For example, if you have 7 notes in sequence contained in a Crescendo block with a value of 5, the final note will be at 35% more than the starting volume."
+#~ msgstr ""
 
 #: js/block.js:962
 
@@ -12109,57 +12109,57 @@ msgstr ""
 
 #: js/basicblocks.js:1034
 
-#~msgid "rhythm ruler"
-#~msgstr ""
+#~ msgid "rhythm ruler"
+#~ msgstr ""
 
 #: js/logo.js:3626
 
 #: js/logo.js:3675
 
-#~msgid "Depth entered is out of range"
-#~msgstr ""
+#~ msgid "Depth entered is out of range"
+#~ msgstr ""
 
 #: js/turtledefs.js:346
 
-#~msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
-#~msgstr ""
+#~ msgid "The <em>Scalar interval</em> block measures the distance between two notes in the current key and mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:272
 
-#~msgid "The <em>Forward</em> block moves the mouse forward."
-#~msgstr ""
+#~ msgid "The <em>Forward</em> block moves the mouse forward."
+#~ msgstr ""
 
 #: js/musicutils.js:246
 
-#~msgid "Pentatonic"
-#~msgstr ""
+#~ msgid "Pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:372
 
-#~msgid "The <em>Temperament</em> tool is used to define custom tuning."
-#~msgstr ""
+#~ msgid "The <em>Temperament</em> tool is used to define custom tuning."
+#~ msgstr ""
 
 #: js/logo.js:4992
 
 #: js/logo.js:5014
 
-#~msgid "Input to Major Block must be 2, 3, 6, or 7"
-#~msgstr ""
+#~ msgid "Input to Major Block must be 2, 3, 6, or 7"
+#~ msgstr ""
 
 #: js/turtledefs.js:289
 
-#~msgid "The <em>Print</em> block displays text at the top of the screen."
-#~msgstr ""
+#~ msgid "The <em>Print</em> block displays text at the top of the screen."
+#~ msgstr ""
 
 #: js/turtledefs.js:356
 
-#~msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
-#~msgstr ""
+#~ msgid "The <em>Weighted partials</em> block is used to specify the partials associated with a timbre."
+#~ msgstr ""
 
 #: js/basicblocks.js:712
 
-#~msgid "articulation"
-#~msgstr ""
+#~ msgid "articulation"
+#~ msgstr ""
 
 #: js/turtledefs.js:387
 
@@ -12169,30 +12169,30 @@ msgstr ""
 
 #: js/turtledefs.js:392
 
-#~msgid "The <em>Calculate</em> block returns a value calculated by an action."
-#~msgstr ""
+#~ msgid "The <em>Calculate</em> block returns a value calculated by an action."
+#~ msgstr ""
 
 #: js/samplesviewer.js:81
 
 #: js/samplesviewer.js:84
 
-#~msgid "Advanced options"
-#~msgstr ""
+#~ msgid "Advanced options"
+#~ msgstr ""
 
 #: js/turtledefs.js:394
 
-#~msgid "The <em>Return</em> block will return a value from an action."
-#~msgstr ""
+#~ msgid "The <em>Return</em> block will return a value from an action."
+#~ msgstr ""
 
 #: js/turtledefs.js:247
 
-#~msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
-#~msgstr ""
+#~ msgid "The <em>Action</em> block is used to group together blocks so that they can be used more than once. It is often used for storing a phrase of music that is repeated."
+#~ msgstr ""
 
 #: js/turtledefs.js:470
 
-#~msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get blue</em> block returns the blue component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12200,112 +12200,112 @@ msgstr ""
 
 #: js/toolbar.js:425
 
-#~msgid "Save sheet music"
-#~msgstr ""
+#~ msgid "Save sheet music"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:320
 
-#~msgid "romanian-minor"
-#~msgstr ""
+#~ msgid "romanian-minor"
+#~ msgstr ""
 
 #: js/block.js:1309
 
-#~msgid "4th"
-#~msgstr ""
+#~ msgid "4th"
+#~ msgstr ""
 
 #: js/turtledefs.js:362
 
-#~msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Set relative volume</em> block changes the volume of the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:380
 
-#~msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
-#~msgstr ""
+#~ msgid "The <em>Switch</em> block will run the code in the matchin <em>Case</em>."
+#~ msgstr ""
 
 #: js/basicblocks.js:282
 
-#~msgid "adjust transposition"
-#~msgstr ""
+#~ msgid "adjust transposition"
+#~ msgstr ""
 
 #: js/turtledefs.js:80
 
-#~msgid "Click to run the project in fast mode."
-#~msgstr ""
+#~ msgid "Click to run the project in fast mode."
+#~ msgstr ""
 
 #: js/turtledefs.js:170
 
-#~msgid "Run note by note"
-#~msgstr ""
+#~ msgid "Run note by note"
+#~ msgstr ""
 
 #: js/logo.js:5092
 
-#~msgid "Partial block should be used inside of a Weighted-partisls block."
-#~msgstr ""
+#~ msgid "Partial block should be used inside of a Weighted-partisls block."
+#~ msgstr ""
 
 #: js/turtledefs.js:428
 
-#~msgid "The Heap length block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The Heap length block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:4324
 
-#~msgid "shell"
-#~msgstr ""
+#~ msgid "shell"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
-#~msgid "Close Planet\","
-#~msgstr ""
+#~ msgid "Close Planet\","
+#~ msgstr ""
 
 #: js/help.js:72
 
-#~msgid "Next page"
-#~msgstr ""
+#~ msgid "Next page"
+#~ msgstr ""
 
 #: js/activity.js:3859
 
 #: js/activity.js:3870
 
-#~msgid "Long press on blocks to copy."
-#~msgstr ""
+#~ msgid "Long press on blocks to copy."
+#~ msgstr ""
 
 #: js/turtledefs.js:351
 
-#~msgid "The <em>Chorus</em> block adds a chorus effect."
-#~msgstr ""
+#~ msgid "The <em>Chorus</em> block adds a chorus effect."
+#~ msgstr ""
 
 #: js/turtledefs.js:239
 
-#~msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-#~msgstr ""
+#~ msgid "The <em>Custom mode</em> block opens a tool to explore musical mode (the spacing of the notes in a scale)."
+#~ msgstr ""
 
 #: js/logo.js:2317
 
-#~msgid "Please close the current matrix before opening a new one."
-#~msgstr ""
+#~ msgid "Please close the current matrix before opening a new one."
+#~ msgstr ""
 
 #: js/turtledefs.js:426
 
-#~msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
-#~msgstr ""
+#~ msgid "The <em>Wait</em> block pauses the program for a specified number of seconds."
+#~ msgstr ""
 
 #: js/turtledefs.js:229
 
-#~msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
-#~msgstr ""
+#~ msgid "The <em>Set drum</em> block will select a drum sound to replace the pitch of any contained notes. In the example above, a <em>kick drum</em> sound will be played instead of <em>sol</em>."
+#~ msgstr ""
 
 #: js/turtledefs.js:420
 
-#~msgid "The <em>Heap length</em> block returns the length of the heap."
-#~msgstr ""
+#~ msgid "The <em>Heap length</em> block returns the length of the heap."
+#~ msgstr ""
 
 #: js/basicblocks.js:1146
 
-#~msgid "on offbeat do"
-#~msgstr ""
+#~ msgid "on offbeat do"
+#~ msgstr ""
 
 #: js/StringHelper.js:17
 
@@ -12313,287 +12313,287 @@ msgstr ""
 
 #: js/StringHelper.js:19
 
-#~msgid "data-tooltip"
-#~msgstr ""
+#~ msgid "data-tooltip"
+#~ msgstr ""
 
 #: js/playback.js:28
 
 #: js/playback.js:28
 
-#~msgid "pause"
-#~msgstr ""
+#~ msgid "pause"
+#~ msgstr ""
 
 #: js/turtledefs.js:195
 
-#~msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
-#~msgstr ""
+#~ msgid "A rest of the specified note value duration can be constructed using a <em>Silence</em> block."
+#~ msgstr ""
 
 #: js/turtledefs.js:225
 
-#~msgid "e.g., guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "e.g., guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/activity.js:4118
 
-#~msgid "Hard stop"
-#~msgstr ""
+#~ msgid "Hard stop"
+#~ msgstr ""
 
 #: js/turtledefs.js:468
 
-#~msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
-#~msgstr ""
+#~ msgid "The <em>Get red</em> block returns the red component of the pixel under the mouse."
+#~ msgstr ""
 
 #: js/basicblocks.js:808
 
-#~msgid "free time"
-#~msgstr ""
+#~ msgid "free time"
+#~ msgstr ""
 
 #: js/turtledefs.js:214
 
-#~msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
-#~msgstr ""
+#~ msgid "e.g., if the last note played was sol, Scalar Step 1 will play la."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:328
 
-#~msgid "whole-tone"
-#~msgstr ""
+#~ msgid "whole-tone"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "You can also use Alt+C to copy a stack of blocks."
-#~msgstr ""
+#~ msgid "You can also use Alt+C to copy a stack of blocks."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:287
 
-#~msgid "natural-minor"
-#~msgstr ""
+#~ msgid "natural-minor"
+#~ msgstr ""
 
 #: js/activity.js:4437
 
 #: js/activity.js:4472
 
-#~msgid "Click here to paste"
-#~msgstr ""
+#~ msgid "Click here to paste"
+#~ msgstr ""
 
-#~msgid "This button opens and closes the primary toolbar."
-#~msgstr ""
+#~ msgid "This button opens and closes the primary toolbar."
+#~ msgstr ""
 
 #: js/activity.js:4426
 
-#~msgid "Run music step by step"
-#~msgstr ""
+#~ msgid "Run music step by step"
+#~ msgstr ""
 
 #: js/turtledefs.js:417
 
-#~msgid "The <em>Saveheap</em> block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The <em>Saveheap</em> block saves the heap to a file."
+#~ msgstr ""
 
 #: js/musicutils.js:230
 
-#~msgid "Ethiopian"
-#~msgstr ""
+#~ msgid "Ethiopian"
+#~ msgstr ""
 
 #: js/turtledefs.js:99
 
-#~msgid "It appears after a long press on a stack."
-#~msgstr ""
+#~ msgid "It appears after a long press on a stack."
+#~ msgstr ""
 
 #: js/logo.js:4851
 
 #: js/logo.js:4872
 
-#~msgid "Input to Perfect Block must be 1, 4, 5, or 8"
-#~msgstr ""
+#~ msgid "Input to Perfect Block must be 1, 4, 5, or 8"
+#~ msgstr ""
 
 #: js/temperament.js:1621
 
-#~msgid "table"
-#~msgstr ""
+#~ msgid "table"
+#~ msgstr ""
 
 #: js/savebox.js:116
 
-#~msgid "Save as .tb"
-#~msgstr ""
+#~ msgid "Save as .tb"
+#~ msgstr ""
 
 #: js/lilypond.js:21
 
-#~msgid "cp"
-#~msgstr ""
+#~ msgid "cp"
+#~ msgstr ""
 
 #: js/turtledefs.js:321
 
-#~msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
-#~msgstr ""
+#~ msgid "The <em>On-weak-beat</em> block let you specify actions to take on weak (off) beats."
+#~ msgstr ""
 
 #: plugins/rodi.rtp:130
 
-#~msgid "sense right"
-#~msgstr ""
+#~ msgid "sense right"
+#~ msgstr ""
 
 #: js/turtledefs.js:423
 
-#~msgid "The <em>Load heap from app</em> block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The <em>Load heap from app</em> block loads the heap from a web page."
+#~ msgstr ""
 
-#~msgid "vspace"
-#~msgstr ""
+#~ msgid "vspace"
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:321
 
-#~msgid "spanish-gypsy"
-#~msgstr ""
+#~ msgid "spanish-gypsy"
+#~ msgstr ""
 
 #: js/turtledefs.js:286
 
-#~msgid "The <em>Color</em> block returns the current pen color."
-#~msgstr ""
+#~ msgid "The <em>Color</em> block returns the current pen color."
+#~ msgstr ""
 
 #: js/musicutils.js:225
 
-#~msgid "Bebop"
-#~msgstr ""
+#~ msgid "Bebop"
+#~ msgstr ""
 
 #: js/turtledefs.js:185
 
-#~msgid "The Paste Button will highlight."
-#~msgstr ""
+#~ msgid "The Paste Button will highlight."
+#~ msgstr ""
 
 #: js/turtledefs.js:431
 
-#~msgid "The Load heap from app block loads the heap from a web page."
-#~msgstr ""
+#~ msgid "The Load heap from app block loads the heap from a web page."
+#~ msgstr ""
 
 #: js/logo.js:1982
 
-#~msgid "The Step Pitch Block must be used insdie of a Note Block."
-#~msgstr ""
+#~ msgid "The Step Pitch Block must be used insdie of a Note Block."
+#~ msgstr ""
 
 #: js/turtledefs.js:118
 
-#~msgid "Remove all content on the canvas, including the blocks."
-#~msgstr ""
+#~ msgid "Remove all content on the canvas, including the blocks."
+#~ msgstr ""
 
 #: js/basicblocks.js:4883
 
-#~msgid "save svg"
-#~msgstr ""
+#~ msgid "save svg"
+#~ msgstr ""
 
 #: js/samplesviewer.js:699
 
-#~msgid "On my device"
-#~msgstr ""
+#~ msgid "On my device"
+#~ msgstr ""
 
 #: js/turtledefs.js:432
 
-#~msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
-#~msgstr ""
+#~ msgid "The <em>No background</em> block eliminates the background from the saved SVG output."
+#~ msgstr ""
 
 #: js/activity.js:2527
 
-#~msgid "My Music Blocks Creation"
-#~msgstr ""
+#~ msgid "My Music Blocks Creation"
+#~ msgstr ""
 
 #: js/turtledefs.js:438
 
-#~msgid "The <em>Open palette</em> block opens a palette."
-#~msgstr ""
+#~ msgid "The <em>Open palette</em> block opens a palette."
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
-#~msgstr ""
+#~ msgid "The <em>Forever</em> block will repeat the contained blocks forever. In this example, a simple drum machine, a kick drum will play 1/4 notes forever."
+#~ msgstr ""
 
 #: js/logo.js:4898
 
 #: js/logo.js:4919
 
-#~msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
-#~msgstr ""
+#~ msgid "Input to Diminished Block must be 1, 2, 3, 4, 5, 6, 7, or 8"
+#~ msgstr ""
 
 #: js/turtledefs.js:168
 
-#~msgid "Run music slow"
-#~msgstr ""
+#~ msgid "Run music slow"
+#~ msgstr ""
 
 #: js/turtledefs.js:120
 
 #: js/turtledefs.js:159
 
-#~msgid "To copy a stack to the clipboard, do a long press on the stack."
-#~msgstr ""
+#~ msgid "To copy a stack to the clipboard, do a long press on the stack."
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "eg guitar, piano, violin, or cello."
-#~msgstr ""
+#~ msgid "eg guitar, piano, violin, or cello."
+#~ msgstr ""
 
 #: js/turtledefs.js:29
 
 #: js/musicutils.js:330
 
-#~msgid "minor-pentatonic"
-#~msgstr ""
+#~ msgid "minor-pentatonic"
+#~ msgstr ""
 
 #: js/turtledefs.js:359
 
-#~msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
-#~msgstr ""
+#~ msgid "The <em>AM synth</em> block is an amplitude modulator used to define a timbre."
+#~ msgstr ""
 
 #: js/turtledefs.js:275
 
-#~msgid "The <em>Right</em> block turns the mouse to the right."
-#~msgstr ""
+#~ msgid "The <em>Right</em> block turns the mouse to the right."
+#~ msgstr ""
 
 #: js/turtledefs.js:355
 
-#~msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
-#~msgstr ""
+#~ msgid "The <em>Harmonic</em> block will add harmonics to the contained notes."
+#~ msgstr ""
 
 #: js/turtledefs.js:217
 
-#~msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
-#~msgstr ""
+#~ msgid "The <em>Staccato</em> block shortens the length of the actual notewhile maintaining the specified rhythmic value of the notes."
+#~ msgstr ""
 
 #: js/pitchtimematrix.js:198
 
-#~msgid "export"
-#~msgstr ""
+#~ msgid "export"
+#~ msgstr ""
 
 #: js/turtledefs.js:402
 
-#~msgid "The <em>Power</em> block calculates a power function."
-#~msgstr ""
+#~ msgid "The <em>Power</em> block calculates a power function."
+#~ msgstr ""
 
 #: js/turtledefs.js:440
 
-#~msgid "The <em>Set heading</em> block sets the heading of the mouse."
-#~msgstr ""
+#~ msgid "The <em>Set heading</em> block sets the heading of the mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:193
 
-#~msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
-#~msgstr ""
+#~ msgid "The <em>Note</em> block is a container for one or more <em>Pitch</em> blocks. The <em>Note</em> block specifies the duration (note value) of its contents."
+#~ msgstr ""
 
 #: js/turtledefs.js:269
 
-#~msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
-#~msgstr ""
+#~ msgid "The <em>Less-than</em> block returns <em>True</em> if the top number is less than the bottom number."
+#~ msgstr ""
 
 #: js/turtledefs.js:201
 
-#~msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
-#~msgstr ""
+#~ msgid "The <em>Beat count</em> block is the number of the current beat, e.g., 1, 2, 3, or 4.\n In the figure, it is used to take an action on the first beat of each measure."
+#~ msgstr ""
 
 #: js/turtledefs.js:483
 
-#~msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
-#~msgstr ""
+#~ msgid "The <em>Mouse color</em> block returns the pen color of the specified mouse."
+#~ msgstr ""
 
 #: js/turtledefs.js:187
 
@@ -12601,13 +12601,13 @@ msgstr ""
 
 #: js/toolbar.js:424
 
-#~msgid "Save as ABC"
-#~msgstr ""
+#~ msgid "Save as ABC"
+#~ msgstr ""
 
 #: js/timbre.js:591
 
-#~msgid "synthesizer"
-#~msgstr ""
+#~ msgid "synthesizer"
+#~ msgstr ""
 
 #: js/logo.js:630
 
@@ -12615,86 +12615,86 @@ msgstr ""
 
 #: js/musicutils.js:205
 
-#~msgid "Major"
-#~msgstr ""
+#~ msgid "Major"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Saveheap block saves the heap to a file."
-#~msgstr ""
+#~ msgid "The Saveheap block saves the heap to a file."
+#~ msgstr ""
 
 #: js/turtledefs.js:363
 
-#~msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
-#~msgstr ""
+#~ msgid "The <em>Set master volume</em> block sets the volume for all synthesizers."
+#~ msgstr ""
 
 #: js/basicblocks.js:883
 
-#~msgid "duplicate notes"
-#~msgstr ""
+#~ msgid "duplicate notes"
+#~ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~msgid "The Setheapentry block sets a value in he heap at the specified location."
-#~msgstr ""
+#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgstr ""
 
 #: js/utilitybox.js:281
 
-#~msgid "Disable scrolling"
-#~msgstr ""
+#~ msgid "Disable scrolling"
+#~ msgstr ""
 
 #: js/turtledefs.js:425
 
-#~msgid "The Scalar interval block measures the distance between two notes in semi-tones."
-#~msgstr ""
+#~ msgid "The Scalar interval block measures the distance between two notes in semi-tones."
+#~ msgstr ""
 
 #: js/logo.js:4259
 
-#~msgid "Rhythm Block: Did you mean to use a Matrix block?"
-#~msgstr ""
+#~ msgid "Rhythm Block: Did you mean to use a Matrix block?"
+#~ msgstr ""
 
 #: js/turtledefs.js:202
 
-#~msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
-#~msgstr ""
+#~ msgid "The <em>Notes played</em> block is the number of notes that have been played. (By default, it counts quarter notes.)"
+#~ msgstr ""
 
 #: js/turtledefs.js:242
 
-#~msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
-#~msgstr ""
+#~ msgid "The default volume is 50; the range is 0 (silence) to 100 (full volume)."
+#~ msgstr ""
 
 #: js/turtledefs.js:248
 
-#~msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
-#~msgstr ""
+#~ msgid "Each <em>Start</em> block is a separate voice. All of the <em>Start</em> blocks run at the same time when the <em>Play</em> button is pressed."
+#~ msgstr ""
 
 #: js/turtledefs.js:352
 
-#~msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
-#~msgstr ""
+#~ msgid "e.g. \"do\" is always \"C-natural\"); when Movable do is true, the solfege note names are assigned to scale degrees (\"do\" is always the first degree of the major scale)."
+#~ msgstr ""
 
 #: js/basicblocks.js:83
 
-#~msgid "current pitch octave"
-#~msgstr ""
+#~ msgid "current pitch octave"
+#~ msgstr ""
 
 #: js/turtledefs.js:415
 
-#~msgid "The <em>Reverseheap</em> block reverses the order of the heap."
-#~msgstr ""
+#~ msgid "The <em>Reverseheap</em> block reverses the order of the heap."
+#~ msgstr ""
 
 #: js/musicutils.js:250
 
-#~msgid "Hirajoshi"
-#~msgstr ""
+#~ msgid "Hirajoshi"
+#~ msgstr ""
 
 #: js/turtledefs.js:433
 
-#~msgid "The <em>Make block</em> block creates a new block."
-#~msgstr ""
+#~ msgid "The <em>Make block</em> block creates a new block."
+#~ msgstr ""
 
 #: js/musicutils.js:201
 
-#~msgid "Spanish"
-#~msgstr ""
+#~ msgid "Spanish"
+#~ msgstr ""
 


### PR DESCRIPTION
This PR fixes syntax errors in all .po translation files in the repository. The errors included:
Missing space after #~ in obsolete entries (#~msgid → #~ msgid, #~msgstr → #~ msgstr)
Unescaped double quotes in msgstr lines.
Incorrectly formatted multi-line msgstr entries.

**Benefits / Impact:**

Resolves Weblate parsing errors that previously locked the translation component.
Ensures all translation files can now be accessed and translated without issues.
Improves maintainability of the .po files and prevents similar parsing errors in the future.

**Example errors fixed:**

zh_TW.po: Syntax error due to #~msgid without space.
ayc.po: Unescaped double quotes in msgstr.
es.po: Complex strings with unescaped quotes corrected.
tr.po: Header formatting issue.